### PR TITLE
Some chan cleanups

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/limits.go
+++ b/pkg/apis/provisioning/v1alpha5/limits.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/apis"
 )
 
 // Limits define bounds on the resources being provisioned by Karpenter
@@ -27,14 +26,10 @@ type Limits struct {
 	Resources v1.ResourceList `json:"resources,omitempty"`
 }
 
-func (l *Limits) validateResourceLimits() (errs *apis.FieldError) {
-	if l.Resources == nil || len(l.Resources) == 0 {
-		return errs.Also(apis.ErrInvalidValue("cannot be empty", "limits"))
-	}
-	return errs
-}
-
 func (l *Limits) ExceededBy(resources v1.ResourceList) error {
+	if l.Resources == nil {
+		return nil
+	}
 	for resourceName, usage := range resources {
 		if limit, ok := l.Resources[resourceName]; ok {
 			if usage.Cmp(limit) >= 0 {

--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -42,7 +42,6 @@ func (s *ProvisionerSpec) validate(ctx context.Context) (errs *apis.FieldError) 
 	return errs.Also(
 		s.validateTTLSecondsUntilExpired(),
 		s.validateTTLSecondsAfterEmpty(),
-		s.Limits.validateResourceLimits(),
 		s.Constraints.Validate(ctx),
 	)
 }

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -68,13 +68,13 @@ var _ = Describe("Validation", func() {
 	})
 
 	Context("Limits", func() {
-		It("should not allow undefined limits", func() {
+		It("should allow undefined limits", func() {
 			provisioner.Spec.Limits = Limits{}
-			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+			Expect(provisioner.Validate(ctx)).To(Succeed())
 		})
-		It("should not allow empty limits", func() {
+		It("should allow empty limits", func() {
 			provisioner.Spec.Limits = Limits{Resources: v1.ResourceList{}}
-			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+			Expect(provisioner.Validate(ctx)).To(Succeed())
 		})
 	})
 

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -108,7 +108,7 @@ func withUserAgent(sess *session.Session) *session.Session {
 }
 
 // Create a node given the constraints.
-func (c *CloudProvider) Create(ctx context.Context, constraints *v1alpha5.Constraints, instanceTypes []cloudprovider.InstanceType, quantity int, callback func(*v1.Node) error) chan error {
+func (c *CloudProvider) Create(ctx context.Context, constraints *v1alpha5.Constraints, instanceTypes []cloudprovider.InstanceType, quantity int, callback func(*v1.Node) error) <-chan error {
 	return c.creationQueue.Add(func() error {
 		return c.create(ctx, constraints, instanceTypes, quantity, callback)
 	})

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -31,7 +31,7 @@ import (
 
 type CloudProvider struct{}
 
-func (c *CloudProvider) Create(_ context.Context, constraints *v1alpha5.Constraints, instanceTypes []cloudprovider.InstanceType, quantity int, bind func(*v1.Node) error) chan error {
+func (c *CloudProvider) Create(_ context.Context, constraints *v1alpha5.Constraints, instanceTypes []cloudprovider.InstanceType, quantity int, bind func(*v1.Node) error) <-chan error {
 	err := make(chan error)
 	for i := 0; i < quantity; i++ {
 		name := strings.ToLower(randomdata.SillyName())

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -31,7 +31,7 @@ type CloudProvider interface {
 	// requests. The callback must be called with a theoretical node object that
 	// is fulfilled by the cloud providers capacity creation request. This API
 	// is called in parallel and then waits for all channels to return nil or error.
-	Create(context.Context, *v1alpha5.Constraints, []InstanceType, int, func(*v1.Node) error) chan error
+	Create(context.Context, *v1alpha5.Constraints, []InstanceType, int, func(*v1.Node) error) <-chan error
 	// Delete node in cloudprovider
 	Delete(context.Context, *v1.Node) error
 	// GetInstanceTypes returns instance types supported by the cloudprovider.

--- a/pkg/utils/parallel/workqueue.go
+++ b/pkg/utils/parallel/workqueue.go
@@ -41,7 +41,7 @@ type task struct {
 }
 
 // Add work to the queue, returns a channel that signals when the work is done.
-func (c *WorkQueue) Add(do func() error) chan error {
+func (c *WorkQueue) Add(do func() error) <-chan error {
 	c.once.Do(c.start)
 	done := make(chan error)
 	c.AddRateLimited(&task{do: do, done: done})


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

Some minor cleanups to `chan` usage per Concurrency in Go book. The main thing is it is good to close when possible, and also it should be clear who owns channel (usually owner should only be able to write/close and reader should only read), using either `<-chan` or `chan<-` types.

Also, I don't understand why provisioner limits are required, so reverted that. But I am probably missing something and someone will point out why :-)

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
