### PR TITLE
Scheduling benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help: ## Display help
 
 dev: verify test ## Run all steps in the developer loop
 
-ci: toolchain verify licenses battletest benchmark ## Run all steps used by continuous integration
+ci: toolchain verify licenses battletest ## Run all steps used by continuous integration
 
 test: ## Run tests
 	ginkgo -r

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,6 @@ LDFLAGS ?= -ldflags=-X=github.com/aws/karpenter/pkg/utils/project.Version=$(shel
 GOFLAGS ?= -tags=$(CLOUD_PROVIDER) $(LDFLAGS)
 WITH_GOFLAGS = GOFLAGS="$(GOFLAGS)"
 
-# detect nice binary
-NICE := $(shell command -v nice 2> /dev/null)
-NICE_PREFIX = ""
-ifdef NICE
-    NICE_PREFIX = ${NICE} -19
-endif
-
 ## Extra helm options
 CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev)
 CLUSTER_ENDPOINT ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}')
@@ -40,7 +33,7 @@ strongertests:
 			--randomizeAllSpecs --randomizeSuites -race
 
 benchmark:
-	${NICE_PREFIX} go test -tags=test_performance -run=NoTests -bench=. ./...
+	go test -tags=test_performance -run=NoTests -bench=. ./...
 
 deflake:
 	for i in {1..10}; do make strongertests || exit 1; done

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -37,6 +37,15 @@ type InstanceType struct {
 	ec2.InstanceTypeInfo
 	AvailableOfferings []cloudprovider.Offering
 	MaxPods            *int32
+	resources          v1.ResourceList
+	overhead           v1.ResourceList
+}
+
+func newInstanceType(info ec2.InstanceTypeInfo) *InstanceType {
+	it := &InstanceType{InstanceTypeInfo: info}
+	it.resources = it.computeResources()
+	it.overhead = it.computeOverhead()
+	return it
 }
 
 func (i *InstanceType) Name() string {
@@ -61,6 +70,10 @@ func (i *InstanceType) Architecture() string {
 }
 
 func (i *InstanceType) Resources() v1.ResourceList {
+	return i.resources
+}
+
+func (i *InstanceType) computeResources() v1.ResourceList {
 	return v1.ResourceList{
 		v1.ResourceCPU:              i.cpu(),
 		v1.ResourceMemory:           i.memory(),
@@ -175,6 +188,9 @@ func (i *InstanceType) awsNeurons() resource.Quantity {
 // While this doesn't calculate the correct overhead for non-ENI-limited nodes, we're using this approach until further
 // analysis can be performed
 func (i *InstanceType) Overhead() v1.ResourceList {
+	return i.overhead
+}
+func (i *InstanceType) computeOverhead() v1.ResourceList {
 	overhead := v1.ResourceList{
 		v1.ResourceCPU: *resource.NewMilliQuantity(
 			100, // system-reserved

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -151,7 +151,7 @@ func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context) (map[string
 	}, func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {
 		for _, instanceType := range page.InstanceTypes {
 			if p.filter(instanceType) {
-				instanceTypes[aws.StringValue(instanceType.InstanceType)] = &InstanceType{InstanceTypeInfo: *instanceType}
+				instanceTypes[aws.StringValue(instanceType.InstanceType)] = newInstanceType(*instanceType)
 			}
 		}
 		return true

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -33,6 +33,12 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 	if options.Resources == nil {
 		options.Resources = map[v1.ResourceName]resource.Quantity{}
 	}
+	if options.Overhead == nil {
+		options.Overhead = v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("10Mi"),
+		}
+	}
 	if len(options.Offerings) == 0 {
 		options.Offerings = []cloudprovider.Offering{
 			{CapacityType: "spot", Zone: "test-zone-1"},
@@ -64,6 +70,7 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 			Architecture:     options.Architecture,
 			OperatingSystems: options.OperatingSystems,
 			Resources:        options.Resources,
+			Overhead:         options.Overhead,
 			Price:            options.Price},
 	}
 }
@@ -127,6 +134,7 @@ type InstanceTypeOptions struct {
 	Offerings        []cloudprovider.Offering
 	Architecture     string
 	OperatingSystems sets.String
+	Overhead         v1.ResourceList
 	Resources        v1.ResourceList
 	Price            float64
 }
@@ -175,8 +183,5 @@ func (i *InstanceType) OperatingSystems() sets.String {
 }
 
 func (i *InstanceType) Overhead() v1.ResourceList {
-	return v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("100m"),
-		v1.ResourceMemory: resource.MustParse("10Mi"),
-	}
+	return i.options.Overhead
 }


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**

Extends scheduling benchmark and adds a minimum pods/sec scheduling threshold to CI builds.

**3. How was this change tested?**

Unit tests & on EKS scaling up/down the inflate deployment.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
