### PR TITLE
Fix broken anchor link to getting started guide

### DIFF
--- a/charts/karpenter/README.md.gotmpl
+++ b/charts/karpenter/README.md.gotmpl
@@ -16,7 +16,7 @@ helm repo add karpenter https://charts.karpenter.sh/
 helm repo update
 ```
 
-You can follow the detailed installation instruction in the [documentation](https://karpenter.sh/v{{ template "chart.version" . }}/getting-started/#install) which covers the Karpenter prerequisites and installation options. The outcome of these instructions should result in something like the following command.
+You can follow the detailed installation instruction in the [documentation](https://karpenter.sh/v{{ template "chart.version" . }}/getting-started/getting-started-with-eksctl/#install) which covers the Karpenter prerequisites and installation options. The outcome of these instructions should result in something like the following command.
 
 ```bash
 helm upgrade --install --namespace karpenter --create-namespace \

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -136,7 +136,7 @@ Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes 
 
 Karpenter requires proper permissions in the `KarpenterNode IAM Role` and the `KarpenterController IAM Role`.
 To upgrade Karpenter to version `$VERSION`, make sure that the `KarpenterNode IAM Role` and the `KarpenterController IAM Role` have the right permission described in `https://karpenter.sh/$VERSION/getting-started/cloudformation.yaml`.
-Next, locate `KarpenterController IAM Role` ARN (i.e., ARN of the resource created in [Create the KarpenterController IAM Role](../getting-started/#create-the-karpentercontroller-iam-role)) and the cluster endpoint, and pass them to the helm upgrade command
+Next, locate `KarpenterController IAM Role` ARN (i.e., ARN of the resource created in [Create the KarpenterController IAM Role](../getting-started/getting-started-with-eksctl/#create-the-karpentercontroller-iam-role)) and the cluster endpoint, and pass them to the helm upgrade command
 ```
 helm upgrade --install --namespace karpenter --create-namespace \
   karpenter karpenter/karpenter \

--- a/website/content/en/preview/tasks/provisioning.md
+++ b/website/content/en/preview/tasks/provisioning.md
@@ -24,7 +24,7 @@ If you want to modify or add provisioners to Karpenter, do the following:
 
 1. Review the following Provisioner documents:
 
-  * [Provisioner](../../getting-started/#provisioner) in the Getting Started guide for a sample default Provisioner
+  * [Provisioner](../../getting-started/getting-started-with-eksctl/#provisioner) in the Getting Started guide for a sample default Provisioner
   * [Provisioner API](../../provisioner/) for descriptions of Provisioner API values
   * [Provisioning Configuration](../../AWS/provisioning) for cloud-specific settings
 


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
After https://github.com/aws/karpenter/pull/1456 `/getting-started/` is moved to `getting-started/getting-started-with-eksctl/` so all these anchor links need to be updated as well.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
