### PR TITLE
add support for EBS snapshotID in block device mappings

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
@@ -166,6 +166,9 @@ type BlockDevice struct {
 	// KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.
 	KMSKeyID *string `json:"kmsKeyID,omitempty"`
 
+	// SnapshotID is the ID of an EBS snapshot
+	SnapshotID *string `json:"snapshotID,omitempty"`
+
 	// Throughput to provision for a gp3 volume, with a maximum of 1,000 MiB/s.
 	// Valid Range: Minimum value of 125. Maximum value of 1000.
 	Throughput *int64 `json:"throughput,omitempty"`

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider_validation.go
@@ -218,7 +218,10 @@ func (a *AWS) validateVolumeType(blockDeviceMapping *BlockDeviceMapping) *apis.F
 }
 
 func (a *AWS) validateVolumeSize(blockDeviceMapping *BlockDeviceMapping) *apis.FieldError {
-	if blockDeviceMapping.EBS.VolumeSize == nil {
+	// if an EBS mapping is present, one of volumeSize or snapshotID must be present
+	if blockDeviceMapping.EBS.SnapshotID != nil && blockDeviceMapping.EBS.VolumeSize == nil {
+		return nil
+	} else if blockDeviceMapping.EBS.VolumeSize == nil {
 		return apis.ErrMissingField("volumeSize")
 	} else if blockDeviceMapping.EBS.VolumeSize.Cmp(minVolumeSize) == -1 || blockDeviceMapping.EBS.VolumeSize.Cmp(maxVolumeSize) == 1 {
 		return apis.ErrOutOfBoundsValue(blockDeviceMapping.EBS.VolumeSize.String(), minVolumeSize.String(), maxVolumeSize.String(), "volumeSize")

--- a/pkg/cloudprovider/aws/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/zz_generated.deepcopy.go
@@ -103,6 +103,11 @@ func (in *BlockDevice) DeepCopyInto(out *BlockDevice) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SnapshotID != nil {
+		in, out := &in.SnapshotID, &out.SnapshotID
+		*out = new(string)
+		**out = **in
+	}
 	if in.Throughput != nil {
 		in, out := &in.Throughput, &out.Throughput
 		*out = new(int64)

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -190,7 +190,7 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 func (p *LaunchTemplateProvider) blockDeviceMappings(blockDeviceMappings []*v1alpha1.BlockDeviceMapping) []*ec2.LaunchTemplateBlockDeviceMappingRequest {
 	blockDeviceMappingsRequest := []*ec2.LaunchTemplateBlockDeviceMappingRequest{}
 	for _, blockDeviceMapping := range blockDeviceMappings {
-		blockDeviceMappingsRequest = append(blockDeviceMappingsRequest, &ec2.LaunchTemplateBlockDeviceMappingRequest{
+		bdmr := &ec2.LaunchTemplateBlockDeviceMappingRequest{
 			DeviceName: blockDeviceMapping.DeviceName,
 			Ebs: &ec2.LaunchTemplateEbsBlockDeviceRequest{
 				DeleteOnTermination: blockDeviceMapping.EBS.DeleteOnTermination,
@@ -199,9 +199,13 @@ func (p *LaunchTemplateProvider) blockDeviceMappings(blockDeviceMappings []*v1al
 				Iops:                blockDeviceMapping.EBS.IOPS,
 				Throughput:          blockDeviceMapping.EBS.Throughput,
 				KmsKeyId:            blockDeviceMapping.EBS.KMSKeyID,
-				VolumeSize:          aws.Int64(blockDeviceMapping.EBS.VolumeSize.ScaledValue(resource.Giga)),
+				SnapshotId:          blockDeviceMapping.EBS.SnapshotID,
 			},
-		})
+		}
+		if blockDeviceMapping.EBS.VolumeSize != nil {
+			bdmr.Ebs.VolumeSize = aws.Int64(blockDeviceMapping.EBS.VolumeSize.ScaledValue(resource.Giga))
+		}
+		blockDeviceMappingsRequest = append(blockDeviceMappingsRequest, bdmr)
 	}
 	return blockDeviceMappingsRequest
 }

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -978,6 +978,18 @@ var _ = Describe("Allocation", func() {
 					provisioner := ProvisionerWithProvider(provisioner, provider)
 					Expect(provisioner.Validate(ctx)).To(Succeed())
 				})
+				It("should validate ebs device mapping with snapshotID only", func() {
+					provider, err := ProviderFromProvisioner(provisioner)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+						EBS: &v1alpha1.BlockDevice{
+							SnapshotID: aws.String("snap-0123456789"),
+						},
+					}}
+					provisioner := ProvisionerWithProvider(provisioner, provider)
+					Expect(provisioner.Validate(ctx)).To(Succeed())
+				})
 				It("should not allow volume size below minimum", func() {
 					provider, err := ProviderFromProvisioner(provisioner)
 					Expect(err).ToNot(HaveOccurred())

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -186,6 +186,7 @@ spec:
           kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
           deleteOnTermination: true
           throughput: 125
+          snapshotID: snap-0123456789
 ```
 
 ## Other Resources


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1538

**2. Description of changes:**
 - Support EBS `snapshotID` in blockDeviceMappings

**3. How was this change tested?**
 - tested manually w/ a Bottlerocket setup. Used a snapshot of the bottlerocket secondary volume. 

```
spec:
   provider:
     amiFamily: Bottlerocket
     apiVersion: extensions.karpenter.sh/v1alpha1
     blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:
         encrypted: true
         volumeSize: 4G
         volumeType: gp3
     - deviceName: /dev/xvdb
       ebs:
         snapshotID: snap-0ab03fec22a151ecf
```

It successfully used the snapshot which carries over the volume configuration of the snapshot. 


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
