### PR TITLE
[AWS] Favor subnets w/ more IP addresses when launching instances

### DIFF
--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -180,11 +180,11 @@ func (e *EC2API) DescribeSubnetsWithContext(context.Context, *ec2.DescribeSubnet
 		return e.DescribeSubnetsOutput, nil
 	}
 	return &ec2.DescribeSubnetsOutput{Subnets: []*ec2.Subnet{
-		{SubnetId: aws.String("test-subnet-1"), AvailabilityZone: aws.String("test-zone-1a"),
+		{SubnetId: aws.String("test-subnet-1"), AvailabilityZone: aws.String("test-zone-1a"), AvailableIpAddressCount: aws.Int64(100),
 			Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-1")}}},
-		{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1b"),
+		{SubnetId: aws.String("test-subnet-2"), AvailabilityZone: aws.String("test-zone-1b"), AvailableIpAddressCount: aws.Int64(100),
 			Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-2")}}},
-		{SubnetId: aws.String("test-subnet-3"), AvailabilityZone: aws.String("test-zone-1c"),
+		{SubnetId: aws.String("test-subnet-3"), AvailabilityZone: aws.String("test-zone-1c"), AvailableIpAddressCount: aws.Int64(100),
 			Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("test-subnet-3")}, {Key: aws.String("TestTag")}}},
 	}}, nil
 }

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -17,6 +17,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -180,6 +181,16 @@ func (p *InstanceProvider) getLaunchTemplateConfigs(ctx context.Context, constra
 // getOverrides creates and returns launch template overrides for the cross product of instanceTypeOptions and subnets (with subnets being constrained by
 // zones and the offerings in instanceTypeOptions)
 func (p *InstanceProvider) getOverrides(instanceTypeOptions []cloudprovider.InstanceType, subnets []*ec2.Subnet, zones sets.String, capacityType string) []*ec2.FleetLaunchTemplateOverridesRequest {
+	// aggregate subnets by zone and sort in descending order of available IP addresses
+	subnetsPerZone := map[string][]*ec2.Subnet{}
+	for _, subnet := range subnets {
+		zoneSubnets := subnetsPerZone[*subnet.AvailabilityZone]
+		zoneSubnets = append(zoneSubnets, subnet)
+		sort.Slice(zoneSubnets, func(i, j int) bool {
+			return aws.Int64Value(zoneSubnets[i].AvailableIpAddressCount) > aws.Int64Value(zoneSubnets[j].AvailableIpAddressCount)
+		})
+		subnetsPerZone[*subnet.AvailabilityZone] = zoneSubnets
+	}
 	var overrides []*ec2.FleetLaunchTemplateOverridesRequest
 	for i, instanceType := range instanceTypeOptions {
 		for _, offering := range instanceType.Offerings() {
@@ -189,27 +200,26 @@ func (p *InstanceProvider) getOverrides(instanceTypeOptions []cloudprovider.Inst
 			if !zones.Has(offering.Zone) {
 				continue
 			}
-			for _, subnet := range subnets {
-				if aws.StringValue(subnet.AvailabilityZone) != offering.Zone {
-					continue
-				}
-				override := &ec2.FleetLaunchTemplateOverridesRequest{
-					InstanceType: aws.String(instanceType.Name()),
-					SubnetId:     subnet.SubnetId,
-					// This is technically redundant, but is useful if we have to parse insufficient capacity errors from
-					// CreateFleet so that we can figure out the zone rather than additional API calls to look up the subnet
-					AvailabilityZone: subnet.AvailabilityZone,
-				}
-				// Add a priority for spot requests since we are using the capacity-optimized-prioritized spot allocation strategy
-				// to reduce the likelihood of getting an excessively large instance type.
-				// instanceTypeOptions are sorted by vcpus and memory so this prioritizes smaller instance types.
-				if capacityType == v1alpha1.CapacityTypeSpot {
-					override.Priority = aws.Float64(float64(i))
-				}
-				overrides = append(overrides, override)
-				// FleetAPI cannot span subnets from the same AZ, so break after the first one.
-				break
+			zoneSubnets := subnetsPerZone[offering.Zone]
+			if len(zoneSubnets) == 0 {
+				continue
 			}
+			// subnets are sorted in descending order of available IP addresses, so take the first entry for the subnet with the most available IPs
+			subnet := zoneSubnets[0]
+			override := &ec2.FleetLaunchTemplateOverridesRequest{
+				InstanceType: aws.String(instanceType.Name()),
+				SubnetId:     subnet.SubnetId,
+				// This is technically redundant, but is useful if we have to parse insufficient capacity errors from
+				// CreateFleet so that we can figure out the zone rather than additional API calls to look up the subnet
+				AvailabilityZone: subnet.AvailabilityZone,
+			}
+			// Add a priority for spot requests since we are using the capacity-optimized-prioritized spot allocation strategy
+			// to reduce the likelihood of getting an excessively large instance type.
+			// instanceTypeOptions are sorted by vcpus and memory so this prioritizes smaller instance types.
+			if capacityType == v1alpha1.CapacityTypeSpot {
+				override.Priority = aws.Float64(float64(i))
+			}
+			overrides = append(overrides, override)
 		}
 	}
 	return overrides

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -41,7 +41,7 @@ Karpenter discovers subnets using [AWS tags](https://docs.aws.amazon.com/AWSEC2/
 
 Subnets may be specified by any AWS tag, including `Name`. Selecting tag values using wildcards ("\*") is supported.
 
-When launching nodes, Karpenter automatically chooses a subnet that matches the desired zone. If multiple subnets exist for a zone, one is chosen randomly.
+When launching nodes, Karpenter automatically chooses a subnet that matches the desired zone. If multiple subnets exist for a zone, the one with the most available IP addresses will be used.
 
 **Examples**
 


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1297

**2. Description of changes:**
 - EC2 Fleet only accepts one subnet per AZ. This change will favor subnets w/ more available IP addresses if the multiple subnets are found for an AZ.

**3. How was this change tested?**
 - Unit testing 
 - Manual testing that existing logic works after change


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
