### PR TITLE
Setup script does not fail if spot SLR already installed

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step06-add-spot-role.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step06-add-spot-role.sh
@@ -1,3 +1,3 @@
-aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
+aws iam create-service-linked-role --aws-service-name spot.amazonaws.com || true
 # If the role has already been successfully created, you will see:
 # An error occurred (InvalidInput) when calling the CreateServiceLinkedRole operation: Service role name AWSServiceRoleForEC2Spot has been taken in this account, please try a different suffix.


### PR DESCRIPTION
**2. Description of changes:**
Since the SLR is optional, and fails if already installed, adding in a `|| true` into this part of the script so it doesn't fail.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
