### PR TITLE
fix eksctl getting started guide create cluster command

### DIFF
--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -54,7 +54,7 @@ export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output te
 Create a cluster with `eksctl`. This example configuration file specifies a basic cluster with one initial node and sets up an IAM OIDC provider for the cluster to enable IAM roles for pods:
 
 ```bash
-eksctl create cluster << 'EOF'
+eksctl create cluster -f - << EOF
 ---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig

--- a/website/content/en/v0.6.3/getting-started/_index.md
+++ b/website/content/en/v0.6.3/getting-started/_index.md
@@ -54,7 +54,7 @@ export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output te
 Create a cluster with `eksctl`. This example configuration file specifies a basic cluster with one initial node and sets up an IAM OIDC provider for the cluster to enable IAM roles for pods:
 
 ```bash
-eksctl create cluster << 'EOF'
+eksctl create cluster -f - << EOF
 ---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
The getting started guide `eksctl create cluster` command is broken.

the current guide has the following:

```
eksctl create cluster << 'EOF'
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: ${CLUSTER_NAME}
  region: ${AWS_DEFAULT_REGION}
  version: "1.21"
  tags:
    karpenter.sh/discovery: ${CLUSTER_NAME}
managedNodeGroups:
  - instanceType: m5.large
    amiFamily: AmazonLinux2
    name: ${CLUSTER_NAME}-ng
    desiredCapacity: 1
    minSize: 1
    maxSize: 10
iam:
  withOIDC: true
EOF
```

if you run the above w/ `--dry-run` to see the generated config, the heredoc passed in does not apply and defaults are taken instead:

```
eksctl create cluster --dry-run << 'EOF'
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: ${CLUSTER_NAME}
  region: ${AWS_DEFAULT_REGION}
  version: "1.21"
  tags:
    karpenter.sh/discovery: ${CLUSTER_NAME}
managedNodeGroups:
  - instanceType: m5.large
    amiFamily: AmazonLinux2
    name: ${CLUSTER_NAME}-ng
    desiredCapacity: 1
    minSize: 1
    maxSize: 10
iam:
  withOIDC: true
EOF

... For brevity just showing one field that verifies it is using the default randomly generated cluster name rather than the spec in the heredoc...

metadata:
  name: exciting-creature-1645053433
```

This PR changes it to the following which works:
```
eksctl create cluster --dry-run -f - << EOF
---
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: ${CLUSTER_NAME}
  region: ${AWS_REGION}
  version: "1.21"
  tags:
    karpenter.sh/discovery: ${CLUSTER_NAME}
managedNodeGroups:
  - instanceType: m5.large
    amiFamily: AmazonLinux2
    name: ${CLUSTER_NAME}-ng
    desiredCapacity: 1
    minSize: 1
    maxSize: 10
iam:
  withOIDC: true
EOF

...again just showing metadata to verify it's picking up the spec...

metadata:
  name: my-cluster
  region: us-east-2
  tags:
    karpenter.sh/discovery: my-cluster
```


**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
