### PR TITLE
Fix emptiness reconciler when ttl not expired

### DIFF
--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -78,7 +78,7 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisi
 			return reconcile.Result{}, fmt.Errorf("deleting node, %w", err)
 		}
 	}
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: emptinessTime.Add(ttl).Sub(injectabletime.Now())}, nil
 }
 
 func (r *Emptiness) isEmpty(ctx context.Context, n *v1.Node) (bool, error) {

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -34,6 +34,7 @@ import (
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var ctx context.Context
@@ -284,6 +285,27 @@ var _ = Describe("Controller", func() {
 
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			Expect(node.DeletionTimestamp.IsZero()).To(BeFalse())
+		})
+		It("should requeue reconcile if node is empty, but not past emptiness TTL", func() {
+			provisioner.Spec.TTLSecondsAfterEmpty = ptr.Int64(30)
+			currentTime := time.Now()
+			injectabletime.Now = func() time.Time { return currentTime } // injectabletime.Now() is called multiple times in function being tested.
+			emptinessTime := injectabletime.Now().Add(-10 * time.Second)
+			// Emptiness timestamps are first formatted to a string friendly (time.RFC3339) (to put it in the node object)
+			// and then eventually parsed back into time.Time when comparing ttls. Repeating that logic in the test.
+			emptinessTimestamp, _ := time.Parse(time.RFC3339, emptinessTime.Format(time.RFC3339))
+			expectedrequeueTime := emptinessTimestamp.Add(time.Duration(30 * time.Second)).Sub(injectabletime.Now()) // we should requeue in ~20 seconds.
+			node := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{
+				Finalizers: []string{v1alpha5.TerminationFinalizer},
+				Labels:     map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner.Name},
+				Annotations: map[string]string{
+					v1alpha5.EmptinessTimestampAnnotationKey: emptinessTime.Format(time.RFC3339),
+				}},
+			})
+			ExpectCreated(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceededWithResult(ctx, controller, client.ObjectKeyFromObject(node), reconcile.Result{Requeue: true, RequeueAfter: expectedrequeueTime})
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.DeletionTimestamp.IsZero()).To(BeTrue())
 		})
 	})
 	Context("Finalizer", func() {

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -303,7 +303,8 @@ var _ = Describe("Controller", func() {
 				}},
 			})
 			ExpectCreated(ctx, env.Client, provisioner, node)
-			ExpectReconcileSucceededWithResult(ctx, controller, client.ObjectKeyFromObject(node), reconcile.Result{Requeue: true, RequeueAfter: expectedrequeueTime})
+			reconcileResult := ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+			Expect(reconcileResult).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedrequeueTime}))
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			Expect(node.DeletionTimestamp.IsZero()).To(BeTrue())
 		})

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -190,3 +190,9 @@ func ExpectReconcileSucceeded(ctx context.Context, reconciler reconcile.Reconcil
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 	Expect(err).ToNot(HaveOccurred())
 }
+
+func ExpectReconcileSucceededWithResult(ctx context.Context, reconciler reconcile.Reconciler, key client.ObjectKey, result reconcile.Result) {
+	actualResult, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+	Expect(actualResult).To(Equal(result))
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -186,13 +186,8 @@ func ExpectProvisioned(ctx context.Context, c client.Client, selectionController
 	return result
 }
 
-func ExpectReconcileSucceeded(ctx context.Context, reconciler reconcile.Reconciler, key client.ObjectKey) {
-	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+func ExpectReconcileSucceeded(ctx context.Context, reconciler reconcile.Reconciler, key client.ObjectKey) reconcile.Result {
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 	Expect(err).ToNot(HaveOccurred())
-}
-
-func ExpectReconcileSucceededWithResult(ctx context.Context, reconciler reconcile.Reconciler, key client.ObjectKey, result reconcile.Result) {
-	actualResult, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
-	Expect(actualResult).To(Equal(result))
-	Expect(err).ToNot(HaveOccurred())
+	return result
 }


### PR DESCRIPTION
**1. Issue, if available:**
#993 

**2. Description of changes:**
* If ttl has not expired, requeueAfter at the right time. 

**3. How was this change tested?**
* Added a unit test. 
* Tested this manually as well. 

Before it would take a long time to clear up (4 minutes)- 
```
2022-02-02T00:47:51.832Z	INFO	controller.node	Added TTL to empty node	{"commit": "4829931", "node": "ip-192-168-191-121.us-west-2.compute.internal"}
2022-02-02T00:47:54.791Z	INFO	controller.node	Removed emptiness TTL from node	{"commit": "4829931", "node": "ip-192-168-191-121.us-west-2.compute.internal"}
2022-02-02T00:48:11.846Z	INFO	controller.node	Added TTL to empty node	{"commit": "4829931", "node": "ip-192-168-191-121.us-west-2.compute.internal"}
2022-02-02T00:52:13.964Z	INFO	controller.node	Triggering termination after 30s for empty node	{"commit": "4829931", "node": "ip-192-168-191-121.us-west-2.compute.internal"}
2022-02-02T00:52:13.996Z	INFO	controller.termination	Cordoned node	{"commit": "4829931", "node": "ip-192-168-191-121.us-west-2.compute.internal"}
2022-02-02T00:52:14.219Z	INFO	controller.termination	Deleted node	{"commit": "4829931", "node": "ip-192-168-191-121.us-west-2.compute.internal"}
```

Now it's as expected on a quick cycle of empty -> full -> empty and it drains as expected. 
```
2022-02-02T16:51:16.166Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "69bb318", "provisioner": "default"}
2022-02-02T16:52:52.765Z	INFO	controller.node	Added TTL to empty node	{"commit": "69bb318", "node": "ip-192-168-179-90.us-west-2.compute.internal"}
2022-02-02T16:52:56.132Z	INFO	controller.node	Removed emptiness TTL from node	{"commit": "69bb318", "node": "ip-192-168-179-90.us-west-2.compute.internal"}
2022-02-02T16:53:09.093Z	INFO	controller.node	Added TTL to empty node	{"commit": "69bb318", "node": "ip-192-168-179-90.us-west-2.compute.internal"}
2022-02-02T16:53:39.001Z	INFO	controller.node	Triggering termination after 30s for empty node	{"commit": "69bb318", "node": "ip-192-168-179-90.us-west-2.compute.internal"}
2022-02-02T16:53:39.040Z	INFO	controller.termination	Cordoned node	{"commit": "69bb318", "node": "ip-192-168-179-90.us-west-2.compute.internal"}
2022-02-02T16:53:39.272Z	INFO	controller.termination	Deleted node	{"commit": "69bb318", "node": "ip-192-168-179-90.us-west-2.compute.internal"}
```

I even tried out a basic emptiness check to verify no regressions - 
```
2022-02-02T16:50:11.094Z	INFO	controller.node	Added TTL to empty node	{"commit": "69bb318", "node": "ip-192-168-171-248.us-west-2.compute.internal"}
2022-02-02T16:50:41.001Z	INFO	controller.node	Triggering termination after 30s for empty node	{"commit": "69bb318", "node": "ip-192-168-171-248.us-west-2.compute.internal"}
2022-02-02T16:50:41.033Z	INFO	controller.termination	Cordoned node	{"commit": "69bb318", "node": "ip-192-168-171-248.us-west-2.compute.internal"}
2022-02-02T16:50:41.254Z	INFO	controller.termination	Deleted node	{"commit": "69bb318", "node": "ip-192-168-171-248.us-west-2.compute.internal"}
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
