### PR TITLE
Setting static value for ephemeral-storage on aws instance-types

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -276,12 +276,13 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 
 			resources := v1.ResourceList{}
 			for resourceName, quantity := range map[v1.ResourceName]resource.Quantity{
-				v1.ResourcePods:            instanceType.Resources()[v1.ResourcePods],
-				v1.ResourceCPU:             instanceType.Resources()[v1.ResourceCPU],
-				v1.ResourceMemory:          instanceType.Resources()[v1.ResourceMemory],
-				v1alpha1.ResourceNVIDIAGPU: instanceType.Resources()[v1alpha1.ResourceNVIDIAGPU],
-				v1alpha1.ResourceAMDGPU:    instanceType.Resources()[v1alpha1.ResourceAMDGPU],
-				v1alpha1.ResourceAWSNeuron: instanceType.Resources()[v1alpha1.ResourceAWSNeuron],
+				v1.ResourcePods:             instanceType.Resources()[v1.ResourcePods],
+				v1.ResourceCPU:              instanceType.Resources()[v1.ResourceCPU],
+				v1.ResourceMemory:           instanceType.Resources()[v1.ResourceMemory],
+				v1.ResourceEphemeralStorage: instanceType.Resources()[v1.ResourceEphemeralStorage],
+				v1alpha1.ResourceNVIDIAGPU:  instanceType.Resources()[v1alpha1.ResourceNVIDIAGPU],
+				v1alpha1.ResourceAMDGPU:     instanceType.Resources()[v1alpha1.ResourceAMDGPU],
+				v1alpha1.ResourceAWSNeuron:  instanceType.Resources()[v1alpha1.ResourceAWSNeuron],
 			} {
 				if !quantity.IsZero() {
 					resources[resourceName] = quantity

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -62,13 +62,14 @@ func (i *InstanceType) Architecture() string {
 
 func (i *InstanceType) Resources() v1.ResourceList {
 	return v1.ResourceList{
-		v1.ResourceCPU:             i.cpu(),
-		v1.ResourceMemory:          i.memory(),
-		v1.ResourcePods:            i.pods(),
-		v1alpha1.ResourceAWSPodENI: i.awsPodENI(),
-		v1alpha1.ResourceNVIDIAGPU: i.nvidiaGPUs(),
-		v1alpha1.ResourceAMDGPU:    i.amdGPUs(),
-		v1alpha1.ResourceAWSNeuron: i.awsNeurons(),
+		v1.ResourceCPU:              i.cpu(),
+		v1.ResourceMemory:           i.memory(),
+		v1.ResourceEphemeralStorage: i.ephemeralStorage(),
+		v1.ResourcePods:             i.pods(),
+		v1alpha1.ResourceAWSPodENI:  i.awsPodENI(),
+		v1alpha1.ResourceNVIDIAGPU:  i.nvidiaGPUs(),
+		v1alpha1.ResourceAMDGPU:     i.amdGPUs(),
+		v1alpha1.ResourceAWSNeuron:  i.awsNeurons(),
 	}
 }
 
@@ -112,6 +113,11 @@ func (i *InstanceType) memory() resource.Quantity {
 			float64(*i.MemoryInfo.SizeInMiB)*EC2VMAvailableMemoryFactor,
 		)),
 	)
+}
+
+// Setting ephemeral-storage to be arbitrarily large so it will be ignored during binpacking
+func (i *InstanceType) ephemeralStorage() resource.Quantity {
+	return resource.MustParse("100Pi")
 }
 
 func (i *InstanceType) pods() resource.Quantity {


### PR DESCRIPTION
**1. Issue, if available:**
#1563 #1467 

**2. Description of changes:**
In v0.7.2, when pods request `ephemeral-storage`, Karpenter cannot schedule those pods to a node as AWS instance types are not reporting any `ephemeral-storage` resources.  This change sets an arbitrarily high value for all instance-types to cause binpacking to ignore ephemeral-storage resources.  Values for `ephemeral-storages` resources are updated on the node once Kubelet is up and running.  A more robust solution is planned in #1467 .

**3. How was this change tested?**
Additional test were added to cover the case of deployments and daemonsets with ephemeral-storage requests.  Also, I manually validated the code changes in a live environment with both a deployment and daemonset with requests defined for `ephemeral-storage`.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: inflate
spec:
  replicas: 5
  selector:
    matchLabels:
      app: inflate
  template:
    metadata:
      labels:
        app: inflate
    spec:
      terminationGracePeriodSeconds: 0
      containers:
        - name: inflate
          image: public.ecr.aws/eks-distro/kubernetes/pause:3.2
          resources:
            requests:
              ephemeral-storage: 1Gi
```
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: test-ds
spec:
  selector:
    matchLabels:
      app: test-ds
  template:
    metadata:
      labels:
        app: test-ds
    spec:
      terminationGracePeriodSeconds: 0
      containers:
        - name: test-ds
          image: public.ecr.aws/eks-distro/kubernetes/pause:3.2
          resources:
            requests:
              ephemeral-storage: 1Gi
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
