### PR TITLE
Draft: Disable CGO so that C code is not used in Go code of the package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ export KUBEBUILDER_ASSETS ?= ${HOME}/.kubebuilder/bin
 LDFLAGS ?= "-ldflags=-X=github.com/aws/karpenter/pkg/utils/project.Version=$(shell git describe --tags --always)"
 GOFLAGS ?= "-tags=$(CLOUD_PROVIDER) $(LDFLAGS)"
 WITH_GOFLAGS = GOFLAGS=$(GOFLAGS)
+export CGO_ENABLED=0 # Disallows inclusion of CGO in the code and all dependencies
 
 ## Extra helm options
 CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev)
@@ -15,8 +16,6 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
       		--set clusterName=${CLUSTER_NAME} \
 			--set clusterEndpoint=${CLUSTER_ENDPOINT} \
 			--set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME}
-
-CGO_ENABLED=0 # Disallows inclusion of CGO in the code and all dependencies
 
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
 			--set clusterEndpoint=${CLUSTER_ENDPOINT} \
 			--set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME}
 
+CGO_ENABLED=0 # Disallows inclusion of CGO in the code and all dependencies
+
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 


### PR DESCRIPTION
Need to do some more testing please do not merge.

Disable CGO so that C code is not used in Go code of the package
and its dependencies thereby disallowing introduction C code with security and compatibility issues
For more info see: https://groups.google.com/g/golang-nuts/c/Jd9tlNc6jUE/m/fJodJUqZV-YJ
With this environment variable in place if any of our dependencies start using CGO we
will know and will either have to avoid the dependency or decide to allow it.

**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1322#issuecomment-1042326861

**2. Description of changes:**

This will disable CGO, as explained in the issue comment above this will add to our future protection against a class of bugs that can exist in C libraries and can be exposed in a Go binary that uses them.

**3. How was this change tested?**
This will make the build process fail if any of the Go libraries including dependencies use CGO, and show a message like `build constraints exclude all Go files in`

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
