### PR TITLE
Add commonly used directory and OS created files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ coverage.out
 coverage.html
 *.test
 *.csv
+
+# Common in OSs and IDEs
+.idea
+.DS_Store


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
These two files are pretty common for users of OSX and IntelliJ line of IDEs, adding them to .gitignore will improve the development experience because they won't have to see these two seemingly new files/dirs every time they do `git status`

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
