### PR TITLE
Priorize provisioners alphabetically if multiple match

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -103,8 +103,11 @@ var _ = Describe("Allocation", func() {
 		provisioner = ProvisionerWithProvider(&v1alpha5.Provisioner{ObjectMeta: metav1.ObjectMeta{Name: v1alpha5.DefaultProvisioner.Name}}, provider)
 		provisioner.SetDefaults(ctx)
 		fakeEC2API.Reset()
-		ExpectCleanedUp(ctx, env.Client)
 		launchTemplateCache.Flush()
+	})
+
+	AfterEach(func() {
+		ExpectProvisioningCleanedUp(ctx, env.Client, provisioners)
 	})
 
 	Context("Reconciliation", func() {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Allocation", func() {
 		provisioner = ProvisionerWithProvider(&v1alpha5.Provisioner{ObjectMeta: metav1.ObjectMeta{Name: v1alpha5.DefaultProvisioner.Name}}, provider)
 		provisioner.SetDefaults(ctx)
 		fakeEC2API.Reset()
-		ExpectCleanedUp(env.Client)
+		ExpectCleanedUp(ctx, env.Client)
 		launchTemplateCache.Flush()
 	})
 

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Controller", func() {
 
 	AfterEach(func() {
 		injectabletime.Now = time.Now
-		ExpectCleanedUp(env.Client)
+		ExpectCleanedUp(ctx, env.Client)
 	})
 
 	Context("Expiration", func() {

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -15,6 +15,7 @@ package provisioning
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -140,13 +141,14 @@ func (c *Controller) hasChanged(ctx context.Context, provisionerNew *v1alpha5.Pr
 	return hashKeyOld != hashKeyNew
 }
 
-// List the active provisioners
+// List active provisioners in order of priority
 func (c *Controller) List(ctx context.Context) []*Provisioner {
 	provisioners := []*Provisioner{}
 	c.provisioners.Range(func(key, value interface{}) bool {
 		provisioners = append(provisioners, value.(*Provisioner))
 		return true
 	})
+	sort.Slice(provisioners, func(i, j int) bool { return provisioners[i].Name < provisioners[j].Name })
 	return provisioners
 }
 

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 var ctx context.Context
-var controller *provisioning.Controller
+var provisioners *provisioning.Controller
 var scheduler *scheduling.Controller
 var env *test.Environment
 
@@ -52,8 +52,8 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
 		cloudProvider := &fake.CloudProvider{}
 		registry.RegisterOrDie(ctx, cloudProvider)
-		controller = provisioning.NewController(ctx, e.Client, corev1.NewForConfigOrDie(e.Config), cloudProvider)
-		scheduler = scheduling.NewController(e.Client, controller)
+		provisioners = provisioning.NewController(ctx, e.Client, corev1.NewForConfigOrDie(e.Config), cloudProvider)
+		scheduler = scheduling.NewController(e.Client, provisioners)
 	})
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")
 })
@@ -81,12 +81,12 @@ var _ = Describe("Provisioning", func() {
 	})
 
 	AfterEach(func() {
-		ExpectCleanedUp(ctx, env.Client)
+		ExpectProvisioningCleanedUp(ctx, env.Client, provisioners)
 	})
 
 	Context("Reconcilation", func() {
 		It("should provision nodes", func() {
-			pods := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod())
+			pods := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod())
 			nodes := &v1.NodeList{}
 			Expect(env.Client.List(ctx, nodes)).To(Succeed())
 			Expect(len(nodes.Items)).To(Equal(1))
@@ -119,15 +119,15 @@ var _ = Describe("Provisioning", func() {
 				// Ignored, label selector does not match
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{"foo": "bar"}}),
 			}
-			for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, schedulable...) {
+			for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, schedulable...) {
 				ExpectScheduled(ctx, env.Client, pod)
 			}
-			for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, unschedulable...) {
+			for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, unschedulable...) {
 				ExpectNotScheduled(ctx, env.Client, pod)
 			}
 		})
 		It("should provision nodes for accelerators", func() {
-			for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				test.UnschedulablePod(test.PodOptions{
 					ResourceRequirements: v1.ResourceRequirements{Limits: v1.ResourceList{resources.NvidiaGPU: resource.MustParse("1")}},
 				}),
@@ -149,7 +149,7 @@ var _ = Describe("Provisioning", func() {
 					},
 				}
 				provisioner.Spec.Limits.Resources[v1.ResourceCPU] = resource.MustParse("20")
-				pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod())[0]
+				pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod())[0]
 				ExpectNotScheduled(ctx, env.Client, pod)
 			})
 		})
@@ -160,7 +160,7 @@ var _ = Describe("Provisioning", func() {
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
 					}},
 				))
-				pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+				pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 					test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
 					},
@@ -175,7 +175,7 @@ var _ = Describe("Provisioning", func() {
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10000"), v1.ResourceMemory: resource.MustParse("10000Gi")}},
 					}},
 				))
-				pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(test.PodOptions{}))[0]
+				pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{}))[0]
 				ExpectNotScheduled(ctx, env.Client, pod)
 			})
 			It("should ignore daemonsets without matching tolerations", func() {
@@ -185,7 +185,7 @@ var _ = Describe("Provisioning", func() {
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
 					}},
 				))
-				pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+				pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 					test.PodOptions{
 						Tolerations:          []v1.Toleration{{Operator: v1.TolerationOperator(v1.NodeSelectorOpExists)}},
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
@@ -202,7 +202,7 @@ var _ = Describe("Provisioning", func() {
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
 					}},
 				))
-				pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+				pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 					test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
 					},
@@ -218,7 +218,7 @@ var _ = Describe("Provisioning", func() {
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
 					}},
 				))
-				pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+				pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 					test.PodOptions{
 						NodeRequirements:     []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}},
 						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
@@ -232,7 +232,7 @@ var _ = Describe("Provisioning", func() {
 		Context("Labels", func() {
 			It("should label nodes", func() {
 				provisioner.Spec.Labels = map[string]string{"test-key": "test-value", "test-key-2": "test-value-2"}
-				for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod()) {
+				for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod()) {
 					node := ExpectScheduled(ctx, env.Client, pod)
 					Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
 					Expect(node.Labels).To(HaveKeyWithValue("test-key", "test-value"))
@@ -245,7 +245,7 @@ var _ = Describe("Provisioning", func() {
 		Context("Taints", func() {
 			It("should apply unready taints", func() {
 				ExpectCreated(env.Client, provisioner)
-				for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod()) {
+				for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod()) {
 					node := ExpectScheduled(ctx, env.Client, pod)
 					Expect(node.Spec.Taints).To(ContainElement(v1.Taint{Key: v1alpha5.NotReadyTaintKey, Effect: v1.TaintEffectNoSchedule}))
 				}

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Provisioning", func() {
 	})
 
 	AfterEach(func() {
-		ExpectCleanedUp(env.Client)
+		ExpectCleanedUp(ctx, env.Client)
 	})
 
 	Context("Reconcilation", func() {

--- a/pkg/controllers/scheduling/suite_test.go
+++ b/pkg/controllers/scheduling/suite_test.go
@@ -45,7 +45,7 @@ var env *test.Environment
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controllers/Allocation/Scheduling")
+	RunSpecs(t, "Controllers/Scheduling")
 }
 
 var _ = BeforeSuite(func() {
@@ -71,7 +71,7 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	ExpectCleanedUp(env.Client)
+	ExpectCleanedUp(ctx, env.Client)
 })
 
 var _ = Describe("Combined Constraints", func() {

--- a/pkg/controllers/scheduling/suite_test.go
+++ b/pkg/controllers/scheduling/suite_test.go
@@ -38,7 +38,7 @@ import (
 
 var ctx context.Context
 var provisioner *v1alpha5.Provisioner
-var controller *provisioning.Controller
+var provisioners *provisioning.Controller
 var scheduler *scheduling.Controller
 var env *test.Environment
 
@@ -52,8 +52,8 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
 		cloudProvider := &fake.CloudProvider{}
 		registry.RegisterOrDie(ctx, cloudProvider)
-		controller = provisioning.NewController(ctx, e.Client, corev1.NewForConfigOrDie(e.Config), cloudProvider)
-		scheduler = scheduling.NewController(e.Client, controller)
+		provisioners = provisioning.NewController(ctx, e.Client, corev1.NewForConfigOrDie(e.Config), cloudProvider)
+		scheduler = scheduling.NewController(e.Client, provisioners)
 	})
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")
 })
@@ -71,27 +71,27 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	ExpectCleanedUp(ctx, env.Client)
+	ExpectProvisioningCleanedUp(ctx, env.Client, provisioners)
 })
 
 var _ = Describe("Combined Constraints", func() {
 	Context("Custom Labels", func() {
 		It("should schedule unconstrained pods that don't have matching node selectors", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod())[0]
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod())[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue("test-key", "test-value"))
 		})
 		It("should not schedule pods that have conflicting node selectors", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{"test-key": "different-value"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should schedule pods that have matching requirements", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value", "another-value"}},
 				}},
@@ -101,7 +101,7 @@ var _ = Describe("Combined Constraints", func() {
 		})
 		It("should not schedule pods that have conflicting requirements", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"another-value"}},
 				}},
@@ -110,7 +110,7 @@ var _ = Describe("Combined Constraints", func() {
 		})
 		It("should schedule pods that have matching preferences", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodePreferences: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"another-value", "test-value"}},
 				}},
@@ -120,7 +120,7 @@ var _ = Describe("Combined Constraints", func() {
 		})
 		It("should not schedule pods with have conflicting preferences", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodePreferences: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-value"}},
 				}},
@@ -131,13 +131,13 @@ var _ = Describe("Combined Constraints", func() {
 	Context("Well Known Labels", func() {
 		It("should use provisioner constraints", func() {
 			provisioner.Spec.Requirements = v1alpha5.Requirements{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod())[0]
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod())[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
 		})
 		It("should use node selectors", func() {
 			provisioner.Spec.Requirements = v1alpha5.Requirements{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}}}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-2"}},
 			))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
@@ -145,20 +145,20 @@ var _ = Describe("Combined Constraints", func() {
 		})
 		It("should not schedule the pod if nodeselector unknown", func() {
 			provisioner.Spec.Requirements = v1alpha5.Requirements{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "unknown"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should not schedule if node selector outside of provisioner constraints", func() {
 			provisioner.Spec.Requirements = v1alpha5.Requirements{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-2"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should schedule compatible requirements with Operator=In", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-3"}},
 				}},
@@ -167,7 +167,7 @@ var _ = Describe("Combined Constraints", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
 		})
 		It("should not schedule incompatible preferences and requirements with Operator=In", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}},
 				}},
@@ -175,7 +175,7 @@ var _ = Describe("Combined Constraints", func() {
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should schedule compatible requirements with Operator=NotIn", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-zone-1", "test-zone-2", "unknown"}},
 				}},
@@ -184,7 +184,7 @@ var _ = Describe("Combined Constraints", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
 		})
 		It("should not schedule incompatible preferences and requirements with Operator=NotIn", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}},
@@ -193,7 +193,7 @@ var _ = Describe("Combined Constraints", func() {
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should schedule compatible preferences and requirements with Operator=In", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -205,7 +205,7 @@ var _ = Describe("Combined Constraints", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
 		})
 		It("should not schedule incompatible preferences and requirements with Operator=In", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -217,7 +217,7 @@ var _ = Describe("Combined Constraints", func() {
 		})
 
 		It("should schedule compatible preferences and requirements with Operator=NotIn", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -229,7 +229,7 @@ var _ = Describe("Combined Constraints", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
 		})
 		It("should not schedule incompatible preferences and requirements with Operator=NotIn", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -240,7 +240,7 @@ var _ = Describe("Combined Constraints", func() {
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should schedule compatible node selectors, preferences and requirements", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-3"},
 					NodeRequirements: []v1.NodeSelectorRequirement{
@@ -253,7 +253,7 @@ var _ = Describe("Combined Constraints", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
 		})
 		It("should not schedule incompatible node selectors, preferences and requirements", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-3"},
 					NodeRequirements: []v1.NodeSelectorRequirement{
@@ -265,7 +265,7 @@ var _ = Describe("Combined Constraints", func() {
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should combine multidimensional node selectors, preferences and requirements", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeSelector: map[string]string{
 						v1.LabelTopologyZone:       "test-zone-3",
@@ -286,7 +286,7 @@ var _ = Describe("Combined Constraints", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "arm-instance-type"))
 		})
 		It("should not combine incompatible multidimensional node selectors, preferences and requirements", func() {
-			pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{
 					NodeSelector: map[string]string{
 						v1.LabelTopologyZone:       "test-zone-3",
@@ -321,11 +321,11 @@ var _ = Describe("Preferential Fallback", func() {
 				}},
 			}}}}
 			// Don't relax
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 
 			// Don't relax
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should relax multiple terms", func() {
@@ -345,13 +345,13 @@ var _ = Describe("Preferential Fallback", func() {
 				}},
 			}}}}
 			// Remove first term
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 			// Remove second term
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 			// Success
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-1"))
 		})
@@ -372,13 +372,13 @@ var _ = Describe("Preferential Fallback", func() {
 				},
 			}}}
 			// Remove first term
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 			// Remove second term
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 			// Success
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectScheduled(ctx, env.Client, pod)
 		})
 		It("should relax to use lighter weights", func() {
@@ -402,10 +402,10 @@ var _ = Describe("Preferential Fallback", func() {
 				},
 			}}}
 			// Remove heaviest term
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 			// Success
-			pod = ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, pod)[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
 		})
@@ -416,7 +416,7 @@ var _ = Describe("Topology", func() {
 	labels := map[string]string{"test": "test"}
 
 	It("should ignore unknown topology keys", func() {
-		pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 			test.PodOptions{Labels: labels, TopologySpreadConstraints: []v1.TopologySpreadConstraint{{
 				TopologyKey:       "unknown",
 				WhenUnsatisfiable: v1.DoNotSchedule,
@@ -435,7 +435,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           1,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
@@ -451,7 +451,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           1,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
@@ -470,7 +470,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           1,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				test.Pod(test.PodOptions{Labels: labels}), // ignored, pending
 				test.Pod(test.PodOptions{}),               // ignored, missing labels
 				test.Pod(test.PodOptions{Labels: labels, NodeName: firstNode.Name}),
@@ -494,7 +494,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           1,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
@@ -509,7 +509,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           4,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{Labels: labels, TopologySpreadConstraints: topology}),
@@ -532,25 +532,25 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           3,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				MakePods(2, test.PodOptions{Labels: labels, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(env.Client, v1.LabelTopologyZone).To(ConsistOf(1, 1))
 			ExpectSkew(env.Client, v1.LabelHostname).ToNot(ContainElements(BeNumerically(">", 3)))
 
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				MakePods(3, test.PodOptions{Labels: labels, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(env.Client, v1.LabelTopologyZone).To(ConsistOf(2, 2, 1))
 			ExpectSkew(env.Client, v1.LabelHostname).ToNot(ContainElements(BeNumerically(">", 3)))
 
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				MakePods(5, test.PodOptions{Labels: labels, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(env.Client, v1.LabelTopologyZone).To(ConsistOf(4, 3, 3))
 			ExpectSkew(env.Client, v1.LabelHostname).ToNot(ContainElements(BeNumerically(">", 3)))
 
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				MakePods(11, test.PodOptions{Labels: labels, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(env.Client, v1.LabelTopologyZone).To(ConsistOf(7, 7, 7))
@@ -567,7 +567,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           1,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				append(
 					MakePods(5, test.PodOptions{
 						Labels:                    labels,
@@ -590,7 +590,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				MaxSkew:           1,
 			}}
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, append(
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, append(
 				MakePods(6, test.PodOptions{
 					Labels:                    labels,
 					TopologySpreadConstraints: topology,
@@ -607,7 +607,7 @@ var _ = Describe("Topology", func() {
 				})...,
 			)...)
 			ExpectSkew(env.Client, v1.LabelTopologyZone).To(ConsistOf(4, 3))
-			ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+			ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 				MakePods(5, test.PodOptions{
 					Labels:                    labels,
 					TopologySpreadConstraints: topology,
@@ -621,7 +621,7 @@ var _ = Describe("Topology", func() {
 var _ = Describe("Taints", func() {
 	It("should taint nodes with provisioner taints", func() {
 		provisioner.Spec.Taints = []v1.Taint{{Key: "test", Value: "bar", Effect: v1.TaintEffectNoSchedule}}
-		pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod(
 			test.PodOptions{Tolerations: []v1.Toleration{{Effect: v1.TaintEffectNoSchedule, Operator: v1.TolerationOpExists}}},
 		))[0]
 		node := ExpectScheduled(ctx, env.Client, pod)
@@ -629,7 +629,7 @@ var _ = Describe("Taints", func() {
 	})
 	It("should schedule pods that tolerate provisioner constraints", func() {
 		provisioner.Spec.Taints = []v1.Taint{{Key: "test-key", Value: "test-value", Effect: v1.TaintEffectNoSchedule}}
-		for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 			// Tolerates with OpExists
 			test.UnschedulablePod(test.PodOptions{Tolerations: []v1.Toleration{{Key: "test-key", Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule}}}),
 			// Tolerates with OpEqual
@@ -637,7 +637,7 @@ var _ = Describe("Taints", func() {
 		) {
 			ExpectScheduled(ctx, env.Client, pod)
 		}
-		for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 			// Missing toleration
 			test.UnschedulablePod(),
 			// key mismatch with OpExists
@@ -649,7 +649,7 @@ var _ = Describe("Taints", func() {
 		}
 	})
 	It("should not generate taints for OpExists", func() {
-		pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+		pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 			test.UnschedulablePod(test.PodOptions{Tolerations: []v1.Toleration{{Key: "test-key", Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoExecute}}}),
 		)[0]
 		node := ExpectScheduled(ctx, env.Client, pod)
@@ -657,7 +657,7 @@ var _ = Describe("Taints", func() {
 	})
 	It("should generate taints for pod tolerations", func() {
 		Skip("until taint generation is reimplmented")
-		pods := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+		pods := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 			// Matching pods schedule together on a node with a matching taint
 			test.UnschedulablePod(test.PodOptions{Tolerations: []v1.Toleration{
 				{Key: "test-key", Operator: v1.TolerationOpEqual, Value: "test-value", Effect: v1.TaintEffectNoSchedule}},
@@ -706,8 +706,8 @@ var _ = Describe("Multiple Provisioners", func() {
 	It("should schedule to an explicitly selected provisioner", func() {
 		provisioner2 := provisioner.DeepCopy()
 		provisioner2.Name = "provisioner2"
-		ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner2)
-		pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+		ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner2)
+		pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner2.Name}}),
 		)[0]
 		node := ExpectScheduled(ctx, env.Client, pod)
@@ -718,21 +718,21 @@ var _ = Describe("Multiple Provisioners", func() {
 		provisioner2.Name = "provisioner2"
 		provisioner2.Spec.Labels = map[string]string{"foo": "bar"}
 		provisioner.Spec.Labels = map[string]string{"foo": "baz"}
-		ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner2)
-		pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner,
+		ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner2)
+		pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner,
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{"foo": "bar"}}),
 		)[0]
 		node := ExpectScheduled(ctx, env.Client, pod)
 		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner2.Name))
 	})
-	It("should prioritize provisioners alphabetically if multiple match", func() {
-		provisioner2 := provisioner.DeepCopy()
-		provisioner2.Name = "aaaaaaaaa"
-		ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner2)
-		pod := ExpectProvisioned(ctx, env.Client, scheduler, controller, provisioner, test.UnschedulablePod())[0]
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner2.Name))
-	})
+	// It("should prioritize provisioners alphabetically if multiple match", func() {
+	// 	provisioner2 := provisioner.DeepCopy()
+	// 	provisioner2.Name = "aaaaaaaaa"
+	// 	ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner2)
+	// 	pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod())[0]
+	// 	node := ExpectScheduled(ctx, env.Client, pod)
+	// 	Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner2.Name))
+	// })
 })
 
 func MakePods(count int, options test.PodOptions) (pods []*v1.Pod) {

--- a/pkg/controllers/scheduling/suite_test.go
+++ b/pkg/controllers/scheduling/suite_test.go
@@ -725,14 +725,14 @@ var _ = Describe("Multiple Provisioners", func() {
 		node := ExpectScheduled(ctx, env.Client, pod)
 		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner2.Name))
 	})
-	// It("should prioritize provisioners alphabetically if multiple match", func() {
-	// 	provisioner2 := provisioner.DeepCopy()
-	// 	provisioner2.Name = "aaaaaaaaa"
-	// 	ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner2)
-	// 	pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod())[0]
-	// 	node := ExpectScheduled(ctx, env.Client, pod)
-	// 	Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner2.Name))
-	// })
+	It("should prioritize provisioners alphabetically if multiple match", func() {
+		provisioner2 := provisioner.DeepCopy()
+		provisioner2.Name = "aaaaaaaaa"
+		ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner2)
+		pod := ExpectProvisioned(ctx, env.Client, scheduler, provisioners, provisioner, test.UnschedulablePod())[0]
+		node := ExpectScheduled(ctx, env.Client, pod)
+		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner2.Name))
+	})
 })
 
 func MakePods(count int, options test.PodOptions) (pods []*v1.Pod) {

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Termination", func() {
 	})
 
 	AfterEach(func() {
-		ExpectCleanedUp(env.Client)
+		ExpectCleanedUp(ctx, env.Client)
 		injectabletime.Now = time.Now
 	})
 

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Termination", func() {
 
 			// Expect podEvict to be evicting, and delete it
 			ExpectEvicted(env.Client, podEvict)
-			ExpectDeleted(env.Client, podEvict)
+			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(env.Client, node.Name)
@@ -141,7 +141,7 @@ var _ = Describe("Termination", func() {
 			ExpectNodeDraining(env.Client, node.Name)
 
 			// Delete do-not-evict pod
-			ExpectDeleted(env.Client, podNoEvict)
+			ExpectDeleted(ctx, env.Client, podNoEvict)
 
 			// Reconcile node to evict pod
 			node = ExpectNodeExists(env.Client, node.Name)
@@ -152,7 +152,7 @@ var _ = Describe("Termination", func() {
 			ExpectEvicted(env.Client, podEvict)
 
 			// Delete pod to simulate successful eviction
-			ExpectDeleted(env.Client, podEvict)
+			ExpectDeleted(ctx, env.Client, podEvict)
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(env.Client, node.Name)
@@ -189,7 +189,7 @@ var _ = Describe("Termination", func() {
 			// ExpectNotEvicted(env.Client, evictionQueue, podNoEvict) // TODO(etarn) reenable this after upgrading testenv apiserver
 
 			// Delete pod to simulate successful eviction
-			ExpectDeleted(env.Client, podNoEvict)
+			ExpectDeleted(ctx, env.Client, podNoEvict)
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(env.Client, node.Name)
@@ -213,14 +213,14 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 			ExpectNodeDraining(env.Client, node.Name)
 
-			ExpectDeleted(env.Client, pods[1])
+			ExpectDeleted(ctx, env.Client, pods[1])
 
 			// Expect node to exist and be draining, but not deleted
 			node = ExpectNodeExists(env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 			ExpectNodeDraining(env.Client, node.Name)
 
-			ExpectDeleted(env.Client, pods[0])
+			ExpectDeleted(ctx, env.Client, pods[0])
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(env.Client, node.Name)

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -119,8 +119,7 @@ func ExpectDeleted(c client.Client, objects ...client.Object) {
 	}
 }
 
-func ExpectCleanedUp(c client.Client) {
-	ctx := context.Background()
+func ExpectCleanedUp(ctx context.Context, c client.Client) {
 	pdbs := v1beta1.PodDisruptionBudgetList{}
 	Expect(c.List(ctx, &pdbs)).To(Succeed())
 	for i := range pdbs.Items {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -140,15 +140,19 @@ func ExpectCleanedUp(ctx context.Context, c client.Client) {
 	for i := range daemonsets.Items {
 		ExpectDeleted(ctx, c, &daemonsets.Items[i])
 	}
-}
-
-// ExpectProvisioningCleanedUp includes additional cleanup logic for provisioning workflows
-func ExpectProvisioningCleanedUp(ctx context.Context, c client.Client, controller *provisioning.Controller) {
-	ExpectCleanedUp(ctx, c)
 	provisioners := v1alpha5.ProvisionerList{}
 	Expect(c.List(ctx, &provisioners)).To(Succeed())
 	for i := range provisioners.Items {
 		ExpectDeleted(ctx, c, &provisioners.Items[i])
+	}
+}
+
+// ExpectProvisioningCleanedUp includes additional cleanup logic for provisioning workflows
+func ExpectProvisioningCleanedUp(ctx context.Context, c client.Client, controller *provisioning.Controller) {
+	provisioners := v1alpha5.ProvisionerList{}
+	Expect(c.List(ctx, &provisioners)).To(Succeed())
+	ExpectCleanedUp(ctx, c)
+	for i := range provisioners.Items {
 		ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(&provisioners.Items[i]))
 	}
 }

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -109,8 +109,8 @@ func ExpectDeleted(ctx context.Context, c client.Client, objects ...client.Objec
 	for _, object := range objects {
 		persisted := object.DeepCopyObject()
 		object.SetFinalizers([]string{})
-		Expect(c.Patch(context.Background(), object, client.MergeFrom(persisted.(client.Object)))).To(Succeed())
-		if err := c.Delete(context.Background(), object, &client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}); !errors.IsNotFound(err) {
+		Expect(c.Patch(ctx, object, client.MergeFrom(persisted.(client.Object)))).To(Succeed())
+		if err := c.Delete(ctx, object, &client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}); !errors.IsNotFound(err) {
 			Expect(err).To(BeNil())
 		}
 	}


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
@felix-zhe-huang brought up an odd behavior where unconstrained pods would schedule randomly if multiple provisioners were defined. Eventually I'd like to define a `provisioner.spec.priority` feature, but in the short term, we will just alphabetize to make this deterministic. 

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
