### PR TITLE
Fix GHA cache key for go modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,17 +13,14 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.17
-    - run: |
-      echo "::set-output name=go-build::$(go env GOCACHE)"
-      echo "::set-output name=go-mod::$(go env GOMODCACHE)"
     - uses: actions/cache@v2
       with:
         path: |
-          ${{ steps.go-cache-paths.outputs.go-build }}
-          ${{ steps.go-cache-paths.outputs.go-mod }}
+          ~/.cache/go-build
+          ~/go/pkg/mod
           ~/go/bin/
           ~/.kubebuilder/bin/k8s
-        key: go-mod-${{ hashFiles('**/go.sum') }}
+        key: go-cache-${{ hashFiles('**/go.sum') }}
     - name: CI - Verifications and Tests
       run: |
         make ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,17 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.17
+    - run: |
+      echo "::set-output name=go-build::$(go env GOCACHE)"
+      echo "::set-output name=go-mod::$(go env GOMODCACHE)"
     - uses: actions/cache@v2
       with:
         path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
           ~/go/bin/
           ~/.kubebuilder/bin/k8s
-        key: gocache
+        key: go-mod-${{ hashFiles('**/go.sum') }}
     - name: CI - Verifications and Tests
       run: |
         make ci

--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -27,7 +27,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["karpenter-cert"]
+    resourceNames: ["{{ include "karpenter.fullname" . }}-cert"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["secrets"]


### PR DESCRIPTION
…o.sum as key

**1. Issue, if available:**


**2. Description of changes:**
Attempt to make the GHA for CI faster by properly caching the go modules and build. Currently it seems like the cache is not as effective since the dependencies are still being deployed 

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
