### PR TITLE
Make it possible to set node naming convention

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -64,7 +64,13 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
-		ctx = injection.WithOptions(ctx, options.Options{ClusterName: "test-cluster", ClusterEndpoint: "https://test-cluster"})
+		opts := options.Options{
+			ClusterName:           "test-cluster",
+			ClusterEndpoint:       "https://test-cluster",
+			AWSNodeNameConvention: "ip-name",
+		}
+		Expect(opts.Validate()).To(Succeed(), "Failed to validate options")
+		ctx = injection.WithOptions(ctx, opts)
 		launchTemplateCache = cache.New(CacheTTL, CacheCleanupInterval)
 		unavailableOfferingsCache = cache.New(InsufficientCapacityErrorCacheTTL, InsufficientCapacityErrorCacheCleanupInterval)
 		fakeEC2API = &fake.EC2API{}


### PR DESCRIPTION
As of k8s 1.23, CCM supports both instance ID (resource name) and private dns (ip name) based naming.
It is not possible for karpenter to determine when which convention is used, and this may also depend on the installer used.
Therefore this is added as a CLI argument.

**1. Issue, if available:**
Fixes #927

**2. Description of changes:**
This adds a CLI flag for the node naming convention.
This is AWS specifc, so I added an "AWS" prefix. I think this is the first "global" cloud provider setting, so I was not sure how you wanted to name this.

I think a CLI arg for this is the only way of fixing this issue. Trying to parse k8s version and whether or not the external CCM is used is a bit fragile. It is also not given that the external CCM is the "official" one.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
