### PR TITLE
Add empty test suite to get rid of the Ginkgo warning

### DIFF
--- a/pkg/controllers/provisioning/binpacking/suite_test.go
+++ b/pkg/controllers/provisioning/binpacking/suite_test.go
@@ -1,0 +1,13 @@
+package binpacking_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBinpacking(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Binpacking Suite")
+}

--- a/pkg/controllers/provisioning/binpacking/suite_test.go
+++ b/pkg/controllers/provisioning/binpacking/suite_test.go
@@ -1,3 +1,17 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package binpacking_test
 
 import (


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1338#issuecomment-1039410294

There's a warning in `make test`
```
make test
ginkgo -r
[1645488461] Validation - 52/52 specs •••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 1.632009ms PASS
[1645488461] CloudProvider/AWS - 41/41 specs ••••••••••••••••••••••••••••••••••••••••• SUCCESS! 11.314522285s PASS
[1645488461] Node - 18/18 specs •••••••••••••••••• SUCCESS! 10.520671872s PASS
[1645488461] Volume - 3/3 specs ••• SUCCESS! 6.879056936s PASS
[1645488461] Controllers/Provisioning - 12/12 specs •••••••••••• SUCCESS! 9.398906116s PASS
PASS
testing: warning: no tests to run
Found no test suites, did you forget to run "ginkgo bootstrap"?[1645488461] Controllers/Scheduling - 44/44 specs •••••••S•••••••••••••••••••••••••••••••••••• SUCCESS! 12.433359071s PASS
[1645488461] Controllers/Selection - 12/12 specs •••••••••••• SUCCESS! 9.188944899s PASS
[1645488461] Termination - 9/9 specs ••••••••• SUCCESS! 11.817598447s PASS
[1645488461] Functional Suite - 6/6 specs •••••• SUCCESS! 253.52µs PASS
[1645488461] Sets Suite - 11/11 specs ••••••••••• SUCCESS! 408.054µs PASS

Ginkgo ran 11 suites in 1m30.812771144s
Test Suite Passed
```

**2. Description of changes:**
Gets rid of the warning. It seems like Ginggo needs to have a test suite defined everywhere there are `*_test.go` files.
With this change the output will have
```
[1645488642] Binpacking Suite - 0/0 specs  SUCCESS! 144.803µs PASS
```

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
