### PR TITLE
README.md: Refer to #karpenter slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For most use cases, a cluster’s capacity can be managed by a single Karpenter 
 However, you can define multiple Provisioners, enabling use cases like isolation, entitlements, and sharding.
 Using a combination of defaults and overrides, Karpenter determines the availability zone, instance type, capacity type, machine image, and scheduling constraints for pods it manages.
 
-Come discuss Karpenter in the [#provider-aws channel](https://kubernetes.slack.com/archives/C0LRMHZ1T) in the [Kubernetes slack](https://slack.k8s.io/)!
+Come discuss Karpenter in the [#karpenter channel](https://kubernetes.slack.com/archives/C02SFFZSA2K) in the [Kubernetes slack](https://slack.k8s.io/)!
 
 Check out the [Docs](https://karpenter.sh/) to learn more.
 


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
I noticed that README still references #provider-aws despite the recent introduction of dedicated #karpenter channel. I'm assuming that we'd want to refer users to the dedicated channel going forward.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
