### PR TITLE
Allow override of webhook port in Helm chart

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -44,6 +44,7 @@ You can follow the detailed installation instruction [here](https://karpenter.sh
 | webhook.hostNetwork | bool | `false` | Set to true if using custom CNI on EKS |
 | webhook.image | string | `"public.ecr.aws/karpenter/webhook:v0.5.0@sha256:bc639160d55a15e1f9362a06d42e4133e692d3c81e96d87e2672bd9c53c98958"` | Image to use for the webhook |
 | webhook.nodeSelector | object | `{}` | Node selectors to schedule to nodes with labels. |
+| webhook.port | int | `8443` |  |
 | webhook.replicas | int | `1` |  |
 | webhook.resources.limits.cpu | string | `"100m"` |  |
 | webhook.resources.limits.memory | string | `"50Mi"` |  |

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -32,20 +32,22 @@ spec:
       containers:
         - name: webhook
           image: {{ .Values.webhook.image }}
+          args:
+            - -port={{ .Values.webhook.port }}
         {{- if .Values.webhook.resources }}
           resources: {{ toYaml .Values.webhook.resources | nindent 12 }}
         {{- end }}
           ports:
             - name: webhook
-              containerPort: 8443
+              containerPort: {{ .Values.webhook.port }}
           livenessProbe:
             httpGet:
               scheme: HTTPS
-              port: 8443
+              port: {{ .Values.webhook.port }}
           readinessProbe:
             httpGet:
               scheme: HTTPS
-              port: 8443
+              port: {{ .Values.webhook.port }}
           env:
             - name: CLUSTER_NAME
               value: {{ .Values.controller.clusterName }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -43,6 +43,7 @@ webhook:
   image: "public.ecr.aws/karpenter/webhook:v0.5.0@sha256:bc639160d55a15e1f9362a06d42e4133e692d3c81e96d87e2672bd9c53c98958"
   # -- Set to true if using custom CNI on EKS
   hostNetwork: false
+  port: 8443
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
**1. Issue, if available:**
No issue

**2. Description of changes:**
This change allows the override of the port used by the webhook deployment when using the Helm chart. This is useful in clusters where the AWS CNI is not used (host networking is required) and we want to ensure pods don't accidentally step on each other's toes if we have other webhook admission controllers. We're specifically mapping the ports used by these controllers to prevent these types of collisions, so having the ability to override the port is quite useful.


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
