### PR TITLE
add logEncoding to helm chart's values.yaml

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -42,6 +42,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | clusterName | string | `""` | Cluster name. |
 | controller.env | list | `[]` | Additional environment variables for the controller pod. |
 | controller.image | string | `"public.ecr.aws/karpenter/controller:v0.8.1@sha256:2dc1d020688bf00ba4c910a9a01b19ebc2b020f61d8a9c78a23f5eab5c258b53"` | Controller image. |
+| controller.logEncoding | string | `""` | Controller log encoding, defaults to the global log encoding |
 | controller.logLevel | string | `""` | Controller log level, defaults to the global log level |
 | controller.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | Resources for the controller pod. |
 | controller.securityContext | object | `{}` | SecurityContext for the controller container. |
@@ -49,6 +50,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | hostNetwork | bool | `false` | Bind the pod to the host network. This is required when using a custom CNI. |
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Docker images. |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images. |
+| logEncoding | string | `"console"` | Gloabl log encoding |
 | logLevel | string | `"debug"` | Global log level |
 | nameOverride | string | `""` | Overrides the chart's name. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selectors to schedule the pod to nodes with labels. |
@@ -68,6 +70,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | tolerations | list | `[]` | Tolerations to allow the pod to be scheduled to nodes with taints. |
 | webhook.env | list | `[]` | Additional environment variables for the webhook pod. |
 | webhook.image | string | `"public.ecr.aws/karpenter/webhook:v0.8.1@sha256:4e72682a63de22a527699e347e78600781612fa1772d1a53f6a2b8530078e423"` | Webhook image. |
+| webhook.logEncoding | string | `""` | Webhook log encoding, defaults to the global log encoding |
 | webhook.logLevel | string | `""` | Webhook log level, defaults to the global log level |
 | webhook.port | int | `8443` | The container port to use for the webhook. |
 | webhook.resources | object | `{"limits":{"cpu":"100m","memory":"50Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Resources for the webhook pod. |

--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -23,7 +23,7 @@ data:
       },
       "outputPaths": ["stdout"],
       "errorOutputPaths": ["stderr"],
-      "encoding": "console",
+      "encoding": "{{ .Values.logEncoding }}",
       "encoderConfig": {
         "timeKey": "time",
         "levelKey": "level",

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -79,6 +79,8 @@ controller:
       memory: 1Gi
   # -- Controller log level, defaults to the global log level
   logLevel: ""
+  # -- Controller log encoding, defaults to the global log encoding
+  logEncoding: ""  
 webhook:
   # -- Webhook image.
   image: "public.ecr.aws/karpenter/webhook:v0.8.1@sha256:4e72682a63de22a527699e347e78600781612fa1772d1a53f6a2b8530078e423"
@@ -101,8 +103,12 @@ webhook:
       memory: 50Mi
   # -- Webhook log level, defaults to the global log level
   logLevel: ""
+  # -- Webhook log encoding, defaults to the global log encoding
+  logEncoding: ""  
 # -- Global log level
 logLevel: debug
+# -- Gloabl log encoding
+logEncoding: console
 # -- Cluster name.
 clusterName: ""
 # -- Cluster endpoint.


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1637

**2. Description of changes:**
 - Add logEncoding to values.yaml so that users can configure between console and json logs

**3. How was this change tested?**
```
helm upgrade --install karpenter charts/karpenter --namespace karpenter \
		--set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::xxxxxxxxxx:role/eksctl-karpenter-demo-addon-iamserviceaccoun-Role1-1EYIC0TUBRWJV 
                --set clusterName=karpenter-demo 
                --set clusterEndpoint=https://xxxxxxxxxx.gr7.us-west-2.eks.amazonaws.com 
                --set logEncoding=json 
                --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-karpenter-demo \
	        --set controller.image=xxxxxxxxxx.dkr.ecr.us-east-2.amazonaws.com/karpenter/controller@sha256:c1fae686e87356a5f49c6e8a8c2577eedc3af63575f37241b308544159deac79 \
		--set webhook.image=xxxxxxxxxx.dkr.ecr.us-east-2.amazonaws.com/karpenter/webhook@sha256:2a758ce4ed8e7488d2bbe19a82bdd3f7155ae2aed61e4f81d6aeac4bb30c21ce
```

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
