### PR TITLE
support optional provisioner.Spec.taintsToIgnore

### DIFF
--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -140,7 +140,8 @@ spec:
               taintsToIgnore:
                 description: TaintsToIgnore is a list of taints for the provisioner
                   to ignore when provisioning new nodes and scheduling pods. If specified,
-                  taints included in this list will be ignored when ...
+                  taints included in this list will be ignored when verifying a pod's
+                  constraints.
                 items:
                   description: The node this Taint is attached to has the "effect"
                     on any pod that does not tolerate the Taint.

--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -137,6 +137,35 @@ spec:
                   - key
                   type: object
                 type: array
+              taintsToIgnore:
+                description: TaintsToIgnore is a list of taints for the provisioner
+                  to ignore when provisioning new nodes and scheduling pods. If specified,
+                  taints included in this list will be ignored when ...
+                items:
+                  description: The node this Taint is attached to has the "effect"
+                    on any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: Required. The effect of the taint on pods that
+                        do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
+                        and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added. It is only written for NoExecute taints.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
               ttlSecondsAfterEmpty:
                 description: "TTLSecondsAfterEmpty is the number of seconds the controller
                   will wait before attempting to delete a node, measured from when

--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -59,7 +59,6 @@ func (c *Constraints) ValidatePod(pod *v1.Pod) error {
 	if err := c.Taints.ToleratesWithIgnores(pod, c.TaintsToIgnore); err != nil {
 		return err
 	}
-
 	requirements := NewPodRequirements(pod)
 	// Test if pod requirements are valid
 	if err := requirements.Validate(); err != nil {

--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -35,6 +35,11 @@ type Constraints struct {
 	// pod tolerations on a per-node basis.
 	// +optional
 	Taints Taints `json:"taints,omitempty"`
+	// TaintsToIgnore is a list of taints for the provisioner to ignore when
+	// provisioning new nodes and scheduling pods. If specified, taints included
+	// in this list will be ignored when ...
+	// +optional
+	TaintsToIgnore Taints `json:"taintsToIgnore,omitempty"`
 	// Requirements are layered with Labels and applied to every node.
 	Requirements Requirements `json:"requirements,inline,omitempty"`
 	// KubeletConfiguration are options passed to the kubelet when provisioning nodes
@@ -51,9 +56,10 @@ type Provider = runtime.RawExtension
 // ValidatePod returns an error if the pod's requirements are not met by the constraints
 func (c *Constraints) ValidatePod(pod *v1.Pod) error {
 	// Tolerate Taints
-	if err := c.Taints.Tolerates(pod); err != nil {
+	if err := c.Taints.ToleratesWithIgnores(pod, c.TaintsToIgnore); err != nil {
 		return err
 	}
+
 	requirements := NewPodRequirements(pod)
 	// Test if pod requirements are valid
 	if err := requirements.Validate(); err != nil {

--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -37,7 +37,7 @@ type Constraints struct {
 	Taints Taints `json:"taints,omitempty"`
 	// TaintsToIgnore is a list of taints for the provisioner to ignore when
 	// provisioning new nodes and scheduling pods. If specified, taints included
-	// in this list will be ignored when ...
+	// in this list will be ignored when verifying a pod's constraints.
 	// +optional
 	TaintsToIgnore Taints `json:"taintsToIgnore,omitempty"`
 	// Requirements are layered with Labels and applied to every node.

--- a/pkg/apis/provisioning/v1alpha5/taints.go
+++ b/pkg/apis/provisioning/v1alpha5/taints.go
@@ -27,7 +27,7 @@ type Taints []v1.Taint
 // Has returns true if taints has a taint for the given key and effect
 func (ts Taints) Has(taint v1.Taint) bool {
 	for _, t := range ts {
-		if taint.MatchTaint(&t) {
+		if t.MatchTaint(&taint) {
 			return true
 		}
 	}

--- a/pkg/apis/provisioning/v1alpha5/taints.go
+++ b/pkg/apis/provisioning/v1alpha5/taints.go
@@ -27,7 +27,7 @@ type Taints []v1.Taint
 // Has returns true if taints has a taint for the given key and effect
 func (ts Taints) Has(taint v1.Taint) bool {
 	for _, t := range ts {
-		if t.Key == taint.Key && t.Effect == taint.Effect {
+		if taint.MatchTaint(&t) {
 			return true
 		}
 	}

--- a/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
@@ -43,6 +43,13 @@ func (in *Constraints) DeepCopyInto(out *Constraints) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TaintsToIgnore != nil {
+		in, out := &in.TaintsToIgnore, &out.TaintsToIgnore
+		*out = make(Taints, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Requirements.DeepCopyInto(&out.Requirements)
 	if in.KubeletConfiguration != nil {
 		in, out := &in.KubeletConfiguration, &out.KubeletConfiguration

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Controller", func() {
 			n = ExpectNodeExists(ctx, env.Client, n.Name)
 			Expect(n.Spec.Taints).To(Equal(n.Spec.Taints))
 		})
-		It("should delete nodes if node not ready even after Initialization timeout ", func() {
+		It("should delete nodes if node not ready even after Initialization timeout", func() {
 			n := test.Node(test.NodeOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Finalizers: []string{v1alpha5.TerminationFinalizer},

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2312,12 +2312,12 @@ var _ = Describe("Taints", func() {
 		provisioner.Spec.Taints = []v1.Taint{{Key: "ignore-me", Value: "nothing-to-see-here", Effect: v1.TaintEffectNoSchedule}}
 		provisioner.Spec.TaintsToIgnore = []v1.Taint{{Key: "ignore-me", Value: "nothing-to-see-here", Effect: v1.TaintEffectNoSchedule}}
 
-		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod())[0]
 		nodes := &v1.NodeList{}
 		Expect(env.Client.List(ctx, nodes)).To(Succeed())
 		Expect(len(nodes.Items)).To(Equal(1))
 
-		ExpectScheduled(ctx, env.Client, pod[0])
+		ExpectScheduled(ctx, env.Client, pod)
 	})
 	It("should not generate taints for OpExists", func() {
 		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner,

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2313,10 +2313,6 @@ var _ = Describe("Taints", func() {
 		provisioner.Spec.TaintsToIgnore = []v1.Taint{{Key: "ignore-me", Value: "nothing-to-see-here", Effect: v1.TaintEffectNoSchedule}}
 
 		pod := ExpectProvisioned(ctx, env.Client, selectionController, provisioners, provisioner, test.UnschedulablePod())[0]
-		nodes := &v1.NodeList{}
-		Expect(env.Client.List(ctx, nodes)).To(Succeed())
-		Expect(len(nodes.Items)).To(Equal(1))
-
 		ExpectScheduled(ctx, env.Client, pod)
 	})
 	It("should not generate taints for OpExists", func() {

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -23,9 +23,16 @@ spec:
   ttlSecondsAfterEmpty: 30
 
   # Provisioned nodes will have these taints
-  # Taints may prevent pods from scheduling if they are not tolerated
+  # Taints may prevent pods from scheduling if they are not tolerated or ignored (below)
   taints:
     - key: example.com/special-taint
+      effect: NoSchedule
+
+  # Karpenter will ignore taints listed here when scheduling pods to nodes.  This can be helpful for cases where a
+  # new node is provisioned with a taint (above), but pods do not have a corresponding toleration.
+  # One use case for this includes daemonset pods which remove taints as part of their execution (CNI pods).
+  taintsToIgnore:
+    - key: example.com/something-fancy-here
       effect: NoSchedule
 
   # Labels are arbitrary key-values that are applied to all nodes


### PR DESCRIPTION
**1. Issue, if available:**
#628 

**2. Description of changes:**
This change allows the provisioner the ability to ignore the listed taints when creating a new node

**3. How was this change tested?**
Added suite test to ensure pods with missing tolerations are still scheduled when the missing taint is in the taintsToIgnore list

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
