### PR TITLE
Allowing settings of a default instance profile

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -25,6 +25,7 @@ You can follow the detailed installation instruction [here](https://karpenter.sh
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalLabels | object | `{}` | Additional labels to add into metadata |
+| aws.defaultInstanceProfile | string | `""` | The default instance profile to use when launching nodes on AWS |
 | controller.affinity | object | `{}` | Affinity rules for scheduling |
 | controller.clusterEndpoint | string | `""` | Cluster endpoint |
 | controller.clusterName | string | `""` | Cluster name |

--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -63,6 +63,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.aws.defaultInstanceProfile }}
+            - name: AWS_DEFAULT_INSTANCE_PROFILE
+              value: {{ .Values.aws.defaultInstanceProfile }}
+            {{- end }}
             {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -62,6 +62,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.aws.defaultInstanceProfile }}
+            - name: AWS_DEFAULT_INSTANCE_PROFILE
+              value: {{ .Values.aws.defaultInstanceProfile }}
+            {{- end }}
           {{- with .Values.webhook.env }}
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -55,3 +55,6 @@ webhook:
       cpu: 100m
       memory: 50Mi
   replicas: 1
+aws:
+  # -- The default instance profile to use when launching nodes on AWS
+  defaultInstanceProfile: ""

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
@@ -43,8 +43,8 @@ type AWS struct {
 	// TypeMeta includes version and kind of the extensions, inferred if not provided.
 	// +optional
 	metav1.TypeMeta `json:",inline"`
-	// InstanceProfile is the AWS identity that instances use.
-	// +required
+	// InstanceProfile to use for provisioned nodes, overriding the default profile.
+	// +optional
 	InstanceProfile string `json:"instanceProfile"`
 	// LaunchTemplate for the node. If not specified, a launch template will be generated.
 	// +optional

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
@@ -28,20 +28,12 @@ func (a *AWS) Validate() (errs *apis.FieldError) {
 
 func (a *AWS) validate() (errs *apis.FieldError) {
 	return errs.Also(
-		a.validateInstanceProfile(),
 		a.validateLaunchTemplate(),
 		a.validateSubnets(),
 		a.validateSecurityGroups(),
 		a.validateTags(),
 		a.validateMetadataOptions(),
 	)
-}
-
-func (a *AWS) validateInstanceProfile() (errs *apis.FieldError) {
-	if a.InstanceProfile == "" {
-		errs = errs.Also(apis.ErrMissingField("instanceProfile"))
-	}
-	return errs
 }
 
 func (a *AWS) validateLaunchTemplate() (errs *apis.FieldError) {

--- a/pkg/utils/options/options.go
+++ b/pkg/utils/options/options.go
@@ -41,6 +41,7 @@ func MustParse() Options {
 	flag.IntVar(&opts.KubeClientBurst, "kube-client-burst", env.WithDefaultInt("KUBE_CLIENT_BURST", 300), "The maximum allowed burst of queries to the kube-apiserver")
 	flag.StringVar(&opts.AWSNodeNameConvention, "aws-node-name-convention", env.WithDefaultString("AWS_NODE_NAME_CONVENTION", string(IPName)), "The node naming convention used by the AWS cloud provider. DEPRECATION WARNING: this field may be deprecated at any time")
 	flag.BoolVar(&opts.AWSENILimitedPodDensity, "aws-eni-limited-pod-density", env.WithDefaultBool("AWS_ENI_LIMITED_POD_DENSITY", true), "Indicates whether new nodes should use ENI-based pod density")
+	flag.StringVar(&opts.AWSDefaultInstanceProfile, "aws-default-instance-profile", env.WithDefaultString("AWS_DEFAULT_INSTANCE_PROFILE", ""), "The default instance profile to use when provisioning nodes in AWS")
 	flag.Parse()
 	if err := opts.Validate(); err != nil {
 		panic(err)
@@ -50,15 +51,16 @@ func MustParse() Options {
 
 // Options for running this binary
 type Options struct {
-	ClusterName             string
-	ClusterEndpoint         string
-	MetricsPort             int
-	HealthProbePort         int
-	WebhookPort             int
-	KubeClientQPS           int
-	KubeClientBurst         int
-	AWSNodeNameConvention   string
-	AWSENILimitedPodDensity bool
+	ClusterName               string
+	ClusterEndpoint           string
+	MetricsPort               int
+	HealthProbePort           int
+	WebhookPort               int
+	KubeClientQPS             int
+	KubeClientBurst           int
+	AWSNodeNameConvention     string
+	AWSENILimitedPodDensity   bool
+	AWSDefaultInstanceProfile string
 }
 
 func (o Options) Validate() (err error) {

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -11,9 +11,9 @@ This section covers parameters of the AWS Cloud Provider.
 [Review these fields in the code.](https://github.com/awslabs/karpenter/blob/main/pkg/cloudprovider/aws/apis/v1alpha1/provider.go#L33)
 
 ### InstanceProfile
-An `InstanceProfile` is a way to pass a single IAM role to an EC2 instance.
-
-It is required, and specified by name. A suitable `KarpenterNodeRole` is created in the getting started guide.
+An `InstanceProfile` is a way to pass a single IAM role to an EC2 instance. Karpenter will not create one automatically.
+A default profile may be specified on the controller, allowing it to be omitted here. If not specified as either a default
+or on the controller, node provisioning will fail.
 
 ```
 spec:

--- a/website/content/en/preview/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started-with-terraform/_index.md
@@ -260,6 +260,11 @@ resource "helm_release" "karpenter" {
     name  = "controller.clusterEndpoint"
     value = module.eks.cluster_endpoint
   }
+
+  set {
+    name  = "aws.defaultInstanceProfile"
+    value = aws_iam_instance_profile.karpenter.name
+  }
 }
 ```
 
@@ -310,7 +315,6 @@ spec:
     resources:
       cpu: 1000
   provider:
-    instanceProfile: KarpenterNodeInstanceProfile-${CLUSTER_NAME}
     subnetSelector:
       karpenter.sh/discovery: ${CLUSTER_NAME}
     securityGroupSelector:

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -145,6 +145,7 @@ helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
   --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
+  --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
   --wait # for the defaulting webhook to install before creating a Provisioner
 ```
 
@@ -226,7 +227,6 @@ spec:
       karpenter.sh/discovery: ${CLUSTER_NAME}
     securityGroupSelector:
       karpenter.sh/discovery: ${CLUSTER_NAME}
-    instanceProfile: KarpenterNodeInstanceProfile-${CLUSTER_NAME}
   ttlSecondsAfterEmpty: 30
 EOF
 ```


### PR DESCRIPTION
**1. Issue, if available:**
#909 

**2. Description of changes:**
- Adds the ability to set `-default-instance-profile` on the controller, which does as it suggests
- Update default constraints setting to use the default if one is provided
- Updated the Helm chart to allow setting of this flag and the website to provide a little bit of documentation about it
- Updated unit tests to test for both default setting and for overriding through a Provisioner

**3. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I'll fully admit I'm not the best Go programmer, so feel free to tell me how it should be made better. I tried to follow along with what was already there. But, might have missed an easier way to do something.