### PR TITLE
Make script path dynamic and related to the page path

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
@@ -49,13 +49,13 @@ export KARPENTER_VERSION={{< param "latest_release_version" >}}
 
 Also set the following environment variables to store commonly used values.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step01-config.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step01-config.sh" language="bash"%}}
 
 ### Create a Cluster
 
 Create a cluster with `eksctl`. This example configuration file specifies a basic cluster with one initial node and sets up an IAM OIDC provider for the cluster to enable IAM roles for pods:
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step02-create-cluster.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step02-create-cluster.sh" language="bash"%}}
 
 This guide uses [AWS EKS managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) to host Karpenter.
 
@@ -69,11 +69,11 @@ Instances launched by Karpenter must run with an InstanceProfile that grants per
 
 First, create the IAM resources using AWS CloudFormation.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step03-iam-cloud-formation.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step03-iam-cloud-formation.sh" language="bash"%}}
 
 Second, grant access to instances using the profile to connect to the cluster. This command adds the Karpenter node role to your aws-auth configmap, allowing nodes with this role to connect to the cluster.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step04-grant-access.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step04-grant-access.sh" language="bash"%}}
 
 Now, Karpenter can launch new EC2 instances and those instances can connect to your cluster.
 
@@ -81,13 +81,13 @@ Now, Karpenter can launch new EC2 instances and those instances can connect to y
 
 Karpenter requires permissions like launching instances. This will create an AWS IAM Role, Kubernetes service account, and associate them using [IRSA](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html).
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step05-controller-iam.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step05-controller-iam.sh" language="bash"%}}
 
 ### Create the EC2 Spot Service Linked Role
 
 This step is only necessary if this is the first time you're using EC2 Spot in this account. More details are available [here](https://docs.aws.amazon.com/batch/latest/userguide/spot_fleet_IAM_role.html).
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step06-add-spot-role.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step06-add-spot-role.sh" language="bash"%}}
 
 ### Install Karpenter Helm Chart
 
@@ -95,25 +95,25 @@ Use Helm to deploy Karpenter to the cluster.
 
 Before the chart can be installed the repo needs to be added to Helm, run the following commands to add the repo.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step07-install-helm-chart.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step07-install-helm-chart.sh" language="bash"%}}
 
 Install the chart passing in the cluster details and the Karpenter role ARN.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh" language="bash"%}}
 
 #### Deploy a temporary Prometheus and Grafana stack (optional)
 
 The following commands will deploy a Prometheus and Grafana stack that is suitable for this guide but does not include persistent storage or other configurations that would be necessary for monitoring a production deployment of Karpenter. This deployment includes two Karpenter dashboards that are automatically onboaraded to Grafana. They provide a variety of visualization examples on Karpenter metrices.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step09-add-prometheus-grafana.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step09-add-prometheus-grafana.sh" language="bash"%}}
 
 The Grafana instance may be accessed using port forwarding.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step10-add-grafana-port-forward.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step10-add-grafana-port-forward.sh" language="bash"%}}
 
 The new stack has only one user, `admin`, and the password is stored in a secret. The following command will retrieve the password.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step11-grafana-get-password.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step11-grafana-get-password.sh" language="bash"%}}
 
 ### Provisioner
 
@@ -135,7 +135,7 @@ Review the [provisioner CRD]({{<ref "../../provisioner.md" >}}) for more informa
 
 Note: This provisioner will create capacity as long as the sum of all created capacity is less than the specified limit.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh" language="bash"%}}
 
 ## First Use
 
@@ -146,14 +146,14 @@ Create some pods using a deployment, and watch Karpenter provision nodes in resp
 
 This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-pause-container) and starts with zero replicas.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step13-automatic-node-provisioning.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step13-automatic-node-provisioning.sh" language="bash"%}}
 
 ### Automatic Node Termination
 
 Now, delete the deployment. After 30 seconds (`ttlSecondsAfterEmpty`),
 Karpenter should terminate the now empty nodes.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step14-deprovisioning.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step14-deprovisioning.sh" language="bash"%}}
 
 ### Manual Node Termination
 
@@ -163,10 +163,10 @@ finalizer to the node object, which blocks deletion until all pods are
 drained and the instance is terminated. Keep in mind, this only works for
 nodes provisioned by Karpenter.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step15-delete-node.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step15-delete-node.sh" language="bash"%}}
 
 ## Cleanup
 
 To avoid additional charges, remove the demo infrastructure from your AWS account.
 
-{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step16-cleanup.sh" language="bash"%}}
+{{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step16-cleanup.sh" language="bash"%}}

--- a/website/layouts/shortcodes/script.html
+++ b/website/layouts/shortcodes/script.html
@@ -1,3 +1,5 @@
-{{ $file := .Get "file" | readFile }}
+{{ $file := .Get "file" }}
+{{ $version := index ( split .Page.Path `/` ) 0 }}
+{{ $fileContents := replace $file `{VERSION}` $version | readFile }}
 {{ $lang := .Get "language" }}
-{{ (print "```" $lang "\n" $file "```") | safeHTML }}
+{{ (print "```" $lang "\n" $fileContents "```") | safeHTML }}


### PR DESCRIPTION
…either release version or preview

**1. Issue, if available:**


**2. Description of changes:**
This will change the behavior where the scripts are being read from the `preview` directory, and instead use the release directory that comes from the path of the page, for example for the preview version it will read from `./website/content/en/preview/...` and for v0.6.4 it will read from `./website/content/en/v0.6.4/...`.

This allows us to manage the scripts of each version independently should we need to.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
