### PR TITLE
Add GHA to close stale issues and PRs

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           days-before-issue-stale: 10
           days-before-issue-close: 5
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
           days-before-pr-stale: 10
           days-before-pr-close: 5

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-issue-stale: 10
+          days-before-issue-close: 5
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-pr-stale: 10
+          days-before-pr-close: 5

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -14,6 +14,6 @@ jobs:
           days-before-issue-stale: 10
           days-before-issue-close: 5
           stale-pr-message: 'This PR is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
           days-before-pr-stale: 10
           days-before-pr-close: 5

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          days-before-issue-stale: 10
+          days-before-issue-stale: 25
           days-before-issue-close: 5
-          stale-pr-message: 'This PR is stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
-          days-before-pr-stale: 10
+          days-before-pr-stale: 25
           days-before-pr-close: 5


### PR DESCRIPTION
**1. Issue, if available:**
This is an attempt to keep issues and PRs fresh and relevant

**2. Description of changes:**
Closes stale issues and PRs.
It will label a PR or issue as stale after 10 days, and if the label is not removed or if there are no new comments it will close the issue or PR.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
