### PR TITLE
Fixed broken links to provisioner docs

### DIFF
--- a/website/content/en/preview/concepts/_index.md
+++ b/website/content/en/preview/concepts/_index.md
@@ -42,7 +42,7 @@ Here are some things to know about the Karpenter provisioner:
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.
 A provisioner contains constraints that impact the nodes that can be provisioned and attributes of those nodes (such timers for removing nodes).
-See [Provisioner API](/docs/provisioner/) for a description of settings and the [Provisioning](../tasks/provisioning) task for provisioner examples.
+See [Provisioner API](../provisioner) for a description of settings and the [Provisioning](../tasks/provisioning) task for provisioner examples.
 
 * **Well-known labels**: The provisioner can use well-known Kubernetes labels to allow pods to request only certain instance types, architectures, operating systems, or other attributes when creating nodes.
 See [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) for details.

--- a/website/content/en/preview/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started-with-terraform/_index.md
@@ -286,7 +286,7 @@ resources like subnets and security groups using the cluster's name.
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provisioner CRD](/docs/provisioner-crd) for more information. For example,
+Review the [provisioner CRD](../provisioner) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -201,7 +201,7 @@ Depending how these resources are shared between clusters, you may need to use d
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provisioner CRD](/docs/provisioner/) for more information. For example,
+Review the [provisioner CRD](../provisioner) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.

--- a/website/content/en/v0.5.0/getting-started/_index.md
+++ b/website/content/en/v0.5.0/getting-started/_index.md
@@ -179,7 +179,7 @@ resources like subnets and security groups using the cluster's name.
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provisioner CRD](/docs/provisioner/) for more information. For example,
+Review the [provisioner CRD](../provisioner) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.

--- a/website/content/en/v0.5.2/concepts/_index.md
+++ b/website/content/en/v0.5.2/concepts/_index.md
@@ -42,7 +42,7 @@ Here are some things to know about the Karpenter provisioner:
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.
 A provisioner contains constraints that impact the nodes that can be provisioned and attributes of those nodes (such timers for removing nodes).
-See [Provisioner API](/docs/provisioner/) for a description of settings and the [Provisioning](../tasks/provisioning-task) task for provisioner examples. 
+See [Provisioner API](../provisioner/) for a description of settings and the [Provisioning](../tasks/provisioning-task) task for provisioner examples. 
 
 * **Well-known labels**: The provisioner can use well-known Kubernetes labels to allow pods to request only certain instance types, architectures, operating systems, or other attributes when creating nodes.
 See [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) for details.

--- a/website/content/en/v0.5.2/getting-started/_index.md
+++ b/website/content/en/v0.5.2/getting-started/_index.md
@@ -179,7 +179,7 @@ resources like subnets and security groups using the cluster's name.
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provisioner CRD](/docs/provisioner/) for more information. For example,
+Review the [provisioner CRD](../provisioner) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.

--- a/website/content/en/v0.5.3/concepts/_index.md
+++ b/website/content/en/v0.5.3/concepts/_index.md
@@ -42,7 +42,7 @@ Here are some things to know about the Karpenter provisioner:
 * **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
 Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.
 A provisioner contains constraints that impact the nodes that can be provisioned and attributes of those nodes (such timers for removing nodes).
-See [Provisioner API](/docs/provisioner/) for a description of settings and the [Provisioning](../tasks/provisioning-task) task for provisioner examples. 
+See [Provisioner API](../provisioner) for a description of settings and the [Provisioning](../tasks/provisioning-task) task for provisioner examples. 
 
 * **Well-known labels**: The provisioner can use well-known Kubernetes labels to allow pods to request only certain instance types, architectures, operating systems, or other attributes when creating nodes.
 See [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) for details.

--- a/website/content/en/v0.5.3/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.5.3/getting-started-with-terraform/_index.md
@@ -286,7 +286,7 @@ resources like subnets and security groups using the cluster's name.
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provisioner CRD](/docs/provisioner-crd) for more information. For example,
+Review the [provisioner CRD](../provisioner) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.

--- a/website/content/en/v0.5.3/getting-started/_index.md
+++ b/website/content/en/v0.5.3/getting-started/_index.md
@@ -213,7 +213,7 @@ resources like subnets and security groups using the cluster's name.
 The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
 This behavior can be disabled by leaving the value undefined.
 
-Review the [provisioner CRD](/docs/provisioner/) for more information. For example,
+Review the [provisioner CRD](../provisioner) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1159

**2. Description of changes:**
Issue 1159 noted some broken links. The directory structure changed since that was filed, so I made the corrections in this PR.

**3. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
