### PR TITLE
[AWS CP] include ephemeral storage in instance type price

### DIFF
--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -92,6 +92,7 @@ func (i *InstanceType) Price() float64 {
 		InferenceCostWeight = 5
 		CPUCostWeight       = 1
 		MemoryMBCostWeight  = 1 / 1024.0
+		LocalStorageWeight  = 1 / 100.0
 	)
 
 	gpuCount := 0.0
@@ -112,9 +113,15 @@ func (i *InstanceType) Price() float64 {
 		}
 	}
 
+	localStorageGiBs := 0.0
+	if i.InstanceStorageInfo != nil {
+		localStorageGiBs += float64(*i.InstanceStorageInfo.TotalSizeInGB)
+	}
+
 	return CPUCostWeight*float64(*i.VCpuInfo.DefaultVCpus) +
 		MemoryMBCostWeight*float64(*i.MemoryInfo.SizeInMiB) +
-		GPUCostWeight*gpuCount + InferenceCostWeight*infCount
+		GPUCostWeight*gpuCount + InferenceCostWeight*infCount +
+		localStorageGiBs*LocalStorageWeight
 }
 func (i *InstanceType) cpu() resource.Quantity {
 	return *resources.Quantity(fmt.Sprint(*i.VCpuInfo.DefaultVCpus))


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - include ephemeral storage in price calc for an instance type. This will order instance type priorities when using spot to differentiate between 'd' instance type variants (storage optimized). 

**3. How was this change tested?**
 - Manual scale-up and printed instance type ordering compared to actual price:

https://gist.github.com/bwagner5/a571dc74a9c52f49efbc373752848fba

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
