### PR TITLE
Update TF guide for removal of default subnet/security group selector

### DIFF
--- a/website/content/en/preview/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started-with-terraform/_index.md
@@ -106,6 +106,10 @@ module "eks" {
       asg_max_size  = 1
     }
   ]
+
+  tags = {
+    "karpenter.sh/discovery" = var.cluster_name
+  }
 }
 ```
 
@@ -307,6 +311,10 @@ spec:
       cpu: 1000
   provider:
     instanceProfile: KarpenterNodeInstanceProfile-${CLUSTER_NAME}
+    subnetSelector:
+      karpenter.sh/discovery: ${CLUSTER_NAME}
+    securityGroupSelector:
+      karpenter.sh/discovery: ${CLUSTER_NAME}
   ttlSecondsAfterEmpty: 30
 EOF
 ```


### PR DESCRIPTION
**1. Issue, if available:**
#1017

**2. Description of changes:**
Updates the TF guide to...

1. Add tags to subnet and security groups
2. Use those tags in the Provisioner

**3. How was this change tested?**


**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
