### PR TITLE
Update Provisioner Docs Example

### DIFF
--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -162,7 +162,7 @@ The provisioner spec includes a limits section (`spec.limits.resources`), which 
 
 Presently, Karpenter supports `memory` and `cpu` limits. 
 
-CPU limits are described with a `DecimalSI` value, usually a natural integer. Note that the Kubernetes API will return a string value here, so when using e.g. ArgoCD, it's better to specify the CPU limit as a string.
+CPU limits are described with a `DecimalSI` value. Note that the Kubernetes API will coerce this into a string, so we recommend against using integers to avoid GitOps skew.
 
 Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
 

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -52,7 +52,7 @@ spec:
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     resources:
-      cpu: 1000 
+      cpu: "1000"
       memory: 1000Gi
 
   # These fields vary per cloud provider, see your cloud provider specific documentation
@@ -162,7 +162,7 @@ The provisioner spec includes a limits section (`spec.limits.resources`), which 
 
 Presently, Karpenter supports `memory` and `cpu` limits. 
 
-CPU limits are described with a `DecimalSI` value, usually a natural integer. 
+CPU limits are described with a `DecimalSI` value, usually a natural integer. Note that the Kubernetes API will return a string value here, so when using e.g. ArgoCD, it's better to specify the CPU limit as a string.
 
 Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
 

--- a/website/content/en/v0.5.6/provisioner.md
+++ b/website/content/en/v0.5.6/provisioner.md
@@ -52,7 +52,7 @@ spec:
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     resources:
-      cpu: 1000 
+      cpu: "1000"
       memory: 1000Gi
 
   # These fields vary per cloud provider, see your cloud provider specific documentation

--- a/website/content/en/v0.5.6/provisioner.md
+++ b/website/content/en/v0.5.6/provisioner.md
@@ -52,7 +52,7 @@ spec:
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     resources:
-      cpu: "1000"
+      cpu: 1000 
       memory: 1000Gi
 
   # These fields vary per cloud provider, see your cloud provider specific documentation


### PR DESCRIPTION
The `spec.limits.resources.cpu` field should be a string, not an int.

**1. Issue, if available:**

An example in the docs is incorrect

**2. Description of changes:**

Updated example to be correct

**3. How was this change tested?**

N/A


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
