### PR TITLE
Fix several links/404s in documentation

### DIFF
--- a/website/content/en/docs/AWS/constraints.md
+++ b/website/content/en/docs/AWS/constraints.md
@@ -27,7 +27,7 @@ A launch template is a set of configuration values sufficient for launching an E
 
 A custom launch template is specified by name. If none is specified, Karpenter will automatically create a launch template.
 
-Review the [Launch Template documentation](launch-templates.md) to learn how to create a custom one.
+Review the [Launch Template documentation]({{< ref "/docs/AWS/launch-templates.md" >}}) to learn how to create a custom one.
 
 ```
 spec:

--- a/website/content/en/docs/AWS/launch-templates.md
+++ b/website/content/en/docs/AWS/launch-templates.md
@@ -219,7 +219,7 @@ aws cloudformation create-stack \
 ### Define LaunchTemplate for Provisioner
 
 The LaunchTemplate is ready to be used. Specify it by name in the [Provisioner
-CRD](provisioner-crd.md). Karpenter will use this template when creating new instances.
+CRD]({{< ref "/docs/provisioner-crd.md" >}}). Karpenter will use this template when creating new instances.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5

--- a/website/content/en/docs/concepts/_index.md
+++ b/website/content/en/docs/concepts/_index.md
@@ -42,7 +42,7 @@ Here are some things to know about the Karpenter provisioner:
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.
 A provisioner contains constraints that impact the nodes that can be provisioned and attributes of those nodes (such timers for removing nodes).
-See [Provisioner API](/docs/provisioner-crd/) for a description of settings and the [Provisioning](../tasks/provisioning-task) task for provisioner examples. 
+See [Provisioner API]({{< ref "/docs/provisioner-crd.md" >}}) for a description of settings and the [Provisioning]({{< ref "/docs/tasks/provisioning-task.md" >}}) task for provisioner examples. 
 
 * **Well-known labels**: The provisioner can use well-known Kubernetes labels to allow pods to request only certain instance types, architectures, operating systems, or other attributes when creating nodes.
 See [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) for details.
@@ -67,7 +67,7 @@ Karpenter handles all clean-up work needed to properly delete the node.
 * **Empty nodes**: When the last workload pod running on a Karpenter-managed node is gone, the node is annotated with an emptiness timestamp.
 Once that "node empty" time-to-live (`ttlSecondsAfterEmpty`) is reached, finalization is triggered.
 
-For more details on how Karpenter deletes nodes, see [Deleting nodes with Karpenter](../tasks/deprov-nodes.md) for details.
+For more details on how Karpenter deletes nodes, see [Deleting nodes with Karpenter]({{< ref "/docs/tasks/deprov-nodes.md" >}}) for details.
 
 ### Upgrading nodes
 
@@ -161,4 +161,4 @@ Kubernetes SIG scalability recommends against these features and Karpenter doesn
 Instead, the Karpenter project recommends `topologySpreadConstraints` to reduce blast radius and `nodeSelectors` and `taints` to implement colocation.
 {{% /alert %}}
 
-For more on how, as a developer, you can add constraints to your pod deployment, see [Running pods](../tasks/running-pods.md) for details.
+For more on how, as a developer, you can add constraints to your pod deployment, see [Running pods]({{< ref "/docs/tasks/running-pods.md" >}}) for details.

--- a/website/content/en/docs/provisioner-crd.md
+++ b/website/content/en/docs/provisioner-crd.md
@@ -141,7 +141,7 @@ Karpenter supports specifying capacity type, which is analogous to [EC2 purchase
 
 This section is cloud provider specific. Reference the appropriate documentation:
 
-- [AWS](../AWS/constraints.md)
+- [AWS]({{< ref "/docs/AWS/constraints.md" >}})
 
 
 

--- a/website/content/en/docs/tasks/deprov-nodes.md
+++ b/website/content/en/docs/tasks/deprov-nodes.md
@@ -31,6 +31,6 @@ Karpenter will delete nodes (and the instance) that are considered empty of pods
 
 ## Expiry
 
-Nodes may be configured to expire. That is, a maximum lifetime in seconds starting with the node joining the cluster. Review the `ttlSecondsUntilExpired` field of the [provisioner API](../provisioner-crd.md).
+Nodes may be configured to expire. That is, a maximum lifetime in seconds starting with the node joining the cluster. Review the `ttlSecondsUntilExpired` field of the [provisioner API]({{< ref "/docs/provisioner-crd.md" >}}).
 
 Note that newly created nodes have a Kubernetes version matching the control plane. One use case for node expiry is to handle node upgrades. Old nodes (with a potentially outdated Kubernetes version) are deleted, and replaced with nodes on the current version. 


### PR DESCRIPTION
**1. Issue, if available:**

None


**2. Description of changes:**

Fixed several 404s/links in website documentation. Updated all broken links to use the `ref` shortcode so builds will fail if the resolution fails.


**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
