### PR TITLE
update to ko release that works with go 1.18

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -13,7 +13,7 @@ tools() {
     go install github.com/mitchellh/golicense@v0.2.0
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1
-    go install github.com/google/ko@v0.10.0
+    go install github.com/google/ko@v0.11.2
     go install github.com/mikefarah/yq/v4@v4.16.1
     go install github.com/mitchellh/golicense@v0.2.0
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.7.0


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

Updated ko version

**3. How was this change tested?**

Building & applying to my EKS cluster using both go 1.17 and 1.18 and ko v0.11.2

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
