### PR TITLE
use v1.conditiontrue instead of string true for compare

### DIFF
--- a/pkg/controllers/metrics/nodes.go
+++ b/pkg/controllers/metrics/nodes.go
@@ -15,8 +15,6 @@ limitations under the License.
 package metrics
 
 import (
-	"strings"
-
 	"github.com/aws/karpenter/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/multierr"
@@ -161,7 +159,7 @@ func filterReadyNodes(consume nodeListConsumerFunc) nodeListConsumerFunc {
 		readyNodes := make([]v1.Node, 0, len(nodes))
 		for _, node := range nodes {
 			for _, condition := range node.Status.Conditions {
-				if condition.Type == nodeConditionTypeReady && strings.ToLower(string(condition.Status)) == "true" {
+				if condition.Type == nodeConditionTypeReady && condition.Status == v1.ConditionTrue {
 					readyNodes = append(readyNodes, node)
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <me@tuananh.org>

**1. Issue, if available:**


**2. Description of changes:**

use `v1.ConditionTrue` instead of `true` string for comparison.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
