### PR TITLE
Explicitly name metrics port in deployment's Helm chart template

### DIFF
--- a/charts/karpenter/templates/controller/deployment.yaml
+++ b/charts/karpenter/templates/controller/deployment.yaml
@@ -7,7 +7,8 @@ metadata:
     {{- include "karpenter.labels" . | indent 4 }}
 spec:
   ports:
-    - port: 8080
+    - name: metrics
+      port: 8080
       targetPort: metrics
   selector:
     karpenter: controller


### PR DESCRIPTION
**1. Issue, if available:**
No issue

**2. Description of changes:**
Adding an explicit name to the metrics port for the controller Service. This is needed to define `ServiceMonitor` objects for Prometheus monitoring, as they can't reference ports by number (for some reason).

**3. How was this change tested?**
Not really tested as it's a pretty unobtrusive update.


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
