### PR TITLE
Support custom CNIs

### DIFF
--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -84,6 +84,9 @@ spec:
               - key: karpenter.sh/provisioner-name
                 operator: DoesNotExist
         {{- end }}
+      {{- if .Values.webhook.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       {{- with .Values.webhook.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -20,3 +20,5 @@ webhook:
   tolerations: []
   affinity: {}
   image: "public.ecr.aws/karpenter/webhook:v0.5.0@sha256:bc639160d55a15e1f9362a06d42e4133e692d3c81e96d87e2672bd9c53c98958"
+  # set to true if using custom CNI on EKS
+  hostNetwork: false


### PR DESCRIPTION
**1. Issue, if available:**
When using a custom CNI in AWS EKS, the control plane will not run in same CNI, so to use webhooks, they must be exposed via the host network.

**2. Description of changes:**
Add hostNetwork flag to webhook deployment

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
