### PR TITLE
Fix the example of Block Device Mapping configuration

### DIFF
--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -173,18 +173,19 @@ Learn more about [block device mappings](https://docs.aws.amazon.com/AWSEC2/late
 
 Note: If a custom launch template is specified, then the `BlockDeviceMappings` field in the launch template is used rather than the provisioner's `blockDeviceMappings`.
 
-```
+```yaml
 spec:
   provider:
     blockDeviceMappings:
       - deviceName: /dev/xvda
-        volumeSize: 100Gi
-        volumeType: gp3
-        iops: 10000
-        encrypted: true
-        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-        deleteOnTermination: true
-        throughput: 125
+        ebs:
+          volumeSize: 100Gi
+          volumeType: gp3
+          iops: 10000
+          encrypted: true
+          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+          deleteOnTermination: true
+          throughput: 125
 ```
 
 ## Other Resources


### PR DESCRIPTION
**1. Issue, if available:**

In the example, several items including `volumeType` and `volumeSize` are at the same level as the deviceName.
However, I found it seems correct that they are under the `ebs`.

https://github.com/aws/karpenter/blob/c1d08c6c91019443746ef310f2cd778335b4be65/pkg/cloudprovider/aws/apis/v1alpha1/provider.go#L129-L190

**2. Description of changes:**

I made the following changes to the example Block Device Mapping configuration.

- Move all items except `deviceName`
- Enable `yaml` syntax highlight

**3. How was this change tested?**

https://deploy-preview-1517--karpenter-docs-prod.netlify.app/preview/aws/provisioning/#block-device-mappings

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
