### PR TITLE
docs/AWS: Fix typo for securityGroupsSelector

### DIFF
--- a/website/content/en/docs/AWS/provisioning.md
+++ b/website/content/en/docs/AWS/provisioning.md
@@ -100,7 +100,7 @@ Select security groups by name, or another tag:
 
 Select security groups by name using a wildcard:
 ```
- subnetSelector:
+ securityGroupSelector:
    Name: *public*
 ```
 


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Looks like there was a copy/paste typo in the securityGroupSelector documentation example.

**3. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
