### PR TITLE
fix stale bot label name issue

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,9 +15,9 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
 
           stale-issue-label: 'closing-soon'
-          exempt-issue-label: 'no-autoclose'
+          exempt-issue-labels: 'no-autoclose'
           stale-pr-label: 'closing-soon'
-          exempt-pr-label: 'no-autoclose'
+          exempt-pr-labels: 'no-autoclose'
           response-requested-label: 'response-requested'
 
           closed-for-staleness-label: 'closed-for-staleness'


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Should fix this err:

```
Unexpected input(s) 'exempt-issue-label', 'exempt-pr-label', valid inputs are ['entryPoint', 'args', 'repo-token', 'issue-types', 'stale-issue-message', 'stale-pr-message', 'days-before-stale', 'days-before-close', 'stale-issue-label', 'exempt-issue-labels', 'stale-pr-label', 'exempt-pr-labels', 'ancient-issue-message', 'ancient-pr-message', 'days-before-ancient', 'response-requested-label', 'closed-for-staleness-label', 'minimum-upvotes-to-exempt', 'loglevel', 'dry-run']
```

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
