### PR TITLE
deeper podAffinity and anti-affinity checks

### DIFF
--- a/pkg/controllers/selection/controller.go
+++ b/pkg/controllers/selection/controller.go
@@ -137,22 +137,22 @@ func validateTopology(pod *v1.Pod) (errs error) {
 	return errs
 }
 
-func validateAffinity(pod *v1.Pod) (errs error) {
-	if pod.Spec.Affinity == nil {
+func validateAffinity(p *v1.Pod) (errs error) {
+	if p.Spec.Affinity == nil {
 		return nil
 	}
-	if pod.Spec.Affinity.PodAffinity != nil {
+	if pod.HasPodAffinity(p) {
 		errs = multierr.Append(errs, fmt.Errorf("pod affinity is not supported"))
 	}
-	if pod.Spec.Affinity.PodAntiAffinity != nil {
+	if pod.HasPodAntiAffinity(p) {
 		errs = multierr.Append(errs, fmt.Errorf("pod anti-affinity is not supported"))
 	}
-	if pod.Spec.Affinity.NodeAffinity != nil {
-		for _, term := range pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+	if p.Spec.Affinity.NodeAffinity != nil {
+		for _, term := range p.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
 			errs = multierr.Append(errs, validateNodeSelectorTerm(term.Preference))
 		}
-		if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-			for _, term := range pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+		if p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			for _, term := range p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
 				errs = multierr.Append(errs, validateNodeSelectorTerm(term))
 			}
 		}

--- a/pkg/controllers/selection/suite_test.go
+++ b/pkg/controllers/selection/suite_test.go
@@ -268,3 +268,42 @@ var _ = Describe("Multiple Provisioners", func() {
 		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner2.Name))
 	})
 })
+
+var _ = Describe("Pod Affinity and AntiAffinity", func() {
+	It("should not schedule a pod with pod affinity", func() {
+		ExpectCreated(ctx, env.Client)
+		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{
+			PodRequirements: []v1.PodAffinityTerm{{TopologyKey: "foo"}},
+		}))[0]
+		ExpectNotScheduled(ctx, env.Client, pod)
+	})
+	It("should not schedule a pod with pod anti-affinity", func() {
+		ExpectCreated(ctx, env.Client)
+		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{
+			PodAntiRequirements: []v1.PodAffinityTerm{{TopologyKey: "foo"}},
+		}))[0]
+		ExpectNotScheduled(ctx, env.Client, pod)
+	})
+	It("should not schedule a pod with pod affinity preference", func() {
+		ExpectCreated(ctx, env.Client)
+		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{
+			PodPreferences: []v1.WeightedPodAffinityTerm{{Weight: 1, PodAffinityTerm: v1.PodAffinityTerm{TopologyKey: "foo"}}},
+		}))[0]
+		ExpectNotScheduled(ctx, env.Client, pod)
+	})
+	It("should not schedule a pod with pod anti-affinity preference", func() {
+		ExpectCreated(ctx, env.Client)
+		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{
+			PodAntiPreferences: []v1.WeightedPodAffinityTerm{{Weight: 1, PodAffinityTerm: v1.PodAffinityTerm{TopologyKey: "foo"}}},
+		}))[0]
+		ExpectNotScheduled(ctx, env.Client, pod)
+	})
+	It("should schedule a pod with empty pod affinity and anti-affinity", func() {
+		ExpectCreated(ctx, env.Client)
+		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{
+			PodRequirements:     []v1.PodAffinityTerm{},
+			PodAntiRequirements: []v1.PodAffinityTerm{},
+		}))[0]
+		ExpectScheduled(ctx, env.Client, pod)
+	})
+})

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -67,3 +67,17 @@ func IsOwnedBy(pod *v1.Pod, gvks []schema.GroupVersionKind) bool {
 	}
 	return false
 }
+
+// HasPodAffinity returns true if a non-empty PodAffinity is defined in the pod spec
+func HasPodAffinity(pod *v1.Pod) bool {
+	return pod.Spec.Affinity.PodAffinity != nil &&
+		(len(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 ||
+			len(pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0)
+}
+
+// HasPodAntiAffinity returns true if a non-empty PodAntiAffinity is defined in the pod spec
+func HasPodAntiAffinity(pod *v1.Pod) bool {
+	return pod.Spec.Affinity.PodAntiAffinity != nil &&
+		(len(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 ||
+			len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0)
+}


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - This adds a deeper check for podAffinity and podAntiAffinity. Before we were only checking if it was nil. There are some helm charts will will expose the podAffinity and anti-affinity in the values.yaml and will therefore populate them as empty instead of not specified. Karpenter would ignore these pods unnecessarily. 


**3. How was this change tested?**
 - Tested a pod w/ anti-affinity -> Karpenter ignores pod
 - Tested a pod w/ empty anti-affinity -> Karpenter schedules
 - Tested a pod w/ no anti-affinity -> Karpenter schedules


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
