### PR TITLE
fix: use darwin instead of mac for kubernetes.io/os label

### DIFF
--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -35,7 +35,7 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 		options.architecture = "amd64"
 	}
 	if len(options.operatingSystems) == 0 {
-		options.operatingSystems = sets.NewString("linux", "windows", "mac")
+		options.operatingSystems = sets.NewString("linux", "windows", "darwin")
 	}
 	if options.cpu.IsZero() {
 		options.cpu = resource.MustParse("4")


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <me@tuananh.org>

**1. Issue, if available:**


**2. Description of changes:**

i thought `kubernetes.io/os` values is from `runtime.GOOS` as defined by Go. the list is here 
https://github.com/golang/go/blob/a19e72cb89fd33e5bf1474887e267806f65b7a40/src/go/build/syslist.go#L10

```
const goosList = "aix android darwin dragonfly freebsd hurd illumos ios js linux nacl netbsd openbsd plan9 solaris windows zos "
```

in there, macOS is darwin instead of `mac`.

https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
