### PR TITLE
Fix default tags in docs

### DIFF
--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -117,8 +117,8 @@ Select security groups by name using a wildcard:
 Karpenter adds tags to all resources it creates, including EC2 Instances, EBS volumes, and Launch Templates. The default set of AWS tags are listed below.
 
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.5.5/AWS/provisioning.md
+++ b/website/content/en/v0.5.5/AWS/provisioning.md
@@ -127,8 +127,8 @@ spec:
 ```
 Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.5.6/AWS/provisioning.md
+++ b/website/content/en/v0.5.6/AWS/provisioning.md
@@ -127,8 +127,8 @@ spec:
 ```
 Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.6.0/AWS/provisioning.md
+++ b/website/content/en/v0.6.0/AWS/provisioning.md
@@ -127,8 +127,8 @@ spec:
 ```
 Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.6.1/AWS/provisioning.md
+++ b/website/content/en/v0.6.1/AWS/provisioning.md
@@ -127,8 +127,8 @@ spec:
 ```
 Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.6.2/AWS/provisioning.md
+++ b/website/content/en/v0.6.2/AWS/provisioning.md
@@ -127,8 +127,8 @@ spec:
 ```
 Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.6.3/AWS/provisioning.md
+++ b/website/content/en/v0.6.3/AWS/provisioning.md
@@ -127,8 +127,8 @@ spec:
 ```
 Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.6.4/AWS/provisioning.md
+++ b/website/content/en/v0.6.4/AWS/provisioning.md
@@ -126,8 +126,8 @@ spec:
 ```
 Note: Karpenter will set the default AWS tags listed below, but these can be overridden in the tags section above.
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.6.5/AWS/provisioning.md
+++ b/website/content/en/v0.6.5/AWS/provisioning.md
@@ -117,8 +117,8 @@ Select security groups by name using a wildcard:
 Karpenter adds tags to all resources it creates, including EC2 Instances, EBS volumes, and Launch Templates. The default set of AWS tags are listed below.
 
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.7.0/AWS/provisioning.md
+++ b/website/content/en/v0.7.0/AWS/provisioning.md
@@ -117,8 +117,8 @@ Select security groups by name using a wildcard:
 Karpenter adds tags to all resources it creates, including EC2 Instances, EBS volumes, and Launch Templates. The default set of AWS tags are listed below.
 
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.7.1/AWS/provisioning.md
+++ b/website/content/en/v0.7.1/AWS/provisioning.md
@@ -117,8 +117,8 @@ Select security groups by name using a wildcard:
 Karpenter adds tags to all resources it creates, including EC2 Instances, EBS volumes, and Launch Templates. The default set of AWS tags are listed below.
 
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 

--- a/website/content/en/v0.7.2/AWS/provisioning.md
+++ b/website/content/en/v0.7.2/AWS/provisioning.md
@@ -117,8 +117,8 @@ Select security groups by name using a wildcard:
 Karpenter adds tags to all resources it creates, including EC2 Instances, EBS volumes, and Launch Templates. The default set of AWS tags are listed below.
 
 ```
-Name: karpenter.sh/cluster/<cluster-name>/provisioner/<provisioner-name>
-karpenter.sh/cluster/<cluster-name>: owned
+Name: karpenter.sh/provisioner/<provisioner-name>
+karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 


### PR DESCRIPTION
**1. Issue, if available:**
#1488 #1525 

**2. Description of changes:**
[Documentation regarding the default tags](https://karpenter.sh/v0.7.2/aws/provisioning/#tags) applied to resources created by Karpenter do not match what is in the code.  This change updates docs going back to v0.5.5 to accurately reflect the set of default tags.

**3. How was this change tested?**
Built locally and validated content.

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
