### PR TITLE
Support for custom EC2 fleet allocation strategy

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/requirements.go
+++ b/pkg/apis/provisioning/v1alpha5/requirements.go
@@ -48,7 +48,8 @@ var (
 		"k8s.io",
 		KarpenterLabelDomain,
 	)
-	LabelCapacityType = KarpenterLabelDomain + "/capacity-type"
+	LabelCapacityType       = KarpenterLabelDomain + "/capacity-type"
+	LabelAllocationStrategy = KarpenterLabelDomain + "/allocation-strategy"
 	// WellKnownLabels supported by karpenter
 	WellKnownLabels = sets.NewString(
 		v1.LabelTopologyZone,
@@ -56,6 +57,7 @@ var (
 		v1.LabelArchStable,
 		v1.LabelOSStable,
 		LabelCapacityType,
+		LabelAllocationStrategy,
 		v1.LabelHostname, // Used internally for hostname topology spread
 	)
 	// NormalizedLabels translate aliased concepts into the controller's
@@ -91,6 +93,14 @@ func (r Requirements) OperatingSystems() sets.String {
 
 func (r Requirements) CapacityTypes() sets.String {
 	return r.Requirement(LabelCapacityType)
+}
+
+func (r Requirements) AllocationStrategy() string {
+	if strategies := r.Requirement(LabelAllocationStrategy); strategies == nil {
+		return ""
+	} else {
+		return strategies.List()[0]
+	}
 }
 
 func (r Requirements) Add(requirements ...v1.NodeSelectorRequirement) Requirements {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -365,6 +365,12 @@ var _ = Describe("Allocation", func() {
 				node := ExpectScheduled(ctx, env.Client, pod)
 				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelCapacityType, v1alpha1.CapacityTypeSpot))
 			})
+			It("should launch spot capacity with allocation strategy", func() {
+				provisioner.Spec.Requirements = v1alpha5.Requirements{{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot}}, {Key: v1alpha5.LabelAllocationStrategy, Operator: v1.NodeSelectorOpIn, Values: []string{"lowest-price"}}}
+				pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod())[0]
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelAllocationStrategy, "lowest-price"))
+			})
 		})
 		Context("LaunchTemplates", func() {
 			It("should use same launch template for equivalent constraints", func() {

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -47,6 +47,9 @@ spec:
     - key: "karpenter.sh/capacity-type" # If not included, the webhook for the AWS cloud provider will default to on-demand
       operator: In
       values: ["spot", "on-demand"]
+    - key: "karpenter.sh/allocation-strategy" # If not included, the webhook for the AWS cloud provider will default to on-demand
+      operator: In
+      values: ["lowest-price"]
 
   # Resource limits constrain the total size of the cluster.
   # Limits prevent Karpenter from creating new instances once the limit is exceeded.
@@ -143,6 +146,18 @@ Karpenter supports `amd64` nodes, and `arm64` nodes.
   - `on-demand`
 
 Karpenter supports specifying capacity type, which is analogous to [EC2 purchase options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html).
+
+### Allocation Strategy
+
+- key: `karpenter.sh/allocation-strategy`
+
+☁️ **AWS**
+
+- values
+  - `capacity-optimized` (default for spot)
+  - `lowest-price` (default for ondemand)
+
+Karpenter supports specifying allocation strategy. See also [Allocation strategies for Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html).
 
 
 ## spec.kubeletConfiguration


### PR DESCRIPTION
**1. Issue, if available:**
Currently Karpenter cannot specify EC2 fleet allocation strategy.
It automatically decides like:

* capacity-optimized - spot
* lowest-price - on-demand

**2. Description of changes:**
Introduces allocation strategy option as well as capacity type in Provisioner API

**3. How was this change tested?**
Created a controller container from the branch, and made sure EC2 fleet request with specified allocation strategy on CloudTrail

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
