### PR TITLE
Version-Aware Documentation Search

### DIFF
--- a/website/assets/js/index.js
+++ b/website/assets/js/index.js
@@ -1,4 +1,7 @@
 import { versionWarning } from "./versionWarning";
+import {OfflineSearch} from "./offlineSearch";
 
 // show warning when viewing outdated or preview docs
 document.addEventListener('DOMContentLoaded', versionWarning, false);
+// enable offine search
+document.addEventListener('DOMContentLoaded', () => new OfflineSearch(), false);

--- a/website/assets/js/offline-search.js
+++ b/website/assets/js/offline-search.js
@@ -1,0 +1,1 @@
+// intentionally empty, do not delete

--- a/website/assets/js/offlineSearch/index.js
+++ b/website/assets/js/offlineSearch/index.js
@@ -1,0 +1,196 @@
+// Adapted from code by Matt Walters https://www.mattwalters.net/posts/hugo-and-lunr/
+import lunr from 'lunr';
+
+export class OfflineSearch {
+  constructor() {
+    this.lunrIndex = null;
+    this.resultDetails = new Map();
+    this.viewingVersion = window.location.pathname.split('/')[1]
+    this.$searchInput = $('.td-search-input');
+
+    this.loadIndex(this.$searchInput.data('offline-search-index-json-src'), this.resultDetails);
+    this.configureSearchInput();
+
+    this.$searchInput.on('change', (event) => {
+      this.render($(event.target));
+      // Hide keyboard on mobile browser
+      this.$searchInput.blur();
+    });
+  }
+
+  configureSearchInput() {
+    this.$searchInput.data('html', true);
+    this.$searchInput.data('placement', 'bottom');
+    this.$searchInput.data(
+      'template',
+      `<div class="popover offline-search-result" role="tooltip">
+        <div class="arrow"></div>
+        <h3 class="popover-header"></h3>
+        <div class="popover-body"></div>
+      </div>`
+    );
+
+    // Prevent reloading page by enter key on sidebar search.
+    this.$searchInput.closest('form').on('submit', () => {
+      return false;
+    });
+  }
+
+  loadIndex(indexSrc, resultDetails) {
+    $.ajax(indexSrc).then(
+      (data) => {
+        this.lunrIndex = lunr(function () {
+          this.ref('ref');
+
+          // If you added more searchable fields to the search index, list them here.
+          // Here you can specify searchable fields to the search index - e.g. individual toxonomies for you project
+          // With "boost" you can add weighting for specific (default weighting without boost: 1)
+          this.field('title', {boost: 5});
+          this.field('categories', {boost: 3});
+          this.field('tags', {boost: 3});
+          this.field('description', {boost: 2});
+          this.field('body');
+
+          data.forEach((doc) => {
+            this.add(doc);
+            resultDetails.set(doc.ref, {
+              title: doc.title,
+              excerpt: doc.excerpt,
+            });
+          });
+        });
+
+        this.$searchInput.trigger('change');
+      }
+    );
+  }
+
+  search(searchQuery, maxResults) {
+    return this.lunrIndex.query((lunrQuery) => {
+      const tokens = lunr.tokenizer(searchQuery.toLowerCase());
+      tokens.forEach((token) => {
+        const tokenString = token.toString();
+        lunrQuery.term(tokenString, {
+          boost: 100,
+        });
+        lunrQuery.term(tokenString, {
+          wildcard:
+            lunr.Query.wildcard.LEADING |
+            lunr.Query.wildcard.TRAILING,
+          boost: 10,
+        });
+        lunrQuery.term(this.viewingVersion, {
+          fields: ["tags"],
+          boost: 25
+        });
+        lunrQuery.term(tokenString, {
+          editDistance: 2,
+        });
+      });
+    })
+      .slice(0, maxResults);
+  }
+
+  render(targetSearchInput) {
+    // Dispose the previous result
+    targetSearchInput.popover('dispose');
+
+    // Search
+    if (this.lunrIndex === null) {
+      return
+    }
+
+    const searchQuery = targetSearchInput.val();
+    const maxResults = targetSearchInput.data('offline-search-max-results');
+    if (searchQuery === '') {
+      return
+    }
+
+    // Search local index
+    const results = this.search(searchQuery, maxResults)
+
+    // Make result html
+    const $html = $('<div>');
+
+    $html.append(
+      $('<div>')
+        .css({
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginBottom: '1em',
+        })
+        .append(
+          $('<span>')
+            .text('Search results')
+            .css({fontWeight: 'bold'})
+        )
+        .append(
+          $('<i>')
+            .addClass('fas fa-times search-result-close-button')
+            .css({
+              cursor: 'pointer',
+            })
+        )
+    );
+
+    const $searchResultBody = $('<div>').css({
+      maxHeight: `calc(100vh - ${
+        targetSearchInput.offset().top -
+        $(window).scrollTop() +
+        180
+      }px)`,
+      overflowY: 'auto',
+    });
+    $html.append($searchResultBody);
+
+    if (results.length === 0) {
+      $searchResultBody.append(
+        $('<p>').text(`No results found for query "${searchQuery}"`)
+      );
+    } else {
+      results.forEach((result) => {
+        $searchResultBody.append(this.renderResult(result));
+      });
+    }
+
+    targetSearchInput.on('shown.bs.popover', () => {
+      $('.search-result-close-button').on('click', () => {
+        targetSearchInput.val('');
+        targetSearchInput.trigger('change');
+      });
+    });
+
+    // Enable inline styles in popover.
+    const whiteList = $.fn.tooltip.Constructor.Default.whiteList;
+    whiteList['*'].push('style');
+
+    targetSearchInput
+      .data('content', $html[0].outerHTML)
+      .popover({whiteList: whiteList})
+      .popover('show');
+  }
+
+  renderResult(result) {
+    const doc = this.resultDetails.get(result.ref);
+    const href =
+      this.$searchInput.data('offline-search-base-href') +
+      result.ref.replace(/^\//, '');
+    const $entry = $('<div>').addClass('mt-4');
+
+    $entry.append(
+      $('<small>').addClass('d-block text-muted').text(result.ref)
+    );
+    $entry.append(
+      $('<a>')
+        .addClass('d-block')
+        .css({
+          fontSize: '1.2rem',
+        })
+        .attr('href', href)
+        .text(doc.title)
+    );
+    $entry.append($('<p>').text(doc.excerpt));
+
+    return $entry;
+  }
+}

--- a/website/content/en/_index.html
+++ b/website/content/en/_index.html
@@ -1,7 +1,8 @@
-+++
-title = "Karpenter"
-linkTitle = "Home"
-+++
+---
+title: "Karpenter"
+linkTitle: "Home"
+exclude_search: true
+---
 
 {{< blocks/cover image_anchor="top" height="max" color="primary" >}}
 <div class="mx-auto hero">

--- a/website/content/en/preview/_index.md
+++ b/website/content/en/preview/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - preview
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.4.3/_index.md
+++ b/website/content/en/v0.4.3/_index.md
@@ -5,7 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
-
+  tags:
+    - v0.4.3
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.5.0/_index.md
+++ b/website/content/en/v0.5.0/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.5.0
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.5.2/_index.md
+++ b/website/content/en/v0.5.2/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.5.2
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.5.3/_index.md
+++ b/website/content/en/v0.5.3/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.5.3
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.5.5/_index.md
+++ b/website/content/en/v0.5.5/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.5.5
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.5.6/_index.md
+++ b/website/content/en/v0.5.6/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.5.6
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.6.0/_index.md
+++ b/website/content/en/v0.6.0/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.6.0
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.6.1/_index.md
+++ b/website/content/en/v0.6.1/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.6.1
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.6.2/_index.md
+++ b/website/content/en/v0.6.2/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.6.2
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.6.3/_index.md
+++ b/website/content/en/v0.6.3/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.6.3
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.6.4/_index.md
+++ b/website/content/en/v0.6.4/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.6.4
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.6.5/_index.md
+++ b/website/content/en/v0.6.5/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.6.5
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.7.0/_index.md
+++ b/website/content/en/v0.7.0/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.7.0
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.7.1/_index.md
+++ b/website/content/en/v0.7.1/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.7.1
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.7.2/_index.md
+++ b/website/content/en/v0.7.2/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.7.2
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.7.3/_index.md
+++ b/website/content/en/v0.7.3/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.7.3
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.8.0/_index.md
+++ b/website/content/en/v0.8.0/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.8.0
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.8.1/_index.md
+++ b/website/content/en/v0.8.1/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.8.1
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/content/en/v0.8.2/_index.md
+++ b/website/content/en/v0.8.2/_index.md
@@ -5,6 +5,8 @@ linkTitle: "Docs"
 weight: 20
 cascade:
   type: docs
+  tags:
+    - v0.8.2
 ---
 Karpenter is an open-source node provisioning project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "ansi-regex": ">=5.0.1",
         "autoprefixer": "^10.4.4",
+        "lunr": "^2.3.9",
         "postcss": "^8.4.12",
         "postcss-cli": "^8.3.1"
       }
@@ -504,6 +505,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1228,6 +1234,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
       "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA=="
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "merge2": {
       "version": "1.4.1",

--- a/website/package.json
+++ b/website/package.json
@@ -2,9 +2,10 @@
   "name": "website",
   "version": "1.0.0",
   "dependencies": {
+    "ansi-regex": ">=5.0.1",
     "autoprefixer": "^10.4.4",
+    "lunr": "^2.3.9",
     "postcss": "^8.4.12",
-    "postcss-cli": "^8.3.1",
-    "ansi-regex": ">=5.0.1"
+    "postcss-cli": "^8.3.1"
   }
 }


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
This updates the documentation site's search to prioritize results from the version of the docs currently being viewed. It's largely built upon the JS from the Docsy theme's [`offline-search.js`](https://github.com/google/docsy/blob/main/assets/js/offline-search.js), but refactored to be slightly less imperative. 

This isn't a perfect solution, but I think it's a step in the right direction.

**3. How was this change tested?**
Manually on my locally hosted documentation site.

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
