### PR TITLE
website: fix typo in link to getting started

### DIFF
--- a/website/content/en/v0.6.1/concepts/_index.md
+++ b/website/content/en/v0.6.1/concepts/_index.md
@@ -24,7 +24,7 @@ Concepts associated with this role are described below.
 Karpenter is designed to run on a node in your Kubernetes cluster.
 As part of the installation process, you need credentials from the underlying cloud provider to allow nodes to be started up and added to the cluster as they are needed.
 
-[Getting Started with Karpenter on AWS]{{< ref "../getting-started" >}})
+[Getting Started with Karpenter on AWS](../getting-started)
 describes the process of installing Karpenter on an AWS cloud provider.
 Because requests to add and delete nodes and schedule pods are made through Kubernetes, AWS IAM Roles for Service Accounts (IRSA) are needed by your Kubernetes cluster to make privileged requests to AWS.
 For example, Karpenter uses AWS IRSA roles to grant the permissions needed to describe EC2 instance types and create EC2 instances.


### PR DESCRIPTION
**1. Issue, if available:**

None.

**2. Description of changes:**

Fix typo in link to redirect from concepts to getting started.

**3. How was this change tested?**

It was not.

**4. Does this change impact docs?**

- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
