### PR TITLE
filter out mac and i386 instance type archs

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -17,9 +17,10 @@ package aws
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/aws/karpenter/pkg/utils/injection"
 	"knative.dev/pkg/ptr"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -141,6 +142,10 @@ func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context) (map[string
 			{
 				Name:   aws.String("supported-virtualization-type"),
 				Values: []*string{aws.String("hvm")},
+			},
+			{
+				Name:   aws.String("processor-info.supported-architecture"),
+				Values: aws.StringSlice([]string{"x86_64", "arm64"}),
 			},
 		},
 	}, func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Filter out mac instance types on the AWS Cloud Provider Instance Types Provider. Mac instance types are shown with an "x86_64_mac" arch which is not playing well with k8s. 

Error from @suket22 
```
ERROR	controller.controller.provisioning	Reconciler error	{"commit": "947831e", "reconciler group": "karpenter.sh", "reconciler kind": "Provisioner", "name": "default", "namespace": "", "error": "requirements are not compatible with cloud provider, invalid value [x86_64_mac] for key kubernetes.io/arch, a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"}
```


**3. How was this change tested?**
 - Tested manually that this scales-up... but I was not getting the error before so can @suket22 test this change?

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
