### PR TITLE
set a grace period of zero when cleaning up between tests

### DIFF
--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -149,7 +149,8 @@ func ExpectCleanedUp(ctx context.Context, c client.Client) {
 		for _, namespace := range namespaces.Items {
 			wg.Add(1)
 			go func(object client.Object, namespace string) {
-				Expect(c.DeleteAllOf(ctx, object, client.InNamespace(namespace))).ToNot(HaveOccurred())
+				Expect(c.DeleteAllOf(ctx, object, client.InNamespace(namespace),
+					&client.DeleteAllOfOptions{DeleteOptions: client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)}})).ToNot(HaveOccurred())
 				wg.Done()
 			}(object, namespace.Name)
 		}


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**

Remove grace period when cleaning up between tests.

**3. How was this change tested?**

Hard-coded a pod name in two different tests, without this change the second test fails due to 'object is being deleted'.  With this change, both tests pass.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
