### PR TITLE
use the karpenter-snapshot alias instead of z4v8y7u8

### DIFF
--- a/hack/snapshot.sh
+++ b/hack/snapshot.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 SNAPSHOT_TAG=$(git rev-parse HEAD)
 CURRENT_MAJOR_VERSION="0"
-PUBLIC_ECR_REGISTRY_ALIAS="public.ecr.aws/z4v8y7u8/"
+PUBLIC_ECR_REGISTRY_ALIAS="public.ecr.aws/karpenter-snapshots/"
 PUBLIC_BUCKET_NAME="karpenter-snapshots"
 RELEASE_REPO=${RELEASE_REPO:-"${PUBLIC_ECR_REGISTRY_ALIAS}"}
 RELEASE_VERSION=${RELEASE_VERSION:-"${SNAPSHOT_TAG}"}


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Uses a human friendlier name.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
