### PR TITLE
Don't provision for pods with nominated node

### DIFF
--- a/pkg/controllers/selection/controller.go
+++ b/pkg/controllers/selection/controller.go
@@ -104,7 +104,12 @@ func (c *Controller) selectProvisioner(ctx context.Context, pod *v1.Pod) (errs e
 }
 
 func isProvisionable(p *v1.Pod) bool {
-	return p.Spec.NodeName == "" && pod.FailedToSchedule(p) && !pod.IsOwnedByDaemonSet(p) && !pod.IsOwnedByNode(p)
+	return !pod.IsScheduled(p) &&
+		!pod.IsPreempting(p) &&
+		pod.FailedToSchedule(p) &&
+		!pod.IsOwnedByDaemonSet(p) &&
+		!pod.IsOwnedByNode(p)
+
 }
 
 func validate(p *v1.Pod) error {

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -32,6 +32,10 @@ func IsScheduled(pod *v1.Pod) bool {
 	return pod.Spec.NodeName != ""
 }
 
+func IsPreempting(pod *v1.Pod) bool {
+	return pod.Status.NominatedNodeName != ""
+}
+
 func IsTerminal(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
 }


### PR DESCRIPTION
**1. Issue, if available:**
Fixes #1050 

**2. Description of changes:**
When a pod can evict other pods due to preemption, scheduler sets `pod.Status.NominatedNodeName` to track that scheduler has considered the pod suitable for the given node. As such, Karpenter does not need to take action on the particular node and can instead focus on the evicted pods.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
