### PR TITLE
raise the minimum TTL seconds until expired to 300

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -28,9 +28,13 @@ import (
 )
 
 var (
-	SupportedNodeSelectorOps sets.String = sets.NewString(string(v1.NodeSelectorOpIn), string(v1.NodeSelectorOpNotIn), string(v1.NodeSelectorOpExists), string(v1.NodeSelectorOpDoesNotExist))
-	SupportedProvisionerOps  sets.String = sets.NewString(string(v1.NodeSelectorOpIn), string(v1.NodeSelectorOpNotIn), string(v1.NodeSelectorOpExists))
+	SupportedNodeSelectorOps = sets.NewString(string(v1.NodeSelectorOpIn), string(v1.NodeSelectorOpNotIn), string(v1.NodeSelectorOpExists), string(v1.NodeSelectorOpDoesNotExist))
+	SupportedProvisionerOps  = sets.NewString(string(v1.NodeSelectorOpIn), string(v1.NodeSelectorOpNotIn), string(v1.NodeSelectorOpExists))
 )
+
+// minTTLSecondsUntilExpired is the minimum pre-determined node lifetime. If this is set too small, nodes come up and may
+// be terminated before pods even become running.
+const minTTLSecondsUntilExpired = 300
 
 func (p *Provisioner) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs.Also(
@@ -48,8 +52,8 @@ func (s *ProvisionerSpec) validate(ctx context.Context) (errs *apis.FieldError) 
 }
 
 func (s *ProvisionerSpec) validateTTLSecondsUntilExpired() (errs *apis.FieldError) {
-	if ptr.Int64Value(s.TTLSecondsUntilExpired) < 0 {
-		return errs.Also(apis.ErrInvalidValue("cannot be negative", "ttlSecondsUntilExpired"))
+	if s.TTLSecondsUntilExpired != nil && ptr.Int64Value(s.TTLSecondsUntilExpired) < minTTLSecondsUntilExpired {
+		return errs.Also(apis.ErrInvalidValue(fmt.Sprintf("cannot be smaller than %d", minTTLSecondsUntilExpired), "ttlSecondsUntilExpired"))
 	}
 	return errs
 }

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -53,6 +53,11 @@ var _ = Describe("Validation", func() {
 		Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 	})
 
+	It("should fail on a small expiry ttl", func() {
+		provisioner.Spec.TTLSecondsUntilExpired = ptr.Int64(299)
+		Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+	})
+
 	It("should fail on negative empty ttl", func() {
 		provisioner.Spec.TTLSecondsAfterEmpty = ptr.Int64(-1)
 		Expect(provisioner.Validate(ctx)).ToNot(Succeed())

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -15,10 +15,10 @@ kind: Provisioner
 metadata:
   name: default
 spec:
-  # If nil, the feature is disabled, nodes will never expire
+  # If omitted, the feature is disabled, nodes will never expire
   ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
 
-  # If nil, the feature is disabled, nodes will never scale down due to low utilization
+  # If omitted, the feature is disabled, nodes will never scale down due to low utilization
   ttlSecondsAfterEmpty: 30
 
   # Provisioned nodes will have these taints


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**

Zero was a valid value which caused nodes to immediately be
terminated after creation. Update docs to replace 'nil' with
'omitted' for clarity when referring to intentionally missing
provisioner spec values.

**3. How was this change tested?**

Unit tests

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
