### PR TITLE
Change "provision pods" to "schedule pods" in docs

### DIFF
--- a/website/content/en/docs/concepts/_index.md
+++ b/website/content/en/docs/concepts/_index.md
@@ -37,7 +37,7 @@ Karpenter's job is to add nodes to handle unschedulable pods, schedule pods on t
 To configure Karpenter, you create *provisioners* that define how Karpenter manages unschedulable pods and expires nodes.
 Here are some things to know about the Karpenter provisioner:
 
-* **Unschedulable pods**: Karpenter only attempts to provision pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
+* **Unschedulable pods**: Karpenter only attempts to schedule pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
 
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.

--- a/website/content/en/v0.4.3-docs/concepts/_index.md
+++ b/website/content/en/v0.4.3-docs/concepts/_index.md
@@ -37,7 +37,7 @@ Karpenter's job is to add nodes to handle unschedulable pods, schedule pods on t
 To configure Karpenter, you create *provisioners* that define how Karpenter manages unschedulable pods and expires nodes.
 Here are some things to know about the Karpenter provisioner:
 
-* **Unschedulable pods**: Karpenter only attempts to provision pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
+* **Unschedulable pods**: Karpenter only attempts to schedule pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
 
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.

--- a/website/content/en/v0.5.0-docs/concepts/_index.md
+++ b/website/content/en/v0.5.0-docs/concepts/_index.md
@@ -37,7 +37,7 @@ Karpenter's job is to add nodes to handle unschedulable pods, schedule pods on t
 To configure Karpenter, you create *provisioners* that define how Karpenter manages unschedulable pods and expires nodes.
 Here are some things to know about the Karpenter provisioner:
 
-* **Unschedulable pods**: Karpenter only attempts to provision pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
+* **Unschedulable pods**: Karpenter only attempts to schedule pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
 
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.

--- a/website/content/en/v0.5.2-docs/concepts/_index.md
+++ b/website/content/en/v0.5.2-docs/concepts/_index.md
@@ -37,7 +37,7 @@ Karpenter's job is to add nodes to handle unschedulable pods, schedule pods on t
 To configure Karpenter, you create *provisioners* that define how Karpenter manages unschedulable pods and expires nodes.
 Here are some things to know about the Karpenter provisioner:
 
-* **Unschedulable pods**: Karpenter only attempts to provision pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
+* **Unschedulable pods**: Karpenter only attempts to schedule pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
 
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.


### PR DESCRIPTION
Changed wording in the concepts docs from "provision pods" to "schedule pods" per a comment in slack.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No