### PR TITLE
Fixed a bug where hostname topology launched extra nodes

### DIFF
--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -98,7 +98,8 @@ func (c *Controller) Apply(ctx context.Context, provisioner *v1alpha5.Provisione
 	provisioner.Spec.Labels = functional.UnionStringMaps(provisioner.Spec.Labels, map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner.Name})
 	provisioner.Spec.Requirements = provisioner.Spec.Requirements.
 		With(requirements(instanceTypes)).
-		With(v1alpha5.LabelRequirements(provisioner.Spec.Labels))
+		With(v1alpha5.LabelRequirements(provisioner.Spec.Labels)).
+		Consolidate()
 	if !c.hasChanged(ctx, provisioner) {
 		// If the provisionerSpecs haven't changed, we don't need to stop and drain the current Provisioner.
 		return nil


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
This bug is caused by the provisioners controller comparing the state of the current provisioner to the persisted provisioner state and the mutation happening in hostname topology. The scheduling logic mutates the provisioners' requirements, which causes the comparison to inadvertently force refresh the provisioner while nodes are being launched. This causes the provisioner to be drained, which can happen after launching capacity but before binding the pods. This results in multiple scale out (and eventual self-healing / scale-in).

The bug is due to me violating my own principles about not mutating state: https://github.com/aws/karpenter/blob/5d5798b5fefc757ef353889204c56138d8042066/pkg/controllers/provisioning/scheduling/topology.go#L99. In the long term, this mutation will be removed as part of a scheduling refactor.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
