### PR TITLE
bump indents for webhook envVars to 12

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -2,6 +2,7 @@ addon
 adfdb
 admissionregistration
 alertmanager
+amazonvpc
 amd
 amdgpu
 amiid

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -58,7 +58,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           {{- with .Values.webhook.env }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
       # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8#issuecomment-636888074 - not needed in k8s versions 1.19+
       securityContext:


### PR DESCRIPTION
**1. Issue, if available:**
Attempting to override `KUBERNETES_MIN_VERSION` per this error log:

> 2022-01-03T22:23:16.180Z        FATAL   webhook Version check failed    {"commit": "5047f3c", "error": "kubernetes version \"1.19.13-eks-8df270\" is not compatible, need at least \"1.20.0-0\" (this can be overridden with the env var \"KUBERNETES_MIN_VERSION\")"}

`helm template` render shows that custom envVars placed in `values.yaml` have incorrect indentation.

Example:
```
          env:
            - name: CLUSTER_NAME
              value: 
            - name: CLUSTER_ENDPOINT
              value: 
            - name: SYSTEM_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
          - name: KUBERNETES_MIN_VERSION 
             value: 1.19.0-0 
 ```

**2. Description of changes:**
Bumping indentation for envVars from `10` to `12`. This keeps the render consistent with indentation found in the [controller charts](https://github.com/aws/karpenter/blob/1e51d5e8f95fab52aeb3301d9e7c5a22986b8904/charts/karpenter/templates/controller/deployment.yaml#L60-L61)

Example:
```
          env:
            - name: CLUSTER_NAME
              value: 
            - name: CLUSTER_ENDPOINT
              value: 
            - name: SYSTEM_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: KUBERNETES_MIN_VERSION
               value: 1.19.0-0
   ```

**3. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
