### PR TITLE
Sped up tests by 1.5seconds/test

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -145,13 +145,13 @@ func (p *Provisioner) batch(ctx context.Context) (pods []*v1.Pod) {
 		logging.FromContext(ctx).Infof("Batched %d pods in %s", len(pods), time.Since(start))
 	}()
 	for {
+		if len(pods) >= MaxPodsPerBatch {
+			return pods
+		}
 		select {
 		case pod := <-p.pods:
 			idle.Reset(MinBatchDuration)
 			pods = append(pods, pod)
-			if len(pods) >= MaxPodsPerBatch {
-				return pods
-			}
 		case <-ctx.Done():
 			return pods
 		case <-timeout.C:


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
```
ginkgo -r
[1640902878] Validation - 19/19 specs ••••••••••••••••••• SUCCESS! 1.219976ms PASS
[1640902878] CloudProvider/AWS - 24/24 specs •••••••••••••••••••••••• SUCCESS! 17.236281736s PASS
[1640902878] Node - 18/18 specs •••••••••••••••••• SUCCESS! 14.276780199s PASS
[1640902878] Controllers/Provisioning - 11/11 specs ••••••••••• SUCCESS! 16.538455717s PASS
PASS
testing: warning: no tests to run
Found no test suites, did you forget to run "ginkgo bootstrap"?[1640902878] Controllers/Scheduling - 39/39 specs ••••••••••••••••S•••••••••••••••••••••• SUCCESS! 40.300813943s PASS
[1640902878] Controllers/Scheduling - 3/3 specs ••• SUCCESS! 15.463171157s PASS
[1640902878] Termination - 6/6 specs •••••• SUCCESS! 15.919283898s PASS
[1640902878] Functional Suite - 10/10 specs •••••••••• SUCCESS! 414.383µs PASS

Ginkgo ran 9 suites in 2m13.910061006s
Test Suite Passed
```

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
