### PR TITLE
Update _index.md

### DIFF
--- a/website/content/en/v0.8.1/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.8.1/getting-started/getting-started-with-terraform/_index.md
@@ -205,6 +205,7 @@ resource "aws_iam_role_policy" "karpenter_controller" {
       {
         Action = [
           "ec2:CreateLaunchTemplate",
+          "ec2:DeleteLaunchTemplate",
           "ec2:CreateFleet",
           "ec2:RunInstances",
           "ec2:CreateTags",


### PR DESCRIPTION
Karpenter also deletes the launch template which it has created so for that we need DeleteLaunchTemplate permission in iam role.
Please refer below logs:

2-04-14T10:59:11.603Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "8280611", "provisioner": "default"}
2022-04-14T11:04:12.160Z	DEBUG	controller.provisioning	Discovered 291 EC2 instance types	{"commit": "8280611", "provisioner": "default"}
2022-04-14T11:04:12.199Z	DEBUG	controller.provisioning	Discovered subnets: [subnet-0049d3e34adf10d01 (ap-south-1a) subnet-05a9f36a366038aa4 (ap-south-1b)]	{"commit": "8280611", "provisioner": "default"}
2022-04-14T11:04:12.262Z	DEBUG	controller.provisioning	Discovered EC2 instance types zonal offerings	{"commit": "8280611", "provisioner": "default"}
2022-04-14T11:08:55.465Z	DEBUG	controller.aws.launchtemplate	Deleted launch template lt-001a2cee44f32023a	{"commit": "8280611"}
2022-04-14T11:08:55.548Z	DEBUG	controller.aws.launchtemplate	Deleted launch template lt-0295923f64935c395	{"commit": "8280611"}
2022-04-14T11:08:55.643Z	DEBUG	controller.aws.launchtemplate	Deleted launch template lt-0fdf6c5557b796dae	{"commit": "8280611"}

**1. Issue, if available:**


**2. Description of changes:**


**3. How was this change tested?**


**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
