### PR TITLE
fix snapshot docs versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ helm: ## Generate Helm Chart
 
 website: ## Generate Docs Website
 	cp -r website/content/en/preview website/content/en/${RELEASE_VERSION}
+	find website/content/en/${RELEASE_VERSION}/ -type f | xargs  perl -i -p -e "s/{{< param \"latest_release_version\" >}}/${RELEASE_VERSION}/g;"
 
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh

--- a/website/content/en/v0.5.0/getting-started/_index.md
+++ b/website/content/en/v0.5.0/getting-started/_index.md
@@ -154,7 +154,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
+  --create-namespace --set serviceAccount.create=false --version v0.5.0 \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --wait # for the defaulting webhook to install before creating a Provisioner

--- a/website/content/en/v0.5.2/getting-started/_index.md
+++ b/website/content/en/v0.5.2/getting-started/_index.md
@@ -154,7 +154,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
+  --create-namespace --set serviceAccount.create=false --version v0.5.2 \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --wait # for the defaulting webhook to install before creating a Provisioner

--- a/website/content/en/v0.5.3/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.5.3/getting-started-with-terraform/_index.md
@@ -239,7 +239,7 @@ resource "helm_release" "karpenter" {
   name       = "karpenter"
   repository = "https://charts.karpenter.sh"
   chart      = "karpenter"
-  version    = "{{< param "latest_release_version" >}}"
+  version    = "v0.5.3"
 
   set {
     name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"

--- a/website/content/en/v0.5.3/getting-started/_index.md
+++ b/website/content/en/v0.5.3/getting-started/_index.md
@@ -154,7 +154,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
+  --create-namespace --set serviceAccount.create=false --version v0.5.3 \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --wait # for the defaulting webhook to install before creating a Provisioner

--- a/website/content/en/v0.5.5/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.5.5/getting-started-with-terraform/_index.md
@@ -243,7 +243,7 @@ resource "helm_release" "karpenter" {
   name       = "karpenter"
   repository = "https://charts.karpenter.sh"
   chart      = "karpenter"
-  version    = "{{< param "latest_release_version" >}}"
+  version    = "v0.5.5"
 
   set {
     name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"

--- a/website/content/en/v0.5.5/getting-started/_index.md
+++ b/website/content/en/v0.5.5/getting-started/_index.md
@@ -142,7 +142,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
+  --create-namespace --set serviceAccount.create=false --version v0.5.5 \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --wait # for the defaulting webhook to install before creating a Provisioner

--- a/website/content/en/v0.5.6/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.5.6/getting-started-with-terraform/_index.md
@@ -243,7 +243,7 @@ resource "helm_release" "karpenter" {
   name       = "karpenter"
   repository = "https://charts.karpenter.sh"
   chart      = "karpenter"
-  version    = "{{< param "latest_release_version" >}}"
+  version    = "v0.5.6"
 
   set {
     name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"

--- a/website/content/en/v0.5.6/getting-started/_index.md
+++ b/website/content/en/v0.5.6/getting-started/_index.md
@@ -142,7 +142,7 @@ eksctl. Thus, we don't need the helm chart to do that.
 helm repo add karpenter https://charts.karpenter.sh
 helm repo update
 helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
-  --create-namespace --set serviceAccount.create=false --version {{< param "latest_release_version" >}} \
+  --create-namespace --set serviceAccount.create=false --version v0.5.6 \
   --set controller.clusterName=${CLUSTER_NAME} \
   --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
   --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
- Snapshot docs versions pinned at a particular version were referencing the `latest_release` param. This change backfills the correct versions at each snapshot. [Here's an example of where the docs are wrong](https://karpenter.sh/v0.5.5/getting-started/#:~:text=serviceAccount.create%3Dfalse-,%2D%2Dversion%20v0.5.6%20%5C,-%2D%2Dset%20controller.clusterName) 
- I've also added a command to the `make website` target to replace the `latest_release` param with the version being released.  (used perl since that's more vendor neutral than sed, since mac's default sed is not gnu-sed)


**3. How was this change tested?**
`make website` resulted in the correct snapshot with a hardcoded version.

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
