### PR TITLE
Lint YAML files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ jobs:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:
     - uses: actions/checkout@v2
+    - uses: ibiqlik/action-yamllint@v3
+      with:
+        config_file: .github/workflows/config/.yamllint.yaml
     - uses: actions/setup-go@v2
       with:
         go-version: 1.17

--- a/.github/workflows/config/.yamllint.yaml
+++ b/.github/workflows/config/.yamllint.yaml
@@ -17,7 +17,7 @@ rules:
   document-end: disable
   document-start:
     level: warning
-  empty-lines: disabled
+  empty-lines: disable
   empty-values: disable
   hyphens: enable
   indentation: disable

--- a/.github/workflows/config/.yamllint.yaml
+++ b/.github/workflows/config/.yamllint.yaml
@@ -1,0 +1,33 @@
+---
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+ignore: charts/karpenter/templates
+rules:
+  braces: disable
+  brackets: disable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines: enable
+  empty-values: disable
+  hyphens: enable
+  indentation: disable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/config/.yamllint.yaml
+++ b/.github/workflows/config/.yamllint.yaml
@@ -17,7 +17,7 @@ rules:
   document-end: disable
   document-start:
     level: warning
-  empty-lines: enable
+  empty-lines: disabled
   empty-values: disable
   hyphens: enable
   indentation: disable


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Adds linting to yaml files.

YAML is a pretty easy format to mess up, and bad YAML files can cause weird unexpected results, hence it's important to protect the code base from introduction of bad yaml files and also lint our yaml files to enforce some level of standardization and cleanliness.

This adds a yaml linter to the repo, for now it disables checking for all the problems that we already have, we can later on enable them one by one after fixing the issues.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
