### PR TITLE
docs: use site params to reference latest release

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -64,6 +64,9 @@ anchor = "smart"
 
 ## Site Params
 [params]
+
+latest_release_version = "0.5.1"
+
 copyright = "Amazon.com, Inc. or its affiliates."
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/aws/karpenter"

--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -157,7 +157,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version 0.5.0 \
+  --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --wait # for the defaulting webhook to install before creating a Provisioner

--- a/website/content/en/docs/reinvent.md
+++ b/website/content/en/docs/reinvent.md
@@ -42,7 +42,7 @@ Happy Building 🔨!
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version 0.5.0 \
+  --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
   --set controller.clusterName=karpenter-demo \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name karpenter-demo --query "cluster.endpoint" --output json) \
   --wait # for the defaulting webhook to install before creating a Provisioner


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <me@tuananh.org>

**1. Issue, if available:**
#912 

an attempt toward docs release automation

**2. Description of changes:**

we define a site param and use it in `docs` so that it stays consistent.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [x] Yes, issue opened: *link to issue* #912 
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
