### PR TITLE
Remove pre-prod wording from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/aws/karpenter/issues)
 
 ![](website/static/banner.png)
-> **Note**: Karpenter is in active development and should be considered **pre-production** software. Backwards incompatible API changes are possible in future releases and support is best-effort by the Karpenter community.
 
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Its goal is to improve the efficiency and cost of running workloads on Kubernetes clusters.


### PR DESCRIPTION
Removed to reduce confusion with GA launch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
