### PR TITLE
Add topologySpreadConstraints to helm chart

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -150,3 +150,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+      {{- end }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -152,5 +152,5 @@ spec:
       {{- end }}
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+        {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
       {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -59,6 +59,10 @@ affinity:
               operator: DoesNotExist
 # -- topologySpreadConstraints to increase the controller resilience
 topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: topology.kubernetes.io/zone
+#   whenUnsatisfiable: ScheduleAnyway
+
 # -- Tolerations to allow the pod to be scheduled to nodes with taints.
 tolerations: []
 controller:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -57,6 +57,8 @@ affinity:
         - matchExpressions:
             - key: karpenter.sh/provisioner-name
               operator: DoesNotExist
+# -- topologySpreadConstraints to increase the controller resilience
+topologySpreadConstraints: []
 # -- Tolerations to allow the pod to be scheduled to nodes with taints.
 tolerations: []
 controller:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -58,10 +58,10 @@ affinity:
             - key: karpenter.sh/provisioner-name
               operator: DoesNotExist
 # -- topologySpreadConstraints to increase the controller resilience
-topologySpreadConstraints: []
-# - maxSkew: 1
-#   topologyKey: topology.kubernetes.io/zone
-#   whenUnsatisfiable: ScheduleAnyway
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
 
 # -- Tolerations to allow the pod to be scheduled to nodes with taints.
 tolerations: []


### PR DESCRIPTION
**1. Issue, if available:**

topologySpreadConstraints was not available in the chart, resulting in karpenter deployment pods scheduled on the same node.

**2. Description of changes:**

Added topologySpreadConstraints logic to values.yaml and deployment template.
Added a sample config as well, maybe you'll prefer to split on the hostname instead of the zone.

**3. How was this change tested?**

Locally, by deploying the chart and scaling the number of replicas to validate the syntax and the spread result.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
