### PR TITLE
Remove AmazonEKS_CNI_Policy from KarpenterNodeRole

### DIFF
--- a/website/content/en/docs/getting-started/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/cloudformation.yaml
@@ -28,7 +28,6 @@ Resources:
               - "sts:AssumeRole"
       ManagedPolicyArns:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
   KarpenterControllerPolicy:


### PR DESCRIPTION

**1. Issue, if available:**
https://github.com/aws/karpenter/issues/507

**2. Description of changes:**

eksctl configures CNI to get `AmazonEKS_CNI_Policy` permissions via IAM for Service accounts. The IAM permissions in `AmazonEKS_CNI_Policy` are broad and shouldn't be available for all pods running on the node. See EKS documentation: https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html

**3. Does this change impact docs?**
Yes, PR includes docs updates


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
