### PR TITLE
Fixed the Helm parameter to set the service account annotations #1355

### DIFF
--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -156,7 +156,7 @@ Install the chart passing in the cluster details and the Karpenter role ARN.
 helm upgrade --install --namespace karpenter --create-namespace \
   karpenter karpenter/karpenter \
   --version {{< param "latest_release_version" >}} \
-  --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN} \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set clusterName=${CLUSTER_NAME} \
   --set clusterEndpoint=${CLUSTER_ENDPOINT} \
   --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \

--- a/website/content/en/v0.6.2/getting-started/_index.md
+++ b/website/content/en/v0.6.2/getting-started/_index.md
@@ -156,7 +156,7 @@ Install the chart passing in the cluster details and the Karpenter role ARN.
 helm upgrade --install --namespace karpenter --create-namespace \
   karpenter karpenter/karpenter \
   --version v0.6.2 \
-  --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN}
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set clusterName=${CLUSTER_NAME} \
   --set clusterEndpoint=${CLUSTER_ENDPOINT} \
   --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \


### PR DESCRIPTION
**1. Issue, if available:**
When installing the Helm chart, it throws an error  #1355

**2. Description of changes:**
Added quotes for the annotation parameters and a missing backslash at the end of the command.

**3. How was this change tested?**
Manually tested by deploying the helm chart in my cluster.

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [x] Yes, issue opened: #1355
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
