### PR TITLE
Simplify conversion of errors to string in formatted function calls

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -96,7 +96,7 @@ func main() {
 		metricsnode.NewController(manager.GetClient()),
 		counter.NewController(manager.GetClient()),
 	).Start(ctx); err != nil {
-		panic(fmt.Sprintf("Unable to start manager, %s", err.Error()))
+		panic(fmt.Sprintf("Unable to start manager, %s", err))
 	}
 }
 
@@ -110,7 +110,7 @@ func LoggingContextOrDie(config *rest.Config, clientSet *kubernetes.Clientset) c
 	cmw := informer.NewInformedWatcher(clientSet, system.Namespace())
 	sharedmain.WatchLoggingConfigOrDie(ctx, cmw, logger, atomicLevel, component)
 	if err := cmw.Start(ctx.Done()); err != nil {
-		logger.Fatalf("Failed to watch logging configuration, %s", err.Error())
+		logger.Fatalf("Failed to watch logging configuration, %s", err)
 	}
 	startinformers()
 	return ctx

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -99,7 +99,7 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *Cloud
 func getRegionFromIMDS(sess *session.Session) string {
 	region, err := ec2metadata.New(sess).Region()
 	if err != nil {
-		panic(fmt.Sprintf("Failed to call the metadata server's region API, %s", err.Error()))
+		panic(fmt.Sprintf("Failed to call the metadata server's region API, %s", err))
 	}
 	return region
 }
@@ -156,12 +156,12 @@ func (c *CloudProvider) Validate(ctx context.Context, constraints *v1alpha5.Cons
 func (c *CloudProvider) Default(ctx context.Context, constraints *v1alpha5.Constraints) {
 	vendorConstraints, err := v1alpha1.Deserialize(constraints)
 	if err != nil {
-		logging.FromContext(ctx).Errorf("Failed to deserialize provider, %s", err.Error())
+		logging.FromContext(ctx).Errorf("Failed to deserialize provider, %s", err)
 		return
 	}
 	vendorConstraints.Default(ctx)
 	if err := vendorConstraints.Serialize(constraints); err != nil {
-		logging.FromContext(ctx).Errorf("Failed to serialize provider, %s", err.Error())
+		logging.FromContext(ctx).Errorf("Failed to serialize provider, %s", err)
 	}
 }
 

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -78,7 +78,7 @@ func (p *InstanceProvider) Create(ctx context.Context, constraints *v1alpha1.Con
 		// Convert Instance to Node
 		node, err := p.instanceToNode(ctx, instance, instanceTypes)
 		if err != nil {
-			logging.FromContext(ctx).Errorf("creating Node from an EC2 Instance: %s", err.Error())
+			logging.FromContext(ctx).Errorf("creating Node from an EC2 Instance: %s", err)
 			continue
 		}
 		nodes = append(nodes, node)

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -72,7 +72,7 @@ func NewLaunchTemplateProvider(ctx context.Context, ec2api ec2iface.EC2API, amiP
 func launchTemplateName(options *launchTemplateOptions) string {
 	hash, err := hashstructure.Hash(options, hashstructure.FormatV2, nil)
 	if err != nil {
-		panic(fmt.Sprintf("hashing launch template, %s", err.Error()))
+		panic(fmt.Sprintf("hashing launch template, %s", err))
 	}
 	return fmt.Sprintf(launchTemplateNameFormat, options.ClusterName, fmt.Sprint(hash))
 }
@@ -231,7 +231,7 @@ func (p *LaunchTemplateProvider) hydrateCache(ctx context.Context) {
 		}
 		return true
 	}); err != nil {
-		panic(fmt.Sprintf("Unable to hydrate the AWS launch template cache, %s", err.Error()))
+		panic(fmt.Sprintf("Unable to hydrate the AWS launch template cache, %s", err))
 	}
 	p.logger.Debugf("Finished hydrating the launch template cache with %d items", p.cache.ItemCount())
 }

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -34,12 +34,12 @@ type GenericControllerManager struct {
 func NewManagerOrDie(ctx context.Context, config *rest.Config, options controllerruntime.Options) Manager {
 	newManager, err := controllerruntime.NewManager(config, options)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create controller newManager, %s", err.Error()))
+		panic(fmt.Sprintf("Failed to create controller newManager, %s", err))
 	}
 	if err := newManager.GetFieldIndexer().IndexField(ctx, &v1.Pod{}, "spec.nodeName", func(o client.Object) []string {
 		return []string{o.(*v1.Pod).Spec.NodeName}
 	}); err != nil {
-		panic(fmt.Sprintf("Failed to setup pod indexer, %s", err.Error()))
+		panic(fmt.Sprintf("Failed to setup pod indexer, %s", err))
 	}
 	return &GenericControllerManager{Manager: newManager}
 }
@@ -52,10 +52,10 @@ func (m *GenericControllerManager) RegisterControllers(ctx context.Context, cont
 		}
 	}
 	if err := m.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		panic(fmt.Sprintf("Failed to add health probe, %s", err.Error()))
+		panic(fmt.Sprintf("Failed to add health probe, %s", err))
 	}
 	if err := m.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		panic(fmt.Sprintf("Failed to add ready probe, %s", err.Error()))
+		panic(fmt.Sprintf("Failed to add ready probe, %s", err))
 	}
 	return m
 }

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -154,7 +154,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 	if err := c.record(ctx, node); err != nil {
-		logging.FromContext(ctx).Errorf("Failed to update gauges: %s", err.Error())
+		logging.FromContext(ctx).Errorf("Failed to update gauges: %s", err)
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
@@ -171,7 +171,7 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) (requests []reconcile.Request) {
 				nodes := &v1.NodeList{}
 				if err := c.KubeClient.List(ctx, nodes, client.MatchingLabels(map[string]string{v1alpha5.ProvisionerNameLabelKey: o.GetName()})); err != nil {
-					logging.FromContext(ctx).Errorf("Failed to list nodes when mapping expiration watch events, %s", err.Error())
+					logging.FromContext(ctx).Errorf("Failed to list nodes when mapping expiration watch events, %s", err)
 					return requests
 				}
 				for _, node := range nodes.Items {

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -126,7 +126,7 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) (requests []reconcile.Request) {
 				nodes := &v1.NodeList{}
 				if err := c.kubeClient.List(ctx, nodes, client.MatchingLabels(map[string]string{v1alpha5.ProvisionerNameLabelKey: o.GetName()})); err != nil {
-					logging.FromContext(ctx).Errorf("Failed to list nodes when mapping expiration watch events, %s", err.Error())
+					logging.FromContext(ctx).Errorf("Failed to list nodes when mapping expiration watch events, %s", err)
 					return requests
 				}
 				for _, node := range nodes.Items {

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -121,11 +121,11 @@ func (c *Controller) hasChanged(ctx context.Context, provisionerNew *v1alpha5.Pr
 	}
 	hashKeyOld, err := hashstructure.Hash(oldProvisioner.(*Provisioner).Spec, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	if err != nil {
-		logging.FromContext(ctx).Fatalf("Unable to hash old provisioner spec: %s", err.Error())
+		logging.FromContext(ctx).Fatalf("Unable to hash old provisioner spec: %s", err)
 	}
 	hashKeyNew, err := hashstructure.Hash(provisionerNew.Spec, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	if err != nil {
-		logging.FromContext(ctx).Fatalf("Unable to hash new provisioner spec: %s", err.Error())
+		logging.FromContext(ctx).Fatalf("Unable to hash new provisioner spec: %s", err)
 	}
 	return hashKeyOld != hashKeyNew
 }

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -53,7 +53,7 @@ func NewProvisioner(ctx context.Context, provisioner *v1alpha5.Provisioner, kube
 	go func() {
 		for running.Err() == nil {
 			if err := p.provision(running); err != nil {
-				logging.FromContext(running).Errorf("Provisioning failed, %s", err.Error())
+				logging.FromContext(running).Errorf("Provisioning failed, %s", err)
 			}
 		}
 		logging.FromContext(running).Info("Stopped provisioner")
@@ -112,12 +112,12 @@ func (p *Provisioner) provision(ctx context.Context) (err error) {
 	workqueue.ParallelizeUntil(ctx, len(schedules), len(schedules), func(i int) {
 		packings, err := p.packer.Pack(ctx, schedules[i].Constraints, schedules[i].Pods, instanceTypes)
 		if err != nil {
-			logging.FromContext(ctx).Errorf("Could not pack pods, %s", err.Error())
+			logging.FromContext(ctx).Errorf("Could not pack pods, %s", err)
 			return
 		}
 		workqueue.ParallelizeUntil(ctx, len(packings), len(packings), func(j int) {
 			if err := p.launch(ctx, schedules[i].Constraints, packings[j]); err != nil {
-				logging.FromContext(ctx).Errorf("Could not launch node, %s", err.Error())
+				logging.FromContext(ctx).Errorf("Could not launch node, %s", err)
 				return
 			}
 		})
@@ -194,7 +194,7 @@ func (p *Provisioner) bind(ctx context.Context, node *v1.Node, pods []*v1.Pod) (
 	var bound int64
 	workqueue.ParallelizeUntil(ctx, len(pods), len(pods), func(i int) {
 		if err := p.coreV1Client.Pods(pods[i].Namespace).Bind(ctx, &v1.Binding{TypeMeta: pods[i].TypeMeta, ObjectMeta: pods[i].ObjectMeta, Target: v1.ObjectReference{Name: node.Name}}, metav1.CreateOptions{}); err != nil {
-			logging.FromContext(ctx).Errorf("Failed to bind %s/%s to %s, %s", pods[i].Namespace, pods[i].Name, node.Name, err.Error())
+			logging.FromContext(ctx).Errorf("Failed to bind %s/%s to %s, %s", pods[i].Namespace, pods[i].Name, node.Name, err)
 		} else {
 			atomic.AddInt64(&bound, 1)
 		}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -89,7 +89,7 @@ func (s *Scheduler) getSchedules(ctx context.Context, constraints *v1alpha5.Cons
 	schedules := map[uint64]*Schedule{}
 	for _, pod := range pods {
 		if err := constraints.ValidatePod(pod); err != nil {
-			logging.FromContext(ctx).Infof("Unable to schedule pod %s/%s, %s", pod.Namespace, pod.Name, err.Error())
+			logging.FromContext(ctx).Infof("Unable to schedule pod %s/%s, %s", pod.Namespace, pod.Name, err)
 			continue
 		}
 		tightened := constraints.Tighten(pod)

--- a/pkg/controllers/selection/controller.go
+++ b/pkg/controllers/selection/controller.go
@@ -71,12 +71,12 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 	if err := validate(pod); err != nil {
-		logging.FromContext(ctx).Debugf("Ignoring pod, %s", err.Error())
+		logging.FromContext(ctx).Debugf("Ignoring pod, %s", err)
 		return reconcile.Result{}, nil
 	}
 	// Select a provisioner, wait for it to bind the pod, and verify scheduling succeeded in the next loop
 	if err := c.selectProvisioner(ctx, pod); err != nil {
-		logging.FromContext(ctx).Debugf("Could not schedule pod, %s", err.Error())
+		logging.FromContext(ctx).Debugf("Could not schedule pod, %s", err)
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{RequeueAfter: time.Second * 5}, nil

--- a/pkg/test/daemonsets.go
+++ b/pkg/test/daemonsets.go
@@ -39,7 +39,7 @@ func DaemonSet(overrides ...DaemonSetOptions) *appsv1.DaemonSet {
 	options := DaemonSetOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge pod options: %s", err.Error()))
+			panic(fmt.Sprintf("Failed to merge pod options: %s", err))
 		}
 	}
 	if options.Name == "" {

--- a/pkg/test/nodes.go
+++ b/pkg/test/nodes.go
@@ -36,7 +36,7 @@ func Node(overrides ...NodeOptions) *v1.Node {
 	options := NodeOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge node options: %s", err.Error()))
+			panic(fmt.Sprintf("Failed to merge node options: %s", err))
 		}
 	}
 	if options.ReadyStatus == "" {

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -56,7 +56,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 	options := PodOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge pod options: %s", err.Error()))
+			panic(fmt.Sprintf("Failed to merge pod options: %s", err))
 		}
 	}
 	if options.Image == "" {
@@ -114,7 +114,7 @@ func PodDisruptionBudget(overrides ...PDBOptions) *v1beta1.PodDisruptionBudget {
 	options := PDBOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge pod options: %s", err.Error()))
+			panic(fmt.Sprintf("Failed to merge pod options: %s", err))
 		}
 	}
 	return &v1beta1.PodDisruptionBudget{

--- a/pkg/test/storage.go
+++ b/pkg/test/storage.go
@@ -34,7 +34,7 @@ func PersistentVolume(overrides ...PersistentVolumeOptions) *v1.PersistentVolume
 	options := PersistentVolumeOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge options: %s", err.Error()))
+			panic(fmt.Sprintf("Failed to merge options: %s", err))
 		}
 	}
 	return &v1.PersistentVolume{
@@ -61,7 +61,7 @@ func PersistentVolumeClaim(overrides ...PersistentVolumeClaimOptions) *v1.Persis
 	options := PersistentVolumeClaimOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge options: %s", err.Error()))
+			panic(fmt.Sprintf("Failed to merge options: %s", err))
 		}
 	}
 	return &v1.PersistentVolumeClaim{
@@ -84,7 +84,7 @@ func StorageClass(overrides ...StorageClassOptions) *storagev1.StorageClass {
 	options := StorageClassOptions{}
 	for _, opts := range overrides {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge options: %s", err.Error()))
+			panic(fmt.Sprintf("Failed to merge options: %s", err))
 		}
 	}
 


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
When using functions that format strings (they  ends with an f suffix e.g. `fmt.Errorf`, or `fmt.Sprintf`)  there is no need to  use `err.Error()` in order to get the error message in string. It is sufficient to use `err` because errors in Go implement the `fmt.Stringer` interface allowing an automatic conversion to string when needed.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
