### PR TITLE
Return stale bot to normal schedule

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: StaleBot
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 12 * * *'
 jobs:
   StaleBot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
During testing Stalebot was scheduled to run every hour, it seems to be working as expected so we can go to the previous daily schedule.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
