### PR TITLE
Fixed logging command

### DIFF
--- a/website/content/en/preview/development-guide.md
+++ b/website/content/en/preview/development-guide.md
@@ -53,10 +53,11 @@ make test       # E2E correctness tests
 make battletest # More rigorous tests run in CI environment
 ```
 
-### Verbose Logging
+### Change Log Level
 
 ```bash
-kubectl patch configmap karpenter-config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}'
+kubectl patch configmap config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}' # Debug Level
+kubectl patch configmap config-logging -n karpenter --patch '{"data":{"loglevel.controller":"info"}}' # Info Level
 ```
 
 ### Debugging Metrics


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Our configmap used to specify logging is no longer called `karpenter-config-logging`. Additionally, we default to `debug` level logs, adding lines to change it as developer desires.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
