### PR TITLE
allow pod scheduling if they express soft pod affinity / anti affinity

### DIFF
--- a/pkg/controllers/selection/controller.go
+++ b/pkg/controllers/selection/controller.go
@@ -142,11 +142,11 @@ func validateAffinity(p *v1.Pod) (errs error) {
 	if p.Spec.Affinity == nil {
 		return nil
 	}
-	if pod.HasPodAffinity(p) {
-		errs = multierr.Append(errs, fmt.Errorf("pod affinity is not supported"))
+	if pod.HasRequiredPodAffinity(p) {
+		errs = multierr.Append(errs, fmt.Errorf("strong pod affinity is not supported"))
 	}
-	if pod.HasPodAntiAffinity(p) {
-		errs = multierr.Append(errs, fmt.Errorf("pod anti-affinity is not supported"))
+	if pod.HasRequiredPodAntiAffinity(p) {
+		errs = multierr.Append(errs, fmt.Errorf("strong pod anti-affinity is not supported"))
 	}
 	if p.Spec.Affinity.NodeAffinity != nil {
 		for _, term := range p.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {

--- a/pkg/controllers/selection/suite_test.go
+++ b/pkg/controllers/selection/suite_test.go
@@ -321,19 +321,19 @@ var _ = Describe("Pod Affinity and AntiAffinity", func() {
 		}))[0]
 		ExpectNotScheduled(ctx, env.Client, pod)
 	})
-	It("should not schedule a pod with pod affinity preference", func() {
+	It("should schedule a pod with pod affinity preference", func() {
 		ExpectCreated(ctx, env.Client)
 		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{
 			PodPreferences: []v1.WeightedPodAffinityTerm{{Weight: 1, PodAffinityTerm: v1.PodAffinityTerm{TopologyKey: "foo"}}},
 		}))[0]
-		ExpectNotScheduled(ctx, env.Client, pod)
+		ExpectScheduled(ctx, env.Client, pod)
 	})
-	It("should not schedule a pod with pod anti-affinity preference", func() {
+	It("should schedule a pod with pod anti-affinity preference", func() {
 		ExpectCreated(ctx, env.Client)
 		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(test.PodOptions{
 			PodAntiPreferences: []v1.WeightedPodAffinityTerm{{Weight: 1, PodAffinityTerm: v1.PodAffinityTerm{TopologyKey: "foo"}}},
 		}))[0]
-		ExpectNotScheduled(ctx, env.Client, pod)
+		ExpectScheduled(ctx, env.Client, pod)
 	})
 	It("should schedule a pod with empty pod affinity and anti-affinity", func() {
 		ExpectCreated(ctx, env.Client)

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -68,16 +68,16 @@ func IsOwnedBy(pod *v1.Pod, gvks []schema.GroupVersionKind) bool {
 	return false
 }
 
-// HasPodAffinity returns true if a non-empty PodAffinity is defined in the pod spec
-func HasPodAffinity(pod *v1.Pod) bool {
+// HasRequiredPodAffinity returns true if a non-empty PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+// is defined in the pod spec
+func HasRequiredPodAffinity(pod *v1.Pod) bool {
 	return pod.Spec.Affinity.PodAffinity != nil &&
-		(len(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 ||
-			len(pod.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0)
+		(len(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0)
 }
 
-// HasPodAntiAffinity returns true if a non-empty PodAntiAffinity is defined in the pod spec
-func HasPodAntiAffinity(pod *v1.Pod) bool {
+// HasRequiredPodAntiAffinity returns true if a non-empty PodAntiAffinity/RequiredDuringSchedulingIgnoredDuringExecution
+// is defined in the pod spec
+func HasRequiredPodAntiAffinity(pod *v1.Pod) bool {
 	return pod.Spec.Affinity.PodAntiAffinity != nil &&
-		(len(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 ||
-			len(pod.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 0)
+		(len(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0)
 }


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
- Changed method name `Pod.HasPodAffinity` to `Pod.HasRequiredPodAffinity` 
- `Pod.HasRequiredPodAffinity` returns true only if `PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution` is not empty
- Changed method name `Pod.HasPodAntiAffinity` to `Pod.HasRequiredPodAntiAffinity` 
- `Pod.HasRequiredPodAntiAffinity` returns true only if `PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution` is not empty
- added the relevant tests

**3. How was this change tested?**
- UnitTest
- Manual testing in an EKS cluster:
    -  pods with `podAffinity.requiredDuringSchedulingIgnoredDuringExecution` spec, fail to be scheduled by Karpenter with `Ignoring pod, strong pod affinity is not supported` error
    -  pods with `podAntyAffinity.requiredDuringSchedulingIgnoredDuringExecution` spec, fail to be scheduled by Karpenter with `Ignoring pod, strong pod anti affinity is not supported` error
   -  pods with `podAffinity.preferredDuringSchedulingIgnoredDuringExecution` spec are scheduled by Karpenter
   -  pods with `podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution` spec are scheduled by Karpenter
   
**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

I looked at the documentation and didn't find any specific reference to podAffinity and antiAffinity, a part from this bit in the scheduling session:
```
Pod affinity is a key exception to this rule.
```
but I'm happy to add more, if needed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
