### PR TITLE
Bottlerocket nvidia

### DIFF
--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -109,7 +109,7 @@ func (p *AMIProvider) getAL2Alias(version string, instanceType cloudprovider.Ins
 func (p *AMIProvider) getBottlerocketAlias(version string, instanceType cloudprovider.InstanceType) string {
 	arch := "x86_64"
 	amiSuffix := ""
-	if !instanceType.NvidiaGPUs().IsZero() || !instanceType.AWSNeurons().IsZero() {
+	if !instanceType.NvidiaGPUs().IsZero() {
 		amiSuffix = "-nvidia"
 	}
 	if instanceType.Architecture() == v1alpha5.ArchitectureArm64 {

--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -111,7 +111,8 @@ func (p *AMIProvider) getBottlerocketAlias(version string, instanceType cloudpro
 	amiSuffix := ""
 	if !instanceType.NvidiaGPUs().IsZero() || !instanceType.AWSNeurons().IsZero() {
 		amiSuffix = "-nvidia"
-	} else if instanceType.Architecture() == v1alpha5.ArchitectureArm64 {
+	}
+	if instanceType.Architecture() == v1alpha5.ArchitectureArm64 {
 		arch = instanceType.Architecture()
 	}
 	return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s%s/%s/latest/image_id", version, amiSuffix, arch)

--- a/pkg/cloudprovider/aws/ami.go
+++ b/pkg/cloudprovider/aws/ami.go
@@ -108,10 +108,13 @@ func (p *AMIProvider) getAL2Alias(version string, instanceType cloudprovider.Ins
 // getBottlerocketAlias returns a properly-formatted alias for a Bottlerocket AMI from SSM
 func (p *AMIProvider) getBottlerocketAlias(version string, instanceType cloudprovider.InstanceType) string {
 	arch := "x86_64"
-	if instanceType.Architecture() == v1alpha5.ArchitectureArm64 {
+	amiSuffix := ""
+	if !instanceType.NvidiaGPUs().IsZero() || !instanceType.AWSNeurons().IsZero() {
+		amiSuffix = "-nvidia"
+	} else if instanceType.Architecture() == v1alpha5.ArchitectureArm64 {
 		arch = instanceType.Architecture()
 	}
-	return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/image_id", version, arch)
+	return fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s%s/%s/latest/image_id", version, amiSuffix, arch)
 }
 
 // getUbuntuAlias returns a properly-formatted alias for an Ubuntu AMI from SSM

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -154,7 +154,7 @@ spec:
 
 The AMI used when provisioning nodes can be controlled by the `amiFamily` field. Based on the value set for `amiFamily`, Karpenter will automatically query for the appropriate [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-amis.html) via AWS Systems Manager (SSM). 
 
-Currently, Karpenter supports `amiFamily` values `al2`, `bottlerocket`, and `ubuntu`. GPUs are only supported with `al2`.
+Currently, Karpenter supports `amiFamily` values `al2`, `bottlerocket`, and `ubuntu`. GPUs are only supported with `al2` and `bottlerocket`.
 
 Note: If a custom launch template is specified, then the AMI value in the launch template is used rather than the `amiFamily` value.
 


### PR DESCRIPTION
**1. Issue, if available:**
If the AMI family type used is Bottlerocket and the instance type is an NVIDIA GPU instance the drivers are not available in the generic Bottlerocket AMI. The lookup for arm64 architecture was also dependent on GPU instances but they're not mutually exclusive (eg G5g).

**2. Description of changes:**
This adds a lookup for Bottlerocket AMIs to use the `-nvidia` variant along with arm64 AMI when needed.

**3. How was this change tested?**
I based the code off the existing AL2 lookups and ran linting and basic tests but did not have the infrastructure in place to deploy it into a live cluster.

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
