### PR TITLE
add a Makefile target for applying the latest known release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,16 @@ licenses: ## Verifies dependency licenses and requires GITHUB_TOKEN to be set
 	$(WITH_GOFLAGS) go build -o karpenter cmd/controller/main.go
 	golicense hack/license-config.hcl karpenter
 
-apply: ## Deploy the controller into your ~/.kube/config cluster
+apply: ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
 	helm upgrade --install karpenter charts/karpenter --namespace karpenter \
 		$(HELM_OPTS) \
 		--set controller.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/controller) \
 		--set webhook.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/webhook)
+
+install:  ## Deploy the latest released version into your ~/.kube/config cluster
+	@echo Upgrading to $(shell grep version charts/karpenter/Chart.yaml)
+	helm upgrade --install karpenter charts/karpenter --namespace karpenter \
+		$(HELM_OPTS) 
 
 delete: ## Delete the controller from your ~/.kube/config cluster
 	helm uninstall karpenter --namespace karpenter


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

This is useful for resetting your cluster back to the latest released
version, or while releasing a new version testing out the newly
pushed public images.

**3. How was this change tested?**

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
