### PR TITLE
Parallelize packing and launching

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -39,8 +39,11 @@ type Constraints struct {
 	KubeletConfiguration KubeletConfiguration `json:"kubeletConfiguration,omitempty"`
 	// Provider contains fields specific to your cloudprovider.
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Provider *runtime.RawExtension `json:"provider,omitempty"`
+	Provider *Provider `json:"provider,omitempty"`
 }
+
+// +kubebuilder:object:generate=false
+type Provider = runtime.RawExtension
 
 // ValidatePod returns an error if the pod's requirements are not met by the constraints
 func (c *Constraints) ValidatePod(pod *v1.Pod) error {

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -129,8 +129,8 @@ func (c *CloudProvider) Create(ctx context.Context, constraints *v1alpha5.Constr
 }
 
 // GetInstanceTypes returns all available InstanceTypes despite accepting a Constraints struct (note that it does not utilize Requirements)
-func (c *CloudProvider) GetInstanceTypes(ctx context.Context, constraints *v1alpha5.Constraints) ([]cloudprovider.InstanceType, error) {
-	vendorConstraints, err := v1alpha1.Deserialize(constraints)
+func (c *CloudProvider) GetInstanceTypes(ctx context.Context, provider *v1alpha5.Provider) ([]cloudprovider.InstanceType, error) {
+	vendorConstraints, err := v1alpha1.Deserialize(&v1alpha5.Constraints{Provider: provider})
 	if err != nil {
 		return nil, apis.ErrGeneric(err.Error())
 	}

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -78,7 +78,7 @@ func (c *CloudProvider) Create(_ context.Context, constraints *v1alpha5.Constrai
 	return err
 }
 
-func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Constraints) ([]cloudprovider.InstanceType, error) {
+func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provider) ([]cloudprovider.InstanceType, error) {
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -76,9 +76,9 @@ func (d *decorator) Delete(ctx context.Context, node *v1.Node) error {
 	return d.CloudProvider.Delete(ctx, node)
 }
 
-func (d *decorator) GetInstanceTypes(ctx context.Context, constraints *v1alpha5.Constraints) ([]cloudprovider.InstanceType, error) {
+func (d *decorator) GetInstanceTypes(ctx context.Context, provider *v1alpha5.Provider) ([]cloudprovider.InstanceType, error) {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(getControllerName(ctx), "GetInstanceTypes", d.Name()))()
-	return d.CloudProvider.GetInstanceTypes(ctx, constraints)
+	return d.CloudProvider.GetInstanceTypes(ctx, provider)
 }
 
 func (d *decorator) Default(ctx context.Context, constraints *v1alpha5.Constraints) {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -36,7 +36,7 @@ type CloudProvider interface {
 	Delete(context.Context, *v1.Node) error
 	// GetInstanceTypes returns instance types supported by the cloudprovider.
 	// Availability of types or zone may vary by provisioner or over time.
-	GetInstanceTypes(context.Context, *v1alpha5.Constraints) ([]InstanceType, error)
+	GetInstanceTypes(context.Context, *v1alpha5.Provider) ([]InstanceType, error)
 	// Default is a hook for additional defaulting logic at webhook time.
 	Default(context.Context, *v1alpha5.Constraints)
 	// Validate is a hook for additional validation logic at webhook time.

--- a/pkg/controllers/provisioning/binpacking/packer.go
+++ b/pkg/controllers/provisioning/binpacking/packer.go
@@ -82,14 +82,8 @@ type Packing struct {
 // Pods provided are all schedulable in the same zone as tightly as possible.
 // It follows the First Fit Decreasing bin packing technique, reference-
 // https://en.wikipedia.org/wiki/Bin_packing_problem#First_Fit_Decreasing_(FFD)
-func (p *Packer) Pack(ctx context.Context, constraints *v1alpha5.Constraints, pods []*v1.Pod) ([]*Packing, error) {
+func (p *Packer) Pack(ctx context.Context, constraints *v1alpha5.Constraints, pods []*v1.Pod, instanceTypes []cloudprovider.InstanceType) ([]*Packing, error) {
 	defer metrics.Measure(packDuration.WithLabelValues(injection.GetNamespacedName(ctx).Name))()
-
-	// Get instance type options
-	instanceTypes, err := p.cloudProvider.GetInstanceTypes(ctx, constraints)
-	if err != nil {
-		return nil, fmt.Errorf("getting instance types, %w", err)
-	}
 	// Get daemons for overhead calculations
 	daemons, err := p.getDaemons(ctx, constraints)
 	if err != nil {

--- a/pkg/controllers/provisioning/binpacking/packer_test.go
+++ b/pkg/controllers/provisioning/binpacking/packer_test.go
@@ -67,7 +67,7 @@ func BenchmarkPacker(b *testing.B) {
 
 	// Pack benchmark
 	for i := 0; i < b.N; i++ {
-		if packings, err := packer.Pack(ctx, schedule.Constraints, pods); err != nil || len(packings) == 0 {
+		if packings, err := packer.Pack(ctx, schedule.Constraints, pods, instanceTypes); err != nil || len(packings) == 0 {
 			b.FailNow()
 		}
 	}

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -93,7 +93,7 @@ func (c *Controller) Delete(name string) {
 // Apply creates or updates the provisioner to the latest configuration
 func (c *Controller) Apply(ctx context.Context, provisioner *v1alpha5.Provisioner) error {
 	// Refresh global requirements using instance type availability
-	instanceTypes, err := c.cloudProvider.GetInstanceTypes(ctx, &provisioner.Spec.Constraints)
+	instanceTypes, err := c.cloudProvider.GetInstanceTypes(ctx, provisioner.Spec.Provider)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
```
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.689Z	INFO	controller.provisioning	Launched instance: i-0f7267f0ba3b1b7eb, hostname: ip-192-168-81-214.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-03d5e9a4e6926ae3e, hostname: ip-192-168-78-88.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-0cfc706bc5b6e328b, hostname: ip-192-168-71-161.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-07faf735d0c85d454, hostname: ip-192-168-79-3.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-048be06197461efda, hostname: ip-192-168-70-120.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-00067e9e9bbe2ec91, hostname: ip-192-168-80-222.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-0e784461e896c9679, hostname: ip-192-168-84-20.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-004baef2d2ae0f1e3, hostname: ip-192-168-78-214.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-0addf690c4a063af8, hostname: ip-192-168-95-115.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.690Z	INFO	controller.provisioning	Launched instance: i-06360d4583113f59b, hostname: ip-192-168-77-20.us-west-2.compute.internal, type: m5.large, zone: us-west-2a, capacityType: spot{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.703Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-81-214.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.727Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-78-88.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.741Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-71-161.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.754Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-79-3.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.766Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-70-120.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.784Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-80-222.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.799Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-84-20.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.819Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-78-214.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.836Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-95-115.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.845Z	INFO	controller.provisioning	Bound 1 pod(s) to node ip-192-168-77-20.us-west-2.compute.internal	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:13.845Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "6b76896", "provisioner": "default"}
karpenter-controller-5fd6d774d7-vvx85 manager 2022-01-25T23:43:35.586Z	DEBUG	controller.provisioning	Discovered subnets: [subnet-04ffb1a3c5e6c19a3 (us-west-2b) subnet-0082841075ccc05d4 (us-west-2d) subnet-0550f22b5de615eac (us-west-2b) subnet-0f3fa09b6ca9de74a (us-west-2a) subnet-05ad119d43b8c07b3 (us-west-2a) subnet-043ae197020acadfb (us-west-2d)]	{"commit": "6b76896", "provisioner": "default"}
```


**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
