### PR TITLE
add go-toml license

### DIFF
--- a/hack/license-config.hcl
+++ b/hack/license-config.hcl
@@ -13,4 +13,5 @@ override = {
   "sigs.k8s.io/yaml" = "MIT",
   "github.com/gogo/protobuf" = "BSD-3-Clause"
   "golang.org/x/crypto" = "BSD-3-Clause"
+  "github.com/pelletier/go-toml" = "Apache-2.0"
 }


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - go-toml's license isn't being detected properly because it's a dual MIT and Apache-2.0 license. I've overridden this in our license check config to `Apache-2.0` (https://github.com/pelletier/go-toml/blob/master/LICENSE). 


**3. How was this change tested?**
`make licenses`

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
