### PR TITLE
add a test/EvictionQueue to eliminate test timing issues

### DIFF
--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -43,7 +43,7 @@ import (
 
 var ctx context.Context
 var controller *termination.Controller
-var evictionQueue *termination.EvictionQueue
+var evictionQueue *test.EvictionQueue
 var env *test.Environment
 
 func TestAPIs(t *testing.T) {
@@ -57,7 +57,7 @@ var _ = BeforeSuite(func() {
 		cloudProvider := &fake.CloudProvider{}
 		registry.RegisterOrDie(ctx, cloudProvider)
 		coreV1Client := corev1.NewForConfigOrDie(e.Config)
-		evictionQueue = termination.NewEvictionQueue(ctx, coreV1Client)
+		evictionQueue = test.NewEvictionQueue(ctx, coreV1Client)
 		controller = &termination.Controller{
 			KubeClient: e.Client,
 			Terminator: &termination.Terminator{
@@ -357,15 +357,15 @@ var _ = Describe("Termination", func() {
 	})
 })
 
-func ExpectEnqueuedForEviction(e *termination.EvictionQueue, pods ...*v1.Pod) {
+func ExpectEnqueuedForEviction(e *test.EvictionQueue, pods ...*v1.Pod) {
 	for _, pod := range pods {
-		Expect(e.Contains(client.ObjectKeyFromObject(pod))).To(BeTrue())
+		Expect(e.HasContained(client.ObjectKeyFromObject(pod))).To(BeTrue())
 	}
 }
 
-func ExpectNotEnqueuedForEviction(e *termination.EvictionQueue, pods ...*v1.Pod) {
+func ExpectNotEnqueuedForEviction(e *test.EvictionQueue, pods ...*v1.Pod) {
 	for _, pod := range pods {
-		Expect(e.Contains(client.ObjectKeyFromObject(pod))).To(BeFalse())
+		Expect(e.HasContained(client.ObjectKeyFromObject(pod))).To(BeFalse())
 	}
 }
 

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -33,7 +33,7 @@ import (
 )
 
 type Terminator struct {
-	EvictionQueue *EvictionQueue
+	EvictionQueue EvictionQueue
 	KubeClient    client.Client
 	CoreV1Client  corev1.CoreV1Interface
 	CloudProvider cloudprovider.CloudProvider

--- a/pkg/test/evictionqueue.go
+++ b/pkg/test/evictionqueue.go
@@ -1,0 +1,61 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+
+	"github.com/aws/karpenter/pkg/controllers/termination"
+	set "github.com/deckarep/golang-set"
+	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EvictionQueue is an eviction queue that provides an additional HasContained
+// method to check if an ObjectKey was ever in the queue at any point.  This is
+// used to eliminate test flakiness as pods can quickly enter and be removed
+// from the eviction queue before a test can check if they are in the queue.
+type EvictionQueue struct {
+	q            termination.EvictionQueue
+	hasContained set.Set
+}
+
+func (e *EvictionQueue) Add(pods []*v1.Pod) {
+	for _, p := range pods {
+		e.hasContained.Add(client.ObjectKeyFromObject(p))
+	}
+	e.q.Add(pods)
+}
+
+func (e EvictionQueue) HasContained(keys ...client.ObjectKey) bool {
+	for _, p := range keys {
+		if !e.hasContained.Contains(p) {
+			return false
+		}
+	}
+
+	return true
+}
+func (e EvictionQueue) Contains(i ...interface{}) bool {
+	return e.q.Contains(i...)
+}
+
+func NewEvictionQueue(ctx context.Context, coreV1Client corev1.CoreV1Interface) *EvictionQueue {
+	return &EvictionQueue{
+		hasContained: set.NewSet(),
+		q:            termination.NewEvictionQueue(ctx, coreV1Client),
+	}
+}


### PR DESCRIPTION
**1. Issue, if available:**

Maybe #706 ?

**2. Description of changes:**

Depending on when the eviction queue was acted upon, items
could be queued and removed before the Expect() calls that
checked for them in the queue.  This change adds a test
eviction queue that maintains a set of all items ever
queued.

**3. How was this change tested?**

Unit tests only

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
