### PR TITLE
Add support for using topologyKey=karpenter.sh/capacity-type in TopologySpreadConstraint

### DIFF
--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -83,6 +83,8 @@ func (t *Topology) computeCurrentTopology(ctx context.Context, constraints *v1al
 		return t.computeHostnameTopology(topologyGroup, constraints)
 	case v1.LabelTopologyZone:
 		return t.computeZonalTopology(ctx, constraints, topologyGroup)
+	case v1alpha5.LabelCapacityType:
+		return t.computeLabelCapacity(ctx, constraints, topologyGroup)
 	default:
 		return nil
 	}
@@ -113,6 +115,14 @@ func (t *Topology) computeHostnameTopology(topologyGroup *TopologyGroup, constra
 // set of nodes, topology calculations will rebalance the new set of zones.
 func (t *Topology) computeZonalTopology(ctx context.Context, constraints *v1alpha5.Constraints, topologyGroup *TopologyGroup) error {
 	topologyGroup.Register(constraints.Requirements.Zones().UnsortedList()...)
+	if err := t.countMatchingPods(ctx, topologyGroup); err != nil {
+		return fmt.Errorf("getting matching pods, %w", err)
+	}
+	return nil
+}
+
+func (t *Topology) computeLabelCapacity(ctx context.Context, constraints *v1alpha5.Constraints, topologyGroup *TopologyGroup) error {
+	topologyGroup.Register(constraints.Requirements.CapacityTypes().UnsortedList()...)
 	if err := t.countMatchingPods(ctx, topologyGroup); err != nil {
 		return fmt.Errorf("getting matching pods, %w", err)
 	}

--- a/pkg/controllers/selection/controller.go
+++ b/pkg/controllers/selection/controller.go
@@ -131,7 +131,7 @@ func validate(p *v1.Pod) error {
 
 func validateTopology(pod *v1.Pod) (errs error) {
 	for _, constraint := range pod.Spec.TopologySpreadConstraints {
-		if supported := sets.NewString(v1.LabelHostname, v1.LabelTopologyZone); !supported.Has(constraint.TopologyKey) {
+		if supported := sets.NewString(v1.LabelHostname, v1.LabelTopologyZone, v1alpha5.LabelCapacityType); !supported.Has(constraint.TopologyKey) {
 			errs = multierr.Append(errs, fmt.Errorf("unsupported topology key, %s not in %s", constraint.TopologyKey, supported))
 		}
 	}

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -168,6 +168,7 @@ Karpenter supports specifying capacity type, which is analogous to [EC2 purchase
 
 Karpenter prioritizes Spot offerings if the provisioner allows Spot and on-demand instances. If the provider API (e.g. EC2 Fleet's API) indicates Spot capacity is unavailable, Karpenter caches that result across all attempts to provision EC2 capacity for that instance type and zone for the next 45 seconds. If there are no other possible offerings available for Spot, Karpenter will attempt to provision on-demand instances, generally within milliseconds. 
 
+Karpenter also allows `karpenter.sh/capacity-type` to be used as a topology key for enforcing topology-spread.
 
 ## spec.kubeletConfiguration
 

--- a/website/content/en/preview/tasks/scheduling.md
+++ b/website/content/en/preview/tasks/scheduling.md
@@ -229,16 +229,28 @@ spec:
       labelSelector:
         matchLabels:
           dev: jjones
+    - maxSkew: 1
+      topologyKey: "karpenter.sh/capacity-type"
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          dev: jjones
 
 ```
 Adding this to your podspec would result in:
 
-* Pods being spread across both zones and hosts (`topologyKey`).
+* Pods being spread across zones, hosts, and capacity-type (`topologyKey`).
 * The `dev` `labelSelector` will include all pods with the label of `dev=jjones` in topology calculations. It is recommended to use a selector to match all pods in a deployment.
 * No more than one pod difference in the number of pods on each host (`maxSkew`).
 For example, if there were three nodes and five pods the pods could be spread 1, 2, 2 or 2, 1, 2 and so on.
 If instead the spread were 5, pods could be 5, 0, 0 or 3, 2, 0, or 2, 1, 2 and so on.
 * Karpenter is always able to improve skew by launching new nodes in the right zones. Therefore, `whenUnsatisfiable` does not change provisioning behavior.
+
+The three supported `topologyKey` values that Karpenter supports are:
+- `topology.kubernetes.io/zone`
+- `kubernetes.io/hostname`
+- `karpenter.sh/capacity-type`
+
 
 See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) for details.
 


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1557

**2. Description of changes:**
* Allows using karpenter.sh/capacity-type as topologyKey in TopologySpreadConstraint

**3. How was this change tested?**
* Tested on EKS using the instructions here: https://karpenter.sh/v0.7.3/development-guide/ 
* Karpenter was able to spin up the correct `capacity-type` based on the PodSpec to respect the distribution. Tested for distribution of pods across on-demand and spot EC2 instances. 

* podSpec used for testing topologySpreadConstraint:
```
topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app: <app-name>
        maxSkew: 1
        topologyKey: karpenter.sh/capacity-type
        whenUnsatisfiable: DoNotSchedule
```

* Karpenter provisioner specified:
```
  requirements:
  - key: karpenter.sh/capacity-type
    operator: In
    values:
    - spot
    - on-demand
```

* Karpenter was successfully spinning up nodes across on-demand and spot as the workload instances was scaled up. 

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
