### PR TITLE
Choose the latest version of the EC2 launchTemplate by default

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -164,7 +164,7 @@ func (p *InstanceProvider) getLaunchTemplateConfigs(ctx context.Context, constra
 			Overrides: p.getOverrides(instanceTypes, subnets, constraints.Requirements.Zones(), capacityType),
 			LaunchTemplateSpecification: &ec2.FleetLaunchTemplateSpecificationRequest{
 				LaunchTemplateName: aws.String(launchTemplateName),
-				Version:            aws.String("$Default"),
+				Version:            aws.String("$Latest"),
 			},
 		}
 		if len(launchTemplateConfig.Overrides) > 0 {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -419,7 +419,7 @@ var _ = Describe("Allocation", func() {
 				launchTemplate := createFleetInput.LaunchTemplateConfigs[0].LaunchTemplateSpecification
 				Expect(*launchTemplate.LaunchTemplateName).To(Equal(*createLaunchTemplateInput.LaunchTemplateName))
 				Expect(createLaunchTemplateInput.LaunchTemplateData.BlockDeviceMappings[0].Ebs.Encrypted).To(Equal(aws.Bool(true)))
-				Expect(*launchTemplate.Version).To(Equal("$Default"))
+				Expect(*launchTemplate.Version).To(Equal("$Latest"))
 			})
 			It("should allow a launch template to be specified", func() {
 				provider.LaunchTemplate = aws.String("test-launch-template")
@@ -430,7 +430,7 @@ var _ = Describe("Allocation", func() {
 				Expect(input.LaunchTemplateConfigs).To(HaveLen(1))
 				launchTemplate := input.LaunchTemplateConfigs[0].LaunchTemplateSpecification
 				Expect(*launchTemplate.LaunchTemplateName).To(Equal("test-launch-template"))
-				Expect(*launchTemplate.Version).To(Equal("$Default"))
+				Expect(*launchTemplate.Version).To(Equal("$Latest"))
 			})
 		})
 		Context("Subnets", func() {


### PR DESCRIPTION
**1. Issue, if available:**
Partially addresses https://github.com/aws/karpenter/issues/1089

**2. Description of changes:**
Changing the version we default to in-memory to be `$Latest` and not `$Default`

**3. How was this change tested?**
None. Just verified the API supports `$Latest` [in API docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_FleetLaunchTemplateSpecificationRequest.html)

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

Whoops, adding it now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
