### PR TITLE
fix two broken links and update troubleshooting webhooks

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
@@ -1,7 +1,7 @@
 
 ---
-title: "Getting started with eksctl"
-linkTitle: "Getting started with eksctl"
+title: "Getting Started with eksctl"
+linkTitle: "Getting Started with eksctl"
 weight: 10
 ---
 

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -66,20 +66,18 @@ This means that your CNI plugin is out of date. You can find instructions on how
 
 If you are not able to create a provisioner due to `Error from server (InternalError): error when creating "provisioner.yaml": Internal error occurred: failed calling webhook "defaulting.webhook.provisioners.karpenter.sh": Post "https://karpenter-webhook.karpenter.svc:443/default-resource?timeout=10s": context deadline exceeded`
 
-Verify that webhook is running
+Verify that the webhook is running (should see 2/2 containers with a "Ready" status)
 ```text
-kubectl get po -A -l karpenter=webhook
-NAMESPACE   NAME                                READY   STATUS    RESTARTS   AGE
-karpenter   karpenter-webhook-d644c7567-cdc4d   1/1     Running   0          37m
-karpenter   karpenter-webhook-d644c7567-dn9xw   1/1     Running   0          37m
+kubectl get po -A -l app.kubernetes.io/name=karpenter
+NAME                       READY   STATUS    RESTARTS   AGE
+karpenter-7b46fb5c-gcr9z   2/2     Running   0          17h
 ```
 
 Webhook service has endpoints assigned to it
 ```text
-kubectl get ep -A -l app.kubernetes.io/component=karpenter
-NAMESPACE   NAME                ENDPOINTS                        AGE
-karpenter   karpenter-metrics   10.0.13.104:8080                 38m
-karpenter   karpenter-webhook   10.0.1.25:8443,10.0.30.46:8443   38m
+kubectl get ep -A -l app.kubernetes.io/name=karpenter
+NAMESPACE   NAME        ENDPOINTS                               AGE
+karpenter   karpenter   192.168.39.88:8443,192.168.39.88:8080   16d
 ```
 
 Your security groups are not blocking you from reaching your webhook.

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -66,14 +66,14 @@ This means that your CNI plugin is out of date. You can find instructions on how
 
 If you are not able to create a provisioner due to `Error from server (InternalError): error when creating "provisioner.yaml": Internal error occurred: failed calling webhook "defaulting.webhook.provisioners.karpenter.sh": Post "https://karpenter-webhook.karpenter.svc:443/default-resource?timeout=10s": context deadline exceeded`
 
-Verify that the webhook is running (should see 2/2 containers with a "Ready" status)
+Verify that the karpenter pod is running (should see 2/2 containers with a "Ready" status)
 ```text
 kubectl get po -A -l app.kubernetes.io/name=karpenter
 NAME                       READY   STATUS    RESTARTS   AGE
 karpenter-7b46fb5c-gcr9z   2/2     Running   0          17h
 ```
 
-Webhook service has endpoints assigned to it
+Karpenter service has endpoints assigned to it
 ```text
 kubectl get ep -A -l app.kubernetes.io/name=karpenter
 NAMESPACE   NAME        ENDPOINTS                               AGE

--- a/website/content/en/v0.5.6/getting-started/_index.md
+++ b/website/content/en/v0.5.6/getting-started/_index.md
@@ -154,10 +154,6 @@ helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
 kubectl patch configmap config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}'
 ```
 
-### Create Grafana dashboards (optional)
-
-The Karpenter repo contains multiple [importable dashboards](https://github.com/aws/karpenter/tree/main/grafana-dashboards) for an existing Grafana instance. See the Grafana documentation for [instructions](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard) to import a dashboard.
-
 #### Deploy a temporary Prometheus and Grafana stack (optional)
 
 The following commands will deploy a Prometheus and Grafana stack that is suitable for this guide but does not include persistent storage or other configurations that would be necessary for monitoring a production deployment of Karpenter.

--- a/website/content/en/v0.6.0/getting-started/_index.md
+++ b/website/content/en/v0.6.0/getting-started/_index.md
@@ -154,10 +154,6 @@ helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
 kubectl patch configmap config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}'
 ```
 
-### Create Grafana dashboards (optional)
-
-The Karpenter repo contains multiple [importable dashboards](https://github.com/aws/karpenter/tree/main/grafana-dashboards) for an existing Grafana instance. See the Grafana documentation for [instructions](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard) to import a dashboard.
-
 #### Deploy a temporary Prometheus and Grafana stack (optional)
 
 The following commands will deploy a Prometheus and Grafana stack that is suitable for this guide but does not include persistent storage or other configurations that would be necessary for monitoring a production deployment of Karpenter.


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Fix two broken links in previous website versions that shows up on the 404 checker when releasing. These sections should have been removed in those version since the dashboards are imported automatically beginning at v0.5.6. 
 - Fix troubleshooting webhooks section which is out-dated since the webhook and controller are now in the same pod.
 - Fix inconsistent casing on the Getting Started landing page. All other links have "Started" capitalized except "Getting started with eksctl" 


**3. How was this change tested?**
 - `make website`

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
