### PR TITLE
Fixed a crash when affinity is defined but requiredaffinity is nil

### DIFF
--- a/pkg/controllers/scheduling/preferences.go
+++ b/pkg/controllers/scheduling/preferences.go
@@ -90,7 +90,10 @@ func (p *Preferences) removePreferredNodeAffinityTerm(pod *v1.Pod) *string {
 }
 
 func (p *Preferences) removeRequiredNodeAffinityTerm(pod *v1.Pod) *string {
-	if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil || len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
+	if pod.Spec.Affinity == nil ||
+		pod.Spec.Affinity.NodeAffinity == nil ||
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil ||
+		len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
 		return nil
 	}
 	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/917

**2. Description of changes:**
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x196a938]

goroutine 10169 [running]:
github.com/aws/karpenter/pkg/controllers/scheduling.(*Preferences).removeRequiredNodeAffinityTerm(0xc000973a48, 0xc000a7cef8)
	github.com/aws/karpenter/pkg/controllers/scheduling/preferences.go:93 +0x38
github.com/aws/karpenter/pkg/controllers/scheduling.(*Preferences).relax.func2(0x0)
	github.com/aws/karpenter/pkg/controllers/scheduling/preferences.go:67 +0x25
github.com/aws/karpenter/pkg/controllers/scheduling.(*Preferences).relax(0xc00093bb00, {0x2630278, 0xc003b39dd0}, 0xc00058e000)
	github.com/aws/karpenter/pkg/controllers/scheduling/preferences.go:69 +0xee
github.com/aws/karpenter/pkg/controllers/scheduling.(*Preferences).Relax(0xc00059c040, {0x2630278, 0xc003b39dd0}, 0xc00058e000)
	github.com/aws/karpenter/pkg/controllers/scheduling/preferences.go:59 +0xaa
github.com/aws/karpenter/pkg/controllers/scheduling.(*Controller).Schedule(0xc000913540, {0x2630278, 0xc003b39dd0}, 0xc000a7cd97)
	github.com/aws/karpenter/pkg/controllers/scheduling/controller.go:79 +0x55
github.com/aws/karpenter/pkg/controllers/scheduling.(*Controller).Reconcile(0xc000913540, {0x2630278, 0xc003b39d40}, {{{0xc000a7cd97, 0x20b0320}, {0xc0009fed68, 0xc0006b90c0}}})
	github.com/aws/karpenter/pkg/controllers/scheduling/controller.go:71 +0x386
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000632960, {0x26301d0, 0xc000966380}, {0x1fc2f40, 0xc00314a500})
	sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:298 +0x303
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000632960, {0x26301d0, 0xc000966380})
	sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:253 +0x205
```


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
