### PR TITLE
Apply tags to resources created by Karpenter

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/tags.go
@@ -28,8 +28,14 @@ import (
 
 func MergeTags(ctx context.Context, custom ...map[string]string) (result []*ec2.Tag) {
 	tags := map[string]string{
+		// karpenter.sh/provisioner-name: <provisioner-name>
 		v1alpha5.ProvisionerNameLabelKey: injection.GetNamespacedName(ctx).Name,
-		"Name":                           fmt.Sprintf("%s/%s", v1alpha5.ProvisionerNameLabelKey, injection.GetNamespacedName(ctx).Name),
+		// karpenter.sh/cluster/<cluster-name>: owned
+		fmt.Sprintf("%s/cluster/%s", v1alpha5.Group, injection.GetOptions(ctx).ClusterName): "owned",
+		// kubernetes.io/cluster/<cluster-name>: owned
+		fmt.Sprintf("kubernetes.io/cluster/%s", injection.GetOptions(ctx).ClusterName): "owned",
+		// Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
+		"Name": fmt.Sprintf("%s/cluster/%s/provisioner/%s", v1alpha5.Group, injection.GetOptions(ctx).ClusterName, injection.GetNamespacedName(ctx).Name),
 	}
 	// Custom tags may override defaults (e.g. Name)
 	for _, t := range custom {

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -137,7 +137,7 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 		return nil, fmt.Errorf("getting launch template configs, %w", err)
 	}
 	// Create fleet
-	tags := v1alpha1.MergeTags(ctx, constraints.Tags, map[string]string{fmt.Sprintf("kubernetes.io/cluster/%s", injection.GetOptions(ctx).ClusterName): "owned"})
+	tags := v1alpha1.MergeTags(ctx, constraints.Tags)
 	createFleetInput := &ec2.CreateFleetInput{
 		Type:                  aws.String(ec2.FleetTypeInstant),
 		LaunchTemplateConfigs: launchTemplateConfigs,
@@ -148,6 +148,7 @@ func (p *InstanceProvider) launchInstances(ctx context.Context, constraints *v1a
 		TagSpecifications: []*ec2.TagSpecification{
 			{ResourceType: aws.String(ec2.ResourceTypeInstance), Tags: tags},
 			{ResourceType: aws.String(ec2.ResourceTypeVolume), Tags: tags},
+			{ResourceType: aws.String(ec2.ResourceTypeFleet), Tags: tags},
 		},
 	}
 	if capacityType == v1alpha1.CapacityTypeSpot {


### PR DESCRIPTION
**1. Issue, if available:**
#1488

**2. Description of changes:**
As part of issue #1488, it was discovered that default tags are not being applied to AWS resources per the [Karpenter documentation](https://karpenter.sh/v0.6.5/aws/provisioning/#tags).  This change applies the default tags to fleets, instances, volumes and launch templates.
```
karpenter.sh/provisioner-name: <provisioner-name>
karpenter.sh/cluster/<cluster-name>: owned
kubernetes.io/cluster/<cluster-name>: owned
Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
```

**3. How was this change tested?**
Added some tests to ensure resources created by Karpenter have the default tags.  Also manually tested and validated all resources have the default tags:
```
        {
            "Key": "karpenter.sh/cluster/dewaard-karpenter-demo",
            "Value": "owned"
        },
        {
            "Key": "Name",
            "Value": "karpenter.sh/cluster/dewaard-karpenter-demo/provisioner/default"
        },
        {
            "Key": "karpenter.sh/provisioner-name",
            "Value": "default"
        },
        {
            "Key": "kubernetes.io/cluster/dewaard-karpenter-demo",
            "Value": "owned"
        }
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
