### PR TITLE
Helm chart: use AppVersion in tags

### DIFF
--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -65,3 +65,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Construct controller and webhook container images
+*/}}
+{{- define "karpenter.controller.image" -}}
+{{- printf "%s:v%s@%s" .Values.controller.image.repository (default .Chart.AppVersion .Values.controller.image.tag) .Values.controller.image.sha }}
+{{- end }}
+
+{{- define "karpenter.webhook.image" -}}i
+{{- printf "%s:v%s@%s" .Values.webhook.image.repository (default .Chart.AppVersion .Values.webhook.image.tag) .Values.webhook.image.sha }}
+{{- end }}

--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: {{ template "karpenter.serviceAccountName" . }}
       containers:
         - name: manager
-          image: {{ .Values.controller.image }}
+          image: {{ include "karpenter.controller.image" . | quote }}
         {{- if .Values.controller.resources }}
           resources: {{ toYaml .Values.controller.resources | nindent 12 }}
         {{- end }}

--- a/charts/karpenter/templates/webhook/deployment.yaml
+++ b/charts/karpenter/templates/webhook/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: {{ template "karpenter.serviceAccountName" . }}
       containers:
         - name: webhook
-          image: {{ .Values.webhook.image }}
+          image: {{ include "karpenter.webhook.image" . | quote }}
           args:
             - -port={{ .Values.webhook.port }}
         {{- if .Values.webhook.resources }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -21,7 +21,10 @@ controller:
   # -- Affinity rules for scheduling
   affinity: {}
   # -- Image to use for the Karpenter controller
-  image: "public.ecr.aws/karpenter/controller:v0.5.4@sha256:19ebf83d64fa41d75fb19ae5047f54b1c66423b4ab5ceef36ae99a0daaad1895"
+  image:
+    repository: "public.ecr.aws/karpenter/controller"
+    tag: ""
+    sha: "sha256:19ebf83d64fa41d75fb19ae5047f54b1c66423b4ab5ceef36ae99a0daaad1895"
   # -- Cluster name
   clusterName: ""
   # -- Cluster endpoint
@@ -44,7 +47,10 @@ webhook:
   # -- Affinity rules for scheduling
   affinity: {}
   # -- Image to use for the webhook
-  image: "public.ecr.aws/karpenter/webhook:v0.5.4@sha256:fd7dd0a3e155cb08a1c1def31258c654ac6c61b2fa8d8d25b7483688664c7de2"
+  image:
+    repository: "public.ecr.aws/karpenter/webhook"
+    tag: ""
+    sha: "sha256:fd7dd0a3e155cb08a1c1def31258c654ac6c61b2fa8d8d25b7483688664c7de2"
   # -- Set to true if using custom CNI on EKS
   hostNetwork: false
   port: 8443


### PR DESCRIPTION
**1. Issue, if available:**
n/a

**2. Description of changes:**
Use `AppVersion` for calculating container image tags. Still allows override via `tag` attribute.

**3. How was this change tested?**
Local chart generation.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
