### PR TITLE
Set karpenter as user agent for the rest client

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -65,6 +65,7 @@ func main() {
 
 	config := controllerruntime.GetConfigOrDie()
 	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(opts.KubeClientQPS), opts.KubeClientBurst)
+	config.UserAgent = "karpenter"
 	clientSet := kubernetes.NewForConfigOrDie(config)
 
 	// Set up logger and watch for changes to log level


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**

The default user agent for rest clients is the binary name, in this case "controller".
This PR will instead make karpenter show as "karpenter" in access/audit logs, as field owner etc. 

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
