### PR TITLE
pdb api version switching

### DIFF
--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -63,3 +63,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/* Get PodDisruptionBudget API Version */}}
+{{- define "karpenter.pdb.apiVersion" -}}
+{{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
+{{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/karpenter/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1
+apiVersion: {{ include "karpenter.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: karpenter
@@ -7,4 +7,3 @@ spec:
   selector:
     matchLabels:
     {{- include "karpenter.selectorLabels" . | nindent 6 }}
-


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Use PDB v1 api on clusters >= 1.21 if < 1.21 then use v1beta1


**3. How was this change tested?**
 - `helm template charts/karpenter`

Kind 1.20:
```
$ kind create cluster --image kindest/node:v1.20.70@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9 --kubeconfig /tmp/kubeconfig
$ export KUBECONFIG=/tmp/kubeconfig
$ make apply
$ kg pdb karpenter -n karpenter -o yaml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  annotations:
    meta.helm.sh/release-name: karpenter
    meta.helm.sh/release-namespace: karpenter
  creationTimestamp: "2022-04-19T16:06:57Z"
  generation: 1
  labels:
    app.kubernetes.io/managed-by: Helm
  name: karpenter
  namespace: karpenter
  resourceVersion: "1004"
  uid: b794ed80-9030-489b-8663-1dd5a3772d96
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: karpenter
      app.kubernetes.io/name: karpenter
status:
  currentHealthy: 0
  desiredHealthy: 0
  disruptionsAllowed: 0
  expectedPods: 1
  observedGeneration: 1
```

Kind 1.21
```
$  kind create cluster --image kindest/node:v1.21.2@sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4 --kubeconfig /tmp/kubeconfig --name kind-121
$ export KUBECONFIG=/tmp/kubeconfig
$ make apply
$ kg pdb karpenter -n karpenter -o yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  annotations:
    meta.helm.sh/release-name: karpenter
    meta.helm.sh/release-namespace: karpenter
  creationTimestamp: "2022-04-19T16:15:26Z"
  generation: 1
  labels:
    app.kubernetes.io/managed-by: Helm
  name: karpenter
  namespace: karpenter
  resourceVersion: "675"
  uid: e43a67a9-1554-4206-b2aa-e4fc0c9cf389
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: karpenter
      app.kubernetes.io/name: karpenter
status:
  conditions:
  - lastTransitionTime: "2022-04-19T16:15:26Z"
    message: ""
    observedGeneration: 1
    reason: InsufficientPods
    status: "False"
    type: DisruptionAllowed
  currentHealthy: 0
  desiredHealthy: 0
  disruptionsAllowed: 0
  expectedPods: 1
  observedGeneration: 1
```


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
