### PR TITLE
update to v1.22.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          k8sVersion: ["1.19.x", "1.20.x", "1.21.x"]
+          k8sVersion: ["1.19.x", "1.20.x", "1.21.x", "1.22.x"]
     env:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export K8S_VERSION ?= 1.21.x
+export K8S_VERSION ?= 1.22.x
 export KUBEBUILDER_ASSETS ?= ${HOME}/.kubebuilder/bin
 
 ## Inject the app version into project.Version

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-K8S_VERSION="${K8S_VERSION:="1.21.x"}"
+K8S_VERSION="${K8S_VERSION:="1.22.x"}"
 KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:="${HOME}/.kubebuilder/bin"}"
 
 main() {


### PR DESCRIPTION
Change our default K8s version to 1.22 and add 1.22 to CI

**1. Issue, if available:**

N/A

**2. Description of changes:**

Defaults developers to 1.22 if they re-run the toolchain script and adds 1.22

**3. How was this change tested?**

Unit tests.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
