### PR TITLE
Reuse the upgrade script, and add trailing backslash where its missing

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -23,7 +23,7 @@ You can follow the detailed installation instruction in the [documentation](http
 helm upgrade --install --namespace karpenter --create-namespace \
   karpenter karpenter/karpenter \
   --version 0.6.4 \
-  --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN}
+  --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN} \
   --set clusterName=${CLUSTER_NAME} \
   --set clusterEndpoint=${CLUSTER_ENDPOINT} \
   --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \

--- a/charts/karpenter/README.md.gotmpl
+++ b/charts/karpenter/README.md.gotmpl
@@ -22,7 +22,7 @@ You can follow the detailed installation instruction in the [documentation](http
 helm upgrade --install --namespace karpenter --create-namespace \
   karpenter karpenter/{{ template "chart.name" . }} \
   --version {{ template "chart.version" . }} \
-  --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN}
+  --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN} \
   --set clusterName=${CLUSTER_NAME} \
   --set clusterEndpoint=${CLUSTER_ENDPOINT} \
   --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -136,14 +136,5 @@ Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes 
 
 Karpenter requires proper permissions in the `KarpenterNode IAM Role` and the `KarpenterController IAM Role`.
 To upgrade Karpenter to version `$VERSION`, make sure that the `KarpenterNode IAM Role` and the `KarpenterController IAM Role` have the right permission described in `https://karpenter.sh/$VERSION/getting-started/cloudformation.yaml`.
-Next, locate `KarpenterController IAM Role` ARN (i.e., ARN of the resource created in [Create the KarpenterController IAM Role](../getting-started/#create-the-karpentercontroller-iam-role)) and the cluster endpoint, and pass them to the helm upgrade command
-```
-helm upgrade --install --namespace karpenter --create-namespace \
-  karpenter karpenter/karpenter \
-  --version ${$VERSION} \
-  --set clusterName=${CLUSTER_NAME} \
-  --set clusterEndpoint=${CLUSTER_ENDPOINT} \
-  --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN}
-  --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
-  --wait # for the defaulting webhook to install before creating a Provisioner
-```
+Next, locate `KarpenterController IAM Role` ARN (i.e., ARN of the resource created in [Create the KarpenterController IAM Role](../getting-started/getting-started-with-eksctl/#create-the-karpenternode-iam-role)) and the cluster endpoint, and pass them to the helm upgrade command
+{{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh" language="bash"%}}

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -136,6 +136,5 @@ Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes 
 
 Karpenter requires proper permissions in the `KarpenterNode IAM Role` and the `KarpenterController IAM Role`.
 To upgrade Karpenter to version `$VERSION`, make sure that the `KarpenterNode IAM Role` and the `KarpenterController IAM Role` have the right permission described in `https://karpenter.sh/$VERSION/getting-started/cloudformation.yaml`.
-<<<<<<< HEAD
 Next, locate `KarpenterController IAM Role` ARN (i.e., ARN of the resource created in [Create the KarpenterController IAM Role](../getting-started/getting-started-with-eksctl/#create-the-karpentercontroller-iam-role)) and the cluster endpoint, and pass them to the helm upgrade command
 {{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh" language="bash"%}}


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
In FAQ under upgrade instructions use the same script used in getting started.
There's a missing backslash in all instances of this script that is also fixed.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
