### PR TITLE
Implement ICE caching for AWS cloud provider and fix bug in filtering for SubnetProvider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo v1.16.5
-	github.com/onsi/gomega v1.16.0
+	github.com/onsi/gomega v1.17.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.11.0
 	go.uber.org/multierr v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,9 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.3.0/go.mod h1:4c3sLeE8xjNqehmF5RpAFLPLJxXscc0R4l6Zg0P1tTQ=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -132,11 +132,7 @@ func (c *CloudProvider) GetInstanceTypes(ctx context.Context, constraints *v1alp
 	if err != nil {
 		return nil, apis.ErrGeneric(err.Error())
 	}
-	instanceTypes, err := c.instanceTypeProvider.Get(ctx, vendorConstraints)
-	if err != nil {
-		return nil, err
-	}
-	return c.instanceProvider.WithoutUnavailableOfferings(ctx, instanceTypes), nil
+	return c.instanceTypeProvider.Get(ctx, vendorConstraints)
 }
 
 func (c *CloudProvider) Delete(ctx context.Context, node *v1.Node) error {
@@ -156,11 +152,11 @@ func (c *CloudProvider) Validate(ctx context.Context, constraints *v1alpha5.Cons
 func (c *CloudProvider) Default(ctx context.Context, constraints *v1alpha5.Constraints) {
 	vendorConstraints, err := v1alpha1.Deserialize(constraints)
 	if err != nil {
-		logging.FromContext(ctx).Fatalf("Failed to deserialize provider, %s", err.Error())
+		logging.FromContext(ctx).Errorf("Failed to deserialize provider, %s", err.Error())
 		return
 	}
 	vendorConstraints.Default(ctx)
 	if err := vendorConstraints.Serialize(constraints); err != nil {
-		logging.FromContext(ctx).Fatalf("Failed to serialize provider, %s", err.Error())
+		logging.FromContext(ctx).Errorf("Failed to serialize provider, %s", err.Error())
 	}
 }

--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -25,8 +25,11 @@ var (
 		"InvalidInstanceID.NotFound",
 		"InvalidLaunchTemplateName.NotFoundException",
 	}
-	iceErrorCode = "InsufficientInstanceCapacity"
 )
+
+// InsufficientCapacityErrorCode indicates that EC2 is temporarily lacking capacity for this
+// instance type and availability zone combination
+const InsufficientCapacityErrorCode = "InsufficientInstanceCapacity"
 
 // isNotFound returns true if the err is an AWS error (even if it's
 // wrapped) and is a known to mean "not found" (as opposed to a more
@@ -37,8 +40,4 @@ func isNotFound(err error) bool {
 		return functional.ContainsString(notFoundErrorCodes, awsError.Code())
 	}
 	return false
-}
-
-func isInsufficientCapacityCode(errorCode string) bool {
-	return errorCode == iceErrorCode
 }

--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -25,6 +25,7 @@ var (
 		"InvalidInstanceID.NotFound",
 		"InvalidLaunchTemplateName.NotFoundException",
 	}
+	iceErrorCode = "InsufficientInstanceCapacity"
 )
 
 // isNotFound returns true if the err is an AWS error (even if it's
@@ -36,4 +37,8 @@ func isNotFound(err error) bool {
 		return functional.ContainsString(notFoundErrorCodes, awsError.Code())
 	}
 	return false
+}
+
+func isInsufficientCapacityCode(errorCode string) bool {
+	return errorCode == iceErrorCode
 }

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -95,7 +95,7 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 		}
 		instances = append(instances, &ec2.Instance{
 			InstanceId:     aws.String(randomdata.SillyName()),
-			Placement:      &ec2.Placement{AvailabilityZone: aws.String("test-zone-1a")},
+			Placement:      &ec2.Placement{AvailabilityZone: input.LaunchTemplateConfigs[0].Overrides[0].AvailabilityZone},
 			PrivateDnsName: aws.String(randomdata.IpV4Address()),
 			InstanceType:   input.LaunchTemplateConfigs[0].Overrides[0].InstanceType,
 		})
@@ -387,6 +387,10 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 			{
 				InstanceType: aws.String("p3.8xlarge"),
 				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("p3.8xlarge"),
+				Location:     aws.String("test-zone-1b"),
 			},
 			{
 				InstanceType: aws.String("inf1.2xlarge"),

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -172,7 +172,6 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 // CacheUnavailable allows the InstanceProvider to communicate recently observed temporary capacity shortages in
 // the provided offerings
 func (p *InstanceTypeProvider) CacheUnavailable(ctx context.Context, instanceType string, zone string, capacityType string) {
-	cacheKey := UnavailableOfferingsCacheKey(capacityType, instanceType, zone)
 	logging.FromContext(ctx).Debugf("Saw %s for offering { instanceType: %s, zone: %s, capacityType: %s }, avoiding for %s",
 		InsufficientCapacityErrorCode,
 		instanceType,
@@ -180,7 +179,7 @@ func (p *InstanceTypeProvider) CacheUnavailable(ctx context.Context, instanceTyp
 		capacityType,
 		InsufficientCapacityErrorCacheTTL)
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
-	p.unavailableOfferings.SetDefault(cacheKey, struct{}{})
+	p.unavailableOfferings.SetDefault(UnavailableOfferingsCacheKey(capacityType, instanceType, zone), struct{}{})
 }
 
 func UnavailableOfferingsCacheKey(capacityType string, instanceType string, zone string) string {

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -179,7 +179,7 @@ func (p *InstanceTypeProvider) CacheUnavailable(ctx context.Context, instanceTyp
 		capacityType,
 		InsufficientCapacityErrorCacheTTL)
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
-	p.unavailableOfferings.SetDefault(UnavailableOfferingsCacheKey(capacityType, instanceType, zone), struct{}{})
+	p.unavailableOfferings.SetDefault(UnavailableOfferingsCacheKey(capacityType, instanceType, zone), sets.Empty{})
 }
 
 func UnavailableOfferingsCacheKey(capacityType string, instanceType string, zone string) string {

--- a/pkg/cloudprovider/aws/subnets.go
+++ b/pkg/cloudprovider/aws/subnets.go
@@ -40,7 +40,7 @@ func NewSubnetProvider(ec2api ec2iface.EC2API) *SubnetProvider {
 	}
 }
 
-func (s *SubnetProvider) Get(ctx context.Context, constraints *v1alpha1.Constraints) ([]*ec2.Subnet, error) {
+func (s *SubnetProvider) Get(ctx context.Context, constraints *v1alpha1.AWS) ([]*ec2.Subnet, error) {
 	filters := getFilters(constraints)
 	hash, err := hashstructure.Hash(filters, hashstructure.FormatV2, nil)
 	if err != nil {
@@ -61,15 +61,9 @@ func (s *SubnetProvider) Get(ctx context.Context, constraints *v1alpha1.Constrai
 	return output.Subnets, nil
 }
 
-func getFilters(constraints *v1alpha1.Constraints) []*ec2.Filter {
+func getFilters(constraints *v1alpha1.AWS) []*ec2.Filter {
 	filters := []*ec2.Filter{}
-	// Filter by zone
-	if zones := constraints.Requirements.Zones(); zones != nil {
-		filters = append(filters, &ec2.Filter{
-			Name:   aws.String("availability-zone"),
-			Values: aws.StringSlice(zones.UnsortedList()),
-		})
-	}
+
 	// Filter by subnet
 	for key, value := range constraints.SubnetSelector {
 		if value == "*" {

--- a/pkg/cloudprovider/aws/subnets.go
+++ b/pkg/cloudprovider/aws/subnets.go
@@ -63,7 +63,6 @@ func (s *SubnetProvider) Get(ctx context.Context, constraints *v1alpha1.AWS) ([]
 
 func getFilters(constraints *v1alpha1.AWS) []*ec2.Filter {
 	filters := []*ec2.Filter{}
-
 	// Filter by subnet
 	for key, value := range constraints.SubnetSelector {
 		if value == "*" {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	. "knative.dev/pkg/logging/testing"
 )
@@ -52,6 +54,8 @@ var launchTemplateCache *cache.Cache
 var fakeEC2API *fake.EC2API
 var provisioners *provisioning.Controller
 var scheduler *scheduling.Controller
+
+const shortenedUnavailableOfferingsTTL = 2 * time.Second
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -65,7 +69,12 @@ var _ = BeforeSuite(func() {
 		launchTemplateCache = cache.New(CacheTTL, CacheCleanupInterval)
 		fakeEC2API = &fake.EC2API{}
 		subnetProvider := NewSubnetProvider(fakeEC2API)
-		instanceTypeProvider := NewInstanceTypeProvider(fakeEC2API, subnetProvider)
+		instanceTypeProvider := &InstanceTypeProvider{
+			ec2api:               fakeEC2API,
+			subnetProvider:       subnetProvider,
+			cache:                cache.New(InstanceTypesAndZonesCacheTTL, CacheCleanupInterval),
+			unavailableOfferings: cache.New(shortenedUnavailableOfferingsTTL, InsufficientCapacityErrorCacheCleanupInterval),
+		}
 		clientSet := kubernetes.NewForConfigOrDie(e.Config)
 		cloudProvider := &CloudProvider{
 			subnetProvider:       subnetProvider,
@@ -110,6 +119,7 @@ var _ = Describe("Allocation", func() {
 	Context("Reconciliation", func() {
 		Context("Specialized Hardware", func() {
 			It("should launch instances for Nvidia GPU resource requests", func() {
+				nodeNames := sets.NewString()
 				for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
@@ -132,17 +142,12 @@ var _ = Describe("Allocation", func() {
 						},
 					})) {
 					ExpectScheduled(ctx, env.Client, pod)
+					nodeNames.Insert(ExpectScheduledWithInstanceType(ctx, env.Client, pod, "p3.8xlarge").Name)
 				}
-				Expect(InstancesLaunchedFrom(fakeEC2API.CalledWithCreateFleetInput.Iter())).To(Equal(2))
-				overrides := []*ec2.FleetLaunchTemplateOverridesRequest{}
-				for i := range fakeEC2API.CalledWithCreateFleetInput.Iter() {
-					overrides = append(overrides, i.(*ec2.CreateFleetInput).LaunchTemplateConfigs[0].Overrides...)
-				}
-				for _, override := range overrides {
-					Expect(*override.InstanceType).To(Equal("p3.8xlarge"))
-				}
+				Expect(nodeNames.Len()).To(Equal(2))
 			})
 			It("should launch instances for AWS Neuron resource requests", func() {
+				nodeNames := sets.NewString()
 				for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
@@ -165,16 +170,67 @@ var _ = Describe("Allocation", func() {
 						},
 					}),
 				) {
-					ExpectScheduled(ctx, env.Client, pod)
+					nodeNames.Insert(ExpectScheduledWithInstanceType(ctx, env.Client, pod, "inf1.6xlarge").Name)
 				}
-				Expect(InstancesLaunchedFrom(fakeEC2API.CalledWithCreateFleetInput.Iter())).To(Equal(2))
-				overrides := []*ec2.FleetLaunchTemplateOverridesRequest{}
-				for input := range fakeEC2API.CalledWithCreateFleetInput.Iter() {
-					overrides = append(overrides, input.(*ec2.CreateFleetInput).LaunchTemplateConfigs[0].Overrides...)
+				Expect(nodeNames.Len()).To(Equal(2))
+			})
+		})
+		Context("Insufficient Capacity Error Cache", func() {
+			It("should launch instances on second recon attempt with Insufficient Capacity Error Cache fallback", func() {
+				fakeEC2API.ShouldTriggerInsufficientCapacity = true
+				pods := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
+					test.UnschedulablePod(test.PodOptions{
+						ResourceRequirements: v1.ResourceRequirements{
+							Requests: v1.ResourceList{resources.AWSNeuron: resource.MustParse("1")},
+							Limits:   v1.ResourceList{resources.AWSNeuron: resource.MustParse("1")},
+						},
+					}),
+					test.UnschedulablePod(test.PodOptions{
+						ResourceRequirements: v1.ResourceRequirements{
+							Requests: v1.ResourceList{resources.AWSNeuron: resource.MustParse("1")},
+							Limits:   v1.ResourceList{resources.AWSNeuron: resource.MustParse("1")},
+						},
+					}),
+				)
+				// it should've tried to pack them on a single inf1.6xlarge then hit an insufficient capacity error
+				for _, pod := range pods {
+					ExpectNotScheduled(ctx, env.Client, pod)
 				}
-				for _, override := range overrides {
-					Expect(*override.InstanceType).To(Equal("inf1.6xlarge"))
+				nodeNames := sets.NewString()
+				for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pods...) {
+					nodeNames.Insert(ExpectScheduledWithInstanceType(ctx, env.Client, pod, "inf1.2xlarge").Name)
 				}
+				Expect(nodeNames.Len()).To(Equal(2))
+			})
+			It("should launch instances on later recon attempt with Insufficient Capacity Error Cache expiry", func() {
+				fakeEC2API.ShouldTriggerInsufficientCapacity = true
+				pods := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
+					test.UnschedulablePod(test.PodOptions{
+						ResourceRequirements: v1.ResourceRequirements{
+							Requests: v1.ResourceList{resources.AWSNeuron: resource.MustParse("2")},
+							Limits:   v1.ResourceList{resources.AWSNeuron: resource.MustParse("2")},
+						},
+					}),
+					test.UnschedulablePod(test.PodOptions{
+						ResourceRequirements: v1.ResourceRequirements{
+							Requests: v1.ResourceList{resources.AWSNeuron: resource.MustParse("2")},
+							Limits:   v1.ResourceList{resources.AWSNeuron: resource.MustParse("2")},
+						},
+					}),
+				)
+				// it should've tried to pack them on a single inf1.6xlarge then hit an insufficient capacity error
+				for _, pod := range pods {
+					ExpectNotScheduled(ctx, env.Client, pod)
+				}
+				// capacity shortage is over - wait for expiry (N.B. the Karpenter logging will not show the overridden cache expiry in this test context)
+				fakeEC2API.ShouldTriggerInsufficientCapacity = false
+				Eventually(func(g Gomega) int {
+					nodeNames := sets.NewString()
+					for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pods...) {
+						nodeNames = nodeNames.Insert(ExpectScheduledWithInstanceTypeAndGomega(ctx, env.Client, pod, "inf1.6xlarge", g).Name)
+					}
+					return len(nodeNames)
+				}, shortenedUnavailableOfferingsTTL*2, RequestInterval).Should(Equal(1))
 			})
 		})
 		Context("CapacityType", func() {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
@@ -77,6 +78,7 @@ var _ = BeforeSuite(func() {
 					securityGroupProvider: NewSecurityGroupProvider(fakeEC2API),
 					cache:                 launchTemplateCache,
 				},
+				cache.New(5*time.Second, 30*time.Second),
 			},
 			creationQueue: parallel.NewWorkQueue(CreationQPS, CreationBurst),
 		}
@@ -269,9 +271,9 @@ var _ = Describe("Allocation", func() {
 				input := fakeEC2API.CalledWithCreateFleetInput.Pop().(*ec2.CreateFleetInput)
 				Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
 				Expect(input.LaunchTemplateConfigs[0].Overrides).To(ContainElements(
-					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-1"), InstanceType: aws.String("m5.large")},
-					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-2"), InstanceType: aws.String("m5.large")},
-					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-3"), InstanceType: aws.String("m5.large")},
+					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-1"), InstanceType: aws.String("m5.large"), AvailabilityZone: aws.String("test-zone-1a")},
+					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-2"), InstanceType: aws.String("m5.large"), AvailabilityZone: aws.String("test-zone-1b")},
+					&ec2.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String("test-subnet-3"), InstanceType: aws.String("m5.large"), AvailabilityZone: aws.String("test-zone-1c")},
 				))
 			})
 		})

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Allocation", func() {
 		})
 		Context("Insufficient Capacity Error Cache", func() {
 			It("should launch instances on second recon attempt with Insufficient Capacity Error Cache fallback", func() {
-				fakeEC2API.ShouldTriggerInsufficientCapacity = true
+				fakeEC2API.InsufficientCapacityPools = []fake.CapacityPool{{InstanceType: "inf1.6xlarge", Zone: "test-zone-1a"}}
 				pods := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
@@ -203,7 +203,7 @@ var _ = Describe("Allocation", func() {
 				Expect(nodeNames.Len()).To(Equal(2))
 			})
 			It("should launch instances on later recon attempt with Insufficient Capacity Error Cache expiry", func() {
-				fakeEC2API.ShouldTriggerInsufficientCapacity = true
+				fakeEC2API.InsufficientCapacityPools = []fake.CapacityPool{{InstanceType: "inf1.6xlarge", Zone: "test-zone-1a"}}
 				pods := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
@@ -223,7 +223,7 @@ var _ = Describe("Allocation", func() {
 					ExpectNotScheduled(ctx, env.Client, pod)
 				}
 				// capacity shortage is over - wait for expiry (N.B. the Karpenter logging will not show the overridden cache expiry in this test context)
-				fakeEC2API.ShouldTriggerInsufficientCapacity = false
+				fakeEC2API.InsufficientCapacityPools = []fake.CapacityPool{}
 				Eventually(func(g Gomega) int {
 					nodeNames := sets.NewString()
 					for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pods...) {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
@@ -78,7 +77,6 @@ var _ = BeforeSuite(func() {
 					securityGroupProvider: NewSecurityGroupProvider(fakeEC2API),
 					cache:                 launchTemplateCache,
 				},
-				cache.New(5*time.Second, 30*time.Second),
 			},
 			creationQueue: parallel.NewWorkQueue(CreationQPS, CreationBurst),
 		}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -69,15 +69,6 @@ func ExpectScheduled(ctx context.Context, c client.Client, pod *v1.Pod) *v1.Node
 	return ExpectNodeExists(c, p.Spec.NodeName)
 }
 
-func ExpectScheduledWithInstanceType(ctx context.Context, c client.Client, pod *v1.Pod, instanceType string) *v1.Node {
-	p := ExpectPodExists(c, pod.Name, pod.Namespace)
-	Expect(p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to be scheduled", pod.Namespace, pod.Name))
-	node := ExpectNodeExists(c, p.Spec.NodeName)
-	Expect(node.Labels["node.kubernetes.io/instance-type"]).To(Equal(instanceType),
-		fmt.Sprintf("expected %s/%s to be scheduled to a node with instance type %s", pod.Namespace, pod.Name, instanceType))
-	return node
-}
-
 func ExpectNotScheduled(ctx context.Context, c client.Client, pod *v1.Pod) {
 	p := ExpectPodExists(c, pod.Name, pod.Namespace)
 	Eventually(p.Spec.NodeName).Should(BeEmpty(), fmt.Sprintf("expected %s/%s to not be scheduled", pod.Namespace, pod.Name))

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -41,30 +41,15 @@ const (
 	RequestInterval           = 1 * time.Second
 )
 
-func defaultGomegaIfNil(g Gomega) Gomega {
-	if g != nil {
-		return g
-	}
-	return Default
-}
-
 func ExpectPodExists(c client.Client, name string, namespace string) *v1.Pod {
-	return ExpectPodExistsWithGomega(c, name, namespace, nil)
-}
-
-func ExpectPodExistsWithGomega(c client.Client, name string, namespace string, g Gomega) *v1.Pod {
 	pod := &v1.Pod{}
-	defaultGomegaIfNil(g).Expect(c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, pod)).To(Succeed())
+	Expect(c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, pod)).To(Succeed())
 	return pod
 }
 
 func ExpectNodeExists(c client.Client, name string) *v1.Node {
-	return ExpectNodeExistsWithGomega(c, name, nil)
-}
-
-func ExpectNodeExistsWithGomega(c client.Client, name string, g Gomega) *v1.Node {
 	node := &v1.Node{}
-	defaultGomegaIfNil(g).Expect(c.Get(context.Background(), client.ObjectKey{Name: name}, node)).To(Succeed())
+	Expect(c.Get(context.Background(), client.ObjectKey{Name: name}, node)).To(Succeed())
 	return node
 }
 
@@ -85,14 +70,10 @@ func ExpectScheduled(ctx context.Context, c client.Client, pod *v1.Pod) *v1.Node
 }
 
 func ExpectScheduledWithInstanceType(ctx context.Context, c client.Client, pod *v1.Pod, instanceType string) *v1.Node {
-	return ExpectScheduledWithInstanceTypeAndGomega(ctx, c, pod, instanceType, nil)
-}
-
-func ExpectScheduledWithInstanceTypeAndGomega(ctx context.Context, c client.Client, pod *v1.Pod, instanceType string, g Gomega) *v1.Node {
-	p := ExpectPodExistsWithGomega(c, pod.Name, pod.Namespace, defaultGomegaIfNil(g))
-	defaultGomegaIfNil(g).Expect(p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to be scheduled", pod.Namespace, pod.Name))
-	node := ExpectNodeExistsWithGomega(c, p.Spec.NodeName, defaultGomegaIfNil(g))
-	defaultGomegaIfNil(g).Expect(node.Labels["node.kubernetes.io/instance-type"]).To(Equal(instanceType),
+	p := ExpectPodExists(c, pod.Name, pod.Namespace)
+	Expect(p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to be scheduled", pod.Namespace, pod.Name))
+	node := ExpectNodeExists(c, p.Spec.NodeName)
+	Expect(node.Labels["node.kubernetes.io/instance-type"]).To(Equal(instanceType),
 		fmt.Sprintf("expected %s/%s to be scheduled to a node with instance type %s", pod.Namespace, pod.Name, instanceType))
 	return node
 }

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -41,15 +41,30 @@ const (
 	RequestInterval           = 1 * time.Second
 )
 
+func defaultGomegaIfNil(g Gomega) Gomega {
+	if g != nil {
+		return g
+	}
+	return Default
+}
+
 func ExpectPodExists(c client.Client, name string, namespace string) *v1.Pod {
+	return ExpectPodExistsWithGomega(c, name, namespace, nil)
+}
+
+func ExpectPodExistsWithGomega(c client.Client, name string, namespace string, g Gomega) *v1.Pod {
 	pod := &v1.Pod{}
-	Expect(c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, pod)).To(Succeed())
+	defaultGomegaIfNil(g).Expect(c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, pod)).To(Succeed())
 	return pod
 }
 
 func ExpectNodeExists(c client.Client, name string) *v1.Node {
+	return ExpectNodeExistsWithGomega(c, name, nil)
+}
+
+func ExpectNodeExistsWithGomega(c client.Client, name string, g Gomega) *v1.Node {
 	node := &v1.Node{}
-	Expect(c.Get(context.Background(), client.ObjectKey{Name: name}, node)).To(Succeed())
+	defaultGomegaIfNil(g).Expect(c.Get(context.Background(), client.ObjectKey{Name: name}, node)).To(Succeed())
 	return node
 }
 
@@ -65,8 +80,21 @@ func ExpectNotFound(c client.Client, objects ...client.Object) {
 
 func ExpectScheduled(ctx context.Context, c client.Client, pod *v1.Pod) *v1.Node {
 	p := ExpectPodExists(c, pod.Name, pod.Namespace)
-	Expect(p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to scheduled", pod.Namespace, pod.Name))
+	Expect(p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to be scheduled", pod.Namespace, pod.Name))
 	return ExpectNodeExists(c, p.Spec.NodeName)
+}
+
+func ExpectScheduledWithInstanceType(ctx context.Context, c client.Client, pod *v1.Pod, instanceType string) *v1.Node {
+	return ExpectScheduledWithInstanceTypeAndGomega(ctx, c, pod, instanceType, nil)
+}
+
+func ExpectScheduledWithInstanceTypeAndGomega(ctx context.Context, c client.Client, pod *v1.Pod, instanceType string, g Gomega) *v1.Node {
+	p := ExpectPodExistsWithGomega(c, pod.Name, pod.Namespace, defaultGomegaIfNil(g))
+	defaultGomegaIfNil(g).Expect(p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to be scheduled", pod.Namespace, pod.Name))
+	node := ExpectNodeExistsWithGomega(c, p.Spec.NodeName, defaultGomegaIfNil(g))
+	defaultGomegaIfNil(g).Expect(node.Labels["node.kubernetes.io/instance-type"]).To(Equal(instanceType),
+		fmt.Sprintf("expected %s/%s to be scheduled to a node with instance type %s", pod.Namespace, pod.Name, instanceType))
+	return node
 }
 
 func ExpectNotScheduled(ctx context.Context, c client.Client, pod *v1.Pod) {


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/awslabs/karpenter/issues/371

**2. Description of changes:**
Finally - the exhilirating conclusion to my set of code changes on ice caching! All the changes I've made fit nicely within the AWS cloud provider
* I added a cache in the InstanceProvider. I debated a bunch with myself for where this should live and decided that it was cleaner to do that than to have the InstanceProvider pass the ICEs back to the cloudprovider to manage it. I liked the idea that the InstanceProvider would encapsulate the interactions with Fleet. 
* After a discussion with Ellis regarding my confusion on the constraints being passed into GetInstanceTypes, I removed the erroneous filtering in the SubnetProvider that was constraining AvailabilityZones (the only place the filtering was supposed to really happen was in the InstanceProvider when creating LT overrides for launch, so I moved the filtering into the InstanceProvider exclusively). I added brief comments to help others understand this better.
* I hope it's not too controversial that I added AvailabilityZone to our LT overrides. It's redundant but it makes our lives easier for processing ICEs and given that we're not near our Fleet request size limits it feels pretty safe.

I haven't done real cluster testing yet, only unit tests (but I believe Brandon has). Will do a sanity test on a real cluster before pushing. I also didn't add a unit test yet where we fall back to another zone - I may still try to add this when addressing the next round of comments.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
