### PR TITLE
use dockerd if requesting gpus

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/bootstrap/bootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/bootstrap.go
@@ -29,6 +29,7 @@ type Options struct {
 	Labels                  map[string]string `hash:"set"`
 	CABundle                *string
 	AWSENILimitedPodDensity bool
+	ContainerRuntime        *string
 }
 
 // Bootstrapper can be implemented to generate a bootstrap script

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -26,6 +26,7 @@ import (
 
 type EKS struct {
 	Options
+	ContainerRuntime string
 }
 
 func (e EKS) Script() string {
@@ -44,6 +45,9 @@ func (e EKS) Script() string {
 	if !e.AWSENILimitedPodDensity {
 		userData.WriteString(" \\\n--use-max-pods false")
 		kubeletExtraArgs += " --max-pods=110"
+	}
+	if e.ContainerRuntime != "" {
+		userData.WriteString(fmt.Sprintf(" \\\n--container-runtime %s", e.ContainerRuntime))
 	}
 	if kubeletExtraArgs = strings.Trim(kubeletExtraArgs, " "); len(kubeletExtraArgs) > 0 {
 		userData.WriteString(fmt.Sprintf(" \\\n--kubelet-extra-args '%s'", kubeletExtraArgs))

--- a/pkg/cloudprovider/aws/amifamily/bottlerocket.go
+++ b/pkg/cloudprovider/aws/amifamily/bottlerocket.go
@@ -47,7 +47,7 @@ func (b Bottlerocket) SSMAlias(version string, instanceType cloudprovider.Instan
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (b Bottlerocket) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string) bootstrap.Bootstrapper {
+func (b Bottlerocket) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string, _ []cloudprovider.InstanceType) bootstrap.Bootstrapper {
 	return bootstrap.Bottlerocket{
 		Options: bootstrap.Options{
 			ClusterName:             b.Options.ClusterName,

--- a/pkg/cloudprovider/aws/amifamily/resolver.go
+++ b/pkg/cloudprovider/aws/amifamily/resolver.go
@@ -67,7 +67,7 @@ type LaunchTemplate struct {
 
 // AMIFamily can be implemented to override the default logic for generating dynamic launch template parameters
 type AMIFamily interface {
-	UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string) bootstrap.Bootstrapper
+	UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string, instanceTypes []cloudprovider.InstanceType) bootstrap.Bootstrapper
 	SSMAlias(version string, instanceType cloudprovider.InstanceType) string
 	DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping
 	DefaultMetadataOptions() *v1alpha1.MetadataOptions
@@ -99,7 +99,7 @@ func (r Resolver) Resolve(ctx context.Context, constraints *v1alpha1.Constraints
 	for amiID, instanceTypes := range amiIDs {
 		resolved := &LaunchTemplate{
 			Options:             options,
-			UserData:            amiFamily.UserData(constraints.KubeletConfiguration, constraints.Taints, options.Labels, options.CABundle),
+			UserData:            amiFamily.UserData(constraints.KubeletConfiguration, constraints.Taints, options.Labels, options.CABundle, instanceTypes),
 			BlockDeviceMappings: constraints.BlockDeviceMappings,
 			MetadataOptions:     constraints.MetadataOptions,
 			AMIID:               amiID,

--- a/pkg/cloudprovider/aws/amifamily/ubuntu.go
+++ b/pkg/cloudprovider/aws/amifamily/ubuntu.go
@@ -36,7 +36,7 @@ func (u Ubuntu) SSMAlias(version string, instanceType cloudprovider.InstanceType
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (u Ubuntu) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string) bootstrap.Bootstrapper {
+func (u Ubuntu) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string, _ []cloudprovider.InstanceType) bootstrap.Bootstrapper {
 	return bootstrap.EKS{
 		Options: bootstrap.Options{
 			ClusterName:             u.Options.ClusterName,

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -152,7 +152,7 @@ func (i *InstanceType) amdGPUs() resource.Quantity {
 	count := int64(0)
 	if i.GpuInfo != nil {
 		for _, gpu := range i.GpuInfo.Gpus {
-			if *gpu.Manufacturer == "NVIDIA" {
+			if *gpu.Manufacturer == "AMD" {
 				count += *gpu.Count
 			}
 		}


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1585

**2. Description of changes:**
 - The AL2 AMI Family now uses containerd by default and dockerd only when requesting GPUs for
 - Fixed a bug where AMD GPU resources were counted as nvidia resources on the node.

**3. How was this change tested?**
 - manual cluster test of nvidia gpu pods
 - added unit-tests 

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
