### PR TITLE
Fix a docs typo

### DIFF
--- a/website/content/en/docs/AWS/constraints.md
+++ b/website/content/en/docs/AWS/constraints.md
@@ -93,7 +93,7 @@ spec:
 
 Select security groups by name, or another tag:
 ```
- securityGroupSSelector:
+ securityGroupSelector:
    Name: sg-01077157b7cf4f5a8
    MySecurityTag: '' # matches all resources with the tag
 ```


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Is the capital letter S intended between the words 'Group' and 'Selector'?

**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
