### PR TITLE
Fix broken links to files in getting started

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -135,6 +135,6 @@ Karpenter is a controller that runs in your cluster, but it is not tied to a spe
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
 Karpenter requires proper permissions in the `KarpenterNode IAM Role` and the `KarpenterController IAM Role`.
-To upgrade Karpenter to version `$VERSION`, make sure that the `KarpenterNode IAM Role` and the `KarpenterController IAM Role` have the right permission described in `https://karpenter.sh/$VERSION/getting-started/cloudformation.yaml`.
+To upgrade Karpenter to version `$VERSION`, make sure that the `KarpenterNode IAM Role` and the `KarpenterController IAM Role` have the right permission described in `https://karpenter.sh/$VERSION/getting-started/getting-started-with-eksctl/cloudformation.yaml`.
 Next, locate `KarpenterController IAM Role` ARN (i.e., ARN of the resource created in [Create the KarpenterController IAM Role](../getting-started/getting-started-with-eksctl/#create-the-karpentercontroller-iam-role)) and the cluster endpoint, and pass them to the helm upgrade command
 {{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh" language="bash"%}}

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.5.6/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.5.6/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.6.0/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.0/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.6.1/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.1/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.6.2/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.2/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.6.3/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.3/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.6.4/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.4/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.6.5/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.6.5/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-pod-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/karpenter-node-metrics.json
+      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1502

**2. Description of changes:**
Fixes broken links to files in the getting started guide

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
