### PR TITLE
support ubuntu amiFamily

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
@@ -48,7 +48,7 @@ type AWS struct {
 	AMIFamily *string `json:"amiFamily,omitempty"`
 	// InstanceProfile is the AWS identity that instances use.
 	// +optional
-	InstanceProfile *string `json:"instanceProfile"`
+	InstanceProfile *string `json:"instanceProfile,omitempty"`
 	// LaunchTemplate for the node. If not specified, a launch template will be generated.
 	// +optional
 	LaunchTemplate *string `json:"launchTemplate,omitempty"`

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
@@ -47,8 +47,8 @@ type AWS struct {
 	// +optional
 	AMIFamily *string `json:"amiFamily,omitempty"`
 	// InstanceProfile is the AWS identity that instances use.
-	// +required
-	InstanceProfile string `json:"instanceProfile"`
+	// +optional
+	InstanceProfile *string `json:"instanceProfile"`
 	// LaunchTemplate for the node. If not specified, a launch template will be generated.
 	// +optional
 	LaunchTemplate *string `json:"launchTemplate,omitempty"`

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_defaults.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_defaults.go
@@ -60,5 +60,5 @@ func (c *Constraints) defaultAMIFamily() {
 	if c.AMIFamily != nil {
 		return
 	}
-	c.AMIFamily = &AMIFamilyEKSOptimized
+	c.AMIFamily = &AMIFamilyAL2
 }

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
@@ -78,7 +78,10 @@ func (a *AWS) validateSubnets() (errs *apis.FieldError) {
 }
 
 func (a *AWS) validateSecurityGroups() (errs *apis.FieldError) {
-	if a.SecurityGroupSelector == nil && a.LaunchTemplate == nil {
+	if a.LaunchTemplate != nil {
+		return nil
+	}
+	if a.SecurityGroupSelector == nil {
 		errs = errs.Also(apis.ErrMissingField(securityGroupSelectorPath))
 	}
 	for key, value := range a.SecurityGroupSelector {

--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -32,11 +32,13 @@ var (
 	AWSRestrictedLabelDomains = []string{
 		"k8s.aws",
 	}
-	AMIFamilyBottlerocket = "Bottlerocket"
-	AMIFamilyEKSOptimized = "EKSOptimized"
+	AMIFamilyBottlerocket = "bottlerocket"
+	AMIFamilyAL2          = "al2"
+	AMIFamilyUbuntu       = "ubuntu"
 	SupportedAMIFamilies  = []string{
 		AMIFamilyBottlerocket,
-		AMIFamilyEKSOptimized,
+		AMIFamilyAL2,
+		AMIFamilyUbuntu,
 	}
 )
 

--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -32,9 +32,9 @@ var (
 	AWSRestrictedLabelDomains = []string{
 		"k8s.aws",
 	}
-	AMIFamilyBottlerocket = "bottlerocket"
-	AMIFamilyAL2          = "al2"
-	AMIFamilyUbuntu       = "ubuntu"
+	AMIFamilyBottlerocket = "Bottlerocket"
+	AMIFamilyAL2          = "AL2"
+	AMIFamilyUbuntu       = "Ubuntu"
 	SupportedAMIFamilies  = []string{
 		AMIFamilyBottlerocket,
 		AMIFamilyAL2,

--- a/pkg/cloudprovider/aws/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/zz_generated.deepcopy.go
@@ -33,6 +33,11 @@ func (in *AWS) DeepCopyInto(out *AWS) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.InstanceProfile != nil {
+		in, out := &in.InstanceProfile, &out.InstanceProfile
+		*out = new(string)
+		**out = **in
+	}
 	if in.LaunchTemplate != nil {
 		in, out := &in.LaunchTemplate, &out.LaunchTemplate
 		*out = new(string)

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -393,8 +393,8 @@ func (p *LaunchTemplateProvider) getNodeTaintArgs(constraints *v1alpha1.Constrai
 }
 
 func (p *LaunchTemplateProvider) getInstanceProfile(ctx context.Context, constraints *v1alpha1.Constraints) (string, error) {
-	if constraints.InstanceProfile != "" {
-		return constraints.InstanceProfile, nil
+	if constraints.InstanceProfile != nil {
+		return aws.StringValue(constraints.InstanceProfile), nil
 	}
 	defaultProfile := injection.GetOptions(ctx).AWSDefaultInstanceProfile
 	if defaultProfile == "" {

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -283,7 +283,7 @@ func (p *LaunchTemplateProvider) getUserData(ctx context.Context, constraints *v
 	if aws.StringValue(constraints.AMIFamily) == v1alpha1.AMIFamilyBottlerocket {
 		return p.getBottlerocketUserData(ctx, constraints, additionalLabels, caBundle)
 	}
-	return p.getEKSOptimizedUserData(ctx, constraints, instanceTypes, additionalLabels, caBundle)
+	return p.getAL2UserData(ctx, constraints, instanceTypes, additionalLabels, caBundle)
 }
 
 func (p *LaunchTemplateProvider) getBottlerocketUserData(ctx context.Context, constraints *v1alpha1.Constraints, additionalLabels map[string]string, caBundle *string) string {
@@ -311,10 +311,11 @@ func (p *LaunchTemplateProvider) getBottlerocketUserData(ctx context.Context, co
 	return base64.StdEncoding.EncodeToString([]byte(userData))
 }
 
-// getEKSOptimizedUserData returns the exact same string for equivalent input,
+// getAL2UserData returns the exact same string for equivalent input,
 // even if elements of those inputs are in differing orders,
 // guaranteeing it won't cause spurious hash differences.
-func (p *LaunchTemplateProvider) getEKSOptimizedUserData(ctx context.Context, constraints *v1alpha1.Constraints, instanceTypes []cloudprovider.InstanceType, additionalLabels map[string]string, caBundle *string) string {
+// AL2 userdata also works on Ubuntu
+func (p *LaunchTemplateProvider) getAL2UserData(ctx context.Context, constraints *v1alpha1.Constraints, instanceTypes []cloudprovider.InstanceType, additionalLabels map[string]string, caBundle *string) string {
 	var containerRuntimeArg string
 	if !needsDocker(instanceTypes) {
 		containerRuntimeArg = "--container-runtime containerd"

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -568,7 +568,7 @@ var _ = Describe("Allocation", func() {
 			provisioner.SetDefaults(ctx)
 			constraints, err := v1alpha1.Deserialize(&provisioner.Spec.Constraints)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(constraints.InstanceProfile).To(Equal(""))
+			Expect(constraints.InstanceProfile).To(BeNil())
 		})
 
 		It("should default requirements", func() {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -519,7 +519,7 @@ var _ = Describe("Allocation", func() {
 					Expect(*input.LaunchTemplateData.IamInstanceProfile.Name).To(Equal("test-instance-profile"))
 				})
 				It("should use the instance profile on the Provisioner when specified", func() {
-					provider = &v1alpha1.AWS{InstanceProfile: "overridden-profile"}
+					provider = &v1alpha1.AWS{InstanceProfile: aws.String("overridden-profile")}
 					ProvisionerWithProvider(&v1alpha5.Provisioner{ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())}}, provider)
 					provisioner.SetDefaults(ctx)
 

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -150,6 +150,21 @@ spec:
       httpTokens: required
 ```
 
+### Amazon Machine Image (AMI) Family
+
+The AMI used when provisioning nodes can be controlled by the `amiFamily` field. Based on the value set for `amiFamily`, Karpenter will automatically query for the appropriate [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-amis.html) via AWS Systems Manager (SSM). 
+
+Currently, Karpenter supports `amiFamily` values `al2`, `bottlerocket`, and `ubuntu`. GPUs are only supported with `al2`.
+
+Note: If a custom launch template is specified, then the AMI value in the launch template is used rather than the `amiFamily` value.
+
+
+```
+spec:
+  provider:
+    amiFamily: bottlerocket
+```
+
 
 ## Other Resources
 

--- a/website/content/en/preview/development-guide.md
+++ b/website/content/en/preview/development-guide.md
@@ -49,7 +49,7 @@ make dev # run codegen, lint, and tests
 ### Testing
 
 ```bash
-make test       # E2e correctness tests
+make test       # E2E correctness tests
 make battletest # More rigorous tests run in CI environment
 ```
 


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/923

**2. Description of changes:**
 - Changed EKSOptimized to AL2 because EKS Optimized is a class of AMIs that can be different AMI Families which are optimized for EKS. 
 - Lowercased values expected in the provisioner
 - Add support for `ubuntu` as an `amiFamily`
 - Adds docs for `amiFamily`

**3. How was this change tested?**
 - Tested on an EKS cluster with 2 deployments `inflate-amd64` and `inflate-arm64`. 
   - I varied the provisioner `amiFamily` between `al2`, `bottlerocket`, and `ubuntu` scaling each to verify the node becomes ready and the pods go to running.


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
