### PR TITLE
fix: properly quote Bottlerocket config

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -287,12 +287,12 @@ func (p *LaunchTemplateProvider) getUserData(ctx context.Context, constraints *v
 }
 
 func (p *LaunchTemplateProvider) getBottlerocketUserData(ctx context.Context, constraints *v1alpha1.Constraints, additionalLabels map[string]string, caBundle *string) string {
-	userData := fmt.Sprintf("[settings.kubernetes]\ncluster-name = \"%s\"\napi-server = \"%s\"\n", injection.GetOptions(ctx).ClusterName, injection.GetOptions(ctx).ClusterEndpoint)
+	userData := fmt.Sprintf("[settings.kubernetes]\n\"cluster-name\" = \"%s\"\n\"api-server\" = \"%s\"\n", injection.GetOptions(ctx).ClusterName, injection.GetOptions(ctx).ClusterEndpoint)
 	if len(constraints.KubeletConfiguration.ClusterDNS) > 0 {
-		userData += fmt.Sprintf("cluster-dns-ip = \"%s\"\n", constraints.KubeletConfiguration.ClusterDNS[0])
+		userData += fmt.Sprintf("\"cluster-dns-ip\" = \"%s\"\n", constraints.KubeletConfiguration.ClusterDNS[0])
 	}
 	if caBundle != nil {
-		userData += fmt.Sprintf("cluster-certificate = \"%s\"\n", *caBundle)
+		userData += fmt.Sprintf("\"cluster-certificate\" = \"%s\"\n", *caBundle)
 	}
 	nodeLabelArgs := functional.UnionStringMaps(additionalLabels, constraints.Labels)
 	if len(nodeLabelArgs) > 0 {
@@ -305,7 +305,7 @@ func (p *LaunchTemplateProvider) getBottlerocketUserData(ctx context.Context, co
 		userData += "[settings.kubernetes.node-taints]\n"
 		sorted := sortedTaints(constraints.Taints)
 		for _, taint := range sorted {
-			userData += fmt.Sprintf("%s=%s:%s\n", taint.Key, taint.Value, taint.Effect)
+			userData += fmt.Sprintf("\"%s\"=\"%s:%s\"\n", taint.Key, taint.Value, taint.Effect)
 		}
 	}
 	return base64.StdEncoding.EncodeToString([]byte(userData))


### PR DESCRIPTION
**1. Issue, if available:**

https://github.com/aws/karpenter/issues/1404

**2. Description of changes:**

In TOML, bare keys have limitations in the keys that they can contain
([A-Za-z0-9_-]) and strings _must_ be quoted. This change quotes all
keys to properly handle e.g. node labels with slashes in them and also
adds missing quotes for node taint values.

**3. How was this change tested?**

Manually, see https://github.com/aws/karpenter/pull/1406#issuecomment-1049307589

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
