### PR TITLE
Remove IAM role and policy properly in cleanup.sh

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/cleanup.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/cleanup.sh
@@ -2,7 +2,6 @@
 
 declare -a steps=(
   step01-config.sh
-  step14-deprovisioning.sh
   step16-cleanup.sh
 )
 

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step16-cleanup.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step16-cleanup.sh
@@ -1,5 +1,7 @@
 helm uninstall karpenter --namespace karpenter
-aws iam delete-role --role-name "${CLUSTER_NAME}-karpenter"
+aws iam detach-role-policy --role-name="${CLUSTER_NAME}-karpenter" --policy-arn="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerPolicy-${CLUSTER_NAME}"
+aws iam delete-policy --policy-arn="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/KarpenterControllerPolicy-${CLUSTER_NAME}"
+aws iam delete-role --role-name="${CLUSTER_NAME}-karpenter"
 aws cloudformation delete-stack --stack-name "Karpenter-${CLUSTER_NAME}"
 aws ec2 describe-launch-templates \
     | jq -r ".LaunchTemplates[].LaunchTemplateName" \


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
We are missing a step in cleanup.sh to remove what we add in:
https://github.com/aws/karpenter/blob/db7ed9c7935332da0fbcdf17ab38c45b956d139a/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step05-controller-iam.sh#L4

This causes the install.sh to fail after running cleanup.

To remove the role, the policy must be detached first. Otherwise the following errors occur:

```
An error occurred (DeleteConflict) when calling the DeleteRole operation: Cannot delete entity, must detach all policies first.
An error occurred (DeleteConflict) when calling the DeletePolicy operation: Cannot delete a policy attached to entities.
```

**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
