### PR TITLE
Don't default AMI Family if LaunchTemplate specified

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_defaults.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_defaults.go
@@ -60,5 +60,8 @@ func (c *Constraints) defaultAMIFamily() {
 	if c.AMIFamily != nil {
 		return
 	}
+	if c.LaunchTemplate != nil {
+		return
+	}
 	c.AMIFamily = &AMIFamilyAL2
 }


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
Fixing an issue where we'd default the AMIFamily even if a launch template was specified. That would then break in the [validation webhook](https://github.com/aws/karpenter/blob/main/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go#L60). 

**3. How was this change tested?**
The provisioner I was using for testing manually - 
```
apiVersion: karpenter.sh/v1alpha5
kind: Provisioner
metadata:
  name: default
spec:
  limits:
    resources:
      cpu: 1000
  provider:
    launchTemplate: myTemplate
    subnetSelector:
      karpenter.sh/discovery: myCluster
  ttlSecondsAfterEmpty: 30
```

First I was able to replicate the failure -
```
for: "../testing/provisionerSpecAMIFix.yaml": admission webhook "validation.webhook.provisioners.karpenter.sh" denied the request: validation failed: expected exactly one, got both: spec.provider.amiFamily, spec.provider.launchTemplate
```

After that I did a `make apply` and recreated my provisioner to verify the fix.
```
> k apply -f ../testing/provisionerSpecAMIFix.yaml
provisioner.karpenter.sh/default configured
```


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
