### PR TITLE
Fix cluster DNS IP format in Bottlerocket userdata

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -289,7 +289,7 @@ func (p *LaunchTemplateProvider) getUserData(ctx context.Context, constraints *v
 func (p *LaunchTemplateProvider) getBottlerocketUserData(ctx context.Context, constraints *v1alpha1.Constraints, additionalLabels map[string]string, caBundle *string) string {
 	userData := fmt.Sprintf("[settings.kubernetes]\ncluster-name = \"%s\"\napi-server = \"%s\"\n", injection.GetOptions(ctx).ClusterName, injection.GetOptions(ctx).ClusterEndpoint)
 	if constraints.KubeletConfiguration.ClusterDNS != nil {
-		userData += fmt.Sprintf("cluster-dns-ip = \"%s\"\n", constraints.KubeletConfiguration.ClusterDNS)
+		userData += fmt.Sprintf("cluster-dns-ip = \"%s\"\n", constraints.KubeletConfiguration.ClusterDNS[0])
 	}
 	if caBundle != nil {
 		userData += fmt.Sprintf("cluster-certificate = \"%s\"\n", *caBundle)

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -288,7 +288,7 @@ func (p *LaunchTemplateProvider) getUserData(ctx context.Context, constraints *v
 
 func (p *LaunchTemplateProvider) getBottlerocketUserData(ctx context.Context, constraints *v1alpha1.Constraints, additionalLabels map[string]string, caBundle *string) string {
 	userData := fmt.Sprintf("[settings.kubernetes]\ncluster-name = \"%s\"\napi-server = \"%s\"\n", injection.GetOptions(ctx).ClusterName, injection.GetOptions(ctx).ClusterEndpoint)
-	if constraints.KubeletConfiguration.ClusterDNS != nil {
+	if len(constraints.KubeletConfiguration.ClusterDNS) > 0 { 
 		userData += fmt.Sprintf("cluster-dns-ip = \"%s\"\n", constraints.KubeletConfiguration.ClusterDNS[0])
 	}
 	if caBundle != nil {

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -288,7 +288,7 @@ func (p *LaunchTemplateProvider) getUserData(ctx context.Context, constraints *v
 
 func (p *LaunchTemplateProvider) getBottlerocketUserData(ctx context.Context, constraints *v1alpha1.Constraints, additionalLabels map[string]string, caBundle *string) string {
 	userData := fmt.Sprintf("[settings.kubernetes]\ncluster-name = \"%s\"\napi-server = \"%s\"\n", injection.GetOptions(ctx).ClusterName, injection.GetOptions(ctx).ClusterEndpoint)
-	if len(constraints.KubeletConfiguration.ClusterDNS) > 0 { 
+	if len(constraints.KubeletConfiguration.ClusterDNS) > 0 {
 		userData += fmt.Sprintf("cluster-dns-ip = \"%s\"\n", constraints.KubeletConfiguration.ClusterDNS[0])
 	}
 	if caBundle != nil {


### PR DESCRIPTION
**1. Issue, if available:**
Using Bottlerocket with `spec.kubeletConfiguration.clusterDNS` in the provider will fail to generate valid user data (`"[ip]"` instead of `"ip"`), which leads to the nodes not becoming ready.

**2. Description of changes:**
This change matches the Bottlerocket behavior to the AL2 one, where only the first IP will be picked into the option. Since Bottlerocket OS also only supports a single IP for that option this seems to be the only plausible way atm.

**3. How was this change tested?**
Built a custom controller image and used it in my own EKS cluster w/ IPv6 (where setting the cluster DNS is required). Used `spec.provider.amiFamily: Bottlerocket`.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
