### PR TITLE
Added failure-domain.beta.kubernetes.io/region to NormalizedLabels

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/requirements.go
+++ b/pkg/apis/provisioning/v1alpha5/requirements.go
@@ -63,10 +63,11 @@ var (
 	// however, Provisioner labels are still restricted to WellKnownLabels.
 	// Additional labels may be injected by cloud providers.
 	NormalizedLabels = map[string]string{
-		v1.LabelFailureDomainBetaZone: v1.LabelTopologyZone,
-		"beta.kubernetes.io/arch":     v1.LabelArchStable,
-		"beta.kubernetes.io/os":       v1.LabelOSStable,
-		v1.LabelInstanceType:          v1.LabelInstanceTypeStable,
+		v1.LabelFailureDomainBetaZone:   v1.LabelTopologyZone,
+		"beta.kubernetes.io/arch":       v1.LabelArchStable,
+		"beta.kubernetes.io/os":         v1.LabelOSStable,
+		v1.LabelInstanceType:            v1.LabelInstanceTypeStable,
+		v1.LabelFailureDomainBetaRegion: v1.LabelTopologyRegion,
 	}
 	// IgnoredLables are not considered in scheduling decisions
 	// and prevent validation errors when specified


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1109

**2. Description of changes:**
Add missing region normalization.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
