### PR TITLE
Add Make target to serve the hugo docs site locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,4 +76,7 @@ issues: ## Run GitHub issue analysis scripts
 	./hack/github/feature_request_reactions.py > "karpenter-feature-requests-$(shell date +"%Y-%m-%d").csv"
 	./hack/github/label_issue_count.py > "karpenter-labels-$(shell date +"%Y-%m-%d").csv"
 
-.PHONY: help dev ci release test battletest verify codegen apply delete toolchain release licenses issues
+docs: ## Serve the docs site locally
+	cd website && npm install && git submodule update --init --recursive && hugo server -l layouts/ --themesDir themes/
+
+.PHONY: help dev ci release test battletest verify codegen apply delete toolchain release licenses issues docs

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ issues: ## Run GitHub issue analysis scripts
 	./hack/github/feature_request_reactions.py > "karpenter-feature-requests-$(shell date +"%Y-%m-%d").csv"
 	./hack/github/label_issue_count.py > "karpenter-labels-$(shell date +"%Y-%m-%d").csv"
 
-docs: ## Serve the docs site locally
-	cd website && npm install && git submodule update --init --recursive && hugo server -l layouts/ --themesDir themes/
+website: ## Serve the docs website locally
+	cd website && npm install && git submodule update --init --recursive && hugo server
 
-.PHONY: help dev ci release test battletest verify codegen apply delete toolchain release licenses issues docs
+.PHONY: help dev ci release test battletest verify codegen apply delete toolchain release licenses issues website


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Add a make target that serves the hugo docs site locally


**3. How was this change tested?**
`make website` 


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
