### PR TITLE
Fix 404 CRD issue

### DIFF
--- a/website/content/en/docs/getting-started-with-terraform/_index.md
+++ b/website/content/en/docs/getting-started-with-terraform/_index.md
@@ -286,7 +286,7 @@ resources like subnets and security groups using the cluster's name.
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provisioner CRD](/docs/provisioner-crd) for more information. For example,
+Review the [provisioner CRD](/website/content/en) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.


### PR DESCRIPTION
Change /docs/provisioner-crd  to /website/content/en

**1. Issue, if available:**

Fix 404 CRD issu

**2. Description of changes:**
[provisioner CRD](/docs/provisioner-crd

to

Review the [provisioner CRD](/website/content/en)

**3. How was this change tested?**
None

**4. Does this change impact docs?**
- [ X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
