### PR TITLE
Resolved two bugs with NodeAffinity and simplified compatibility logic

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -71,7 +71,7 @@ func (c *Constraints) GenerateLabels() map[string]string {
 	for key := range c.Requirements.Keys() {
 		if !IsRestrictedNodeLabel(key) {
 			// Ignore cases when values set is empty (i.e., DoesNotExist or <In, NotIn> cancling out)
-			if c.Requirements.Get(key).IsEmpty() {
+			if c.Requirements.Get(key).Len() == 0 {
 				continue
 			}
 			labels[key] = c.Requirements.Label(key)

--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -19,6 +19,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/aws/karpenter/pkg/utils/rand"
 )
 
 // Constraints are applied to all nodes created by the provisioner.
@@ -70,11 +72,12 @@ func (c *Constraints) GenerateLabels() map[string]string {
 	}
 	for key := range c.Requirements.Keys() {
 		if !IsRestrictedNodeLabel(key) {
-			// Ignore cases when values set is empty (i.e., DoesNotExist or <In, NotIn> cancling out)
-			if c.Requirements.Get(key).Len() == 0 {
-				continue
+			switch c.Requirements.Get(key).Type() {
+			case v1.NodeSelectorOpIn:
+				labels[key] = c.Requirements.Get(key).Values().UnsortedList()[0]
+			case v1.NodeSelectorOpExists:
+				labels[key] = rand.String(10)
 			}
-			labels[key] = c.Requirements.Label(key)
 		}
 	}
 	return labels

--- a/pkg/apis/provisioning/v1alpha5/requirements.go
+++ b/pkg/apis/provisioning/v1alpha5/requirements.go
@@ -24,7 +24,6 @@ import (
 	stringsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	"github.com/aws/karpenter/pkg/utils/rand"
 	"github.com/aws/karpenter/pkg/utils/sets"
 )
 
@@ -100,8 +99,6 @@ func (r Requirements) Add(requirements ...v1.NodeSelectorRequirement) Requiremen
 			values = sets.NewComplementSet()
 		case v1.NodeSelectorOpDoesNotExist:
 			values = sets.NewSet()
-		default:
-			values = sets.NewSet()
 		}
 		if existing, ok := r.requirements[requirement.Key]; ok {
 			values = values.Intersection(existing)
@@ -118,21 +115,6 @@ func (r Requirements) Keys() stringsets.String {
 		keys.Insert(requirement.Key)
 	}
 	return keys
-}
-
-// Labels returns value realization for the provided key.
-// If the set is a complement set, return a randomly generated value.
-// If the set is not a complement set, return the first value in the set.
-func (r Requirements) Label(key string) string {
-	values := r.Get(key)
-	if values.IsComplement() {
-		label := rand.String(10)
-		for !values.Has(label) {
-			label = rand.String(10)
-		}
-		return label
-	}
-	return values.Values().UnsortedList()[0]
 }
 
 func (r Requirements) Has(key string) bool {
@@ -180,18 +162,9 @@ func (r Requirements) Validate() (errs error) {
 		if !SupportedNodeSelectorOps.Has(string(requirement.Operator)) {
 			errs = multierr.Append(errs, fmt.Errorf("operator %s not in %s for key %s", requirement.Operator, SupportedNodeSelectorOps.UnsortedList(), requirement.Key))
 		}
-		// Excludes cases when DoesNotExists appears together with In, NotIn, Exists
-		if requirement.Operator == v1.NodeSelectorOpDoesNotExist {
-			if r.hasRequirement(withKeyAndOperator(requirement.Key, v1.NodeSelectorOpIn)) ||
-				r.hasRequirement(withKeyAndOperator(requirement.Key, v1.NodeSelectorOpNotIn)) ||
-				r.hasRequirement(withKeyAndOperator(requirement.Key, v1.NodeSelectorOpExists)) {
-				errs = multierr.Append(errs, fmt.Errorf("operator %s cannot coexist with other operators for key %s", v1.NodeSelectorOpDoesNotExist, requirement.Key))
-			}
-		}
-	}
-	for key := range r.Keys() {
-		if r.Get(key).Len() == 0 && !r.hasRequirement(withKeyAndOperator(key, v1.NodeSelectorOpDoesNotExist)) {
-			errs = multierr.Append(errs, fmt.Errorf("no feasible value for key %s", key))
+		// Combined requirements must have some possible value unless Operator=DoesNotExist.
+		if values := r.Get(requirement.Key); values.Len() == 0 && requirement.Operator != v1.NodeSelectorOpDoesNotExist {
+			errs = multierr.Append(errs, fmt.Errorf("no feasible value for key %s", requirement.Key))
 		}
 	}
 	return errs
@@ -200,35 +173,20 @@ func (r Requirements) Validate() (errs error) {
 // Compatible ensures the provided requirements can be met.
 func (r Requirements) Compatible(requirements Requirements) (errs error) {
 	for key, requirement := range requirements.requirements {
-		if requirement.Type() == v1.NodeSelectorOpIn && requirement.Intersection(r.Get(key)).Len() == 0 {
+		intersection := requirement.Intersection(r.Get(key))
+		// There must be some value, except in these cases
+		if intersection.Len() == 0 {
+			// Where incoming requirement has operator { NotIn, DoesNotExist }
+			if requirement.Type() == v1.NodeSelectorOpNotIn || requirement.Type() == v1.NodeSelectorOpDoesNotExist {
+				// And existing requirement has operator { NotIn, DoesNotExist }
+				if r.Get(key).Type() == v1.NodeSelectorOpNotIn || r.Get(key).Type() == v1.NodeSelectorOpDoesNotExist {
+					continue
+				}
+			}
 			errs = multierr.Append(errs, fmt.Errorf("%s not in %s, key %s", requirement, r.Get(key), key))
-		}
-		if requirement.Type() == v1.NodeSelectorOpExists && requirement.Intersection(r.Get(key)).Len() == 0 {
-			errs = multierr.Append(errs, fmt.Errorf("%s not in %s, key %s", requirement, r.Get(key), key))
-		}
-		if requirement.Type() == v1.NodeSelectorOpNotIn && r.Get(key).Type() == v1.NodeSelectorOpIn && requirement.Intersection(r.Get(key)).Len() == 0 {
-			errs = multierr.Append(errs, fmt.Errorf("%s not in %s, key %s", requirement, r.Get(key), key))
-		}
-		if requirement.Type() == v1.NodeSelectorOpDoesNotExist && r.Get(key).Len() > 0 {
-			errs = multierr.Append(errs, fmt.Errorf("operator DoesNotExist prohibits %s, key %s", r.Get(key), key))
 		}
 	}
 	return errs
-}
-
-func (r Requirements) hasRequirement(f func(v1.NodeSelectorRequirement) bool) bool {
-	for _, requirement := range r.Requirements {
-		if f(requirement) {
-			return true
-		}
-	}
-	return false
-}
-
-func withKeyAndOperator(key string, operator v1.NodeSelectorOperator) func(v1.NodeSelectorRequirement) bool {
-	return func(requirement v1.NodeSelectorRequirement) bool {
-		return key == requirement.Key && requirement.Operator == operator
-	}
 }
 
 func (r *Requirements) MarshalJSON() ([]byte, error) {

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -314,20 +314,20 @@ var _ = Describe("Validation", func() {
 			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist})
 			Expect(A.Compatible(B)).ToNot(Succeed())
 		})
-		It("A should fail to be compatible to B, <Exists, Empty> operator, conflicting", func() {
+		It("A should be compatible to B, <Exists, Empty> operator", func() {
 			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpExists})
 			B := NewRequirements()
-			Expect(A.Compatible(B)).ToNot(Succeed())
+			Expect(A.Compatible(B)).To(Succeed())
 		})
 		It("A should fail to be compatible to B, <DoesNotExist, In> operator, conflicting", func() {
 			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist})
 			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"foo"}})
 			Expect(A.Compatible(B)).ToNot(Succeed())
 		})
-		It("A should fail to be compatible to B, <DoesNotExist, NotIn> operator, conflicting", func() {
+		It("A should be compatible to B, <DoesNotExist, NotIn> operator", func() {
 			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist})
 			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"foo"}})
-			Expect(A.Compatible(B)).ToNot(Succeed())
+			Expect(A.Compatible(B)).To(Succeed())
 		})
 		It("A should fail to be compatible to B, <DoesNotExists, Exists> operator, conflicting", func() {
 			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist})
@@ -340,7 +340,7 @@ var _ = Describe("Validation", func() {
 			Expect(A.Compatible(B)).To(Succeed())
 		})
 		It("A should be compatible to B, <DoesNotExist, Empty> operator", func() {
-			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist, Values: []string{"foo"}})
+			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist})
 			B := NewRequirements()
 			Expect(A.Compatible(B)).To(Succeed())
 		})
@@ -354,14 +354,14 @@ var _ = Describe("Validation", func() {
 			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"foo"}})
 			Expect(A.Compatible(B)).To(Succeed())
 		})
-		It("A should fail to be compatible to B,, <Empty, Exists> operator, conflicting", func() {
+		It("A should fail to be compatible to B, <Empty, Exists> operator, conflicting", func() {
 			A := NewRequirements()
 			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpExists})
 			Expect(A.Compatible(B)).ToNot(Succeed())
 		})
 		It("A should be compatible to B, <Empty, DoesNotExist> operator", func() {
 			A := NewRequirements()
-			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist, Values: []string{"foo"}})
+			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist})
 			Expect(A.Compatible(B)).To(Succeed())
 		})
 	})

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -284,10 +284,10 @@ var _ = Describe("Validation", func() {
 			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpExists})
 			Expect(A.Compatible(B)).To(Succeed())
 		})
-		It("A should fail to be compatible to B, <NotIn, DoesNotExist> operator, conflicting", func() {
+		It("A should be compatible to B, <NotIn, DoesNotExist> operator, conflicting", func() {
 			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"test", "foo"}})
 			B := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpDoesNotExist})
-			Expect(A.Compatible(B)).ToNot(Succeed())
+			Expect(A.Compatible(B)).To(Succeed())
 		})
 		It("A should be compatible to B, <NotIn, Empty> operator", func() {
 			A := NewRequirements(v1.NodeSelectorRequirement{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"foo"}})

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -16,12 +16,9 @@ package scheduling_test
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strings"
 	"testing"
 	"time"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/Pallinder/go-randomdata"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
@@ -31,6 +28,8 @@ import (
 	"github.com/aws/karpenter/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter/pkg/controllers/selection"
 	"github.com/aws/karpenter/pkg/test"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "k8s.io/api/core/v1"

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -401,7 +401,7 @@ var _ = Describe("Custom Constraints", func() {
 				}}))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
-		It("should schedule pods that have node selectors with DoesNotExists operator and undefined key", func() {
+		It("should schedule pods that with DoesNotExists operator and undefined key", func() {
 			pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpDoesNotExist},

--- a/pkg/utils/sets/sets.go
+++ b/pkg/utils/sets/sets.go
@@ -73,7 +73,7 @@ func (s Set) Type() v1.NodeSelectorOperator {
 }
 
 // Values returns the values of the set.
-// If the set has an infinite size, it will panic
+// If the set is negatively defined, it will panic
 func (s Set) Values() sets.String {
 	if s.complement {
 		panic("infinite set")

--- a/pkg/utils/sets/sets.go
+++ b/pkg/utils/sets/sets.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -53,14 +54,22 @@ func (s Set) DeepCopy() Set {
 	}
 }
 
-//  IsComplement returns whether the set is a complement set.
+// IsComplement returns whether the set is a complement set.
 func (s Set) IsComplement() bool {
 	return s.complement
 }
 
-//  IsEmpty returns whether the set is an empty set.
-func (s Set) IsEmpty() bool {
-	return !s.complement && s.values.Len() == 0
+func (s Set) Type() v1.NodeSelectorOperator {
+	if s.IsComplement() {
+		if s.Len() < math.MaxInt64 {
+			return v1.NodeSelectorOpNotIn
+		}
+		return v1.NodeSelectorOpExists
+	}
+	if s.Len() > 0 {
+		return v1.NodeSelectorOpIn
+	}
+	return v1.NodeSelectorOpDoesNotExist
 }
 
 // Values returns the values of the set.

--- a/pkg/utils/sets/suite_test.go
+++ b/pkg/utils/sets/suite_test.go
@@ -57,9 +57,6 @@ var _ = Describe("Set", func() {
 		})
 	})
 	Context("Functional Correctness", func() {
-		It("A should not be empty", func() {
-			Expect(setA.IsEmpty()).To(BeFalse())
-		})
 		It("size of AB should be 2", func() {
 			Expect(setAB.Len()).To(Equal(2))
 		})


### PR DESCRIPTION
## Description of changes 
### Fixed: A should be compatible to B, <DoesNotExist, NotIn> operator
According to the second bullet at https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement, DoesNotExist and NotIn are compatible. For example, A Pod that requires `foo 'not in' bar` may schedule to a node without a label with key `foo`. 

Previously, we required the node to have the label `foo` with a value of something other than `bar`.

### Fixed: A should be compatible to B, <Exists, Empty> operator
Node labels cannot repel a pod (see: taints), unless a pod has conflicting requirements. In this case, a pod with empty requirements should happily schedule to a node with an Exists requirement on a node.

Previously, the pod needed to have a requirement for label `foo` in order to schedule onto node with requirement `foo: Exists`.

*Note: ` provisioner only supports [In NotIn Exists]`, so it wasn't currently possible to run into this bug.*

### Cleanup: NullSet == EmptySet
Previously, we treated the undefined set to be the same as the universal set. In set theory, the nil set and the empty set are typically modeled equivalently (https://en.wikipedia.org/wiki/Empty_set). Treating NullSet == UniversalSet set was relied upon in `requirements.Add`, but significantly increased the complexity of our compatibility checks. Instead, we intersect requirements in `requirements.Add` if a requirement for the given key already exists, otherwise we use the added requirement as-is.

### Cleanup: Compatibility Checks
Previously we oriented the logic around NodeSelectorOp rules via `requirements.hasRequirement(withKeyAndOperator(key, v1.NodeSelectorOpExists))`. Instead, we can use the properties of the underlying set (e.g. Full, Empty, Positive, Negative). This collapses O(n^2) iteration through requirements to O(n), and simplifies the predicates.

### Cleanup: Requirement Validation
Previously, requirement validation logic redundantly checked that DoesNotExist operators did not coexist with other operators as well as ensuring that valid values exist for any requirement with an operator other than DoesNotExist. This has been collapsed into a single check, and no longer relies on `requirements.hasRequirement(withKeyAndOperator`. This also collapses O(n^2) iteration through requirements to O(n), and simplifies the predicates.

**3. How was this change tested?**
- `make test`
- Manually

```
kind: Provisioner
metadata:
  name: default
spec:
  requirements:
  - key: isolation
    operator: Exists
```
```
apiVersion: v1
kind: Pod
metadata:
  name: inflate-6d7d985f4d-8pkgx
  namespace: default
spec:
  containers:
  - image: public.ecr.aws/eks-distro/kubernetes/pause:3.2
    name: inflate
    resources:
      requests:
        cpu: "1"
  nodeSelector:
    isolation: ellis
```
```
apiVersion: v1
kind: Node
metadata:
  annotations:
    node.alpha.kubernetes.io/ttl: "0"
  creationTimestamp: "2022-03-19T19:47:34Z"
  finalizers:
  - karpenter.sh/termination
  labels:
    isolation: ellis <------------------------------ Here it is!
    karpenter.sh/capacity-type: on-demand
    karpenter.sh/provisioner-name: default
    node.kubernetes.io/instance-type: t3a.micro
    topology.kubernetes.io/zone: us-west-2b
  name: ip-192-168-120-29.us-west-2.compute.internal
```


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
