### PR TITLE
Allow controller/webhook replicas to be set using helm values

### DIFF
--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
   name: karpenter-controller
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.controller.replicas }}
   strategy:
     type: Recreate
   selector:

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
   name: karpenter-webhook
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.webhook.replicas }}
   strategy:
     type: Recreate
   selector:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -14,6 +14,7 @@ controller:
   image: "public.ecr.aws/karpenter/controller:v0.5.0@sha256:76fab69a5a2b1f5736c8beea349e60174d8903b26b65c4cc5009c6528f9aea72"
   clusterName: ""
   clusterEndpoint: ""
+  replicas: 1
 webhook:
   env: []
   nodeSelector: {}
@@ -22,3 +23,4 @@ webhook:
   image: "public.ecr.aws/karpenter/webhook:v0.5.0@sha256:bc639160d55a15e1f9362a06d42e4133e692d3c81e96d87e2672bd9c53c98958"
   # set to true if using custom CNI on EKS
   hostNetwork: false
+  replicas: 1


### PR DESCRIPTION
**1. Issue:**
The number of replicas for the controler and the webhook are not currently exposed on the helm chart

**2. Description of changes:**
I have modified both templates to use the value provided using helm (it's default value is still 1)

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
