### PR TITLE
support baremetal instance types

### DIFF
--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -382,6 +382,27 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2
 					Ipv4AddressesPerInterface: aws.Int64(60),
 				},
 			},
+			{
+				InstanceType:                  aws.String("m5.metal"),
+				SupportedUsageClasses:         DefaultSupportedUsageClasses,
+				SupportedVirtualizationTypes:  []*string{aws.String("hvm")},
+				BurstablePerformanceSupported: aws.Bool(false),
+				BareMetal:                     aws.Bool(true),
+				Hypervisor:                    nil,
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
+				},
+				VCpuInfo: &ec2.VCpuInfo{
+					DefaultVCpus: aws.Int64(96),
+				},
+				MemoryInfo: &ec2.MemoryInfo{
+					SizeInMiB: aws.Int64(393216),
+				},
+				NetworkInfo: &ec2.NetworkInfo{
+					MaximumNetworkInterfaces:  aws.Int64(15),
+					Ipv4AddressesPerInterface: aws.Int64(50),
+				},
+			},
 		},
 	}, false)
 	return nil
@@ -453,6 +474,18 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 			{
 				InstanceType: aws.String("c6g.large"),
 				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("m5.metal"),
+				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("m5.metal"),
+				Location:     aws.String("test-zone-1b"),
+			},
+			{
+				InstanceType: aws.String("m5.metal"),
+				Location:     aws.String("test-zone-1c"),
 			},
 		},
 	}, false)

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -147,6 +147,10 @@ func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context) (map[string
 				Name:   aws.String("supported-virtualization-type"),
 				Values: []*string{aws.String("hvm")},
 			},
+			{
+				Name:   aws.String("processor-info.supported-architecture"),
+				Values: aws.StringSlice([]string{"x86_64", "arm64"}),
+			},
 		},
 	}, func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {
 		for _, instanceType := range page.InstanceTypes {
@@ -168,10 +172,6 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	if instanceType.FpgaInfo != nil {
 		return false
 	}
-	if aws.BoolValue(instanceType.BareMetal) {
-		return false
-	}
-	// TODO exclude if not available for spot
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
 		"m", "c", "r", "a", // Standard
 		"i3",       // Storage-optimized

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -166,6 +166,20 @@ var _ = Describe("Allocation", func() {
 					ExpectNotScheduled(ctx, env.Client, pod)
 				}
 			})
+			It("should launch on metal", func() {
+				for _, pod := range ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner,
+					test.UnschedulablePod(test.PodOptions{
+						NodeSelector: map[string]string{
+							v1.LabelInstanceTypeStable: "m5.metal",
+						},
+						ResourceRequirements: v1.ResourceRequirements{
+							Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+							Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+						},
+					})) {
+					ExpectScheduled(ctx, env.Client, pod)
+				}
+			})
 			It("should launch AWS Pod ENI on a compatible instance type", func() {
 				for _, pod := range ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner,
 					test.UnschedulablePod(test.PodOptions{

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -93,6 +93,10 @@ Yes, see [Example Provisioner Resource]({{< ref "./provisioner/#example-provisio
 * Attribute-based requests are currently not possible.
 * You can select instances with special hardware, such as gpu.
 
+### Can I use Bare Metal instance types?
+
+Yes, Karpenter supports provisioning metal instance types when a Provisioner's `node.kubernetes.io/instance-type` Requirements only include `metal` instance types. If a Provisioner's instance types are not constrained, then Karpenter will not provision metal instance types.
+
 ### How does Karpenter dynamically select instance types?
 
 Karpenter batches pending pods and then binpacks them based on CPU, memory, and GPUs required, taking into account node overhead, VPC CNI resources required, and daemon sets that will be packed when bringing up a new node.


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1336
https://github.com/aws/karpenter/issues/1371

**2. Description of changes:**

Support Bare Metal Instance Types. 
 
Before this change, Bare Metal was filtered out of the universe of instance types making it impossible to use Bare Metal (even if directly specified in the Provisioner `node.kubernetes.io/instance-type` requirements). 
 
This PR removes the bare metal filter and instead prioritizes Bare Metal instance types as a last resort in the AWS Cloud Provider (similar to the way GPUs are utilized). Since bare metal instance types have the exact same resource specs as the largest instance type in an instance family, bare metal will only engage if the Provisioner is properly constrained to only bare metal instance types. 


**3. How was this change tested?**
 - Manually in an EKS cluster:
   -  I scaled an inflate deployment without constraining a provisioner and examined the ec2 Fleet request where I saw that metal instance types were not in the request
   - I constrained the provisioner to only m5.metal and scaled an inflate deployment. An m5.metal was provisioned. 

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
