### PR TITLE
Pin version for eks module in getting-started-with-terraform docs

### DIFF
--- a/website/content/en/docs/getting-started-with-terraform/_index.md
+++ b/website/content/en/docs/getting-started-with-terraform/_index.md
@@ -91,6 +91,7 @@ module "vpc" {
 
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
+  version         = "<18"
 
   cluster_version = "1.21"
   cluster_name    = var.cluster_name


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
This PR pins the version of the aws eks module to < 18. That project recently released some breaking changes that break the example in the docs without the pin.

Their release: https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v18.0.0

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
