### PR TITLE
Makefile

### DIFF
--- a/hack/nightly.sh
+++ b/hack/nightly.sh
@@ -4,6 +4,11 @@ RELEASE_REPO=${RELEASE_REPO:-public.ecr.aws/z3c6l6z9/karpenter-nightly}
 RELEASE_VERSION=${RELEASE_VERSION:-$(date "${NIGHTLY_TAG_FMT}")}
 RELEASE_PLATFORM="--platform=linux/amd64,linux/arm64"
 
+if [ -z "$CLOUD_PROVIDER" ]; then
+    echo "CLOUD_PROVIDER environment variable is not set: 'export CLOUD_PROVIDER=aws'"
+    exit 1
+fi
+
 # TODO restore https://reproducible-builds.org/docs/source-date-epoch/
 if [ -z "$SOURCE_DATE_EPOCH" ]; then
     BUILD_DATE=$(date -u ${DATE_FMT})

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -4,6 +4,11 @@ RELEASE_REPO=${RELEASE_REPO:-public.ecr.aws/karpenter}
 RELEASE_VERSION=${RELEASE_VERSION:-$(git describe --tags --always)}
 RELEASE_PLATFORM="--platform=linux/amd64,linux/arm64"
 
+if [ -z "$CLOUD_PROVIDER" ]; then
+    echo "CLOUD_PROVIDER environment variable is not set: 'export CLOUD_PROVIDER=aws'"
+    exit 1
+fi
+
 # TODO restore https://reproducible-builds.org/docs/source-date-epoch/
 DATE_FMT="+%Y-%m-%dT%H:%M:%SZ"
 if [ -z "$SOURCE_DATE_EPOCH" ]; then

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -36,7 +36,7 @@ chart() {
 }
 
 website() {
-    cp -r website/content/en/preview website/content/en/${RELEASE_VERSION}
+    mkdir -p website/content/en/${RELEASE_VERSION} && cp -r website/content/en/preview/* website/content/en/${RELEASE_VERSION}/
     find website/content/en/${RELEASE_VERSION}/ -type f | xargs perl -i -p -e "s/{{< param \"latest_release_version\" >}}/${RELEASE_VERSION}/g;"
 }
 


### PR DESCRIPTION
**1. Issue, if available:**
When releasing a new version of Karpenter, it's possible to leave CLOUD_PROVIDER environment variable unset.  If CLOUD_PROVIDER is not set, the resultant artifact defaults to the fake/test cloud provider.

If you run `make release` more than once, the 'preview' website content is copied inside of the 'versioned' website content when it should not be.

**2. Description of changes:**
This changes requires the CLOUD_PROVIDER environment variable to be set when running `make release`.  Additionally, it makes the website content copy step idempotent.

**3. How was this change tested?**
Ran `make release` multiple times with the CLOUD_PROVIDER env set and unset.  When unset or set to an empty string, the release fails.  
```
GOFLAGS="-tags= -ldflags=-X=github.com/aws/karpenter/pkg/utils/project.Version=v0.7.3-13-g5495dd3" ./hack/release.sh
CLOUD_PROVIDER environment variable is not set: 'export CLOUD_PROVIDER=aws'
make: *** [release] Error 1
```

When the CLOUD_PROVIDER env is set and `make release` is executed multiple times, the 'preview' content is not copied inside of the versioned content folder.

```
drwxr-xr-x  7 user group 4.0K Mar 29 14:58 .
drwxr-xr-x 20 user group 4.0K Mar 29 14:57 ..
drwxr-xr-x  2 user group 4.0K Mar 29 14:58 AWS
drwxr-xr-x  2 user group 4.0K Mar 29 14:58 concepts
-rw-r--r--  1 user group 4.2K Mar 29 14:58 development-guide.md
-rw-r--r--  1 user group  12K Mar 29 14:58 faq.md
drwxr-xr-x  5 user group 4.0K Mar 29 14:58 getting-started
-rwxr-xr-x  1 user group 1.6K Mar 29 14:58 _index.md
-rw-r--r--  1 user group  7.7K Mar 29 14:58 provisioner.md
drwxr-xr-x  2 user group  4.0K Mar 29 14:58 tasks
-rw-r--r--  1 user group  4.8K Mar 29 14:58 troubleshooting.md
drwxr-xr-x  2 user group  4.0K Mar 29 14:58 upgrade-guide
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
