### PR TITLE
fix: env var example in chart values

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -74,7 +74,7 @@ controller:
   # -- Additional environment variables for the controller pod.
   env: []
   # - name: AWS_REGION
-  # - value: eu-west-1
+  #   value: eu-west-1
 
   # -- Resources for the controller pod.
   resources:
@@ -98,7 +98,7 @@ webhook:
   # -- Additional environment variables for the webhook pod.
   env: []
   # - name: AWS_REGION
-  # - value: eu-west-1
+  #   value: eu-west-1
 
   # -- Resources for the webhook pod.
   resources:


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Fixed example of env vars in chart values.yaml: removed extra '-' symbol.
It's partially a pure cosmetic change, but personally I often change default charts values by uncommenting and modifying provided examples, so in this case almost missed it:)

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
