### PR TITLE
init draft of desc of resource limits

### DIFF
--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -47,6 +47,14 @@ spec:
     - key: "karpenter.sh/capacity-type" # If not included, the webhook for the AWS cloud provider will default to on-demand
       operator: In
       values: ["spot", "on-demand"]
+
+  # Resource limits constrain the total size of the cluster.
+  # Limits prevent Karpenter from creating new instances once the limit is exceeded.
+  limits:
+    resources:
+      cpu: 1000 
+      memory: 1000Gi
+
   # These fields vary per cloud provider, see your cloud provider specific documentation
   provider: {}
 ```
@@ -147,6 +155,21 @@ spec:
   kubeletConfiguration:
     clusterDNS: ["10.0.1.100"]
 ```
+
+## spec.limits
+
+The provisioner spec includes a limits section (`spec.limits.resources`), which constrains the maximum amount of resources that the provisioner will manage. 
+
+Presently, Karpenter supports `memory` and `cpu` limits. 
+
+CPU limits are described with a `DecimalSI` value, usually a natural integer. 
+
+Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
+
+Karpenter stops allocating resources once at least one resource limit is met/exceeded.
+
+Review the [resource limit task](../tasks/set-resource-limits) for more information.
+
 
 
 ## spec.provider

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -164,7 +164,7 @@ Presently, Karpenter supports `memory` and `cpu` limits.
 
 CPU limits are described with a `DecimalSI` value, usually a natural integer. 
 
-Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
+Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
 
 Karpenter stops allocating resources once at least one resource limit is met/exceeded.
 

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -6,22 +6,33 @@ weight: 10
 
 Karpenter automatically provisions instances from the cloud provider. This often incurs hard costs. To control resource utilization and cluster size, use resource limits.
 
-The provisioner spec includes a limits section (`spec.limits.resources`), which constrains the maximum amount of resources that provisioner will manage. 
+The provisioner spec includes a limits section (`spec.limits.resources`), which constrains the maximum amount of resources that the provisioner will manage. 
 
 For example, setting "spec.limits.resources.cpu" to "1000" limits the provisioner to a total of 1000 CPU cores across all instances. This prevents unwanted excessive growth of a cluster. 
 
-The [Kubernetes core API](https://github.com/kubernetes/api/blob/37748cca582229600a3599b40e9a82a951d8bbbf/core/v1/resource.go#L23) (`k8s.io/api/core/v1`) defines the `resources` which may be limited.
-
-These resources are described with a `DecimalSI` value, usually a natural integer. 
+At this time, Karpenter only supports:
 - CPU
-- Pods
+- Memory
 
-These resources are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
-- memory
-- storage
-- StorageEphemeral 
+CPU limits are described with a `DecimalSI` value, usually a natural integer. 
 
-[[Question -- If Karpenter is at 995, and wants to provision a 6 core instance, will it auto step down to 4-5 cores, or will it fail at 995 of the limit?]]
+Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
+
+Review the [Kubernetes core API](https://github.com/kubernetes/api/blob/37748cca582229600a3599b40e9a82a951d8bbbf/core/v1/resource.go#L23) (`k8s.io/api/core/v1`) for more information on `resources`.
+
+### Implementation
+
+Karpenter refuses to allocate new resources while at least one resoruce limit is *exceeded*. In other words, resource limits aren't hard limits, they only apply once Karpenter detects that a limit has been crossed.
+
+**Example:**
+
+A resource limit of 1000 CPUs is set. 996 CPU cores are currently allocated. The resource limit is not met.
+
+In response to pending pods, Karpenter calculates a new 6 core instance is needed. Karpenter *creates* the instance.
+
+1002 CPU cores are now allocated. The resource limit is in now met/exceeded. 
+
+In response to a new set of pending pods, Karpenter calculates another 6 core instance is needed. Karpenter *does not create* the instance, because the resource limit has been met.
 
 ### Example Provisioner:
 
@@ -38,8 +49,5 @@ spec:
   limits:
     resources:
       cpu: 1000 
-      memory: 1000Gi 
-      storage: 1000Ti 
-      pods: 1000
-      StorageEphemeral: 1000Gi
+      memory: 1000Gi
 ```

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -22,7 +22,7 @@ Review the [Kubernetes core API](https://github.com/kubernetes/api/blob/37748cca
 
 ### Implementation
 
-Karpenter refuses to allocate new resources while at least one resoruce limit is *exceeded*. In other words, resource limits aren't hard limits, they only apply once Karpenter detects that a limit has been crossed.
+Karpenter refuses to allocate new resources while at least one resource limit is *exceeded*. In other words, resource limits aren't hard limits, they only apply once Karpenter detects that a limit has been crossed.
 
 **Example:**
 

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -1,0 +1,45 @@
+---
+title: "Set Resource Limits"
+linkTitle: "Set Resource Limits"
+weight: 10
+---
+
+Karpenter automatically provisions instances from the cloud provider. This often incurs hard costs. To control resource utilization and cluster size, use resource limits.
+
+The provisioner spec includes a limits section (`spec.limits.resources`), which constrains the maximum amount of resources that provisioner will manage. 
+
+For example, setting "spec.limits.resources.cpu" to "1000" limits the provisioner to a total of 1000 CPU cores across all instances. This prevents unwanted excessive growth of a cluster. 
+
+The [Kubernetes core API](https://github.com/kubernetes/api/blob/37748cca582229600a3599b40e9a82a951d8bbbf/core/v1/resource.go#L23) (`k8s.io/api/core/v1`) defines the `resources` which may be limited.
+
+These resources are described with a `DecimalSI` value, usually a natural integer. 
+- CPU
+- Pods
+
+These resources are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
+- memory
+- storage
+- StorageEphemeral 
+
+[[Question -- If Karpenter is at 995, and wants to provision a 6 core instance, will it auto step down to 4-5 cores, or will it fail at 995 of the limit?]]
+
+### Example Provisioner:
+
+```
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: default
+spec:
+  requirements:
+    - key: karpenter.sh/capacity-type
+      operator: In
+      values: ["spot"]
+  limits:
+    resources:
+      cpu: 1000 
+      memory: 1000Gi 
+      storage: 1000Ti 
+      pods: 1000
+      StorageEphemeral: 1000Gi
+```

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -20,7 +20,7 @@ Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://g
 
 You can view the current consumption of cpu and memory on your cluster by running:
 ```
-kubectl get provisioner -o=jsonpath='{.items[0].stat
+kubectl get provisioner -o=jsonpath='{.items[0].status}'
 ```
 
 Review the [Kubernetes core API](https://github.com/kubernetes/api/blob/37748cca582229600a3599b40e9a82a951d8bbbf/core/v1/resource.go#L23) (`k8s.io/api/core/v1`) for more information on `resources`.

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -18,6 +18,11 @@ CPU limits are described with a `DecimalSI` value, usually a natural integer.
 
 Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
 
+You can view the current consumption of cpu and memory on your cluster by running:
+```
+kubectl get provisioner -o=jsonpath='{.items[0].stat
+```
+
 Review the [Kubernetes core API](https://github.com/kubernetes/api/blob/37748cca582229600a3599b40e9a82a951d8bbbf/core/v1/resource.go#L23) (`k8s.io/api/core/v1`) for more information on `resources`.
 
 ### Implementation

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -39,6 +39,10 @@ In response to pending pods, Karpenter calculates a new 6 core instance is neede
 
 In response to a new set of pending pods, Karpenter calculates another 6 core instance is needed. Karpenter *does not create* the instance, because the resource limit has been met.
 
+{{% alert title="Note" color="primary" %}}
+Karpenter provisioning is highly parallel. Because of this, limit checking is eventually consistent, which can result in overrun during rapid scale outs.
+{{% /alert %}}
+
 ### Example Provisioner:
 
 ```


### PR DESCRIPTION
**1. Issue, if available:**
#1003 

**2. Description of changes:**
add new task for setting resource limits.


From standup, @ellistarn indicated non-specific complexities associated with "eventual consistency" regarding resource limits? 

I'm open to moving this under the "run pods" task (subpage or new section), where do you think @chrisnegus ?

requesting review from @suket22 

**3. How was this change tested?**
tested on my own cluster (only tested CPUs)


**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
