### PR TITLE
rework search indexing

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -43,6 +43,9 @@ chart() {
 website() {
     mkdir -p website/content/en/${RELEASE_VERSION} && cp -r website/content/en/preview/* website/content/en/${RELEASE_VERSION}/
     find website/content/en/${RELEASE_VERSION}/ -type f | xargs perl -i -p -e "s/{{< param \"latest_release_version\" >}}/${RELEASE_VERSION}/g;"
+    # make only the latest version searchable
+    find website/content/en/ -type f | xargs perl -i -p -e "s/exclude_search:.*/exclude_search: true/"
+    find website/content/en/${RELEASE_VERSION}/ -type f | xargs perl -i -p -e "s/exclude_search:.*/exclude_search: false/"
 }
 
 image

--- a/website/archetypes/default.md
+++ b/website/archetypes/default.md
@@ -1,5 +1,6 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
+exclude_search: false
 date: {{ .Date }}
 draft: true
 ---

--- a/website/content/en/preview/AWS/_index.md
+++ b/website/content/en/preview/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/preview/AWS/launch-templates.md
+++ b/website/content/en/preview/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/preview/_index.md
+++ b/website/content/en/preview/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/preview/concepts/_index.md
+++ b/website/content/en/preview/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/preview/development-guide.md
+++ b/website/content/en/preview/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with eksctl"
+exclude_search: true
 linkTitle: "Getting Started with eksctl"
 weight: 10
 ---

--- a/website/content/en/preview/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/preview/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/preview/getting-started/migrating-from-cas/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Migrating from Cluster Autoscaler"
+exclude_search: true
 linkTitle: "Migrating from Cluster Autoscaler"
 weight: 10
 ---

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/preview/tasks/_index.md
+++ b/website/content/en/preview/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/preview/tasks/deprovisioning.md
+++ b/website/content/en/preview/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/preview/tasks/pod-density.md
+++ b/website/content/en/preview/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/preview/tasks/provisioning.md
+++ b/website/content/en/preview/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/preview/tasks/scheduling.md
+++ b/website/content/en/preview/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/preview/testing-guide.md
+++ b/website/content/en/preview/testing-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Karpenter Testing Guide"
+exclude_search: true
 linkTitle: "Testing Guide"
 weight: 80
 ---

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Upgrade Guide"
+exclude_search: true
 linkTitle: "Upgrade Guide"
 weight: 10
 ---

--- a/website/content/en/v0.4.3/_index.md
+++ b/website/content/en/v0.4.3/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.4.3/cloud-providers/AWS/_index.md
+++ b/website/content/en/v0.4.3/cloud-providers/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.4.3/cloud-providers/AWS/aws-spec-fields.md
+++ b/website/content/en/v0.4.3/cloud-providers/AWS/aws-spec-fields.md
@@ -1,5 +1,6 @@
 ---
 title: "Specifying Values to Control AWS Provisioning"
+exclude_search: true
 linkTitle: "Spec Fields"
 weight: 10
 ---

--- a/website/content/en/v0.4.3/cloud-providers/AWS/launch-templates.md
+++ b/website/content/en/v0.4.3/cloud-providers/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.4.3/cloud-providers/_index.md
+++ b/website/content/en/v0.4.3/cloud-providers/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Cloud Providers"
+exclude_search: true
 linkTitle: "Cloud Providers"
 weight: 70
 ---

--- a/website/content/en/v0.4.3/concepts/_index.md
+++ b/website/content/en/v0.4.3/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.4.3/development-guide.md
+++ b/website/content/en/v0.4.3/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.4.3/faqs.md
+++ b/website/content/en/v0.4.3/faqs.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 30
 ---

--- a/website/content/en/v0.4.3/getting-started/_index.md
+++ b/website/content/en/v0.4.3/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.4.3/provisioner-crd.md
+++ b/website/content/en/v0.4.3/provisioner-crd.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner CRD"
+exclude_search: true
 linkTitle: "Provisioner CRD"
 weight: 40
 date: 2017-01-05

--- a/website/content/en/v0.5.0/AWS/_index.md
+++ b/website/content/en/v0.5.0/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.5.0/AWS/launch-templates.md
+++ b/website/content/en/v0.5.0/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.5.0/AWS/provisioning.md
+++ b/website/content/en/v0.5.0/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.5.0/_index.md
+++ b/website/content/en/v0.5.0/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.5.0/concepts/_index.md
+++ b/website/content/en/v0.5.0/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.5.0/development-guide.md
+++ b/website/content/en/v0.5.0/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.5.0/getting-started/_index.md
+++ b/website/content/en/v0.5.0/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.5.0/provisioner.md
+++ b/website/content/en/v0.5.0/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.5.0/tasks/_index.md
+++ b/website/content/en/v0.5.0/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.5.0/tasks/deprov-nodes.md
+++ b/website/content/en/v0.5.0/tasks/deprov-nodes.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning nodes"
+exclude_search: true
 linkTitle: "Deprovisioning nodes"
 weight: 20
 ---

--- a/website/content/en/v0.5.0/tasks/provisioning-task.md
+++ b/website/content/en/v0.5.0/tasks/provisioning-task.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning nodes"
+exclude_search: true
 linkTitle: "Provisioning nodes"
 weight: 5
 ---

--- a/website/content/en/v0.5.0/tasks/running-pods.md
+++ b/website/content/en/v0.5.0/tasks/running-pods.md
@@ -1,5 +1,6 @@
 ---
 title: "Running pods"
+exclude_search: true
 linkTitle: "Running pods"
 weight: 10
 ---

--- a/website/content/en/v0.5.2/AWS/_index.md
+++ b/website/content/en/v0.5.2/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.5.2/AWS/launch-templates.md
+++ b/website/content/en/v0.5.2/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.5.2/AWS/provisioning.md
+++ b/website/content/en/v0.5.2/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.5.2/_index.md
+++ b/website/content/en/v0.5.2/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.5.2/concepts/_index.md
+++ b/website/content/en/v0.5.2/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.5.2/development-guide.md
+++ b/website/content/en/v0.5.2/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.5.2/getting-started/_index.md
+++ b/website/content/en/v0.5.2/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.5.2/provisioner.md
+++ b/website/content/en/v0.5.2/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.5.2/tasks/_index.md
+++ b/website/content/en/v0.5.2/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.5.2/tasks/deprov-nodes.md
+++ b/website/content/en/v0.5.2/tasks/deprov-nodes.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning nodes"
+exclude_search: true
 linkTitle: "Deprovisioning nodes"
 weight: 20
 ---

--- a/website/content/en/v0.5.2/tasks/provisioning-task.md
+++ b/website/content/en/v0.5.2/tasks/provisioning-task.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning nodes"
+exclude_search: true
 linkTitle: "Provisioning nodes"
 weight: 5
 ---

--- a/website/content/en/v0.5.2/tasks/running-pods.md
+++ b/website/content/en/v0.5.2/tasks/running-pods.md
@@ -1,5 +1,6 @@
 ---
 title: "Running pods"
+exclude_search: true
 linkTitle: "Running pods"
 weight: 10
 ---

--- a/website/content/en/v0.5.3/AWS/_index.md
+++ b/website/content/en/v0.5.3/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.5.3/AWS/launch-templates.md
+++ b/website/content/en/v0.5.3/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.5.3/AWS/provisioning.md
+++ b/website/content/en/v0.5.3/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.5.3/_index.md
+++ b/website/content/en/v0.5.3/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.5.3/concepts/_index.md
+++ b/website/content/en/v0.5.3/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.5.3/development-guide.md
+++ b/website/content/en/v0.5.3/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.5.3/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.5.3/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.5.3/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.5.3/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.5.3/getting-started/_index.md
+++ b/website/content/en/v0.5.3/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.5.3/provisioner.md
+++ b/website/content/en/v0.5.3/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 description: >

--- a/website/content/en/v0.5.3/tasks/_index.md
+++ b/website/content/en/v0.5.3/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.5.3/tasks/deprov-nodes.md
+++ b/website/content/en/v0.5.3/tasks/deprov-nodes.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning nodes"
+exclude_search: true
 linkTitle: "Deprovisioning nodes"
 weight: 20
 ---

--- a/website/content/en/v0.5.3/tasks/provisioning-task.md
+++ b/website/content/en/v0.5.3/tasks/provisioning-task.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning nodes"
+exclude_search: true
 linkTitle: "Provisioning nodes"
 weight: 5
 ---

--- a/website/content/en/v0.5.3/tasks/running-pods.md
+++ b/website/content/en/v0.5.3/tasks/running-pods.md
@@ -1,5 +1,6 @@
 ---
 title: "Running pods"
+exclude_search: true
 linkTitle: "Running pods"
 weight: 10
 ---

--- a/website/content/en/v0.5.5/AWS/_index.md
+++ b/website/content/en/v0.5.5/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.5.5/AWS/launch-templates.md
+++ b/website/content/en/v0.5.5/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.5.5/AWS/provisioning.md
+++ b/website/content/en/v0.5.5/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.5.5/_index.md
+++ b/website/content/en/v0.5.5/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.5.5/concepts/_index.md
+++ b/website/content/en/v0.5.5/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.5.5/development-guide.md
+++ b/website/content/en/v0.5.5/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.5.5/faq.md
+++ b/website/content/en/v0.5.5/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.5.5/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.5.5/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.5.5/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.5.5/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.5.5/getting-started/_index.md
+++ b/website/content/en/v0.5.5/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.5.5/provisioner.md
+++ b/website/content/en/v0.5.5/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.5.5/tasks/_index.md
+++ b/website/content/en/v0.5.5/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.5.5/tasks/deprovisioning.md
+++ b/website/content/en/v0.5.5/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.5.5/tasks/provisioning.md
+++ b/website/content/en/v0.5.5/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.5.5/tasks/scheduling.md
+++ b/website/content/en/v0.5.5/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.5.6/AWS/_index.md
+++ b/website/content/en/v0.5.6/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.5.6/AWS/launch-templates.md
+++ b/website/content/en/v0.5.6/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.5.6/AWS/provisioning.md
+++ b/website/content/en/v0.5.6/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.5.6/_index.md
+++ b/website/content/en/v0.5.6/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.5.6/concepts/_index.md
+++ b/website/content/en/v0.5.6/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.5.6/development-guide.md
+++ b/website/content/en/v0.5.6/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.5.6/faq.md
+++ b/website/content/en/v0.5.6/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.5.6/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.5.6/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.5.6/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.5.6/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.5.6/getting-started/_index.md
+++ b/website/content/en/v0.5.6/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.5.6/provisioner.md
+++ b/website/content/en/v0.5.6/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.5.6/tasks/_index.md
+++ b/website/content/en/v0.5.6/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.5.6/tasks/deprovisioning.md
+++ b/website/content/en/v0.5.6/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.5.6/tasks/provisioning.md
+++ b/website/content/en/v0.5.6/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.5.6/tasks/scheduling.md
+++ b/website/content/en/v0.5.6/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.5.6/tasks/set-resource-limits.md
+++ b/website/content/en/v0.5.6/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.6.0/AWS/_index.md
+++ b/website/content/en/v0.6.0/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.6.0/AWS/launch-templates.md
+++ b/website/content/en/v0.6.0/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.6.0/AWS/provisioning.md
+++ b/website/content/en/v0.6.0/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.0/_index.md
+++ b/website/content/en/v0.6.0/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.6.0/concepts/_index.md
+++ b/website/content/en/v0.6.0/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.6.0/development-guide.md
+++ b/website/content/en/v0.6.0/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.6.0/faq.md
+++ b/website/content/en/v0.6.0/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.6.0/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.6.0/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.6.0/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.6.0/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.6.0/getting-started/_index.md
+++ b/website/content/en/v0.6.0/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.6.0/provisioner.md
+++ b/website/content/en/v0.6.0/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.6.0/tasks/_index.md
+++ b/website/content/en/v0.6.0/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.6.0/tasks/deprovisioning.md
+++ b/website/content/en/v0.6.0/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.0/tasks/provisioning.md
+++ b/website/content/en/v0.6.0/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.6.0/tasks/scheduling.md
+++ b/website/content/en/v0.6.0/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.6.0/tasks/set-resource-limits.md
+++ b/website/content/en/v0.6.0/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.6.1/AWS/_index.md
+++ b/website/content/en/v0.6.1/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.6.1/AWS/launch-templates.md
+++ b/website/content/en/v0.6.1/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.6.1/AWS/provisioning.md
+++ b/website/content/en/v0.6.1/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.1/_index.md
+++ b/website/content/en/v0.6.1/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.6.1/concepts/_index.md
+++ b/website/content/en/v0.6.1/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.6.1/development-guide.md
+++ b/website/content/en/v0.6.1/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.6.1/faq.md
+++ b/website/content/en/v0.6.1/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.6.1/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.6.1/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.6.1/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.6.1/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.6.1/getting-started/_index.md
+++ b/website/content/en/v0.6.1/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.6.1/provisioner.md
+++ b/website/content/en/v0.6.1/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.6.1/tasks/_index.md
+++ b/website/content/en/v0.6.1/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.6.1/tasks/deprovisioning.md
+++ b/website/content/en/v0.6.1/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.1/tasks/provisioning.md
+++ b/website/content/en/v0.6.1/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.6.1/tasks/scheduling.md
+++ b/website/content/en/v0.6.1/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.6.1/tasks/set-resource-limits.md
+++ b/website/content/en/v0.6.1/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.6.2/AWS/_index.md
+++ b/website/content/en/v0.6.2/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.6.2/AWS/launch-templates.md
+++ b/website/content/en/v0.6.2/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.6.2/AWS/provisioning.md
+++ b/website/content/en/v0.6.2/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.2/_index.md
+++ b/website/content/en/v0.6.2/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.6.2/concepts/_index.md
+++ b/website/content/en/v0.6.2/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.6.2/development-guide.md
+++ b/website/content/en/v0.6.2/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.6.2/faq.md
+++ b/website/content/en/v0.6.2/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.6.2/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.6.2/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.6.2/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.6.2/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.6.2/getting-started/_index.md
+++ b/website/content/en/v0.6.2/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.6.2/provisioner.md
+++ b/website/content/en/v0.6.2/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.6.2/tasks/_index.md
+++ b/website/content/en/v0.6.2/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.6.2/tasks/deprovisioning.md
+++ b/website/content/en/v0.6.2/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.2/tasks/provisioning.md
+++ b/website/content/en/v0.6.2/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.6.2/tasks/scheduling.md
+++ b/website/content/en/v0.6.2/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.6.2/tasks/set-resource-limits.md
+++ b/website/content/en/v0.6.2/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.6.3/AWS/_index.md
+++ b/website/content/en/v0.6.3/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.6.3/AWS/launch-templates.md
+++ b/website/content/en/v0.6.3/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.6.3/AWS/provisioning.md
+++ b/website/content/en/v0.6.3/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.3/_index.md
+++ b/website/content/en/v0.6.3/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.6.3/concepts/_index.md
+++ b/website/content/en/v0.6.3/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.6.3/development-guide.md
+++ b/website/content/en/v0.6.3/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.6.3/faq.md
+++ b/website/content/en/v0.6.3/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.6.3/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.6.3/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.6.3/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.6.3/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.6.3/getting-started/_index.md
+++ b/website/content/en/v0.6.3/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.6.3/provisioner.md
+++ b/website/content/en/v0.6.3/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.6.3/tasks/_index.md
+++ b/website/content/en/v0.6.3/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.6.3/tasks/deprovisioning.md
+++ b/website/content/en/v0.6.3/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.3/tasks/provisioning.md
+++ b/website/content/en/v0.6.3/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.6.3/tasks/scheduling.md
+++ b/website/content/en/v0.6.3/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.6.3/tasks/set-resource-limits.md
+++ b/website/content/en/v0.6.3/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.6.4/AWS/_index.md
+++ b/website/content/en/v0.6.4/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.6.4/AWS/launch-templates.md
+++ b/website/content/en/v0.6.4/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.6.4/AWS/provisioning.md
+++ b/website/content/en/v0.6.4/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.4/_index.md
+++ b/website/content/en/v0.6.4/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.6.4/concepts/_index.md
+++ b/website/content/en/v0.6.4/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.6.4/development-guide.md
+++ b/website/content/en/v0.6.4/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.6.4/faq.md
+++ b/website/content/en/v0.6.4/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.6.4/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.6.4/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.6.4/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.6.4/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.6.4/getting-started/_index.md
+++ b/website/content/en/v0.6.4/getting-started/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Karpenter on AWS"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 ---

--- a/website/content/en/v0.6.4/provisioner.md
+++ b/website/content/en/v0.6.4/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.6.4/tasks/_index.md
+++ b/website/content/en/v0.6.4/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.6.4/tasks/deprovisioning.md
+++ b/website/content/en/v0.6.4/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.4/tasks/pod-density.md
+++ b/website/content/en/v0.6.4/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.6.4/tasks/provisioning.md
+++ b/website/content/en/v0.6.4/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.6.4/tasks/scheduling.md
+++ b/website/content/en/v0.6.4/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.6.4/tasks/set-resource-limits.md
+++ b/website/content/en/v0.6.4/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.6.5/AWS/_index.md
+++ b/website/content/en/v0.6.5/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.6.5/AWS/launch-templates.md
+++ b/website/content/en/v0.6.5/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.6.5/AWS/provisioning.md
+++ b/website/content/en/v0.6.5/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.5/_index.md
+++ b/website/content/en/v0.6.5/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.6.5/concepts/_index.md
+++ b/website/content/en/v0.6.5/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.6.5/development-guide.md
+++ b/website/content/en/v0.6.5/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.6.5/faq.md
+++ b/website/content/en/v0.6.5/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.6.5/getting-started/_index.md
+++ b/website/content/en/v0.6.5/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.6.5/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.6.5/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting started with eksctl"
+exclude_search: true
 linkTitle: "Getting started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.6.5/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.6.5/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.6.5/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.6.5/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.6.5/provisioner.md
+++ b/website/content/en/v0.6.5/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.6.5/tasks/_index.md
+++ b/website/content/en/v0.6.5/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.6.5/tasks/deprovisioning.md
+++ b/website/content/en/v0.6.5/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.6.5/tasks/pod-density.md
+++ b/website/content/en/v0.6.5/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.6.5/tasks/provisioning.md
+++ b/website/content/en/v0.6.5/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.6.5/tasks/scheduling.md
+++ b/website/content/en/v0.6.5/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.6.5/tasks/set-resource-limits.md
+++ b/website/content/en/v0.6.5/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.6.5/troubleshooting.md
+++ b/website/content/en/v0.6.5/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.7.0/AWS/_index.md
+++ b/website/content/en/v0.7.0/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.7.0/AWS/launch-templates.md
+++ b/website/content/en/v0.7.0/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.7.0/AWS/provisioning.md
+++ b/website/content/en/v0.7.0/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.0/_index.md
+++ b/website/content/en/v0.7.0/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.7.0/concepts/_index.md
+++ b/website/content/en/v0.7.0/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.7.0/development-guide.md
+++ b/website/content/en/v0.7.0/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.7.0/faq.md
+++ b/website/content/en/v0.7.0/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.7.0/getting-started/_index.md
+++ b/website/content/en/v0.7.0/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.7.0/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.7.0/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting started with eksctl"
+exclude_search: true
 linkTitle: "Getting started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.7.0/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.7.0/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.7.0/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.7.0/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.7.0/provisioner.md
+++ b/website/content/en/v0.7.0/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.7.0/tasks/_index.md
+++ b/website/content/en/v0.7.0/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.7.0/tasks/deprovisioning.md
+++ b/website/content/en/v0.7.0/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.0/tasks/pod-density.md
+++ b/website/content/en/v0.7.0/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.7.0/tasks/provisioning.md
+++ b/website/content/en/v0.7.0/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.7.0/tasks/scheduling.md
+++ b/website/content/en/v0.7.0/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.7.0/tasks/set-resource-limits.md
+++ b/website/content/en/v0.7.0/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.7.0/troubleshooting.md
+++ b/website/content/en/v0.7.0/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.7.1/AWS/_index.md
+++ b/website/content/en/v0.7.1/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.7.1/AWS/launch-templates.md
+++ b/website/content/en/v0.7.1/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.7.1/AWS/provisioning.md
+++ b/website/content/en/v0.7.1/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.1/_index.md
+++ b/website/content/en/v0.7.1/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.7.1/concepts/_index.md
+++ b/website/content/en/v0.7.1/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.7.1/development-guide.md
+++ b/website/content/en/v0.7.1/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.7.1/faq.md
+++ b/website/content/en/v0.7.1/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.7.1/getting-started/_index.md
+++ b/website/content/en/v0.7.1/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.7.1/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.7.1/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting started with eksctl"
+exclude_search: true
 linkTitle: "Getting started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.7.1/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.7.1/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.7.1/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.7.1/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.7.1/provisioner.md
+++ b/website/content/en/v0.7.1/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.7.1/tasks/_index.md
+++ b/website/content/en/v0.7.1/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.7.1/tasks/deprovisioning.md
+++ b/website/content/en/v0.7.1/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.1/tasks/pod-density.md
+++ b/website/content/en/v0.7.1/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.7.1/tasks/provisioning.md
+++ b/website/content/en/v0.7.1/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.7.1/tasks/scheduling.md
+++ b/website/content/en/v0.7.1/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.7.1/tasks/set-resource-limits.md
+++ b/website/content/en/v0.7.1/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.7.1/troubleshooting.md
+++ b/website/content/en/v0.7.1/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.7.2/AWS/_index.md
+++ b/website/content/en/v0.7.2/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.7.2/AWS/launch-templates.md
+++ b/website/content/en/v0.7.2/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.7.2/AWS/provisioning.md
+++ b/website/content/en/v0.7.2/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.2/_index.md
+++ b/website/content/en/v0.7.2/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.7.2/concepts/_index.md
+++ b/website/content/en/v0.7.2/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.7.2/development-guide.md
+++ b/website/content/en/v0.7.2/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.7.2/faq.md
+++ b/website/content/en/v0.7.2/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.7.2/getting-started/_index.md
+++ b/website/content/en/v0.7.2/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.7.2/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.7.2/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting started with eksctl"
+exclude_search: true
 linkTitle: "Getting started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.7.2/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.7.2/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.7.2/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.7.2/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.7.2/provisioner.md
+++ b/website/content/en/v0.7.2/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.7.2/tasks/_index.md
+++ b/website/content/en/v0.7.2/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.7.2/tasks/deprovisioning.md
+++ b/website/content/en/v0.7.2/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.2/tasks/pod-density.md
+++ b/website/content/en/v0.7.2/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.7.2/tasks/provisioning.md
+++ b/website/content/en/v0.7.2/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.7.2/tasks/scheduling.md
+++ b/website/content/en/v0.7.2/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.7.2/tasks/set-resource-limits.md
+++ b/website/content/en/v0.7.2/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.7.2/troubleshooting.md
+++ b/website/content/en/v0.7.2/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.7.2/upgrade-guide/_index.md
+++ b/website/content/en/v0.7.2/upgrade-guide/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Upgrade Guide"
+exclude_search: true
 linkTitle: "Upgrade Guide"
 weight: 10
 ---

--- a/website/content/en/v0.7.3/AWS/_index.md
+++ b/website/content/en/v0.7.3/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.7.3/AWS/launch-templates.md
+++ b/website/content/en/v0.7.3/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.7.3/AWS/provisioning.md
+++ b/website/content/en/v0.7.3/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.3/_index.md
+++ b/website/content/en/v0.7.3/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.7.3/concepts/_index.md
+++ b/website/content/en/v0.7.3/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.7.3/development-guide.md
+++ b/website/content/en/v0.7.3/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.7.3/faq.md
+++ b/website/content/en/v0.7.3/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.7.3/getting-started/_index.md
+++ b/website/content/en/v0.7.3/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.7.3/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.7.3/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting started with eksctl"
+exclude_search: true
 linkTitle: "Getting started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.7.3/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.7.3/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.7.3/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.7.3/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.7.3/provisioner.md
+++ b/website/content/en/v0.7.3/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.7.3/tasks/_index.md
+++ b/website/content/en/v0.7.3/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.7.3/tasks/deprovisioning.md
+++ b/website/content/en/v0.7.3/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.7.3/tasks/pod-density.md
+++ b/website/content/en/v0.7.3/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.7.3/tasks/provisioning.md
+++ b/website/content/en/v0.7.3/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.7.3/tasks/scheduling.md
+++ b/website/content/en/v0.7.3/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.7.3/tasks/set-resource-limits.md
+++ b/website/content/en/v0.7.3/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.7.3/troubleshooting.md
+++ b/website/content/en/v0.7.3/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.7.3/upgrade-guide/_index.md
+++ b/website/content/en/v0.7.3/upgrade-guide/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Upgrade Guide"
+exclude_search: true
 linkTitle: "Upgrade Guide"
 weight: 10
 ---

--- a/website/content/en/v0.8.0/AWS/_index.md
+++ b/website/content/en/v0.8.0/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.8.0/AWS/launch-templates.md
+++ b/website/content/en/v0.8.0/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.8.0/AWS/provisioning.md
+++ b/website/content/en/v0.8.0/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.8.0/_index.md
+++ b/website/content/en/v0.8.0/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.8.0/concepts/_index.md
+++ b/website/content/en/v0.8.0/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.8.0/development-guide.md
+++ b/website/content/en/v0.8.0/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.8.0/faq.md
+++ b/website/content/en/v0.8.0/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.8.0/getting-started/_index.md
+++ b/website/content/en/v0.8.0/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.8.0/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.8.0/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting started with eksctl"
+exclude_search: true
 linkTitle: "Getting started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.8.0/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.8.0/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.8.0/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.8.0/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.8.0/provisioner.md
+++ b/website/content/en/v0.8.0/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.8.0/tasks/_index.md
+++ b/website/content/en/v0.8.0/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.8.0/tasks/deprovisioning.md
+++ b/website/content/en/v0.8.0/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.8.0/tasks/pod-density.md
+++ b/website/content/en/v0.8.0/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.8.0/tasks/provisioning.md
+++ b/website/content/en/v0.8.0/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.8.0/tasks/scheduling.md
+++ b/website/content/en/v0.8.0/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.8.0/tasks/set-resource-limits.md
+++ b/website/content/en/v0.8.0/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.8.0/troubleshooting.md
+++ b/website/content/en/v0.8.0/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.8.0/upgrade-guide/_index.md
+++ b/website/content/en/v0.8.0/upgrade-guide/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Upgrade Guide"
+exclude_search: true
 linkTitle: "Upgrade Guide"
 weight: 10
 ---

--- a/website/content/en/v0.8.1/AWS/_index.md
+++ b/website/content/en/v0.8.1/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: true
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.8.1/AWS/launch-templates.md
+++ b/website/content/en/v0.8.1/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: true
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.8.1/AWS/provisioning.md
+++ b/website/content/en/v0.8.1/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.8.1/_index.md
+++ b/website/content/en/v0.8.1/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: true
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.8.1/concepts/_index.md
+++ b/website/content/en/v0.8.1/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: true
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.8.1/development-guide.md
+++ b/website/content/en/v0.8.1/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: true
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.8.1/faq.md
+++ b/website/content/en/v0.8.1/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: true
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.8.1/getting-started/_index.md
+++ b/website/content/en/v0.8.1/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: true
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.8.1/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.8.1/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting started with eksctl"
+exclude_search: true
 linkTitle: "Getting started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.8.1/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.8.1/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: true
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.8.1/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.8.1/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: true
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.8.1/provisioner.md
+++ b/website/content/en/v0.8.1/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: true
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.8.1/tasks/_index.md
+++ b/website/content/en/v0.8.1/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: true
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.8.1/tasks/deprovisioning.md
+++ b/website/content/en/v0.8.1/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: true
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.8.1/tasks/pod-density.md
+++ b/website/content/en/v0.8.1/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: true
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.8.1/tasks/provisioning.md
+++ b/website/content/en/v0.8.1/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: true
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.8.1/tasks/scheduling.md
+++ b/website/content/en/v0.8.1/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: true
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.8.1/tasks/set-resource-limits.md
+++ b/website/content/en/v0.8.1/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: true
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.8.1/troubleshooting.md
+++ b/website/content/en/v0.8.1/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: true
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.8.1/upgrade-guide/_index.md
+++ b/website/content/en/v0.8.1/upgrade-guide/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Upgrade Guide"
+exclude_search: true
 linkTitle: "Upgrade Guide"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/AWS/_index.md
+++ b/website/content/en/v0.8.2/AWS/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "AWS"
+exclude_search: false
 linkTitle: "AWS"
 weight: 70
 ---

--- a/website/content/en/v0.8.2/AWS/launch-templates.md
+++ b/website/content/en/v0.8.2/AWS/launch-templates.md
@@ -1,5 +1,6 @@
 ---
 title: "Launch Templates and Custom Images"
+exclude_search: false
 linkTitle: "Launch Templates"
 weight: 80
 ---

--- a/website/content/en/v0.8.2/AWS/provisioning.md
+++ b/website/content/en/v0.8.2/AWS/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning Configuration"
+exclude_search: false
 linkTitle: "Provisioning"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/_index.md
+++ b/website/content/en/v0.8.2/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Documentation"
+exclude_search: false
 linkTitle: "Docs"
 weight: 20
 cascade:

--- a/website/content/en/v0.8.2/concepts/_index.md
+++ b/website/content/en/v0.8.2/concepts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Concepts"
+exclude_search: false
 linkTitle: "Concepts"
 weight: 35
 ---

--- a/website/content/en/v0.8.2/development-guide.md
+++ b/website/content/en/v0.8.2/development-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Guide"
+exclude_search: false
 linkTitle: "Development Guide"
 weight: 80
 ---

--- a/website/content/en/v0.8.2/faq.md
+++ b/website/content/en/v0.8.2/faq.md
@@ -1,5 +1,6 @@
 ---
 title: "FAQs"
+exclude_search: false
 linkTitle: "FAQs"
 weight: 90
 ---

--- a/website/content/en/v0.8.2/getting-started/_index.md
+++ b/website/content/en/v0.8.2/getting-started/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+exclude_search: false
 linkTitle: "Getting Started"
 weight: 10
 cascade:

--- a/website/content/en/v0.8.2/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/v0.8.2/getting-started/getting-started-with-eksctl/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with eksctl"
+exclude_search: false
 linkTitle: "Getting Started with eksctl"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/v0.8.2/getting-started/getting-started-with-kops/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with kOps"
+exclude_search: false
 linkTitle: "Getting Started with kOps"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.8.2/getting-started/getting-started-with-terraform/_index.md
@@ -1,6 +1,7 @@
 
 ---
 title: "Getting Started with Terraform"
+exclude_search: false
 linkTitle: "Getting Started with Terraform"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.8.2/getting-started/migrating-from-cas/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Migrating from Cluster Autoscaler"
+exclude_search: false
 linkTitle: "Migrating from Cluster Autoscaler"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/provisioner.md
+++ b/website/content/en/v0.8.2/provisioner.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioner API"
+exclude_search: false
 linkTitle: "Provisioner API"
 weight: 70
 date: 2017-01-05

--- a/website/content/en/v0.8.2/tasks/_index.md
+++ b/website/content/en/v0.8.2/tasks/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Tasks"
+exclude_search: false
 linkTitle: "Tasks"
 weight: 45
 ---

--- a/website/content/en/v0.8.2/tasks/deprovisioning.md
+++ b/website/content/en/v0.8.2/tasks/deprovisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Deprovisioning"
+exclude_search: false
 linkTitle: "Deprovisioning"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/tasks/pod-density.md
+++ b/website/content/en/v0.8.2/tasks/pod-density.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Pod Density"
+exclude_search: false
 linkTitle: "Control Pod Density"
 weight: 20
 ---

--- a/website/content/en/v0.8.2/tasks/provisioning.md
+++ b/website/content/en/v0.8.2/tasks/provisioning.md
@@ -1,5 +1,6 @@
 ---
 title: "Provisioning"
+exclude_search: false
 linkTitle: "Provisioning"
 weight: 5
 ---

--- a/website/content/en/v0.8.2/tasks/scheduling.md
+++ b/website/content/en/v0.8.2/tasks/scheduling.md
@@ -1,5 +1,6 @@
 ---
 title: "Scheduling"
+exclude_search: false
 linkTitle: "Scheduling"
 weight: 15
 ---

--- a/website/content/en/v0.8.2/tasks/set-resource-limits.md
+++ b/website/content/en/v0.8.2/tasks/set-resource-limits.md
@@ -1,5 +1,6 @@
 ---
 title: "Set Resource Limits"
+exclude_search: false
 linkTitle: "Set Resource Limits"
 weight: 10
 ---

--- a/website/content/en/v0.8.2/testing-guide.md
+++ b/website/content/en/v0.8.2/testing-guide.md
@@ -1,5 +1,6 @@
 ---
 title: "Karpenter Testing Guide"
+exclude_search: false
 linkTitle: "Testing Guide"
 weight: 80
 ---

--- a/website/content/en/v0.8.2/troubleshooting.md
+++ b/website/content/en/v0.8.2/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+exclude_search: false
 linkTitle: "Troubleshooting"
 weight: 100
 ---

--- a/website/content/en/v0.8.2/upgrade-guide/_index.md
+++ b/website/content/en/v0.8.2/upgrade-guide/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Upgrade Guide"
+exclude_search: false
 linkTitle: "Upgrade Guide"
 weight: 10
 ---


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**

- make all content non-indexable by default
- during release, ensure everything is non-indexeable and
  only enable indexing for the current release

**3. How was this change tested?**

Went to Netlify preview and searched, only v0.8.2 results displayed.

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
