### PR TITLE
switch markdownify to safeHTML

### DIFF
--- a/website/layouts/shortcodes/script.html
+++ b/website/layouts/shortcodes/script.html
@@ -1,3 +1,3 @@
 {{ $file := .Get "file" | readFile }}
 {{ $lang := .Get "language" }}
-{{ (print "```" $lang "\n" $file "```") | markdownify }}
+{{ (print "```" $lang "\n" $file "```") | safeHTML }}


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**

markdownify turns '--' into an emdash which makes the included scripts
invalid for copying/pasting into a shell.

**3. How was this change tested?**

Netlify preview

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
