### PR TITLE
Enable debug logging by default

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -102,7 +102,7 @@ webhook:
   # -- Webhook log level, defaults to the global log level
   logLevel: ""
 # -- Global log level
-logLevel: info
+logLevel: debug
 # -- Cluster name.
 clusterName: ""
 # -- Cluster endpoint.

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -105,10 +105,6 @@ Install the chart passing in the cluster details and the Karpenter role ARN.
 
 {{% script file="./content/en/preview/getting-started/scripts/step07-apply-helm-chart.sh" language="bash"%}}
 
-### Enable Debug Logging (optional)
-
-The global log level can be modified with the `logLevel` chart value (e.g. `--set logLevel=debug`) or the individual components can have their log level set with `controller.logLevel` or `webhook.logLevel` chart values.
-
 #### Deploy a temporary Prometheus and Grafana stack (optional)
 
 The following commands will deploy a Prometheus and Grafana stack that is suitable for this guide but does not include persistent storage or other configurations that would be necessary for monitoring a production deployment of Karpenter. This deployment includes two Karpenter dashboards that are automatically onboaraded to Grafana. They provide a variety of visualization examples on Karpenter metrices.


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Users have been facing issues that would have been resolved by viewing debug logging. Given how we treat debug logging today, it's useful to leave on as default, and users can filter (or turn down) as necessary.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
