### PR TITLE
fix toolchain install for arm64 mac

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -21,7 +21,12 @@ kubebuilder() {
     KUBEBUILDER_ASSETS="/usr/local/kubebuilder"
     sudo rm -rf $KUBEBUILDER_ASSETS
     sudo mkdir -p $KUBEBUILDER_ASSETS
-    sudo mv "$(setup-envtest use -p path 1.19.x)" $KUBEBUILDER_ASSETS/bin
+    arch=$(go env GOARCH)
+    ## Kubebuilder does not support darwin/arm64, so use amd64 through Rosetta instead 
+    if [[ $(go env GOOS) == "darwin" ]] && [[ $(go env GOARCH) == "arm64" ]]; then
+        arch="amd64"
+    fi
+    sudo mv "$(setup-envtest use -p path 1.21.x --arch=${arch})" $KUBEBUILDER_ASSETS/bin
     find $KUBEBUILDER_ASSETS
 }
 


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Upped k8s bins for testing from 1.19 to 1.21 
 - Currently, Karpenter's `make toolchain` fails on arm64 (m1) macs because of kubebuilder's `setup-env` which downloads k8s component binaries which are not available for the darwin/arm64 platform.  Macs with arm64 processors are able to run x86 compiled binaries using Rosetta virtualization which happens transparently to the user when executing an x86 binary. 

 This change overrides the machine's architecture to amd64 if running on an arm64 mac. Previously, the command would fail to fetch the binaries and tests could not be run.  


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
