### PR TITLE
docs(concepts): Clarify podAffinity/podAntiAffinity note

### DIFF
--- a/website/content/en/docs/concepts/_index.md
+++ b/website/content/en/docs/concepts/_index.md
@@ -157,7 +157,7 @@ Those that are implemented in Karpenter include:
 
 {{% alert title="Note" color="primary" %}}
 Don't use `podAffinity` and `podAntiAffinity` to schedule pods on the same or different nodes as other pods.
-Kubernetes SIG scalability recommends against these features due to their negative performance impact on the Kubernetes Scheduler (see [Motivation](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/895-pod-topology-spread#motivation)) and Karpenter doesn't support them.
+Kubernetes SIG scalability recommends against these features due to their negative performance impact on the Kubernetes Scheduler (see [KEP 895](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/895-pod-topology-spread#impact-to-other-features)) and Karpenter doesn't support them.
 Instead, the Karpenter project recommends `topologySpreadConstraints` to reduce blast radius and `nodeSelectors` and `taints` to implement colocation.
 {{% /alert %}}
 

--- a/website/content/en/docs/concepts/_index.md
+++ b/website/content/en/docs/concepts/_index.md
@@ -157,7 +157,7 @@ Those that are implemented in Karpenter include:
 
 {{% alert title="Note" color="primary" %}}
 Don't use `podAffinity` and `podAntiAffinity` to schedule pods on the same or different nodes as other pods.
-Kubernetes SIG scalability recommends against these features and Karpenter doesn't support them.
+Kubernetes SIG scalability recommends against these features due to their negative performance impact on the Kubernetes Scheduler (see [Motivation](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/895-pod-topology-spread#motivation)) and Karpenter doesn't support them.
 Instead, the Karpenter project recommends `topologySpreadConstraints` to reduce blast radius and `nodeSelectors` and `taints` to implement colocation.
 {{% /alert %}}
 

--- a/website/content/en/docs/concepts/_index.md
+++ b/website/content/en/docs/concepts/_index.md
@@ -157,7 +157,7 @@ Those that are implemented in Karpenter include:
 
 {{% alert title="Note" color="primary" %}}
 Don't use `podAffinity` and `podAntiAffinity` to schedule pods on the same or different nodes as other pods.
-Kubernetes SIG scalability recommends against these features due to their negative performance impact on the Kubernetes Scheduler (see [KEP 895](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/895-pod-topology-spread#impact-to-other-features)) and Karpenter doesn't support them.
+Kubernetes SIG scalability recommends against these features due to their negative performance impact on the Kubernetes Scheduler (see [KEP 895](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/895-pod-topology-spread#impact-to-other-features)) and Karpenter doesn't support them for the moment (you can follow their consideration by subscribing to the [issue](https://github.com/aws/karpenter/issues/942)).".
 Instead, the Karpenter project recommends `topologySpreadConstraints` to reduce blast radius and `nodeSelectors` and `taints` to implement colocation.
 {{% /alert %}}
 


### PR DESCRIPTION
**1. Issue, if available:**

Related to #942

**2. Description of changes:**

Hello 👋 

This notes has been confusing me since I read  it. At first, I thought `podAntiAffinity` would cause scalability issues for the deployments using them, but reading further around `topologySpreadConstraints` (especially its KEP), it seems to be an issue for scalability of the Kubernetes Scheduler.

Do they plan to deprecate `podAffinity`/`podAntiAffinity`? It has been mentioned, but no concrete action toward it.
Or do they plan to improve them? They seem to be some activity in this direction (e.g. kubernetes/enhancements#2249), thus should Karpenter plan to actually support them? (And update the doc to something like "Karpenter doesn't support them for the moment (You can follow their consideration by subscribing to #942).")

TL;DR For this recommendation, imho the doc should have:

- a short reason
- its source (e.g. official Kubernetes documentation, KEP)

I may still be wrong about the why, but I hope to use this PR to get clarification for myself  and everyone else.

**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
