### PR TITLE
k8s backtesting within gha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,11 @@ on: [pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          k8sVersion: ["1.19.x", "1.20.x", "1.21.x"]
+    env:
+      K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -14,11 +19,10 @@ jobs:
           ~/.cache/go-build
           ~/go/pkg/mod
           ~/go/bin/
+          ~/.kubebuilder/bin/k8s
         key: gocache
     - name: CI - Verifications and Tests
       run: |
-        make toolchain
-        echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
         make ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+export K8S_VERSION ?= 1.21.x
+export KUBEBUILDER_ASSETS ?= ${HOME}/.kubebuilder/bin
+
 ## Inject the app version into project.Version
 LDFLAGS ?= "-ldflags=-X=github.com/aws/karpenter/pkg/utils/project.Version=$(shell git describe --tags --always)"
 GOFLAGS ?= "-tags=$(CLOUD_PROVIDER) $(LDFLAGS)"
@@ -15,7 +18,7 @@ help: ## Display help
 
 dev: verify test ## Run all steps in the developer loop
 
-ci: verify licenses battletest ## Run all steps used by continuous integration
+ci: toolchain verify licenses battletest ## Run all steps used by continuous integration
 
 test: ## Run tests
 	ginkgo -r

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -eu -o pipefail
+K8S_VERSION="${K8S_VERSION:="1.21.x"}"
+KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:="${HOME}/.kubebuilder/bin"}"
 
 main() {
     tools
@@ -26,15 +28,13 @@ tools() {
 }
 
 kubebuilder() {
-    KUBEBUILDER_ASSETS="/usr/local/kubebuilder"
-    sudo rm -rf $KUBEBUILDER_ASSETS
-    sudo mkdir -p $KUBEBUILDER_ASSETS
+    mkdir -p $KUBEBUILDER_ASSETS
     arch=$(go env GOARCH)
     ## Kubebuilder does not support darwin/arm64, so use amd64 through Rosetta instead
     if [[ $(go env GOOS) == "darwin" ]] && [[ $(go env GOARCH) == "arm64" ]]; then
         arch="amd64"
     fi
-    sudo mv "$(setup-envtest use -p path 1.21.x --arch=${arch})" $KUBEBUILDER_ASSETS/bin
+    ln -sf $(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")/* ${KUBEBUILDER_ASSETS}
     find $KUBEBUILDER_ASSETS
 }
 


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - added matrix testing for k8s versions 1.19 - 1.21 (for some reason 1.22 doesn't work and 1.18 is missing... so we can investigate those later). There's no added latency since these all kick off in parallel. 
 - I removed the dependency of sudo in `make toolchain` since it's unnecessary to install the toolchain.


**3. How was this change tested?**
 - https://github.com/bwagner5/karpenter/actions/runs/1767207765

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
