### PR TITLE
run GHA on push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: [pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**

This will cause https://github.com/aws/karpenter/blob/main/.github/workflows/ci.yaml to run not only on pull_requests but also on push.

A few reasons this is a good idea
- It will update the coverage data of the `main` branch in coveralls.io
- GH will add a check icon to the commit, we currently have that since [this](https://github.com/aws/karpenter/commit/4c55110d70439135763404e24bd6937c0ba569fd) but with this change the check will be more meaningful as it would mean we have done all our tests on this specific commit

It will also have some other less important but possible effects
- An administrator can sometimes ignore the checks in a PR (a Github setting can disable this), the tests will still run and have a sign indicating that the commit is breaking the tests in such case
- Some race conditions are not detected every time the code runs in Go. The race detector would (probably) need to observe the occurrence of a race to be able to detect it, if the program logic does not always lead to that occurrence then the race condition will remain undetected, either due to internal mechanics of race detection or the way the application code behaves the race condition detection is improved when you run the tests multiple times rather than once. So running the tests one more time after merge can help us detect such cases
- A commit can sometimes be pushed into the main branch without a PR with a direct push to main (a Github setting can disable this), our checks would still run against that commit
- There can be a drift in dependencies from the time the PR checks ran to the time we merged the PR, for example one of them maybe removed, compromised etc... With this change would know about that after we merge the PR. 
- There can be a change in other parts of the code base from the time PR checks ran to the time we merged. I'm not sure that Github invalidates the PR checks if another file in the repo is modified in main branch or not; This could mean some tests passed at the time the PR checks ran but not anymore after we merge. With this check we will not be taking that risk.

So it does somewhat add to our stability by doing the checks one more time!

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
