### PR TITLE
Allow EC2 "Name" tag to be supplied in the provisioner spec

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
@@ -75,7 +75,7 @@ func (a *AWS) validateSecurityGroups() (errs *apis.FieldError) {
 func (a *AWS) validateTags(ctx context.Context) (errs *apis.FieldError) {
 	// Avoiding a check on number of tags (hard limit of 50) since that limit is shared by user
 	// defined and Karpenter tags, and the latter could change over time.
-	managedTags := ManagedTagsFor(injection.GetOptions(ctx).ClusterName)
+	managedTags := ManagedTagsFor(injection.GetOptions(ctx).ClusterName, a.Tags)
 	for tagKey, tagValue := range a.Tags {
 		if tagKey == "" {
 			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf(

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
@@ -15,23 +15,22 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
 	"fmt"
 
 	"knative.dev/pkg/apis"
 )
 
-func (a *AWS) Validate(ctx context.Context) (errs *apis.FieldError) {
-	return a.validate(ctx).ViaField("provider")
+func (a *AWS) Validate() (errs *apis.FieldError) {
+	return a.validate().ViaField("provider")
 }
 
-func (a *AWS) validate(ctx context.Context) (errs *apis.FieldError) {
+func (a *AWS) validate() (errs *apis.FieldError) {
 	return errs.Also(
 		a.validateInstanceProfile(),
 		a.validateLaunchTemplate(),
 		a.validateSubnets(),
 		a.validateSecurityGroups(),
-		a.validateTags(ctx),
+		a.validateTags(),
 	)
 }
 
@@ -71,7 +70,7 @@ func (a *AWS) validateSecurityGroups() (errs *apis.FieldError) {
 	return errs
 }
 
-func (a *AWS) validateTags(ctx context.Context) (errs *apis.FieldError) {
+func (a *AWS) validateTags() (errs *apis.FieldError) {
 	// Avoiding a check on number of tags (hard limit of 50) since that limit is shared by user
 	// defined and Karpenter tags, and the latter could change over time.
 	for tagKey, tagValue := range a.Tags {

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
@@ -75,7 +75,7 @@ func (a *AWS) validateSecurityGroups() (errs *apis.FieldError) {
 func (a *AWS) validateTags(ctx context.Context) (errs *apis.FieldError) {
 	// Avoiding a check on number of tags (hard limit of 50) since that limit is shared by user
 	// defined and Karpenter tags, and the latter could change over time.
-	managedTags := ManagedTagsFor(injection.GetOptions(ctx).ClusterName, a.Tags)
+	managedTags := ManagedTagsFor(injection.GetOptions(ctx).ClusterName)
 	for tagKey, tagValue := range a.Tags {
 		if tagKey == "" {
 			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf(

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/karpenter/pkg/utils/injection"
 	"knative.dev/pkg/apis"
 )
 
@@ -75,13 +74,10 @@ func (a *AWS) validateSecurityGroups() (errs *apis.FieldError) {
 func (a *AWS) validateTags(ctx context.Context) (errs *apis.FieldError) {
 	// Avoiding a check on number of tags (hard limit of 50) since that limit is shared by user
 	// defined and Karpenter tags, and the latter could change over time.
-	managedTags := ManagedTagsFor(injection.GetOptions(ctx).ClusterName)
 	for tagKey, tagValue := range a.Tags {
 		if tagKey == "" {
 			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf(
 				"the tag with key : '' and value : '%s' is invalid because empty tag keys aren't supported", tagValue), "tags"))
-		} else if _, exists := managedTags[tagKey]; exists {
-			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("tag key '%s' is reserved", tagKey), "tags"))
 		}
 	}
 	return errs

--- a/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
@@ -42,7 +42,8 @@ func ManagedTagsFor(clusterName string) map[string]string {
 func MergeTags(ctx context.Context, customTags map[string]string) []*ec2.Tag {
 	managedTags := ManagedTagsFor(injection.GetOptions(ctx).ClusterName)
 	// We'll set the default Name tag, but allow it to be overridden in the merge
-	managedTags["Name"] = fmt.Sprintf("karpenter.sh/cluster/%s", injection.GetOptions(ctx).ClusterName)
+	managedTags["Name"] = fmt.Sprintf("karpenter.sh/cluster/%s/provisioner/%s",
+		injection.GetOptions(ctx).ClusterName, injection.GetNamespacedName(ctx).Name)
 	ec2Tags := []*ec2.Tag{}
 	for key, value := range functional.UnionStringMaps(managedTags, customTags) {
 		ec2Tags = append(ec2Tags, &ec2.Tag{Key: aws.String(key), Value: aws.String(value)})

--- a/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
@@ -29,13 +29,17 @@ const (
 	KarpenterTagKeyFormat = "karpenter.sh/cluster/%s"
 )
 
-func ManagedTagsFor(clusterName string) map[string]string {
-	// tags to be applied on AWS resources created by Karpenter (instances, launchTemplates..)
-	return map[string]string{
-		"Name": fmt.Sprintf("karpenter.sh/%s", clusterName),
+func ManagedTagsFor(clusterName string, customTags map[string]string) map[string]string {
+	managedTags := map[string]string{
 		fmt.Sprintf(ClusterTagKeyFormat, clusterName):   "owned",
 		fmt.Sprintf(KarpenterTagKeyFormat, clusterName): "owned",
 	}
+	// If the provisioner spec includes the Name tag, honor that value. Otherwise, use the default.
+	if _, exists := customTags["Name"]; !exists {
+		managedTags["Name"] = fmt.Sprintf("karpenter.sh/%s", clusterName)
+	}
+	// tags to be applied on AWS resources created by Karpenter (instances, launchTemplates..)
+	return managedTags
 }
 
 func MergeTags(tags ...map[string]string) []*ec2.Tag {

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -151,7 +151,7 @@ func (c *CloudProvider) Validate(ctx context.Context, constraints *v1alpha5.Cons
 	if err != nil {
 		return apis.ErrGeneric(err.Error())
 	}
-	return vendorConstraints.AWS.Validate(ctx)
+	return vendorConstraints.AWS.Validate()
 }
 
 // Default the provisioner

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -33,7 +33,6 @@ import (
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
-	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
 type InstanceProvider struct {
@@ -124,7 +123,7 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 		TagSpecifications: []*ec2.TagSpecification{
 			{
 				ResourceType: aws.String(ec2.ResourceTypeInstance),
-				Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(injection.GetOptions(ctx).ClusterName, constraints.Tags), constraints.Tags),
+				Tags:         v1alpha1.MergeTags(ctx, constraints.Tags),
 			},
 		},
 		// OnDemandOptions are allowed to be specified even when requesting spot

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -124,7 +124,7 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 		TagSpecifications: []*ec2.TagSpecification{
 			{
 				ResourceType: aws.String(ec2.ResourceTypeInstance),
-				Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(injection.GetOptions(ctx).ClusterName), constraints.Tags),
+				Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(injection.GetOptions(ctx).ClusterName, constraints.Tags), constraints.Tags),
 			},
 		},
 		// OnDemandOptions are allowed to be specified even when requesting spot

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -180,7 +180,7 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 		},
 		TagSpecifications: []*ec2.TagSpecification{{
 			ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
-			Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(options.ClusterName), options.Tags),
+			Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(options.ClusterName, options.Tags), options.Tags),
 		}},
 	})
 	if err != nil {

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -180,7 +180,7 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 		},
 		TagSpecifications: []*ec2.TagSpecification{{
 			ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
-			Tags:         v1alpha1.MergeTags(v1alpha1.ManagedTagsFor(options.ClusterName, options.Tags), options.Tags),
+			Tags:         v1alpha1.MergeTags(ctx, options.Tags),
 		}},
 	})
 	if err != nil {

--- a/website/content/en/docs/AWS/provisioning.md
+++ b/website/content/en/docs/AWS/provisioning.md
@@ -116,6 +116,7 @@ spec:
       dev.corp.net/app: Calculator
       dev.corp.net/team: MyTeam
 ```
+Note: If the "Name" tag is not spplied in the above spec, the following default tag will be applied: `Name: karpenter.sh/<cluster-name>`
 
 ## Other Resources
 

--- a/website/content/en/docs/AWS/provisioning.md
+++ b/website/content/en/docs/AWS/provisioning.md
@@ -116,7 +116,12 @@ spec:
       dev.corp.net/app: Calculator
       dev.corp.net/team: MyTeam
 ```
-Note: If the "Name" tag is not supplied in the above spec, the following default tag will be applied: `Name: karpenter.sh/<cluster-name>`
+Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
+```
+Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
+karpenter.sh/cluster/<cluster-name>: owned
+kubernetes.io/cluster/<cluster-name>: owned
+```
 
 
 ## Other Resources

--- a/website/content/en/docs/AWS/provisioning.md
+++ b/website/content/en/docs/AWS/provisioning.md
@@ -116,7 +116,8 @@ spec:
       dev.corp.net/app: Calculator
       dev.corp.net/team: MyTeam
 ```
-Note: If the "Name" tag is not spplied in the above spec, the following default tag will be applied: `Name: karpenter.sh/<cluster-name>`
+Note: If the "Name" tag is not supplied in the above spec, the following default tag will be applied: `Name: karpenter.sh/<cluster-name>`
+
 
 ## Other Resources
 


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/944

**2. Description of changes:**
These changes allow the EC2 "Name" tag to be set in the provisioner spec as:
```
spec:
  provider: 
    tags:
      Name: <custom-name>
```
If the Name tag is not supplied in the spec, the logic falls back to the previous default value of `Name: karpenter.sh/<cluster-name>`

**3. Does this change impact docs?**
- [ X] Yes, PR includes docs updates

**4. Testing**
All local tests passed
```
$ make test
ginkgo -r
[1639147378] Validation - 18/18 specs •••••••••••••••••• SUCCESS! 1.195387ms PASS
[1639147378] CloudProvider/AWS - 23/23 specs ••••••••••••••••••••••• SUCCESS! 30.781316015s PASS
[1639147378] Node - 18/18 specs •••••••••••••••••• SUCCESS! 10.892751879s PASS
[1639147378] Controllers/Provisioning - 11/11 specs ••••••••••• SUCCESS! 21.831135136s PASS
[1639147378] Controllers/Scheduling - 42/42 specs •••••••••••••••••••••••••••••••••••••••••S SUCCESS! 45.285634007s PASS
[1639147378] Termination - 6/6 specs •••••• SUCCESS! 10.720924721s PASS
[1639147378] Functional Suite - 10/10 specs •••••••••• SUCCESS! 497.654µs PASS

Ginkgo ran 7 suites in 2m19.232043138s
Test Suite Passed
```
```
$ make battletest
# Ensure all files have cyclo-complexity =< 10
gocyclo -over 11 ./pkg
# Run randomized, parallelized, racing, code coveraged, tests
ginkgo -r \
		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./pkg/... \
		--randomizeAllSpecs --randomizeSuites -race
[1639147539] Controllers/Scheduling - 42/42 specs •••••••••••••••••••••••••••S•••••••••••••• SUCCESS! 51.444836812s PASS
coverage: 65.4% of statements in ./pkg/...
[1639147539] Node - 18/18 specs •••••••••••••••••• SUCCESS! 12.241039979s PASS
coverage: 19.9% of statements in ./pkg/...
[1639147539] Validation - 18/18 specs •••••••••••••••••• SUCCESS! 5.150438ms PASS
coverage: 18.1% of statements in ./pkg/...
[1639147539] Termination - 6/6 specs •••••• SUCCESS! 13.146216705s PASS
coverage: 16.4% of statements in ./pkg/...
[1639147539] Controllers/Provisioning - 11/11 specs ••••••••••• SUCCESS! 24.261611134s PASS
coverage: 61.1% of statements in ./pkg/...
[1639147539] CloudProvider/AWS - 23/23 specs ••••••••••••••••••••••• SUCCESS! 35.156795382s PASS
coverage: 65.7% of statements in ./pkg/...
[1639147539] Functional Suite - 10/10 specs •••••••••• SUCCESS! 1.776086ms PASS
coverage: 66.0% of statements in ./pkg/...
path is /Users/mslavin/dev/cic2/go/src/github.com/aws/karpenter
All profiles combined

Ginkgo ran 7 suites in 2m43.801290943s
Test Suite Passed
```
In addition to the above local tests, the updated images were built locally and pushed to my development ECR. The updated chart was then deployed and the code changes were tested in AWS EKS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
