### PR TITLE
Fix the wrong launch template name in the doc

### DIFF
--- a/website/content/en/preview/AWS/launch-templates.md
+++ b/website/content/en/preview/AWS/launch-templates.md
@@ -232,6 +232,6 @@ apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 spec:
   provider:
-    launchTemplate: CustomKarpenterLaunchTemplateDemo
+    launchTemplate: KarpenterCustomLaunchTemplate
 
 ```

--- a/website/content/en/v0.8.2/AWS/launch-templates.md
+++ b/website/content/en/v0.8.2/AWS/launch-templates.md
@@ -232,6 +232,6 @@ apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 spec:
   provider:
-    launchTemplate: CustomKarpenterLaunchTemplateDemo
+    launchTemplate: KarpenterCustomLaunchTemplate
 
 ```


### PR DESCRIPTION
**1. Issue, if available:**
The current document about using the custom launch template will use a wrong template name in the provisioner.

**2. Description of changes:**
Replace the incorrect name with the correct one.

**3. How was this change tested?**
N/A

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
