### PR TITLE
Remove subnet and security group selector defaulting.

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/register.go
+++ b/pkg/apis/provisioning/v1alpha5/register.go
@@ -40,11 +40,11 @@ var (
 		metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 		return nil
 	})
-	ProvisionerNameLabelKey         = SchemeGroupVersion.Group + "/provisioner-name"
-	NotReadyTaintKey                = SchemeGroupVersion.Group + "/not-ready"
-	DoNotEvictPodAnnotationKey      = SchemeGroupVersion.Group + "/do-not-evict"
-	EmptinessTimestampAnnotationKey = SchemeGroupVersion.Group + "/emptiness-timestamp"
-	TerminationFinalizer            = SchemeGroupVersion.Group + "/termination"
+	ProvisionerNameLabelKey         = Group + "/provisioner-name"
+	NotReadyTaintKey                = Group + "/not-ready"
+	DoNotEvictPodAnnotationKey      = Group + "/do-not-evict"
+	EmptinessTimestampAnnotationKey = Group + "/emptiness-timestamp"
+	TerminationFinalizer            = Group + "/termination"
 )
 
 const (

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_defaults.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_defaults.go
@@ -16,22 +16,16 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/utils/functional"
-	"github.com/aws/karpenter/pkg/utils/injection"
 	v1 "k8s.io/api/core/v1"
 )
-
-var ClusterDiscoveryTagKeyFormat = "kubernetes.io/cluster/%s"
 
 // Default the constraints.
 func (c *Constraints) Default(ctx context.Context) {
 	c.defaultArchitecture()
 	c.defaultCapacityTypes()
-	c.defaultSubnets(injection.GetOptions(ctx).ClusterName)
-	c.defaultSecurityGroups(injection.GetOptions(ctx).ClusterName)
 }
 
 func (c *Constraints) defaultCapacityTypes() {
@@ -60,18 +54,4 @@ func (c *Constraints) defaultArchitecture() {
 		Operator: v1.NodeSelectorOpIn,
 		Values:   []string{v1alpha5.ArchitectureAmd64},
 	})
-}
-
-func (c *Constraints) defaultSubnets(clusterName string) {
-	if c.SubnetSelector != nil {
-		return
-	}
-	c.SubnetSelector = map[string]string{fmt.Sprintf(ClusterDiscoveryTagKeyFormat, clusterName): "*"}
-}
-
-func (c *Constraints) defaultSecurityGroups(clusterName string) {
-	if c.SecurityGroupSelector != nil {
-		return
-	}
-	c.SecurityGroupSelector = map[string]string{fmt.Sprintf(ClusterDiscoveryTagKeyFormat, clusterName): "*"}
 }

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -124,7 +124,7 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 		TagSpecifications: []*ec2.TagSpecification{
 			{
 				ResourceType: aws.String(ec2.ResourceTypeInstance),
-				Tags:         v1alpha1.MergeTags(ctx, constraints.Tags),
+				Tags:         v1alpha1.MergeTags(ctx, constraints.Tags, map[string]string{fmt.Sprintf("kubernetes.io/cluster/%s", injection.GetOptions(ctx).ClusterName): "owned"}),
 			},
 		},
 	}

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -189,7 +189,7 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 		},
 		TagSpecifications: []*ec2.TagSpecification{{
 			ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
-			Tags:         v1alpha1.MergeTags(ctx, options.Tags),
+			Tags:         v1alpha1.MergeTags(ctx, options.Tags, map[string]string{fmt.Sprintf("kubernetes.io/cluster/%s", injection.GetOptions(ctx).ClusterName): "owned"}),
 		}},
 	})
 	if err != nil {

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -189,7 +189,7 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 		},
 		TagSpecifications: []*ec2.TagSpecification{{
 			ResourceType: aws.String(ec2.ResourceTypeLaunchTemplate),
-			Tags:         v1alpha1.MergeTags(ctx, options.Tags, map[string]string{fmt.Sprintf("kubernetes.io/cluster/%s", injection.GetOptions(ctx).ClusterName): "owned"}),
+			Tags:         v1alpha1.MergeTags(ctx, options.Tags),
 		}},
 	})
 	if err != nil {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -120,7 +120,9 @@ var _ = Describe("Allocation", func() {
 
 	BeforeEach(func() {
 		provider = &v1alpha1.AWS{
-			InstanceProfile: "test-instance-profile",
+			InstanceProfile:       "test-instance-profile",
+			SubnetSelector:        map[string]string{"foo": "bar"},
+			SecurityGroupSelector: map[string]string{"foo": "bar"},
 		}
 		provisioner = ProvisionerWithProvider(&v1alpha5.Provisioner{ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())}}, provider)
 		provisioner.SetDefaults(ctx)
@@ -512,18 +514,6 @@ var _ = Describe("Allocation", func() {
 		})
 	})
 	Context("Defaulting", func() {
-		It("should default subnetSelector", func() {
-			provisioner.SetDefaults(ctx)
-			constraints, err := v1alpha1.Deserialize(&provisioner.Spec.Constraints)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(constraints.SubnetSelector).To(Equal(map[string]string{"kubernetes.io/cluster/test-cluster": "*"}))
-		})
-		It("should default securityGroupSelector", func() {
-			provisioner.SetDefaults(ctx)
-			constraints, err := v1alpha1.Deserialize(&provisioner.Spec.Constraints)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(constraints.SecurityGroupSelector).To(Equal(map[string]string{"kubernetes.io/cluster/test-cluster": "*"}))
-		})
 		It("should default requirements", func() {
 			provisioner.SetDefaults(ctx)
 			Expect(provisioner.Spec.Requirements.CapacityTypes().UnsortedList()).To(ConsistOf(v1alpha1.CapacityTypeOnDemand))

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -193,9 +193,10 @@ shapes. Karpenter makes scheduling and provisioning decisions based on pod
 attributes such as labels and affinity. In other words, Karpenter eliminates
 the need to manage many different node groups.
 
-Create a default provisioner using the command below. This provisioner
-configures instances to connect to your cluster's endpoint and discovers
-resources like subnets and security groups using the cluster's name.
+Create a default provisioner using the command below.
+This provisioner uses `securityGroupSelector` and `subnetSelector` to discover resources used to launch nodes.
+We applied the tag `karpenter.sh/discovery` in the `eksctl` command above.
+Depending how these resources are shared between clusters, you may need to use different tagging schemes.
 
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1017

**2. Description of changes:**
Removed discovery via cluster name to avoid tag limitations for multi-cluster discovery. Instead, users must define their own discovery mechanisms for their use case. Moved cluster-based discovery to the getting started guide.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
