### PR TITLE
Updated provisioner in persistent volume documentation

### DIFF
--- a/website/content/en/preview/tasks/scheduling.md
+++ b/website/content/en/preview/tasks/scheduling.md
@@ -281,7 +281,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: ebs
-provisioner: ebs.csi.aws.com
+provisioner: kubernetes.io/aws-ebs
 volumeBindingMode: WaitForFirstConsumer
 allowedTopologies:
 - matchLabelExpressions:


### PR DESCRIPTION
**1. Issue, if available:**
- The persistent volume documentation was using an outdated provisioner.

**2. Description of changes:**
Changed the provsioner to kubernetes.io/aws-ebs [based on this AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html)

**3. How was this change tested?**
Locally with my own persistent volumes

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [x] Yes, issue opened: https://github.com/aws/karpenter/issues/1644


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
