### PR TITLE
Correct the example provisioner for AWS custom launch template doc

### DIFF
--- a/website/content/en/preview/AWS/launch-templates.md
+++ b/website/content/en/preview/AWS/launch-templates.md
@@ -226,6 +226,7 @@ aws cloudformation create-stack \
 
 The LaunchTemplate is ready to be used. Specify it by name in the [Provisioner
 CRD](../../provisioner/). Karpenter will use this template when creating new instances.
+The following is an example of a provisioner using the new template. Please replace the `CLUSTER_NAME` with the correct value.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5
@@ -233,5 +234,6 @@ kind: Provisioner
 spec:
   provider:
     launchTemplate: KarpenterCustomLaunchTemplate
-
+    subnetSelector:
+      karpenter.sh/discovery: CLUSTER_NAME
 ```

--- a/website/content/en/v0.8.2/AWS/launch-templates.md
+++ b/website/content/en/v0.8.2/AWS/launch-templates.md
@@ -226,6 +226,7 @@ aws cloudformation create-stack \
 
 The LaunchTemplate is ready to be used. Specify it by name in the [Provisioner
 CRD](../../provisioner/). Karpenter will use this template when creating new instances.
+The following is an example of a provisioner using the new template. Please replace the `CLUSTER_NAME` with the correct value.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5
@@ -233,5 +234,6 @@ kind: Provisioner
 spec:
   provider:
     launchTemplate: KarpenterCustomLaunchTemplate
-
+    subnetSelector:
+      karpenter.sh/discovery: CLUSTER_NAME
 ```


### PR DESCRIPTION
**1. Issue, if available:**
The example provisioner is missing the subnet selector. It will fail the validation webhook check.

**2. Description of changes:**
Include the subnet selector to the example provisioner.

**3. How was this change tested?**
N/A

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
