### PR TITLE
Fix webhook cert update issue if resource name differs from Helm chart

### DIFF
--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -27,7 +27,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["karpenter-cert"]
+    resourceNames: ["{{ include "karpenter.fullname" . }}-cert"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["secrets"]


### PR DESCRIPTION
**1. Issue, if available:**
When installing with custom release name, webhook cannot be created. https://github.com/aws/karpenter/issues/1359

**2. Description of changes:**
remove the hardcoded resourceName and make it `{{ include "karpenter.fullname" . }}-cert`
[same as secrets](https://github.com/aws/karpenter/blob/main/charts/karpenter/templates/secret-webhook-cert.yaml#L4)

**3. How was this change tested?**
```
helm install . --generate-name --namespace kube-system --version 0.6.3 --dry-run --debug
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [x] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
