### PR TITLE
Fixed Testing Guide to show up in website

### DIFF
--- a/website/content/en/preview/testing-guide.md
+++ b/website/content/en/preview/testing-guide.md
@@ -1,5 +1,8 @@
-# Karpenter Testing User Guide
-
+---
+title: "Karpenter Testing Guide"
+linkTitle: "Testing Guide"
+weight: 80
+---
 Currently, users can only test Karpenter by adding to a list of integration tests run in a mock environment or installing and testing Karpenter on a real cluster. Users who want to run more comprehensive tests are limited by the lack of test automation and configurability.
 
 To increase testing of Karpenter, this document introduces plans to create infrastructure and tools to extend the current mechanisms and enable developers to contribute with more confidence.

--- a/website/content/en/v0.8.2/testing-guide.md
+++ b/website/content/en/v0.8.2/testing-guide.md
@@ -1,5 +1,8 @@
-# Karpenter Testing User Guide
-
+---
+title: "Karpenter Testing Guide"
+linkTitle: "Testing Guide"
+weight: 80
+---
 Currently, users can only test Karpenter by adding to a list of integration tests run in a mock environment or installing and testing Karpenter on a real cluster. Users who want to run more comprehensive tests are limited by the lack of test automation and configurability.
 
 To increase testing of Karpenter, this document introduces plans to create infrastructure and tools to extend the current mechanisms and enable developers to contribute with more confidence.


### PR DESCRIPTION
**1. Issue, if available:**
Testing guide was reachable by URL but did not by navigation bar due to how Netlify works.

**2. Description of changes:**
Added the Testing Guide to show up in the Navigation Bar

**3. How was this change tested?**
ran `make website` and saw the page appear locally.

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
