### PR TITLE
Check DoNotEvict after filtering evictable pods to ensure termination can complete.

### DIFF
--- a/pkg/controllers/termination/eviction.go
+++ b/pkg/controllers/termination/eviction.go
@@ -54,7 +54,7 @@ func NewEvictionQueue(ctx context.Context, coreV1Client corev1.CoreV1Interface) 
 }
 
 // Add adds pods to the EvictionQueue
-func (e *EvictionQueue) Add(ctx context.Context, pods []*v1.Pod) {
+func (e *EvictionQueue) Add(pods []*v1.Pod) {
 	for _, pod := range pods {
 		if nn := client.ObjectKeyFromObject(pod); !e.Set.Contains(nn) {
 			e.Set.Add(nn)

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -56,6 +56,7 @@ func (t *Terminator) cordon(ctx context.Context, node *v1.Node) error {
 }
 
 // drain evicts pods from the node and returns true when all pods are evicted
+// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 	// Get evictable pods
 	pods, err := t.getPods(ctx, node)

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -64,7 +64,6 @@ func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 	}
 	// Skip node due to do-not-evict
 	for _, pod := range pods {
-		// https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 		if val := pod.Annotations[v1alpha5.DoNotEvictPodAnnotationKey]; val == "true" {
 			logging.FromContext(ctx).Debugf("Unable to drain node, pod %s/%s has do-not-evict annotation", pod.Namespace, pod.Name)
 			return false, nil
@@ -94,7 +93,7 @@ func (t *Terminator) terminate(ctx context.Context, node *v1.Node) error {
 	return nil
 }
 
-// getPods returns a list of pods scheduled to a node based on some filters
+// getPods returns a list of evictable pods for the node
 func (t *Terminator) getPods(ctx context.Context, node *v1.Node) ([]*v1.Pod, error) {
 	podList := &v1.PodList{}
 	if err := t.KubeClient.List(ctx, podList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -70,7 +70,7 @@ func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 		}
 	}
 	// Enqueue for eviction
-	t.evict(ctx, pods)
+	t.evict(pods)
 	return len(pods) == 0, nil
 }
 
@@ -118,7 +118,7 @@ func (t *Terminator) getPods(ctx context.Context, node *v1.Node) ([]*v1.Pod, err
 	return pods, nil
 }
 
-func (t *Terminator) evict(ctx context.Context, pods []*v1.Pod) {
+func (t *Terminator) evict(pods []*v1.Pod) {
 	// 1. Prioritize noncritical pods https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 	critical := []*v1.Pod{}
 	nonCritical := []*v1.Pod{}
@@ -134,9 +134,9 @@ func (t *Terminator) evict(ctx context.Context, pods []*v1.Pod) {
 	}
 	// 2. Evict critical pods if all noncritical are evicted
 	if len(nonCritical) == 0 {
-		t.EvictionQueue.Add(ctx, critical)
+		t.EvictionQueue.Add(critical)
 	} else {
-		t.EvictionQueue.Add(ctx, nonCritical)
+		t.EvictionQueue.Add(nonCritical)
 	}
 }
 

--- a/website/content/en/preview/tasks/deprovisioning.md
+++ b/website/content/en/preview/tasks/deprovisioning.md
@@ -24,16 +24,16 @@ There are both automated and manual ways of deprovisioning nodes provisioned by 
     Keep in mind that a small NodeExpiry results in a higher churn in cluster activity. So, for example, if a cluster
     brings up all nodes at once, all the pods on those nodes would fall into the same batching window on expiration.
     {{% /alert %}}
-    
+
 * **Node deleted**: You could use `kubectl` to manually remove a single Karpenter node:
 
     ```bash
     # Delete a specific node
     kubectl delete node $NODE_NAME
-    
+
     # Delete all nodes owned any provisioner
     kubectl delete nodes -l karpenter.sh/provisioner-name
-    
+
     # Delete all nodes owned by a specific provisioner
     kubectl delete nodes -l karpenter.sh/provisioner-name=$PROVISIONER_NAME
     ```
@@ -44,7 +44,7 @@ If the Karpenter controller is removed or fails, the finalizers on the nodes are
 
 {{% alert title="Note" color="primary" %}}
 By adding the finalizer, Karpenter improves the default Kubernetes process of node deletion.
-When you run `kubectl delete node` on a node without a finalizer, the node is deleted without triggering the finalization logic. The instance will continue running in EC2, even though there is no longer a node object for it. 
+When you run `kubectl delete node` on a node without a finalizer, the node is deleted without triggering the finalization logic. The instance will continue running in EC2, even though there is no longer a node object for it.
 The kubelet isn’t watching for its own existence, so if a node is deleted the kubelet doesn’t terminate itself.
 All the pod objects get deleted by a garbage collection process later, because the pods’ node is gone.
 {{% /alert %}}
@@ -56,7 +56,7 @@ There are a few cases where requesting to deprovision a Karpenter node will fail
 ### Disruption budgets
 
 Karpenter respects Pod Disruption Budgets (PDBs) by using a backoff retry eviction strategy. Pods will never be forcibly deleted, so pods that fail to shut down will prevent a node from deprovisioning.
-Kubernetes PDBs let you specify how much of a Deployment, ReplicationController, ReplicaSet, or StatefulSet must be protected from disruptions when pod eviction requests are made. 
+Kubernetes PDBs let you specify how much of a Deployment, ReplicationController, ReplicaSet, or StatefulSet must be protected from disruptions when pod eviction requests are made.
 
 PDBs can be used to strike a balance by protecting the application's availability while still allowing a cluster administrator to manage the cluster.
 Here is an example where the pods matching the label `myapp` will block node termination if evicting the pod would reduce the number of available pods below 4.
@@ -78,11 +78,9 @@ Review what [disruptions are](https://kubernetes.io/docs/concepts/workloads/pods
 
 ### Pod set to do-not-evict
 
-If a pod exists with the annotation `karpenter.sh/do-not-evict` on a node, and a request is made to delete the node, Karpenter will not drain any pods from that node or otherwise try to delete the node.
-However, if a `do-not-evict` pod is added to a node while the node is draining, the remaining pods will still evict, but that pod will block termination until it is removed.
-In either case, the node will be cordoned to prevent additional work from scheduling.
+If a pod exists with the annotation `karpenter.sh/do-not-evict` on a node, and a request is made to delete the node, Karpenter will not drain any pods from that node or otherwise try to delete the node. This annotation does not apply to static pods, pods that tolerate `NoSchedule`, or pods terminating past their graceful termination period.
 
-That annotation is used for pods that you want to run on one node from start to finish without interruption.
+This is useful for pods that you want to run from start to finish without interruption.
 Examples might include a real-time, interactive game that you don't want to interrupt or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
 
-If you want to terminate a `do-not-evict` pod, you can simply remove the annotation and the finalizer will delete the pod and continue the node deprovisioning process.
+If you want to terminate node with a `do-not-evict` pod, you can simply remove the annotation and the deprovisioning process will continue.

--- a/website/content/en/preview/tasks/deprovisioning.md
+++ b/website/content/en/preview/tasks/deprovisioning.md
@@ -83,4 +83,4 @@ If a pod exists with the annotation `karpenter.sh/do-not-evict` on a node, and a
 This is useful for pods that you want to run from start to finish without interruption.
 Examples might include a real-time, interactive game that you don't want to interrupt or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
 
-If you want to terminate node with a `do-not-evict` pod, you can simply remove the annotation and the deprovisioning process will continue.
+If you want to terminate a node with a `do-not-evict` pod, you can simply remove the annotation and the deprovisioning process will continue.

--- a/website/content/en/preview/tasks/deprovisioning.md
+++ b/website/content/en/preview/tasks/deprovisioning.md
@@ -78,7 +78,7 @@ Review what [disruptions are](https://kubernetes.io/docs/concepts/workloads/pods
 
 ### Pod set to do-not-evict
 
-If a pod exists with the annotation `karpenter.sh/do-not-evict` on a node, and a request is made to delete the node, Karpenter will not drain any pods from that node or otherwise try to delete the node. This annotation does not apply to static pods, pods that tolerate `NoSchedule`, or pods terminating past their graceful termination period.
+If a pod exists with the annotation `karpenter.sh/do-not-evict` on a node, and a request is made to delete the node, Karpenter will not drain any pods from that node or otherwise try to delete the node. This annotation will have no effect for static pods, pods that tolerate `NoSchedule`, or pods terminating past their graceful termination period.
 
 This is useful for pods that you want to run from start to finish without interruption.
 Examples might include a real-time, interactive game that you don't want to interrupt or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1166

**2. Description of changes:**
Previously, the`do-not-evict` annotation could block termination logic, even if the node was unreachable. This change modifies the `do-not-evict` logic to only apply to evictable pods. Currently, evictable pods exclude

- Pods owned by the node (a.k.a. static pods)
- Pods with deletion time stamp set past their graceful termination period (a.k.a. stuck termination)
- Pods that tolerate the nodes taints (i.e. would reschedule immediately) 

This means that the `do-not-evict` annotation will no longer work for pods in the above categories. Given that we already did not attempt to evict these pods, the semantic holds. However, previously, pods in these categories with the `do-not-evict` annotation could block node termination.  

**3. How was this change tested?**

Reproduced 
1. Added do not evict annotation to pod
2. Manually terminated a node in EC2
3. Observe Node and Pod stuck Terminating

Fixed
1. Start with step 3 of above scenario
2. Apply PR changes to local environment
3. Node is gracefully terminated

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
