### PR TITLE
Added succeeded pods to emptiness criteria

### DIFF
--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -88,7 +88,7 @@ func (r *Emptiness) isEmpty(ctx context.Context, n *v1.Node) (bool, error) {
 	}
 	for i := range pods.Items {
 		p := pods.Items[i]
-		if pod.HasFailed(&p) {
+		if pod.HasFinished(&p) {
 			continue
 		}
 		if !pod.IsOwnedByDaemonSet(&p) && !pod.IsOwnedByNode(&p) {

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -28,8 +28,8 @@ func FailedToSchedule(pod *v1.Pod) bool {
 	return false
 }
 
-func HasFailed(pod *v1.Pod) bool {
-	return pod.Status.Phase == "Failed"
+func HasFinished(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
 }
 
 func IsOwnedByDaemonSet(pod *v1.Pod) bool {


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/946

**2. Description of changes:**
There are 5 pod phases [here](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) which we use to determine emptiness criteria. `Failed` and `Succeeded` are both phases that indicate that all containers on the pod are completed and terminated, so this will not interrupt pod workloads.


**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
