### PR TITLE
Correct broken links to rbac.yaml

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -29,7 +29,7 @@ Specify the desired architecture when you deploy workloads.
 
 ### What RBAC access is required?
 All of the required RBAC rules can be found in the helm chart template.
-See the [rbac.yaml](https://github.com/aws/karpenter/blob/main/charts/karpenter/templates/controller/rbac.yaml) file for details.
+See [clusterrolebinding.yaml](https://github.com/aws/karpenter/blob/main/charts/karpenter/templates/clusterrolebinding.yaml), [clusterrole.yaml](https://github.com/aws/karpenter/blob/main/charts/karpenter/templates/clusterrole.yaml), [rolebinding.yaml](https://github.com/aws/karpenter/blob/main/charts/karpenter/templates/rolebinding.yaml), and [role.yaml](https://github.com/aws/karpenter/blob/main/charts/karpenter/templates/role.yaml) files for details.
 
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.


### PR DESCRIPTION
**1. Issue, if available:**

**2. Description of changes:**
Replaces the link to non-existent rbac.yaml into the four files it is broken down to after https://github.com/aws/karpenter/pull/1145

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
