### PR TITLE
 Change the schedule of GA crons

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   schedule:
-    - cron: '22 18 * * 0'
+    - cron: '0 12 * * *'
 
 jobs:
   analyze:

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -1,7 +1,7 @@
 name: Deflake
 on:
   schedule:
-    - cron: '22 18 * * 0'
+    - cron: '0 12 * * *'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**1. Issue, if available:**
Changes the schedule so that both actions run every day at 12:00 UTC (5AM PST & 8AM EST) this is a better schedule because it runs right before people start working in our team hence giving us a chance to quickly respond to failures, also doesn't take the computing capacity when we need it (during working hours). Finally this will capture more changes than before because
there's a chance the code gets updated after hours.

**2. Description of changes:**


**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
