### PR TITLE
[AWS] Allow i3* instances to pass the filter

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -164,6 +164,7 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	// TODO exclude if not available for spot
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
 		"m", "c", "r", "a", // Standard
+		"i3",       // Storage-optimized
 		"t3", "t4", // Burstable
 		"p", "inf", "g", // Accelerators
 	)


### PR DESCRIPTION
Towards resolving #1053.

**1. Issue, if available:** #1053


**2. Description of changes:** Avoid filtering i3* instance types, allowing them to be provisioned by karpenter


**3. How was this change tested?** Unittests


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
