### PR TITLE
fix yaml download cmds in grafana docs

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -168,6 +168,40 @@ helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
 kubectl patch configmap config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}'
 ```
 
+### Create Grafana dashboards (optional)
+
+The Karpenter repo contains multiple [importable dashboards](https://github.com/aws/karpenter/tree/main/grafana-dashboards) for an existing Grafana instance. See the Grafana documentation for [instructions](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard) to import a dashboard.
+
+#### Deploy a temporary Prometheus and Grafana stack (optional)
+
+The following commands will deploy a Prometheus and Grafana stack that is suitable for this guide but does not include persistent storage or other configurations that would be necessary for monitoring a production deployment of Karpenter.
+
+```sh
+helm repo add grafana-charts https://grafana.github.io/helm-charts
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+kubectl create namespace monitoring
+
+curl -fsSL https://karpenter.sh/docs/getting-started/prometheus-values.yaml | tee prometheus-values.yaml
+helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
+
+curl -fsSL https://karpenter.sh/docs/getting-started/grafana-values.yaml | tee grafana-values.yaml
+helm install --namespace monitoring grafana grafana-charts/grafana --values grafana-values.yaml
+```
+
+The Grafana instance may be accessed using port forwarding.
+
+```sh
+kubectl port-forward --namespace monitoring svc/grafana 3000:80
+```
+
+The new stack has only one user, `admin`, and the password is stored in a secret. The following command will retrieve the password.
+
+```sh
+kubectl get secret --namespace monitoring grafana -o jsonpath="{.data.admin-password}" | base64 --decode
+```
+
 ### Provisioner
 
 A single Karpenter provisioner is capable of handling many different pod

--- a/website/content/en/docs/getting-started/grafana-values.yaml
+++ b/website/content/en/docs/getting-started/grafana-values.yaml
@@ -1,0 +1,9 @@
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      version: 1
+      url: http://prometheus-server:80
+      access: proxy

--- a/website/content/en/docs/getting-started/prometheus-values.yaml
+++ b/website/content/en/docs/getting-started/prometheus-values.yaml
@@ -1,0 +1,14 @@
+alertmanager:
+  persistentVolume:
+    enabled: false
+
+server:
+  fullnameOverride: prometheus-server
+  persistentVolume:
+    enabled: false
+
+extraScrapeConfigs: |
+    - job_name: karpenter
+      static_configs:
+      - targets:
+        - karpenter-metrics.karpenter:8080


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Save grafana and prometheus curl'd values.yaml files to a file so the next line can be copy and pasted.

**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
