### PR TITLE
Fix constraints validation bug, add corresponding test cases

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -138,6 +138,11 @@ func (c *Constraints) validateRequirements() (errs *apis.FieldError) {
 		if err := validateRequirement(requirement); err != nil {
 			errs = errs.Also(apis.ErrInvalidArrayValue(err, "requirements", i))
 		}
+		// The constraints contains conflicting requirements
+		// e.g., label In [A] && label In [B], there is no overlap
+		if c.Requirements.Requirement(requirement.Key).Len() == 0 {
+			errs = errs.Also(apis.ErrInvalidArrayValue(fmt.Sprintf("conflicting, %s", requirement.Key), "requirements", i))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -164,5 +164,12 @@ var _ = Describe("Validation", func() {
 				Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 			}
 		})
+		It("should fail for conflicting constraints", func() {
+			provisioner.Spec.Requirements = Requirements{
+				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
+				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"bar"}},
+			}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+		})
 	})
 })

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -232,6 +232,41 @@ var _ = Describe("Provisioning", func() {
 				Expect(*node.Status.Allocatable.Cpu()).To(Equal(resource.MustParse("2")))
 				Expect(*node.Status.Allocatable.Memory()).To(Equal(resource.MustParse("2Gi")))
 			})
+			It("should ignore daemonsets that have conflicting requirements", func() {
+				ExpectCreated(ctx, env.Client, test.DaemonSet(
+					test.DaemonSetOptions{PodOptions: test.PodOptions{
+						NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}},
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}},
+						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+					}},
+				))
+				pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioningController, provisioner, test.UnschedulablePod(
+					test.PodOptions{
+						NodeRequirements:     []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}},
+						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+					},
+				))[0]
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(*node.Status.Allocatable.Cpu()).To(Equal(resource.MustParse("2")))
+				Expect(*node.Status.Allocatable.Memory()).To(Equal(resource.MustParse("2Gi")))
+			})
+			It("should include daemonsets that have compatible NotIn requirements", func() {
+				ExpectCreated(ctx, env.Client, test.DaemonSet(
+					test.DaemonSetOptions{PodOptions: test.PodOptions{
+						NodeRequirements:     []v1.NodeSelectorRequirement{{Key: "foo", Operator: v1.NodeSelectorOpNotIn, Values: []string{"bar"}}},
+						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+					}},
+				))
+				pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioningController, provisioner, test.UnschedulablePod(
+					test.PodOptions{
+						NodeRequirements:     []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}},
+						ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+					},
+				))[0]
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(*node.Status.Allocatable.Cpu()).To(Equal(resource.MustParse("4")))
+				Expect(*node.Status.Allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
+			})
 		})
 		Context("Labels", func() {
 			It("should label nodes", func() {


### PR DESCRIPTION
**1. Issue, if available:**
resolve #1084 

**2. Description of changes:**

- Provisioner validation now checks if constraints are conflicting
- Modify the podValidation logic to include node selector NotIn operator


**3. How was this change tested?**
- Unit test cases are added

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [X] Yes, issue opened: *https://github.com/aws/karpenter/issues/1084*
- [ ] No



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
