### PR TITLE
Allow kOps to set labels required for cluster operations

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -90,6 +90,9 @@ func (c *Constraints) validateLabels() (errs *apis.FieldError) {
 
 func IsRestrictedLabelDomain(key string) bool {
 	labelDomain := getLabelDomain(key)
+	if AllowedLabelDomains.Has(labelDomain) {
+		return false
+	}
 	for restrictedLabelDomain := range RestrictedLabelDomains {
 		if strings.HasSuffix(labelDomain, restrictedLabelDomain) {
 			return true

--- a/pkg/apis/provisioning/v1alpha5/register.go
+++ b/pkg/apis/provisioning/v1alpha5/register.go
@@ -46,7 +46,16 @@ var (
 		EmptinessTimestampAnnotationKey,
 		v1.LabelHostname,
 	)
+
+	// AllowedLabelDomains are domains that may be restricted, but that is allowed because
+	// they are not used in a context where they may be passed as argument to kubelet.
+	// AllowedLabelDomains are evaluated before RestrictedLabelDomains
+	AllowedLabelDomains = sets.NewString(
+		"kops.k8s.io",
+	)
+
 	// These are either prohibited by the kubelet or reserved by karpenter
+	// They are evaluated after AllowedLabelDomains
 	KarpenterLabelDomain   = "karpenter.sh"
 	RestrictedLabelDomains = sets.NewString(
 		"kubernetes.io",

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -103,6 +103,13 @@ var _ = Describe("Validation", func() {
 				Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 			}
 		})
+		It("should allow labels kOps require", func() {
+			provisioner.Spec.Labels = map[string]string{
+				"kops.k8s.io/instancegroup": "karpenter-nodes",
+				"kops.k8s.io/gpu":           "1",
+			}
+			Expect(provisioner.Validate(ctx)).To(Succeed())
+		})
 	})
 	Context("Taints", func() {
 		It("should succeed for valid taints", func() {


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:*
kOps require two labels set on Nodes: `kops.k8s.io/instancegroup` and `kops.k8s.io/gpu`.
The latter is especially important as any pod using the `nvidia` runtimeclass will get that label as nodeSelector.

To make this more future proof, I allowed the entire `kops.k8s.io` domain as there will not be a case where these labels are restricted from Karpenters point of view.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
