### PR TITLE
fix selector labels on helm chart

### DIFF
--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -26,7 +26,6 @@ spec:
   selector:
     matchLabels:
       karpenter: controller
-      {{- include "karpenter.selectorLabels" . | indent 6 }}
   template:
     metadata:
       labels:

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -11,7 +11,6 @@ spec:
       targetPort: webhook
   selector:
     karpenter: webhook
-    {{- include "karpenter.selectorLabels" . | indent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -27,7 +26,6 @@ spec:
   selector:
     matchLabels:
       karpenter: webhook
-      {{- include "karpenter.selectorLabels" . | indent 6 }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - #1001 added standard k8s labels across all resources and the ability for users to provide labels that are propagated to all resources. Part of that PR also updated the selectorLabels with these additional labels, however, selectorLabels are immutable so when upgrading the chart from the previous, those resources fail to Patch.  This PR removes the additional selectors and sticks with the `karpenter: controller` and `karpenter: webhook` to maintain backwards compatibility.  


**3. How was this change tested?**
tested in my local cluster by updating a previous installation with helm.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
