### PR TITLE
Fail if multiple aws security groups tagged for cluster

### DIFF
--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -68,6 +68,7 @@ func (e *EC2API) Reset() {
 	e.EC2Behavior = EC2Behavior{
 		CalledWithCreateFleetInput:          set.NewSet(),
 		CalledWithCreateLaunchTemplateInput: set.NewSet(),
+		DescribeSecurityGroupsOutput:        nil,
 		Instances:                           sync.Map{},
 		LaunchTemplates:                     sync.Map{},
 		InsufficientCapacityPools:           []CapacityPool{},


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1039

**2. Description of changes:**

*Previous Behavior* - 
If no SecurityGroupSelector is specified, we find all securityGroups that have a tag key of `kubernetes.io/cluster/$clusterName` and randomly select a single one of them. We select just one of them because the Load Balancer controller forces us to. See [this](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2367) for more information

* New Behavior* - 
* If no SecurityGroupSelector is specified, we will find a securityGroup that has a tag key of `kubernetes.io/cluster/$clusterName` and use that. If we find more than one such securityGroup with that tag key, we will fail launching worker nodes. 

This will likely force customers using kOps or eksctl to provide a securityGroupSelector in their provisionerSpec to ensure worker nodes are launched successfully. 

**3. Does this change impact docs?**
(WIP - will add)
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

**Testing**

I added that tag to an additional SG in my VPC and saw the provisioner complain - 
```
2022-01-04T21:35:28.621Z	INFO	controller.provisioning	Computed packing of 1 node(s) for 7 pod(s) with instance type option(s) [c1.xlarge c4.2xlarge c3.2xlarge c5ad.2xlarge c5a.2xlarge c6i.2xlarge c5d.2xlarge c5.2xlarge c5n.2xlarge m3.2xlarge t3.2xlarge m6a.2xlarge m5ad.2xlarge m5.2xlarge m5dn.2xlarge m4.2xlarge t3a.2xlarge m6i.2xlarge m5zn.2xlarge m5d.2xlarge]	{"commit": "32dbe02", "provisioner": "default"}
2022-01-04T21:35:28.627Z	ERROR	controller.provisioning	Could not launch node, launching instances, getting launch template configs, getting launch templates, only one group with tag kubernetes.io/cluster/pdx-cluster is allowed	{"commit": "32dbe02", "provisioner": "default"}
```

I then made my securityGroupSelector a little more specific and saw nodes were being launched successfully.
