### PR TITLE
Adds GitHub Issue Analysis Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 coverage.out
 coverage.html
 *.test
+karpenter-plus-ones-*.csv
+karpenter-labels-*.csv
 website/node_modules
 website/resources

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 coverage.out
 coverage.html
 *.test
-karpenter-plus-ones-*.csv
-karpenter-labels-*.csv
+*.csv
 website/node_modules
 website/resources

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ toolchain: ## Install developer toolchain
 	./hack/toolchain.sh
 
 issues: ## Run GitHub issue analysis scripts
-	./hack/feature_request_reactions.py
-	./hack/label_issue_count.py
+	./hack/feature_request_reactions.py > "karpenter-feature-requests-$(date +"%Y-%m-%d").csv"
+	./hack/label_issue_count.py > "karpenter-labels-$(date +"%Y-%m-%d").csv"
 
 .PHONY: help dev ci release test battletest verify codegen apply delete publish helm website toolchain licenses

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,6 @@ toolchain: ## Install developer toolchain
 
 issues: ## Run GitHub issue analysis scripts
 	./hack/feature_request_reactions.py
-	./hack/feature_request_reactions.py
+	./hack/label_issue_count.py
 
 .PHONY: help dev ci release test battletest verify codegen apply delete publish helm website toolchain licenses

--- a/Makefile
+++ b/Makefile
@@ -92,4 +92,8 @@ website: ## Generate Docs Website
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh
 
+issues: ## Run GitHub issue analysis scripts
+	./hack/feature_request_reactions.py
+	./hack/feature_request_reactions.py
+
 .PHONY: help dev ci release test battletest verify codegen apply delete publish helm website toolchain licenses

--- a/hack/feature_request_reactions.py
+++ b/hack/feature_request_reactions.py
@@ -2,9 +2,9 @@
 
 import csv
 import os
-from datetime import date
+import sys
 from operator import itemgetter
-from typing import Dict, Set, Union
+from typing import Union
 
 # This script requires the python GitHub client:
 # pip install PyGithub
@@ -13,11 +13,9 @@ from github.Repository import Repository
 
 print('Getting popular feature requests...')
 
-# create a Github instance using an access token
+# To create a GitHub token, see below (the token doesn't need to include any scopes):
+# https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
 github = Github(os.environ.get('GH_TOKEN'))
-# to create a token
-# see https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
-# note, the token doesn't need to include any scopes
 
 issue_reaction_count: list[dict[str, Union[int, str]]] = []
 PLUS_ONE_REACTION_STRINGS = ['+1', 'heart', 'hooray', 'rocket', 'eyes']
@@ -49,8 +47,9 @@ for issue in sorted(issue_reaction_count, key=itemgetter('reactions'), reverse=T
     issue['reactions']
   ])
 
-with open(os.path.expanduser('karpenter-plus-ones-%s.csv' % (date.today())), 'w') as file:
-  writer = csv.writer(file)
-  writer.writerows(issue_row_list)
+# Write CSV data to STDOUT, redirect to file to persist, e.g.
+# ./hack/feature_request_reactions.py > "karpenter-feature-requests-$(date +"%Y-%m-%d").csv"
+writer = csv.writer(sys.stdout)
+writer.writerows(issue_row_list)
 
 print('Done!')

--- a/hack/feature_request_reactions.py
+++ b/hack/feature_request_reactions.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import csv
+import os
+from datetime import date
+from operator import itemgetter
+from typing import Dict, Set, Union
+
+# This script requires the python GitHub client:
+# pip install PyGithub
+from github import Github
+from github.Repository import Repository
+
+print('Getting popular feature requests...')
+
+# create a Github instance using an access token
+github = Github(os.environ.get('GH_TOKEN'))
+# to create a token
+# see https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+# note, the token doesn't need to include any scopes
+
+issue_reaction_count: list[dict[str, Union[int, str]]] = []
+PLUS_ONE_REACTION_STRINGS = ['+1', 'heart', 'hooray', 'rocket', 'eyes']
+ISSUE_LABELS = ['feature']
+
+repo: Repository = github.get_repo('aws/karpenter')
+open_issues = repo.get_issues(state='open', labels=ISSUE_LABELS)
+for issue in open_issues:
+  # count unique +1s
+  usernames: set[str] = set()
+  plus_ones = 0
+  for reaction in issue.get_reactions():
+    username = reaction.user.login
+    if reaction.content in PLUS_ONE_REACTION_STRINGS and username not in usernames:
+      usernames.add(reaction.user.login)
+      plus_ones += 1
+
+  issue_reaction_count.append({
+    'title': issue.title,
+    'url': issue.html_url,
+    'reactions': plus_ones
+  })
+
+issue_row_list = [['Title', 'Url', 'Plus Ones']]
+for issue in sorted(issue_reaction_count, key=itemgetter('reactions'), reverse=True):
+  issue_row_list.append([
+    issue['title'],
+    issue['url'],
+    issue['reactions']
+  ])
+
+with open(os.path.expanduser('karpenter-plus-ones-%s.csv' % (date.today())), 'w') as file:
+  writer = csv.writer(file)
+  writer.writerows(issue_row_list)
+
+print('Done!')

--- a/hack/label_issue_count.py
+++ b/hack/label_issue_count.py
@@ -2,8 +2,7 @@
 
 import csv
 import os
-from datetime import date
-from typing import Dict, Set
+import sys
 
 # This script requires the python GitHub client:
 # pip install PyGithub
@@ -12,11 +11,9 @@ from github.Repository import Repository
 
 print('Getting popular issue labels...')
 
-# create a Github instance using an access token
+# To create a GitHub token, see below (the token doesn't need to include any scopes):
+# https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
 github = Github(os.environ.get('GH_TOKEN'))
-# to create a token
-# see https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
-# note, the token doesn't need to include any scopes
 
 issue_label_counts: dict[str, int] = {}
 PLUS_ONE_REACTION_STRINGS = {'+1', 'heart', 'hooray', 'rocket', 'eyes'}
@@ -34,8 +31,9 @@ label_row_list = [['Label', 'Issue Count']]
 for label in sorted(issue_label_counts, key=issue_label_counts.get, reverse=True):
   label_row_list.append([label, issue_label_counts[label]])
 
-with open(os.path.expanduser('karpenter-labels-%s.csv' % (date.today())), 'w') as file:
-  writer = csv.writer(file)
-  writer.writerows(label_row_list)
+# Write CSV data to STDOUT, redirect to file to persist, e.g.
+# ./hack/label_issue_count.py > "karpenter-labels-$(date +"%Y-%m-%d").csv"
+writer = csv.writer(sys.stdout)
+writer.writerows(label_row_list)
 
 print('Done!')

--- a/hack/label_issue_count.py
+++ b/hack/label_issue_count.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import csv
+import os
+from datetime import date
+from typing import Dict, Set
+
+# This script requires the python GitHub client:
+# pip install PyGithub
+from github import Github
+from github.Repository import Repository
+
+print('Getting popular issue labels...')
+
+# create a Github instance using an access token
+github = Github(os.environ.get('GH_TOKEN'))
+# to create a token
+# see https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+# note, the token doesn't need to include any scopes
+
+issue_label_counts: dict[str, int] = {}
+PLUS_ONE_REACTION_STRINGS = {'+1', 'heart', 'hooray', 'rocket', 'eyes'}
+
+repo: Repository = github.get_repo('aws/karpenter')
+open_issues = repo.get_issues(state='open')
+for issue in open_issues:
+  for label in issue.get_labels():
+    if label.name not in issue_label_counts.keys():
+      issue_label_counts[label.name] = 1
+    else:
+      issue_label_counts[label.name] += 1
+
+label_row_list = [['Label', 'Issue Count']]
+for label in sorted(issue_label_counts, key=issue_label_counts.get, reverse=True):
+  label_row_list.append([label, issue_label_counts[label]])
+
+with open(os.path.expanduser('karpenter-labels-%s.csv' % (date.today())), 'w') as file:
+  writer = csv.writer(file)
+  writer.writerows(label_row_list)
+
+print('Done!')


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
This PR adds a couple simple python scripts to analyze the GitHub issues for the project. The first, `hack/feature_request_reactions.py`, creates a CSV file with the number of "+1s" for each feature request. The second, `hack/label_issue_count.py`, counts the number of open issues for each label. I've also included a Makefile target (`make issues`) for easy consumption.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
