### PR TITLE
Fix overhead calculation to correctly apply kube-reserved cpu

### DIFF
--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"fmt"
+
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -155,7 +156,9 @@ func (i *InstanceType) Overhead() v1.ResourceList {
 			if cpu < cpuRange.end {
 				r = float64(cpu - cpuRange.start)
 			}
-			overhead.Cpu().Add(*resource.NewMilliQuantity(int64(r*cpuRange.percentage), resource.DecimalSI))
+			cpuOverhead := overhead[v1.ResourceCPU]
+			cpuOverhead.Add(*resource.NewMilliQuantity(int64(r*cpuRange.percentage), resource.DecimalSI))
+			overhead[v1.ResourceCPU] = cpuOverhead
 		}
 	}
 	return overhead


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - The kube-reserved overhead calculation was not being applied correctly on the incremental core percentages.


**3. How was this change tested?**
 - Printed the overhead calc when investigating the #1306 (this change does not fix that issue) and found that the overhead didn't include the incremental core calc. It only used the initial 100m cpu overhead. 
 - After this change, I printed the overhead for r5.12xl and it correctly showed `cpu 290m` of overhead


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
