### PR TITLE
fix issue regarding not pre-filtering instance types by provider constraints

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -109,6 +109,8 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provider
 		NewInstanceType(InstanceTypeOptions{
 			Name:         "arm-instance-type",
 			Architecture: "arm64",
+			CPU:          resource.MustParse("16"),
+			Memory:       resource.MustParse("128Gi"),
 		}),
 	}, nil
 }


### PR DESCRIPTION

**1. Issue, if available:**

Fixes #1540

**2. Description of changes:**

Pre-filter the available instance types by the provider constraints

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
