### PR TITLE
doc: fix getting started with terraform

### DIFF
--- a/website/content/en/preview/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started-with-terraform/_index.md
@@ -86,6 +86,7 @@ module "vpc" {
 
   private_subnet_tags = {
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    "karpenter.sh/discovery" = var.cluster_name
   }
 }
 
@@ -134,6 +135,14 @@ terraform apply -var cluster_name=$CLUSTER_NAME
 
 Everything should apply successfully now!
 
+### Create the EC2 Spot Service Linked Role
+
+This step is only necessary if this is the first time you're using EC2 Spot in this account. More details are available [here](https://docs.aws.amazon.com/batch/latest/userguide/spot_fleet_IAM_role.html).
+```bash
+aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
+# If the role has already been successfully created, you will see:
+# An error occurred (InvalidInput) when calling the CreateServiceLinkedRole operation: Service role name AWSServiceRoleForEC2Spot has been taken in this account, please try a different suffix.
+```
 
 ### Configure the KarpenterNode IAM Role
 


### PR DESCRIPTION
Hi I tried [Terraform tutorial](https://karpenter.sh/v0.5.6/getting-started-with-terraform/) and found minor issues. This PR should fix them.

**1. Issue, if available:**

**2. Description of changes:**
1. Add tag `"karpenter.sh/discovery" = var.cluster_name` because otherwise karpenter cannot find the subnet specified in [provisioner](https://karpenter.sh/v0.5.6/getting-started-with-terraform/#provisioner). (btw I'm very new to karpenter so please teach me if this fix is as expected...)
2. Add a step to create service linked role for spot. It's copied from the [other tutorial](https://karpenter.sh/v0.5.6/getting-started/#create-the-ec2-spot-service-linked-role).

**3. How was this change tested?**
I confirmed tutorial now works with those changes.

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
