### PR TITLE
add option to set AWS_ENI_LIMITED_POD_DENSITY true/false

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
           {{- if .Values.aws.defaultInstanceProfile }}
             - name: AWS_DEFAULT_INSTANCE_PROFILE
               value: {{ .Values.aws.defaultInstanceProfile }}
+            - name: AWS_ENI_LIMITED_POD_DENSITY
+              value: {{ quote .Values.aws.eni_limited_pod_density }}
           {{- end }}
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -110,4 +110,4 @@ clusterEndpoint: ""
 aws:
   # -- The default instance profile to use when launching nodes on AWS
   defaultInstanceProfile: ""
-  eni_limited_pod_density: "true"
+  eni_limited_pod_density: true

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -110,3 +110,4 @@ clusterEndpoint: ""
 aws:
   # -- The default instance profile to use when launching nodes on AWS
   defaultInstanceProfile: ""
+  eni_limited_pod_density: "true"


### PR DESCRIPTION
**1. Issue, if available:**

[#1524](https://github.com/aws/karpenter/issues/1524)

**2. Description of changes:**

Set AWS_ENI_LIMITED_POD_DENSITY envar directly, using tools like terraform the value can only be passed as string and Karpenter expects bool 

**3. How was this change tested?**

I tested locally on my cluster

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened:
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
