### PR TITLE
Added note fsGroup removal from deployments

### DIFF
--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-      # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074
+      # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074 - not needed in k8s versions 1.19+
       securityContext:
         fsGroup: 1000
       {{- with .Values.controller.nodeSelector }}

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- with .Values.webhook.env }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074
+      # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074 - not needed in k8s versions 1.19+
       securityContext:
         fsGroup: 1000
       {{- with .Values.webhook.nodeSelector }}


### PR DESCRIPTION
**2. Description of changes:**
We currently set `fsGroup` in the deployment spec for the `controller` and `webhook`, but this is fixed in k8s versions 1.19+. This was added into the spec a while ago, so committing the change here for future reference.

https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
