### PR TITLE
Create GPU resources on new node

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -203,6 +203,7 @@ var _ = Describe("Allocation", func() {
 					})) {
 					node := ExpectScheduled(ctx, env.Client, pod)
 					Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "p3.8xlarge"))
+					Expect(node.Status.Capacity).To(HaveKeyWithValue(nvidiaGPUResourceName, resource.MustParse("4")))
 					nodeNames.Insert(node.Name)
 				}
 				Expect(nodeNames.Len()).To(Equal(2))
@@ -233,6 +234,7 @@ var _ = Describe("Allocation", func() {
 				) {
 					node := ExpectScheduled(ctx, env.Client, pod)
 					Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "inf1.6xlarge"))
+					Expect(node.Status.Capacity).To(HaveKeyWithValue(awsNeuronResourceName, resource.MustParse("4")))
 					nodeNames.Insert(node.Name)
 				}
 				Expect(nodeNames.Len()).To(Equal(2))


### PR DESCRIPTION
**1. Issue, if available:**
#1459 

**2. Description of changes:**
This change will create GPU resources on any new nvidia, AMD or AWS Neuron capable nodes. 

**3. How was this change tested?**
All local dev tests pass. This change was deployed to a v1.21 EKS cluster with a GPU provisioner and test pod specs as below. The new g5.xlarge node was correctly created and had the expected `nvidia.com/gpu` resource applied. 

I also verified that the nvidia-device-plugin also still functioned as normal with no unusual logs. 

```
apiVersion: karpenter.sh/v1alpha5
kind: Provisioner
metadata:
  name: gpu
spec:
  requirements:
    - key: karpenter.sh/capacity-type
      operator: In
      values: ["spot", "on-demand"]
    - key: "node.kubernetes.io/instance-type"
      operator: In
      values: ["g4dn.xlarge", "g5.xlarge"]
  limits:
    resources:
      nvidia.com/gpu: 10
  provider:
    launchTemplate: karpenter-gpu
    subnetSelector:
      Tier: private
  ttlSecondsAfterEmpty: 30
```

```
apiVersion: v1
kind: Pod
metadata:
  name: gpu-test-pod
spec:
  containers:
    - name: gpu-test
      image: nvcr.io/nvidia/cuda:10.1-base-ubuntu18.04
      command: [ "/bin/bash", "-c", "--" ]
      args: [ "while true; do nvidia-smi; sleep 5; done;" ]
      resources:
        limits:
          nvidia.com/gpu: 1
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
