### PR TITLE
upgrade helm-docs

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -16,7 +16,7 @@ tools() {
     go install github.com/google/ko@v0.10.0
     go install github.com/mikefarah/yq/v4@v4.16.1
     go install github.com/mitchellh/golicense@v0.2.0
-    go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.7.0
+    go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.8.1
     go install github.com/onsi/ginkgo/ginkgo@v1.16.5
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20220113220429-45b13b951f77
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - helm-docs v1.7.0 causes a checksum mismatch when using GOPROXY=direct, v1.8.1 is a stable release that matches the checksum 
 - helm-docs v1.7.0 depends on golang.org/x/sys/unix@20190215142949 which doesn't work with go 1.18 on darwin
```
$ go verison 
go version go1.17.8 darwin/amd64

$ GOPROXY=direct go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.7.0
 # golang.org/x/sys/unix
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:136:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:151:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:166:3: //go:linkname must refer to declared function or variable
../../go/pkg/mod/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a/unix/zsyscall_darwin_amd64.go:166:3: too many errors
```


**3. How was this change tested?**
```
$ go version
go version go1.18 darwin/amd64

$ GOPROXY=direct go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.8.1
$ echo $?
0
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
