### PR TITLE
deeper podAffinity and anit-affinity checks

### DIFF
--- a/pkg/controllers/selection/controller.go
+++ b/pkg/controllers/selection/controller.go
@@ -141,10 +141,14 @@ func validateAffinity(pod *v1.Pod) (errs error) {
 	if pod.Spec.Affinity == nil {
 		return nil
 	}
-	if pod.Spec.Affinity.PodAffinity != nil {
+	if pod.Spec.Affinity.PodAffinity != nil &&
+		(len(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 ||
+			len(pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0) {
 		errs = multierr.Append(errs, fmt.Errorf("pod affinity is not supported"))
 	}
-	if pod.Spec.Affinity.PodAntiAffinity != nil {
+	if pod.Spec.Affinity.PodAntiAffinity != nil &&
+		(len(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 ||
+			len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0) {
 		errs = multierr.Append(errs, fmt.Errorf("pod anti-affinity is not supported"))
 	}
 	if pod.Spec.Affinity.NodeAffinity != nil {


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
  - Perform a deeper check to allow for empty PodAffinity and AntiAffinity since some helm charts are adding empty values for those keys. 


**3. How was this change tested?**
Tested with this podSpec:

```
apiVersion: apps/v1
 kind: Deployment
 metadata:
  spec:
     replicas: 10
     selector:
       matchLabels:
         app: inflate-amd64
     template:
         labels:
           app: inflate-amd64
       spec:
         affinity:
           podAntiAffinity: {}
         containers:
         - image: public.ecr.aws/eks-distro/kubernetes/pause:3.2
           name: inflate-amd64
           resources:
             requests:
               cpu: 100m
               memory: 10M
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
