### PR TITLE
[WIP]: use a static vm overhead for memory rather than 7.5%

### DIFF
--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -29,9 +29,6 @@ import (
 	"knative.dev/pkg/ptr"
 )
 
-// EC2VMAvailableMemoryFactor assumes the EC2 VM will consume <7.25% of the memory of a given machine
-const EC2VMAvailableMemoryFactor = .925
-
 type InstanceType struct {
 	ec2.InstanceTypeInfo
 	AvailableOfferings []cloudprovider.Offering
@@ -64,11 +61,7 @@ func (i *InstanceType) CPU() *resource.Quantity {
 }
 
 func (i *InstanceType) Memory() *resource.Quantity {
-	return resources.Quantity(
-		fmt.Sprintf("%dMi", int32(
-			float64(*i.MemoryInfo.SizeInMiB)*EC2VMAvailableMemoryFactor,
-		)),
-	)
+	return resources.Quantity(fmt.Sprintf("%dMi", *i.MemoryInfo.SizeInMiB))
 }
 
 func (i *InstanceType) Pods() *resource.Quantity {
@@ -136,6 +129,8 @@ func (i *InstanceType) Overhead() v1.ResourceList {
 				// system-reserved
 				100+
 				// eviction threshold https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/pkg/kubelet/apis/config/v1beta1/defaults_linux.go#L23
+				100+
+				// additional VM overhead
 				100,
 		)),
 	}


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1306

**2. Description of changes:**
 - Use a constant VM memory overhead of 100MiB rather than the 7.5% overhead which was used before. The VM memory overhead doesn't really scale with more memory, so I think the static value will work well. There's not much of a reason for setting it at 100MiB except that this brings a t4g.nano overhead to 569MiB which excludes it from hosting any pods. 

**3. How was this change tested?**
 - Tested the workload from the #1306 on an r5.12xlarge which now fits. This was somewhat of a corner case since it just so happened the workload was barely over the limit with the overhead we were computing. Whereas on CA, the workload fit. 
 - Tested that nanos were excluded naturally during binpacking 
 - Tested a scale-up of several 10Mib memory pause pods to see if any pods would get OOM killed.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [x] Yes, issue opened: *link to issue* https://github.com/aws/karpenter/issues/1329
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
