### PR TITLE
lower the number of max reconciles to 100 for the selection controller

### DIFF
--- a/pkg/controllers/selection/controller.go
+++ b/pkg/controllers/selection/controller.go
@@ -179,7 +179,7 @@ func (c *Controller) Register(_ context.Context, m manager.Manager) error {
 		NewControllerManagedBy(m).
 		Named(controllerName).
 		For(&v1.Pod{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 10_000}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 100}).
 		WithLogger(zapr.NewLogger(zap.NewNop())).
 		Complete(c)
 }


### PR DESCRIPTION
**1. Issue, if available:**

Each 'max concurrent reconcile' is turned into a launched goroutine
by the controller-runtime that watches the queue.  I found this as
the race detector errors out when you have more than 8k goroutines
running simultaneously.


**2. Description of changes:**

Lower concurrent reconciliations to 100

**3. How was this change tested?**

unit testing

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
