### PR TITLE
A few getting started doc improvements

### DIFF
--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -34,8 +34,8 @@ Install these tools before proceeding:
 3. `eksctl` - [the CLI for AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
 4. `helm` - [the package manager for Kubernetes](https://helm.sh/docs/intro/install/)
 
-Login to the AWS CLI with a user that has sufficient privileges to create a
-cluster.
+[Configure the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+with a user that has sufficient privileges to create an EKS cluster.
 
 ### Environment Variables
 

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -78,6 +78,11 @@ eksctl create cluster -f cluster.yaml
 export CLUSTER_ENDPOINT="$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output text)"
 ```
 
+You can add the details of the newly created EKS cluster to your local kubectl as a new context by running:
+```bash
+aws eks update-kubeconfig --region ${AWS_DEFAULT_REGION} --name ${CLUSTER_NAME}
+```
+
 This guide uses a managed node group to host Karpenter.
 
 Karpenter itself can run anywhere, including on [self-managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/worker.html), [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), or [AWS Fargate](https://aws.amazon.com/fargate/).

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -45,7 +45,7 @@ commonly used values.
 ```bash
 export CLUSTER_NAME="${USER}-karpenter-demo"
 export AWS_DEFAULT_REGION="us-west-2"
-AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 ```
 
 ### Create a Cluster


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Few documentation improvements in the getting started guide.
1. Clarify what is meant by configuring the local `aws` cli tool
2. Add export to the environment variable that misses it
3. Add command to allow `kubectl` authenticate against the created EKS cluster

**3. How was this change tested?**


**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
