### PR TITLE
fix: amiFamily values

### DIFF
--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -154,7 +154,7 @@ spec:
 
 The AMI used when provisioning nodes can be controlled by the `amiFamily` field. Based on the value set for `amiFamily`, Karpenter will automatically query for the appropriate [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-amis.html) via AWS Systems Manager (SSM). 
 
-Currently, Karpenter supports `amiFamily` values `al2`, `bottlerocket`, and `ubuntu`. GPUs are only supported with `al2` and `bottlerocket`.
+Currently, Karpenter supports `amiFamily` values `AL2`, `Bottlerocket`, and `Ubuntu`. GPUs are only supported with `AL2` and `Bottlerocket`.
 
 Note: If a custom launch template is specified, then the AMI value in the launch template is used rather than the `amiFamily` value.
 
@@ -162,7 +162,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 ```
 spec:
   provider:
-    amiFamily: bottlerocket
+    amiFamily: Bottlerocket
 ```
 
 

--- a/website/content/en/v0.6.2/AWS/provisioning.md
+++ b/website/content/en/v0.6.2/AWS/provisioning.md
@@ -154,7 +154,7 @@ spec:
 
 The AMI used when provisioning nodes can be controlled by the `amiFamily` field. Based on the value set for `amiFamily`, Karpenter will automatically query for the appropriate [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-amis.html) via AWS Systems Manager (SSM). 
 
-Currently, Karpenter supports `amiFamily` values `al2`, `bottlerocket`, and `ubuntu`. GPUs are only supported with `al2` and `bottlerocket`.
+Currently, Karpenter supports `amiFamily` values `AL2`, `Bottlerocket`, and `Ubuntu`. GPUs are only supported with `AL2` and `Bottlerocket`.
 
 Note: If a custom launch template is specified, then the AMI value in the launch template is used rather than the `amiFamily` value.
 
@@ -162,7 +162,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 ```
 spec:
   provider:
-    amiFamily: bottlerocket
+    amiFamily: Bottlerocket
 ```
 
 

--- a/website/content/en/v0.6.3/AWS/provisioning.md
+++ b/website/content/en/v0.6.3/AWS/provisioning.md
@@ -154,7 +154,7 @@ spec:
 
 The AMI used when provisioning nodes can be controlled by the `amiFamily` field. Based on the value set for `amiFamily`, Karpenter will automatically query for the appropriate [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-amis.html) via AWS Systems Manager (SSM). 
 
-Currently, Karpenter supports `amiFamily` values `al2`, `bottlerocket`, and `ubuntu`. GPUs are only supported with `al2` and `bottlerocket`.
+Currently, Karpenter supports `amiFamily` values `AL2`, `Bottlerocket`, and `Ubuntu`. GPUs are only supported with `AL2` and `Bottlerocket`.
 
 Note: If a custom launch template is specified, then the AMI value in the launch template is used rather than the `amiFamily` value.
 
@@ -162,7 +162,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 ```
 spec:
   provider:
-    amiFamily: bottlerocket
+    amiFamily: Bottlerocket
 ```
 
 


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
The value of `amiFamily` in a Document is incorrect.

[error]
```
$ kubectl apply -f provisioner.yaml
Error from server (BadRequest): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"karpenter.sh/v1alpha5\",\"kind\":\"Provisioner\",\"metadata\":{\"annotations\":{},\"name\":\"default\"},\"spec\":{\"limits\":{\"resources\":{\"cpu\":1000}},\"provider\":{\"amiFamily\":\"bottlerocket\",\"instanceProfile\":\"KarpenterNodeInstanceProfile-xxxxxxxxxx\",\"securityGroupSelector\":{\"karpenter.sh/discovery\":\"xxxxxxxxxx\"},\"subnetSelector\":{\"karpenter.sh/discovery\":\"xxxxxxxxxx\"}},\"requirements\":[{\"key\":\"karpenter.sh/capacity-type\",\"operator\":\"In\",\"values\":[\"on-demand\"]},{\"key\":\"node.kubernetes.io/instance-type\",\"operator\":\"In\",\"values\":[\"m5.large\"]}],\"ttlSecondsAfterEmpty\":30}}\n"}},"spec":{"limits":{"resources":{"cpu":1000}},"provider":{"amiFamily":"bottlerocket"},"requirements":[{"key":"karpenter.sh/capacity-type","operator":"In","values":["on-demand"]},{"key":"node.kubernetes.io/instance-type","operator":"In","values":["m5.large"]}]}}
to:
Resource: "karpenter.sh/v1alpha5, Resource=provisioners", GroupVersionKind: "karpenter.sh/v1alpha5, Kind=Provisioner"
Name: "default", Namespace: ""
for: "provisioner.yaml": admission webhook "validation.webhook.provisioners.karpenter.sh" denied the request: validation failed: invalid value: bottlerocket not in Bottlerocket, AL2, Ubuntu: spec.provider.amiFamily
```


[values]
https://github.com/aws/karpenter/blob/0518fb3440467d59ca836d57fa674bf06ba3c0be/pkg/cloudprovider/aws/apis/v1alpha1/register.go#L35-L37

[docs v0.6.1]
https://github.com/aws/karpenter/blob/a301ce8be13f57d985797f1535e7495f9dbf2964/website/content/en/v0.6.2/AWS/provisioning.md?plain=1#L157

https://github.com/aws/karpenter/blob/a301ce8be13f57d985797f1535e7495f9dbf2964/website/content/en/v0.6.2/AWS/provisioning.md?plain=1#L163-L165

[docs v0.6.2]
https://github.com/aws/karpenter/blob/a301ce8be13f57d985797f1535e7495f9dbf2964/website/content/en/v0.6.3/AWS/provisioning.md?plain=1#L157

https://github.com/aws/karpenter/blob/a301ce8be13f57d985797f1535e7495f9dbf2964/website/content/en/v0.6.3/AWS/provisioning.md?plain=1#L163-L165

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
