### PR TITLE
Patch logging

### DIFF
--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -65,9 +65,9 @@ func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 
 	// 2. Separate pods as non-critical and critical
 	// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
-	for _, pod := range pods {
-		if val := pod.Annotations[v1alpha5.DoNotEvictPodAnnotationKey]; val == "true" {
-			logging.FromContext(ctx).Debugf("Unable to drain node, pod %s has do-not-evict annotation", pod.Name)
+	for _, p := range pods {
+		if val := p.Annotations[v1alpha5.DoNotEvictPodAnnotationKey]; val == "true" {
+			logging.FromContext(ctx).Debugf("Unable to drain node, pod %s has do-not-evict annotation", p.Name)
 			return false, nil
 		}
 	}
@@ -134,14 +134,14 @@ func (t *Terminator) evict(pods []*v1.Pod) {
 	// 1. Prioritize noncritical pods https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 	critical := []*v1.Pod{}
 	nonCritical := []*v1.Pod{}
-	for _, pod := range pods {
-		if !pod.DeletionTimestamp.IsZero() {
+	for _, p := range pods {
+		if !p.DeletionTimestamp.IsZero() {
 			continue
 		}
-		if pod.Spec.PriorityClassName == "system-cluster-critical" || pod.Spec.PriorityClassName == "system-node-critical" {
-			critical = append(critical, pod)
+		if p.Spec.PriorityClassName == "system-cluster-critical" || p.Spec.PriorityClassName == "system-node-critical" {
+			critical = append(critical, p)
 		} else {
-			nonCritical = append(nonCritical, pod)
+			nonCritical = append(nonCritical, p)
 		}
 	}
 	// 2. Evict critical pods if all noncritical are evicted

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -73,7 +73,7 @@ func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 	}
 
 	// 4. Get and evict pods
-	evictable := t.getEvictablePods(pods)
+	evictable := t.getEvictablePods(ctx, pods)
 	if len(evictable) == 0 {
 		return true, nil
 	}
@@ -109,7 +109,7 @@ func (t *Terminator) getPods(ctx context.Context, node *v1.Node) ([]*v1.Pod, err
 	return ptr.PodListToSlice(pods), nil
 }
 
-func (t *Terminator) getEvictablePods(pods []*v1.Pod) []*v1.Pod {
+func (t *Terminator) getEvictablePods(ctx context.Context, pods []*v1.Pod) []*v1.Pod {
 	evictable := []*v1.Pod{}
 	for _, p := range pods {
 		// Ignore if unschedulable is tolerated, since they will reschedule
@@ -124,6 +124,7 @@ func (t *Terminator) getEvictablePods(pods []*v1.Pod) []*v1.Pod {
 		if pod.IsOwnedByNode(p) {
 			continue
 		}
+		logging.FromContext(ctx).Debugf("pod %s marked as evictable", p.Name)
 		evictable = append(evictable, p)
 	}
 	return evictable


### PR DESCRIPTION
**1. Issue, if available:**
Related to https://github.com/aws/karpenter/issues/1166 (won't solve it but will give a hand with future debugging)

**2. Description of changes:**
Atm,  there is a "black hole" in eviction routine. As long as karpenter thinks there are evictable pods, it will return on 
```
	if !drained {
		return reconcile.Result{Requeue: true}, nil
	}
```
without any log, thus leaving human operator in the dark as to why nothing is happening. 

This change adds a debug logging line covering this scenario (in case of a loop, at least operator will see whats exactly is stopping draining and termination process and will be able to investigate/intervene) 

Also: fixed variable name colliding with pod name. 

**3. How was this change tested?**
on local cluster


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

