### PR TITLE
Enabled `kubectl delete karpenter --all` with crd categories

### DIFF
--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: karpenter.sh
   names:
+    categories:
+    - karpenter
     kind: Provisioner
     listKind: ProvisionerList
     plural: provisioners

--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -47,7 +47,7 @@ type ProvisionerSpec struct {
 
 // Provisioner is the Schema for the Provisioners API
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=provisioners,scope=Cluster
+// +kubebuilder:resource:path=provisioners,scope=Cluster,categories=karpenter
 // +kubebuilder:subresource:status
 type Provisioner struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Simple ease-of-use tweak to karpenter CRD.

```
k delete karpenter --all
provisioner.karpenter.sh "default" deleted
```
😮 

https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#categories
https://book.kubebuilder.io/reference/markers/crd.html

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
