### PR TITLE
Add logging for unexpected pod eviction errors

### DIFF
--- a/pkg/controllers/termination/eviction.go
+++ b/pkg/controllers/termination/eviction.go
@@ -73,7 +73,6 @@ func (e *EvictionQueue) Start(ctx context.Context) {
 		nn := item.(types.NamespacedName)
 		// Evict pod
 		if e.evict(ctx, nn) {
-			logging.FromContext(ctx).Debugf("Evicted pod %s", nn.String())
 			e.RateLimitingInterface.Forget(nn)
 			e.Set.Remove(nn)
 			e.RateLimitingInterface.Done(nn)
@@ -83,27 +82,26 @@ func (e *EvictionQueue) Start(ctx context.Context) {
 		// Requeue pod if eviction failed
 		e.RateLimitingInterface.AddRateLimited(nn)
 	}
-	logging.FromContext(ctx).Errorf("EvictionQueue is broken and has shutdown.")
+	logging.FromContext(ctx).Errorf("EvictionQueue is broken and has shutdown")
 }
 
 // evict returns true if successful eviction call, error is returned if not eviction-related error
 func (e *EvictionQueue) evict(ctx context.Context, nn types.NamespacedName) bool {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("pod", nn))
 	err := e.coreV1Client.Pods(nn.Namespace).Evict(ctx, &v1beta1.Eviction{
 		ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace},
 	})
-	if errors.IsInternalError(err) { // 500
-		logging.FromContext(ctx).Errorf("Could not evict pod %s due to PDB misconfiguration error.", nn.String())
-		return false
-	}
-	if errors.IsTooManyRequests(err) { // 429
-		logging.FromContext(ctx).Debugf("Did not evict pod %s due to PDB violation.", nn.String())
-		return false
-	}
 	if errors.IsNotFound(err) { // 404
 		return true
 	}
-	if err != nil {
+	if errors.IsTooManyRequests(err) { // 429
+		logging.FromContext(ctx).Debug(err)
 		return false
 	}
+	if err != nil {
+		logging.FromContext(ctx).Error(err)
+		return false
+	}
+	logging.FromContext(ctx).Debug("Evicted pod")
 	return true
 }


### PR DESCRIPTION
**1. Issue, if available:**
#1414

**2. Description of changes:**
The eviction API is supposed to only return 429 or 500 status codes when an error is encountered while evicting a pod (per [k8s documentation](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#eviction-api)).  Today, Karpenter only writes a debug log when a 500 or 429 status code is returned from the eviction API, but doesn't account for the case where an unexpected error/status code is received.  This change adds a catch-all so Karpenter will also log unexpected errors from the eviction API.  

Edit: This change also introduces structured logging for log emitted by eviction attempts.  Also, logs the returned error messages reported by the eviction API for consistency, instead of using custom error messages.

Related to this change, we identified what looks like a [bug in the eviction API](https://github.com/kubernetes/kubernetes/blob/v1.21.5/pkg/registry/core/pod/storage/eviction.go#L194-L198).  In the case where multiple PDBs are found for a pod, the error which is returned correlates to an InternalServerError (500), but the "reason" field excluded.  We believe this is the root cause of the problem identified in #1414 .  We will be pursuing an upstream fix, but this "catch-all" is also worth implementing to account for unexpected errors.  

**3. How was this change tested?**
* Deployed Karpenter including the change to a test EKS cluster
* Enabled debug logging
* Introduced a conflicting PDB

(edit) Result:
```
2022-03-03T15:37:19.267Z	DEBUG	controller.eviction	Cannot evict pod as it would violate the pod's disruption budget.	{"commit": "cd8a26f", "pod": "istio-system/istiod-d8576dfdf-hrsnk"}
2022-03-03T15:37:29.274Z	ERROR	controller.eviction	This pod has more than one PodDisruptionBudget, which the eviction subresource does not support.	{"commit": "cd8a26f", "pod": "istio-system/istio-ingressgateway-6559b68fb5-gpm29"}
2022-03-03T15:37:29.327Z	DEBUG	controller.eviction	Evicted pod	{"commit": "cd8a26f", "pod": "istio-system/istiod-d8576dfdf-hrsnk"}
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
