### PR TITLE
fix topologySpread nil label selector bug

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -493,7 +493,7 @@ var _ = Describe("Topology", func() {
 			Expect(env.Client.List(ctx, &nodes)).To(Succeed())
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2, 2, 1))
 		})
-		It("should match all pods when labelSelector is nil", func() {
+		It("should match all pods when labelSelector is not specified", func() {
 			topology := []v1.TopologySpreadConstraint{{
 				TopologyKey:       v1.LabelTopologyZone,
 				WhenUnsatisfiable: v1.DoNotSchedule,

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -493,6 +493,18 @@ var _ = Describe("Topology", func() {
 			Expect(env.Client.List(ctx, &nodes)).To(Succeed())
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2, 2, 1))
 		})
+		It("should match all pods when labelSelector is nil", func() {
+			topology := []v1.TopologySpreadConstraint{{
+				TopologyKey:       v1.LabelTopologyZone,
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector:     nil,
+				MaxSkew:           1,
+			}}
+			ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner,
+				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),
+			)
+			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
+		})
 	})
 
 	Context("Hostname", func() {

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -497,11 +497,10 @@ var _ = Describe("Topology", func() {
 			topology := []v1.TopologySpreadConstraint{{
 				TopologyKey:       v1.LabelTopologyZone,
 				WhenUnsatisfiable: v1.DoNotSchedule,
-				LabelSelector:     nil,
 				MaxSkew:           1,
 			}}
 			ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner,
-				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),
+				test.UnschedulablePod(),
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
 		})

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -141,6 +141,9 @@ func (t *Topology) countMatchingPods(ctx context.Context, topologyGroup *Topolog
 
 func TopologyListOptions(namespace string, constraint *v1.TopologySpreadConstraint) *client.ListOptions {
 	selector := labels.Everything()
+	if constraint.LabelSelector == nil {
+		return &client.ListOptions{Namespace: namespace, LabelSelector: selector}
+	}
 	for key, value := range constraint.LabelSelector.MatchLabels {
 		requirement, _ := labels.NewRequirement(key, selection.Equals, []string{value})
 		selector = selector.Add(*requirement)


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1021

**2. Description of changes:**
Fixes #1021 where if the labelSelector was not provided for a topologySpread, then Karpenter would crash. This fix makes a nil labelSelector select everything per [labelSelector docs](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/label-selector/#:~:text=An%20empty%20label%20selector%20matches%20all%20objects)

**3. How was this change tested?**
Wrote a unit-test to reproduce the issue, after the fix was implemented, the unit test now passes.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
