### PR TITLE
ICE cache bin-packing validation fix

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/requirements.go
+++ b/pkg/apis/provisioning/v1alpha5/requirements.go
@@ -158,7 +158,6 @@ func (r Requirements) WellKnown() (requirements Requirements) {
 	for _, requirement := range r {
 		if WellKnownLabels.Has(requirement.Key) {
 			requirements = requirements.Add(requirement)
-
 		}
 	}
 	return requirements

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -410,6 +410,10 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 				Location:     aws.String("test-zone-1a"),
 			},
 			{
+				InstanceType: aws.String("m5.xlarge"),
+				Location:     aws.String("test-zone-1b"),
+			},
+			{
 				InstanceType: aws.String("m5.2xlarge"),
 				Location:     aws.String("test-zone-1a"),
 			},

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -172,7 +172,7 @@ func (p *InstanceProvider) getLaunchTemplateConfigs(ctx context.Context, constra
 		}
 	}
 	if len(launchTemplateConfigs) == 0 {
-		return nil, fmt.Errorf("no capacity offerings are currently available for the instance types and capacity type requested")
+		return nil, fmt.Errorf("no capacity offerings are currently available given the constraints")
 	}
 	return launchTemplateConfigs, nil
 }

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -160,13 +160,19 @@ func (p *InstanceProvider) getLaunchTemplateConfigs(ctx context.Context, constra
 		return nil, fmt.Errorf("getting launch templates, %w", err)
 	}
 	for launchTemplateName, instanceTypes := range launchTemplates {
-		launchTemplateConfigs = append(launchTemplateConfigs, &ec2.FleetLaunchTemplateConfigRequest{
+		launchTemplateConfig := &ec2.FleetLaunchTemplateConfigRequest{
 			Overrides: p.getOverrides(instanceTypes, subnets, constraints.Requirements.Zones(), capacityType),
 			LaunchTemplateSpecification: &ec2.FleetLaunchTemplateSpecificationRequest{
 				LaunchTemplateName: aws.String(launchTemplateName),
 				Version:            aws.String("$Default"),
 			},
-		})
+		}
+		if len(launchTemplateConfig.Overrides) > 0 {
+			launchTemplateConfigs = append(launchTemplateConfigs, launchTemplateConfig)
+		}
+	}
+	if len(launchTemplateConfigs) == 0 {
+		return nil, fmt.Errorf("no capacity offerings are currently available for the instance types and capacity type requested")
 	}
 	return launchTemplateConfigs, nil
 }

--- a/pkg/controllers/provisioning/binpacking/packable.go
+++ b/pkg/controllers/provisioning/binpacking/packable.go
@@ -199,7 +199,7 @@ func (p *Packable) validateOfferings(constraints *v1alpha5.Constraints) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("offerings %v are not available for capacity types %v and zones %v", p.Offerings(), constraints.Requirements.CapacityTypes(), constraints.Requirements.Zones())
+	return fmt.Errorf("offerings %v are not available for capacity types %v and zones %v", p.Offerings(), constraints.Requirements.CapacityTypes().List(), constraints.Requirements.Zones().List())
 }
 
 func (p *Packable) validateGPUs(pods []*v1.Pod) error {


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1126

**2. Description of changes:**
Fixes an issue where if an instance type offering is found to be unavailable and therefore placed in the ICE cache, the binpacking logic could still use the instance type in the packing. 

The bug is occurring in the bin packing's packable validation logic. Packables (Instance Type and Offering) are validated by zone and capacity type separately even though an offering is the tuple of (zone, capacity type). This change validates an offering and removes the independent zone and capacity-type validation.


The issue was originally found while doing load tests where I ran into an Insufficient Capacity Error (ICE). After the ICE, Karpenter behaved very strangely, by throwing "Security Group does not belong to the same network as Subnet". This error is because of the overrides bug described in the issue linked. 

**3. How was this change tested?**
- Reproduced in a cluster by injecting ICEs directly into the cache (was able to reproduce and verified the fix)
- Added a unit-test that fails without the patch and passes with the patch.



**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
