### PR TITLE
fix: fix Helm Chart

### DIFF
--- a/charts/karpenter/templates/webhook/webhooks.yaml
+++ b/charts/karpenter/templates/webhook/webhooks.yaml
@@ -18,7 +18,7 @@ webhooks:
     - v1alpha5
     resources:
     - provisioners
-      provisioners/status
+    - provisioners/status
     operations:
     - CREATE
     - UPDATE
@@ -43,10 +43,11 @@ webhooks:
     - v1alpha5
     resources:
     - provisioners
-      provisioners/status
+    - provisioners/status
     operations:
     - CREATE
     - UPDATE
+    - DELETE
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
The Webhooks resources generated by the Helm Chart are not the same that Karpenter redeploys.
This is annoying when using a tool like ArgoCD to deploy Karpenter because it never converges.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
