### PR TITLE
Enforce error checking in CI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,6 @@ linters:
     - unconvert
     - unparam
   disable:
-    - errcheck
     - prealloc
 
   linters-settings:

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -179,7 +179,10 @@ func ExpectProvisioned(ctx context.Context, c client.Client, selectionController
 	for _, pod := range pods {
 		wg.Add(1)
 		go func(pod *v1.Pod) {
-			selectionController.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+			_, err := selectionController.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
+			if err != nil {
+				Expect(err).ToNot(HaveOccurred())
+			}
 			wg.Done()
 		}(pod)
 	}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -179,9 +179,8 @@ func ExpectProvisioned(ctx context.Context, c client.Client, selectionController
 	for _, pod := range pods {
 		wg.Add(1)
 		go func(pod *v1.Pod) {
-			_, err := selectionController.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pod)})
-			if err != nil {
-				Expect(err).ToNot(HaveOccurred())
+			if _, err := selectionController.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pod)}); err != nil {
+				Expect(err).To(HaveOccurred()) // This is expected to sometimes happen
 			}
 			wg.Done()
 		}(pod)


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**

Enables a check that makes sure all errors are checked. This is good idea specially because we are already checking all errors except only in one test which this PR fixes.

There is really no good reason to leave errors unchecked. Beginners to Go are often surprised by how much error handling they have to do. In my perspective this is one of the beauties of Go. It makes the programmer think and react everywhere things can go wrong and we know at scale things that can go wrong will go wrong. Handling all errors therefore is  part of what it takes to produce high quality and reliable software.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
