### PR TITLE
Fix the Getting Started link to point to the current docs

### DIFF
--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -3,6 +3,9 @@
 title: "Getting Started with Karpenter on AWS"
 linkTitle: "Getting Started"
 weight: 10
+menu:
+  main:
+    weight: 10
 ---
 
 Karpenter automatically provisions new nodes in response to unschedulable


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
The Getting Started link is pointing to the old version of the docs (v0.4.3-docs), to fix this the file `website/content/en/docs/getting-started/_index.md` should contains the same menu options as the one in `website/content/en/v0.4.3-docs/getting-started/_index.md`.
basically adding:
```
menu:
  main:
    weight: 10
```

**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
