### PR TITLE
Switch to prism syntax highlighting for website

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -48,6 +48,7 @@ params:
   version_menu: Releases
   archived_version: false
   offlineSearch: true
+  prism_syntax_highlighting: true
   ui:
     sidebar_menu_compact: true
     sidebar_menu_foldable: true


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Switch hugo theme code blocks to render with prism so code blocks have a copy button

**3. How was this change tested?**
It was not tested locally but I can verify it with the PR site provided by opening this PR.

I should mention the docs for it are here https://www.docsy.dev/docs/adding-content/lookandfeel/#code-highlighting-with-prism

**4. Does this change impact docs?**
- [ x ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
