### PR TITLE
Windows support

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	ArchitectureAmd64    = "amd64"
-	ArchitectureArm64    = "arm64"
-	OperatingSystemLinux = "linux"
+	ArchitectureAmd64      = "amd64"
+	ArchitectureArm64      = "arm64"
+	OperatingSystemLinux   = "linux"
+	OperatingSystemWindows = "windows"
 
 	// Karpenter specific domains and labels
 	KarpenterLabelDomain = "karpenter.sh"

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -19,9 +19,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
-	"sync"
-
-	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 )
 
 type EKS struct {
@@ -52,29 +49,4 @@ func (e EKS) Script() string {
 		userData.WriteString(fmt.Sprintf(" \\\n--dns-cluster-ip '%s'", e.KubeletConfig.ClusterDNS[0]))
 	}
 	return base64.StdEncoding.EncodeToString(userData.Bytes())
-}
-
-func (e EKS) nodeTaintArg() string {
-	nodeTaintsArg := ""
-	taintStrings := []string{}
-	var once sync.Once
-	for _, taint := range e.Taints {
-		once.Do(func() { nodeTaintsArg = "--register-with-taints=" })
-		taintStrings = append(taintStrings, fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect))
-	}
-	return fmt.Sprintf("%s%s", nodeTaintsArg, strings.Join(taintStrings, ","))
-}
-
-func (e EKS) nodeLabelArg() string {
-	nodeLabelArg := ""
-	labelStrings := []string{}
-	var once sync.Once
-	for k, v := range e.Labels {
-		if v1alpha5.LabelDomainExceptions.Has(k) {
-			continue
-		}
-		once.Do(func() { nodeLabelArg = "--node-labels=" })
-		labelStrings = append(labelStrings, fmt.Sprintf("%s=%v", k, v))
-	}
-	return fmt.Sprintf("%s%s", nodeLabelArg, strings.Join(labelStrings, ","))
 }

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/windows.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/windows.go
@@ -1,0 +1,48 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+type Windows struct {
+	Options
+}
+
+func (w Windows) Script() string {
+	var caBundleArg string
+	if w.CABundle != nil {
+		caBundleArg = fmt.Sprintf(`-Base64ClusterCA "%s"`, *w.CABundle)
+	}
+	var userData bytes.Buffer
+	userData.WriteString("<powershell>\n")
+	userData.WriteString(`[string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1\n`)
+	userData.WriteString(fmt.Sprintf(`& $EKSBootstrapScriptFile -EKSClusterName "%s" -APIServerEndpoint "%s" %s`, w.ClusterName, w.ClusterEndpoint, caBundleArg))
+
+	kubeletExtraArgs := strings.Join([]string{w.nodeLabelArg(), w.nodeTaintArg()}, " ")
+
+	if kubeletExtraArgs = strings.Trim(kubeletExtraArgs, " "); len(kubeletExtraArgs) > 0 {
+		userData.WriteString(fmt.Sprintf(` -KubeletExtraArgs "%s"`, kubeletExtraArgs))
+	}
+	if w.KubeletConfig != nil && len(w.KubeletConfig.ClusterDNS) > 0 {
+		userData.WriteString(fmt.Sprintf(` -DNSClusterIP "%s"`, w.KubeletConfig.ClusterDNS[0]))
+	}
+	userData.WriteString("\n<powershell>")
+	return base64.StdEncoding.EncodeToString(userData.Bytes())
+}

--- a/pkg/cloudprovider/aws/amifamily/windows.go
+++ b/pkg/cloudprovider/aws/amifamily/windows.go
@@ -1,0 +1,64 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amifamily
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/cloudprovider"
+	"github.com/aws/karpenter/pkg/cloudprovider/aws/amifamily/bootstrap"
+	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+)
+
+type Windows struct {
+	*Options
+}
+
+// SSMAlias returns the AMI Alias to query SSM
+func (w Windows) SSMAlias(version string, _ cloudprovider.InstanceType) string {
+	return fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-%s/image_id", version)
+}
+
+// UserData returns the default userdata script for the AMI Family
+func (w Windows) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string) bootstrap.Windows {
+	return bootstrap.Windows{
+		Options: bootstrap.Options{
+			ClusterName:             w.ClusterName,
+			ClusterEndpoint:         w.ClusterEndpoint,
+			AWSENILimitedPodDensity: w.AWSENILimitedPodDensity,
+			KubeletConfig:           kubeletConfig,
+			Taints:                  taints,
+			Labels:                  labels,
+			CABundle:                caBundle,
+		},
+	}
+}
+
+// DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
+func (w Windows) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
+	sda := defaultEBS
+	sda.VolumeSize = resource.NewScaledQuantity(50, resource.Giga)
+	return []*v1alpha1.BlockDeviceMapping{
+		{
+			DeviceName: aws.String("/dev/sda1"),
+			EBS:        &sda,
+		},
+	}
+}

--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -36,10 +36,12 @@ var (
 	AMIFamilyBottlerocket = "Bottlerocket"
 	AMIFamilyAL2          = "AL2"
 	AMIFamilyUbuntu       = "Ubuntu"
+	AMIFamilyWindows      = "Windows"
 	SupportedAMIFamilies  = []string{
 		AMIFamilyBottlerocket,
 		AMIFamilyAL2,
 		AMIFamilyUbuntu,
+		AMIFamilyWindows,
 	}
 )
 

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -382,6 +382,48 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2
 					Ipv4AddressesPerInterface: aws.Int64(60),
 				},
 			},
+			{
+				InstanceType:                  aws.String("m4.xlarge"),
+				SupportedUsageClasses:         DefaultSupportedUsageClasses,
+				SupportedVirtualizationTypes:  []*string{aws.String("hvm")},
+				BurstablePerformanceSupported: aws.Bool(false),
+				BareMetal:                     aws.Bool(false),
+				Hypervisor:                    aws.String("xen"),
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
+				},
+				VCpuInfo: &ec2.VCpuInfo{
+					DefaultVCpus: aws.Int64(4),
+				},
+				MemoryInfo: &ec2.MemoryInfo{
+					SizeInMiB: aws.Int64(16384),
+				},
+				NetworkInfo: &ec2.NetworkInfo{
+					MaximumNetworkInterfaces:  aws.Int64(4),
+					Ipv4AddressesPerInterface: aws.Int64(15),
+				},
+			},
+			{
+				InstanceType:                  aws.String("m4.16xlarge"),
+				SupportedUsageClasses:         DefaultSupportedUsageClasses,
+				SupportedVirtualizationTypes:  []*string{aws.String("hvm")},
+				BurstablePerformanceSupported: aws.Bool(false),
+				BareMetal:                     aws.Bool(false),
+				Hypervisor:                    aws.String("xen"),
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
+				},
+				VCpuInfo: &ec2.VCpuInfo{
+					DefaultVCpus: aws.Int64(64),
+				},
+				MemoryInfo: &ec2.MemoryInfo{
+					SizeInMiB: aws.Int64(262144),
+				},
+				NetworkInfo: &ec2.NetworkInfo{
+					MaximumNetworkInterfaces:  aws.Int64(8),
+					Ipv4AddressesPerInterface: aws.Int64(30),
+				},
+			},
 		},
 	}, false)
 	return nil
@@ -453,6 +495,22 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 			{
 				InstanceType: aws.String("c6g.large"),
 				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("m4.xlarge"),
+				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("m4.xlarge"),
+				Location:     aws.String("test-zone-1b"),
+			},
+			{
+				InstanceType: aws.String("m4.16xlarge"),
+				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("m4.16xlarge"),
+				Location:     aws.String("test-zone-1b"),
 			},
 		},
 	}, false)

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -290,6 +290,11 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 				}
 			}
 
+			os := v1alpha5.OperatingSystemLinux
+			if aws.StringValue(instance.Platform) == "Windows" {
+				os = v1alpha5.OperatingSystemWindows
+			}
+
 			return &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: nodeName,
@@ -308,7 +313,7 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 					NodeInfo: v1.NodeSystemInfo{
 						Architecture:    v1alpha1.AWSToKubeArchitectures[aws.StringValue(instance.Architecture)],
 						OSImage:         aws.StringValue(instance.ImageId),
-						OperatingSystem: v1alpha5.OperatingSystemLinux,
+						OperatingSystem: os,
 					},
 				},
 			}, nil

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -110,6 +110,10 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provider
 			Name:         "arm-instance-type",
 			Architecture: "arm64",
 		}),
+		NewInstanceType(InstanceTypeOptions{
+			Name:              "pod-private-ipv4-instance-type",
+			AWSPodPrivateIPv4: resource.MustParse("1"),
+		}),
 	}, nil
 }
 

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -84,17 +84,18 @@ func InstanceTypes(total int) []cloudprovider.InstanceType {
 }
 
 type InstanceTypeOptions struct {
-	Name             string
-	Offerings        []cloudprovider.Offering
-	Architecture     string
-	OperatingSystems sets.String
-	CPU              resource.Quantity
-	Memory           resource.Quantity
-	Pods             resource.Quantity
-	NvidiaGPUs       resource.Quantity
-	AMDGPUs          resource.Quantity
-	AWSNeurons       resource.Quantity
-	AWSPodENI        resource.Quantity
+	Name              string
+	Offerings         []cloudprovider.Offering
+	Architecture      string
+	OperatingSystems  sets.String
+	CPU               resource.Quantity
+	Memory            resource.Quantity
+	Pods              resource.Quantity
+	NvidiaGPUs        resource.Quantity
+	AMDGPUs           resource.Quantity
+	AWSNeurons        resource.Quantity
+	AWSPodENI         resource.Quantity
+	AWSPodPrivateIPv4 resource.Quantity
 }
 
 type InstanceType struct {
@@ -143,6 +144,10 @@ func (i *InstanceType) AWSNeurons() *resource.Quantity {
 
 func (i *InstanceType) AWSPodENI() *resource.Quantity {
 	return &i.options.AWSPodENI
+}
+
+func (i *InstanceType) AWSPodPrivateIPv4() *resource.Quantity {
+	return &i.options.AWSPodPrivateIPv4
 }
 
 func (i *InstanceType) Overhead() v1.ResourceList {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -66,6 +66,7 @@ type InstanceType interface {
 	AMDGPUs() *resource.Quantity
 	AWSNeurons() *resource.Quantity
 	AWSPodENI() *resource.Quantity
+	AWSPodPrivateIPv4() *resource.Quantity
 	Overhead() v1.ResourceList
 }
 

--- a/pkg/controllers/provisioning/binpacking/packable.go
+++ b/pkg/controllers/provisioning/binpacking/packable.go
@@ -78,13 +78,14 @@ func PackableFor(i cloudprovider.InstanceType) *Packable {
 	return &Packable{
 		InstanceType: i,
 		total: v1.ResourceList{
-			v1.ResourceCPU:      *i.CPU(),
-			v1.ResourceMemory:   *i.Memory(),
-			resources.NvidiaGPU: *i.NvidiaGPUs(),
-			resources.AMDGPU:    *i.AMDGPUs(),
-			resources.AWSNeuron: *i.AWSNeurons(),
-			resources.AWSPodENI: *i.AWSPodENI(),
-			v1.ResourcePods:     *i.Pods(),
+			v1.ResourceCPU:              *i.CPU(),
+			v1.ResourceMemory:           *i.Memory(),
+			resources.NvidiaGPU:         *i.NvidiaGPUs(),
+			resources.AMDGPU:            *i.AMDGPUs(),
+			resources.AWSNeuron:         *i.AWSNeurons(),
+			resources.AWSPodENI:         *i.AWSPodENI(),
+			resources.AWSPodPrivateIPv4: *i.AWSPodPrivateIPv4(),
+			v1.ResourcePods:             *i.Pods(),
 		},
 	}
 }

--- a/pkg/controllers/provisioning/scheduling/node.go
+++ b/pkg/controllers/provisioning/scheduling/node.go
@@ -165,6 +165,10 @@ func (n Node) hasCompatibleResources(resourceList v1.ResourceList, it cloudprovi
 			if it.AWSPodENI().Cmp(quantity) < 0 {
 				return false
 			}
+		case resources.AWSPodPrivateIPv4:
+			if it.AWSPodPrivateIPv4().Cmp(quantity) < 0 {
+				return false
+			}
 		default:
 			continue
 		}

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	NvidiaGPU = "nvidia.com/gpu"
-	AMDGPU    = "amd.com/gpu"
-	AWSNeuron = "aws.amazon.com/neuron"
-	AWSPodENI = "vpc.amazonaws.com/pod-eni"
+	NvidiaGPU         = "nvidia.com/gpu"
+	AMDGPU            = "amd.com/gpu"
+	AWSNeuron         = "aws.amazon.com/neuron"
+	AWSPodENI         = "vpc.amazonaws.com/pod-eni"
+	AWSPodPrivateIPv4 = "vpc.amazonaws.com/PrivateIPv4Address"
 )
 
 // RequestsForPods returns the total resources of a variadic list of podspecs.


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1131

**2. Description of changes:**
- add windows operating system support
- recognize aws vpc private ipv4 address resources requests/limits
- add windows amiFamily

**3. How was this change tested?**
- Functional Tests
- Manual tests on EKS:
   - Enable IAM permissions so [vpc-resource-controller](https://github.com/aws/amazon-vpc-resource-controller-k8s) run and configure vpc-cni to enable windows ipam
   - Create windows example deployment:
```
    spec:
      containers:
      - name: windows-server-iis
        image: mcr.microsoft.com/windows/servercore:ltsc2019
        resources:
          requests:
            cpu: 1000m
            memory: 2Gi
        command:
        - powershell.exe
        - -command
        - "Add-WindowsFeature Web-Server; Invoke-WebRequest -UseBasicParsing -Uri 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe' -OutFile 'C:\\ServiceMonitor.exe'; echo '<html><body><br/><br/><marquee><H1>Hello EKS!!!<H1><marquee></body><html>' > C:\\inetpub\\wwwroot\\default.html; C:\\ServiceMonitor.exe 'w3svc'; "
      nodeSelector:
        kubernetes.io/os: windows
        kubernetes.io/arch: amd64
```
   - Tested a provisioner with custom launch template using windows ami -> windows instances can join cluster, pod is scheduled
   - Tested a provisioner with amiFamily: Windows -> launchtemplate for windows instances created, can join cluster, pod is scheduled

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
