### PR TITLE
[AWS CP] use t1 and t2 if no other instance types are available

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/utils/functional"
 	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/options"
 	"github.com/aws/karpenter/pkg/utils/resources"
@@ -327,6 +328,9 @@ func (p *InstanceProvider) getCapacityType(nodeRequest *cloudprovider.NodeReques
 func (p *InstanceProvider) filterInstanceTypes(instanceTypes []cloudprovider.InstanceType) []cloudprovider.InstanceType {
 	var genericInstanceTypes []cloudprovider.InstanceType
 	for _, it := range instanceTypes {
+		if functional.HasAnyPrefix(*it.(*InstanceType).InstanceType, "t1", "t2") {
+			continue
+		}
 		if aws.BoolValue(it.(*InstanceType).BareMetal) {
 			continue
 		}

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -173,9 +173,8 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 		return false
 	}
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
-		"m", "c", "r", "a", // Standard
-		"i3",       // Storage-optimized
-		"t3", "t4", // Burstable
+		"m", "c", "r", "a", "t", // Standard
+		"i3",            // Storage-optimized
 		"p", "inf", "g", // Accelerators
 	)
 }


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Use t1 or t2 only if no other instance types are available (this is similar to how we handle bare metal instance types)


**3. How was this change tested?**
 - Manually in an EKS cluster
   - constraints cluster to m5.16xlarge and t2.2xlarge
   - Provisioned a pod that needs 1vcpu, Karpenter chose m5.16xlarge
   - removed m5.16xlarge and Karpenter provisioned a t2.2xlarge 


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
