### PR TITLE
Fix the makefile bug when the cluster name includes region [WIP]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WITH_GOFLAGS = GOFLAGS=$(GOFLAGS)
 WITH_RELEASE_REPO = KO_DOCKER_REPO=$(RELEASE_REPO)
 
 ## Extra helm options
-CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev)
+CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
 CLUSTER_ENDPOINT ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}')
 HELM_OPTS ?= --set controller.clusterName=${CLUSTER_NAME} --set controller.clusterEndpoint=${CLUSTER_ENDPOINT}
 


### PR DESCRIPTION
**1. Issue, if available:**
When creating cluster using eksctl, the cluster name in kube config file is ${CLUSTER_NAME}.${AWS_DEFAULT_REGION}.eksctl.io.
It causes the helm options in the makefile to use the wrong ${CLUSTER_NAME} value.

**2. Description of changes:**
Fix the command that compute the CLUSTER_NAME environment value in makefile.

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
