### PR TITLE
Don't fail on missing privatednsname if using RBN

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 		opts := options.Options{
 			ClusterName:           "test-cluster",
 			ClusterEndpoint:       "https://test-cluster",
-			AWSNodeNameConvention: "ip-name",
+			AWSNodeNameConvention: string(options.IPName),
 		}
 		Expect(opts.Validate()).To(Succeed(), "Failed to validate options")
 		ctx = injection.WithOptions(ctx, opts)


### PR DESCRIPTION
**1. Issue, if available:**
#1067 

**2. Description of changes:**
If we are using resource-based naming, we do not need to bail on private DNS name missing.
We still need the describeInstances call for emulating CCM.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
