### PR TITLE
Get rid of the equal char when calling bootstrap.sh

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -41,7 +41,7 @@ func (e EKS) Script() string {
 	kubeletExtraArgs := strings.Join([]string{e.nodeLabelArg(), e.nodeTaintArg()}, " ")
 
 	if !e.AWSENILimitedPodDensity {
-		userData.WriteString(" \\\n--use-max-pods false")
+		userData.WriteString(" \\\n--use-max-pods=false")
 		kubeletExtraArgs += " --max-pods=110"
 	}
 	if kubeletExtraArgs = strings.Trim(kubeletExtraArgs, " "); len(kubeletExtraArgs) > 0 {

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -36,6 +36,7 @@ func (e EKS) Script() string {
 	var userData bytes.Buffer
 	userData.WriteString("#!/bin/bash -xe\n")
 	userData.WriteString("exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1\n")
+	// Due to the way bootstrap.sh is written, parameters should not be passed to it with an equal sign
 	userData.WriteString(fmt.Sprintf("/etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' %s", e.ClusterName, e.ClusterEndpoint, caBundleArg))
 
 	kubeletExtraArgs := strings.Join([]string{e.nodeLabelArg(), e.nodeTaintArg()}, " ")

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -41,14 +41,14 @@ func (e EKS) Script() string {
 	kubeletExtraArgs := strings.Join([]string{e.nodeLabelArg(), e.nodeTaintArg()}, " ")
 
 	if !e.AWSENILimitedPodDensity {
-		userData.WriteString(" \\\n--use-max-pods=false")
+		userData.WriteString(" \\\n--use-max-pods false")
 		kubeletExtraArgs += " --max-pods=110"
 	}
 	if kubeletExtraArgs = strings.Trim(kubeletExtraArgs, " "); len(kubeletExtraArgs) > 0 {
-		userData.WriteString(fmt.Sprintf(" \\\n--kubelet-extra-args='%s'", kubeletExtraArgs))
+		userData.WriteString(fmt.Sprintf(" \\\n--kubelet-extra-args '%s'", kubeletExtraArgs))
 	}
 	if e.KubeletConfig != nil && len(e.KubeletConfig.ClusterDNS) > 0 {
-		userData.WriteString(fmt.Sprintf(" \\\n--dns-cluster-ip='%s'", e.KubeletConfig.ClusterDNS[0]))
+		userData.WriteString(fmt.Sprintf(" \\\n--dns-cluster-ip '%s'", e.KubeletConfig.ClusterDNS[0]))
 	}
 	return base64.StdEncoding.EncodeToString(userData.Bytes())
 }

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -31,12 +31,12 @@ type EKS struct {
 func (e EKS) Script() string {
 	var caBundleArg string
 	if e.CABundle != nil {
-		caBundleArg = fmt.Sprintf("--b64-cluster-ca='%s'", *e.CABundle)
+		caBundleArg = fmt.Sprintf("--b64-cluster-ca '%s'", *e.CABundle)
 	}
 	var userData bytes.Buffer
 	userData.WriteString("#!/bin/bash -xe\n")
 	userData.WriteString("exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1\n")
-	userData.WriteString(fmt.Sprintf("/etc/eks/bootstrap.sh '%s' --apiserver-endpoint='%s' %s", e.ClusterName, e.ClusterEndpoint, caBundleArg))
+	userData.WriteString(fmt.Sprintf("/etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' %s", e.ClusterName, e.ClusterEndpoint, caBundleArg))
 
 	kubeletExtraArgs := strings.Join([]string{e.nodeLabelArg(), e.nodeTaintArg()}, " ")
 

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -41,7 +41,7 @@ func (e EKS) Script() string {
 	kubeletExtraArgs := strings.Join([]string{e.nodeLabelArg(), e.nodeTaintArg()}, " ")
 
 	if !e.AWSENILimitedPodDensity {
-		userData.WriteString(" \\\n--use-max-pods=false")
+		userData.WriteString(" \\\n--use-max-pods false")
 		kubeletExtraArgs += " --max-pods=110"
 	}
 	if kubeletExtraArgs = strings.Trim(kubeletExtraArgs, " "); len(kubeletExtraArgs) > 0 {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -630,7 +630,7 @@ var _ = Describe("Allocation", func() {
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
 				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-				Expect(string(userData)).NotTo(ContainSubstring("--use-max-pods=false"))
+				Expect(string(userData)).NotTo(ContainSubstring("--use-max-pods false"))
 			})
 			It("should specify --use-max-pods=false when not using ENI-based pod density", func() {
 				opts.AWSENILimitedPodDensity = false
@@ -640,7 +640,7 @@ var _ = Describe("Allocation", func() {
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
 				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-				Expect(string(userData)).To(ContainSubstring("--use-max-pods=false"))
+				Expect(string(userData)).To(ContainSubstring("--use-max-pods false"))
 				Expect(string(userData)).To(ContainSubstring("--max-pods=110"))
 			})
 			Context("Kubelet Args", func() {
@@ -651,7 +651,7 @@ var _ = Describe("Allocation", func() {
 					Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Cardinality()).To(Equal(1))
 					input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().(*ec2.CreateLaunchTemplateInput)
 					userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-					Expect(string(userData)).To(ContainSubstring("--dns-cluster-ip='10.0.10.100'"))
+					Expect(string(userData)).To(ContainSubstring("--dns-cluster-ip '10.0.10.100'"))
 				})
 			})
 			Context("Instance Profile", func() {


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Get rid of the equal sign because the bootstrap.sh will not properly parse it and assume it is empty. Which will result in it trying to find the API server automatically which works for EKS cluster but does not for others.

The extra `=`s were added in https://github.com/aws/karpenter/pull/1420

This is a problem introduced in 


**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
