### PR TITLE
Relax PreferNoSchedule Taint

### DIFF
--- a/pkg/controllers/selection/preferences.go
+++ b/pkg/controllers/selection/preferences.go
@@ -49,16 +49,23 @@ func NewPreferences() *Preferences {
 // scheduled to that zone. Preferences are removed iteratively until only hard
 // constraints remain. Pods relaxation is reset (forgotten) after 5 minutes.
 func (p *Preferences) Relax(ctx context.Context, pod *v1.Pod) {
-	affinity, ok := p.cache.Get(string(pod.UID))
+	spec, ok := p.cache.Get(string(pod.UID))
 	// Add to cache if we've never seen it before
 	if !ok {
-		p.cache.SetDefault(string(pod.UID), pod.Spec.Affinity)
+		// Limit cached PodSpec to only required data
+		cachedSpec := v1.PodSpec{
+			Affinity:    pod.Spec.Affinity,
+			Tolerations: pod.Spec.Tolerations,
+		}
+		p.cache.SetDefault(string(pod.UID), cachedSpec)
 		return
 	}
 	// Attempt to relax the pod and update the cache
-	pod.Spec.Affinity = affinity.(*v1.Affinity)
+	cachedSpec := spec.(v1.PodSpec)
+	pod.Spec.Affinity = cachedSpec.Affinity
+	pod.Spec.Tolerations = cachedSpec.Tolerations
 	if relaxed := p.relax(ctx, pod); relaxed {
-		p.cache.SetDefault(string(pod.UID), pod.Spec.Affinity)
+		p.cache.SetDefault(string(pod.UID), pod.Spec)
 	}
 }
 
@@ -66,9 +73,10 @@ func (p *Preferences) relax(ctx context.Context, pod *v1.Pod) bool {
 	for _, relaxFunc := range []func(*v1.Pod) *string{
 		func(pod *v1.Pod) *string { return p.removePreferredNodeAffinityTerm(pod) },
 		func(pod *v1.Pod) *string { return p.removeRequiredNodeAffinityTerm(pod) },
+		func(pod *v1.Pod) *string { return p.toleratePreferNoScheduleTaints(pod) },
 	} {
 		if reason := relaxFunc(pod); reason != nil {
-			logging.FromContext(ctx).Debugf("Relaxing soft constraints for %s/%s since it previously failed to schedule, removing: %s", pod.Namespace, pod.Name, ptr.StringValue(reason))
+			logging.FromContext(ctx).Debugf("Relaxing soft constraints for pod since it previously failed to schedule, %s", ptr.StringValue(reason))
 			return true
 		}
 	}
@@ -85,7 +93,7 @@ func (p *Preferences) removePreferredNodeAffinityTerm(pod *v1.Pod) *string {
 		// Sort descending by weight to remove heaviest preferences to try lighter ones
 		sort.SliceStable(terms, func(i, j int) bool { return terms[i].Weight > terms[j].Weight })
 		pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = terms[1:]
-		return ptr.String(fmt.Sprintf("spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]=%s", pretty.Concise(terms[0])))
+		return ptr.String(fmt.Sprintf("removing: spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]=%s", pretty.Concise(terms[0])))
 	}
 	return nil
 }
@@ -101,7 +109,23 @@ func (p *Preferences) removeRequiredNodeAffinityTerm(pod *v1.Pod) *string {
 	// Remove the first term if there's more than one (terms are an OR semantic), Unlike preferred affinity, we cannot remove all terms
 	if len(terms) > 1 {
 		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = terms[1:]
-		return ptr.String(fmt.Sprintf("spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution[0]=%s", pretty.Concise(terms[0])))
+		return ptr.String(fmt.Sprintf("removing: spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution[0]=%s", pretty.Concise(terms[0])))
 	}
 	return nil
+}
+
+func (p *Preferences) toleratePreferNoScheduleTaints(pod *v1.Pod) *string {
+	// Tolerate all Taints with PreferNoSchedule effect
+	toleration := v1.Toleration{
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectPreferNoSchedule,
+	}
+	for _, t := range pod.Spec.Tolerations {
+		if t.MatchToleration(&toleration) {
+			return nil
+		}
+	}
+	tolerations := append(pod.Spec.Tolerations, toleration)
+	pod.Spec.Tolerations = tolerations
+	return ptr.String("adding: toleration for PreferNoSchedule taints")
 }


### PR DESCRIPTION
**1. Issue, if available:**
#1433

**2. Description of changes:**
When taints with the effect of `PreferNoSchedule` are applied to nodes, the behavior of kube-scheduler is to only schedule pods to said nodes when no other scheduling options exist.  Currently, Karpenter treats taints with the effect of `PreferNoSchedule` as `NoSchedule` and will not provision a node with the `PreferNoSchedule` taint unless the pod tolerates it explicitly.  

This change adds a blanket `PreferNoSchedule` toleration to pods when no other Provisioners are selectable and after attempting to relax Affinity terms.  In short, Provisioners with `PreferNoSchedule` taints which would otherwise meet the pods requirements will be used, but only as a last resort.  

**3. How was this change tested?**
A test was implemented in the test suite.  Additionally, manual tests were executed with a combination of provisioners configured.

**Example using a matching provisioner (PreferNoSchedule toleration is not added to pod):**
```
2022-03-08T17:23:29.999Z	INFO	controller.provisioning	Batched 5 pods in 1.074480675s	{"commit": "774d5ed", "provisioner": "default"}
````

**Example where Affinity terms exist and are relaxed which then match a provisioner (PreferNoSchedule toleration is not added to pod):**
```
2022-03-08T18:06:52.002Z	DEBUG	controller.selection	Could not schedule pod, matched 0/2 provisioners, tried provisioner/restricted: did not tolerate fake=fake:NoSchedule; tried provisioner/zonal: incompatible requirements, [us-west-2d] not in [us-west-2a], key topology.kubernetes.io/zone	{"commit": "774d5ed", "pod": "default/inflate-7c98f5b68d-kd78b"}
2022-03-08T18:06:52.007Z	DEBUG	controller.selection	Relaxing soft constraints for pod since it previously failed to schedule, removing: spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]={"weight":1,"preference":{"matchExpressions":[{"key":"topology.kubernetes.io/zone","operator":"In","values":["us-west-2a"]}]}}	{"commit": "774d5ed", "pod": "default/inflate-7c98f5b68d-kd78b"}
2022-03-08T18:06:53.008Z	INFO	controller.provisioning	Batched 1 pods in 1.000311298s	{"commit": "774d5ed", "provisioner": "zonal"}
```

**Example where only matching provisioner has PreferNoSchedule taint (PreferNoSchedule toleration is added to pod):**
```
2022-03-08T17:31:32.796Z	DEBUG	controller.selection	Could not schedule pod, matched 0/2 provisioners, tried provisioner/prefer-no-schedule: did not tolerate fake=fake:PreferNoSchedule; tried provisioner/restricted: did not tolerate fake=fake:NoSchedule	{"commit": "774d5ed", "pod": "default/inflate-6b88c9fb68-t7cvm"}
2022-03-08T17:31:32.801Z	DEBUG	controller.selection	Relaxing soft constraints for pod since it previously failed to schedule, adding: toleration for PreferNoSchedule taints	{"commit": "774d5ed", "pod": "default/inflate-6b88c9fb68-t7cvm"}
2022-03-08T17:31:33.802Z	INFO	controller.provisioning	Batched 1 pods in 1.000636795s	{"commit": "774d5ed", "provisioner": "prefer-no-schedule"}
```

**Example where no provisioners match (PreferNoSchedule toleration is added to pod, but still no provisioners match):**
```
2022-03-08T17:36:28.079Z	DEBUG	controller.selection	Could not schedule pod, matched 0/1 provisioners, tried provisioner/restricted: did not tolerate fake=fake:NoSchedule	{"commit": "774d5ed", "pod": "default/inflate-6b88c9fb68-5jj8f"}
2022-03-08T17:36:28.085Z	DEBUG	controller.selection	Relaxing soft constraints for pod since it previously failed to schedule, adding: toleration for PreferNoSchedule taints	{"commit": "774d5ed", "pod": "default/inflate-6b88c9fb68-5jj8f"}
2022-03-08T17:36:28.085Z	DEBUG	controller.selection	Could not schedule pod, matched 0/1 provisioners, tried provisioner/restricted: did not tolerate fake=fake:NoSchedule	{"commit": "774d5ed", "pod": "default/inflate-6b88c9fb68-5jj8f"}
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
