### PR TITLE
Spot failover

### DIFF
--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -28,9 +28,13 @@ var (
 	}
 )
 
-// InsufficientCapacityErrorCode indicates that EC2 is temporarily lacking capacity for this
-// instance type and availability zone combination
-const InsufficientCapacityErrorCode = "InsufficientInstanceCapacity"
+const (
+	// InsufficientCapacityErrorCode indicates that EC2 is temporarily lacking capacity for this
+	// instance type and availability zone combination
+	InsufficientCapacityErrorCode = "InsufficientInstanceCapacity"
+	// MaxSpotInstanceCountExceededErrorCode indicates that the spot quota has been reached for the account
+	MaxSpotInstanceCountExceededErrorCode = "MaxSpotInstanceCountExceeded"
+)
 
 // isNotFound returns true if the err is an AWS error (even if it's
 // wrapped) and is a known to mean "not found" (as opposed to a more

--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/aws/karpenter/pkg/utils/functional"
 )
@@ -26,14 +27,13 @@ var (
 		"InvalidInstanceID.NotFound",
 		"InvalidLaunchTemplateName.NotFoundException",
 	}
-)
-
-const (
-	// InsufficientCapacityErrorCode indicates that EC2 is temporarily lacking capacity for this
-	// instance type and availability zone combination
-	InsufficientCapacityErrorCode = "InsufficientInstanceCapacity"
-	// MaxSpotInstanceCountExceededErrorCode indicates that the spot quota has been reached for the account
-	MaxSpotInstanceCountExceededErrorCode = "MaxSpotInstanceCountExceeded"
+	// unfulfillableCapacityErrorCodes signify that capacity is temporarily unable to be launched
+	unfulfillableCapacityErrorCodes = []string{
+		"InsufficientInstanceCapacity",
+		"MaxSpotInstanceCountExceeded",
+		"VcpuLimitExceeded",
+		"UnfulfillableCapacity",
+	}
 )
 
 // isNotFound returns true if the err is an AWS error (even if it's
@@ -45,4 +45,11 @@ func isNotFound(err error) bool {
 		return functional.ContainsString(notFoundErrorCodes, awsError.Code())
 	}
 	return false
+}
+
+// isUnfulfillableCapacity returns true if the Fleet err means
+// capacity is temporarily unavailable for launching.
+// This could be due to account limits, insufficient ec2 capacity, etc.
+func isUnfulfillableCapacity(err *ec2.CreateFleetError) bool {
+	return functional.ContainsString(unfulfillableCapacityErrorCodes, *err.ErrorCode)
 }

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -300,7 +300,7 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 
 func (p *InstanceProvider) updateUnavailableOfferingsCache(ctx context.Context, errors []*ec2.CreateFleetError, capacityType string) {
 	for _, err := range errors {
-		if InsufficientCapacityErrorCode == aws.StringValue(err.ErrorCode) {
+		if functional.ContainsString([]string{InsufficientCapacityErrorCode, MaxSpotInstanceCountExceededErrorCode}, aws.StringValue(err.ErrorCode)) {
 			p.instanceTypeProvider.CacheUnavailable(ctx, aws.StringValue(err.LaunchTemplateAndOverrides.Overrides.InstanceType), aws.StringValue(err.LaunchTemplateAndOverrides.Overrides.AvailabilityZone), capacityType)
 		}
 	}

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -34,11 +34,11 @@ import (
 )
 
 const (
-	InstanceTypesCacheKey                         = "types"
-	InstanceTypeZonesCacheKey                     = "zones"
-	InstanceTypesAndZonesCacheTTL                 = 5 * time.Minute
-	InsufficientCapacityErrorCacheTTL             = 45 * time.Second
-	InsufficientCapacityErrorCacheCleanupInterval = 5 * time.Minute
+	InstanceTypesCacheKey                          = "types"
+	InstanceTypeZonesCacheKey                      = "zones"
+	InstanceTypesAndZonesCacheTTL                  = 5 * time.Minute
+	UnfulfillableCapacityErrorCacheTTL             = 1 * time.Minute
+	UnfulfillableCapacityErrorCacheCleanupInterval = 5 * time.Minute
 )
 
 type InstanceTypeProvider struct {
@@ -57,7 +57,7 @@ func NewInstanceTypeProvider(ec2api ec2iface.EC2API, subnetProvider *SubnetProvi
 		ec2api:               ec2api,
 		subnetProvider:       subnetProvider,
 		cache:                cache.New(InstanceTypesAndZonesCacheTTL, CacheCleanupInterval),
-		unavailableOfferings: cache.New(InsufficientCapacityErrorCacheTTL, InsufficientCapacityErrorCacheCleanupInterval),
+		unavailableOfferings: cache.New(UnfulfillableCapacityErrorCacheTTL, UnfulfillableCapacityErrorCacheCleanupInterval),
 	}
 }
 
@@ -171,13 +171,15 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 
 // CacheUnavailable allows the InstanceProvider to communicate recently observed temporary capacity shortages in
 // the provided offerings
-func (p *InstanceTypeProvider) CacheUnavailable(ctx context.Context, instanceType string, zone string, capacityType string) {
+func (p *InstanceTypeProvider) CacheUnavailable(ctx context.Context, fleetErr *ec2.CreateFleetError, capacityType string) {
+	instanceType := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.InstanceType)
+	zone := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.AvailabilityZone)
 	logging.FromContext(ctx).Debugf("%s for offering { instanceType: %s, zone: %s, capacityType: %s }, avoiding for %s",
-		InsufficientCapacityErrorCode,
+		aws.StringValue(fleetErr.ErrorCode),
 		instanceType,
 		zone,
 		capacityType,
-		InsufficientCapacityErrorCacheTTL)
+		UnfulfillableCapacityErrorCacheTTL)
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
 	p.unavailableOfferings.SetDefault(UnavailableOfferingsCacheKey(capacityType, instanceType, zone), struct{}{})
 }

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -34,11 +34,10 @@ import (
 )
 
 const (
-	InstanceTypesCacheKey                          = "types"
-	InstanceTypeZonesCacheKey                      = "zones"
-	InstanceTypesAndZonesCacheTTL                  = 5 * time.Minute
-	UnfulfillableCapacityErrorCacheTTL             = 1 * time.Minute
-	UnfulfillableCapacityErrorCacheCleanupInterval = 5 * time.Minute
+	InstanceTypesCacheKey              = "types"
+	InstanceTypeZonesCacheKey          = "zones"
+	InstanceTypesAndZonesCacheTTL      = 5 * time.Minute
+	UnfulfillableCapacityErrorCacheTTL = 3 * time.Minute
 )
 
 type InstanceTypeProvider struct {
@@ -57,7 +56,7 @@ func NewInstanceTypeProvider(ec2api ec2iface.EC2API, subnetProvider *SubnetProvi
 		ec2api:               ec2api,
 		subnetProvider:       subnetProvider,
 		cache:                cache.New(InstanceTypesAndZonesCacheTTL, CacheCleanupInterval),
-		unavailableOfferings: cache.New(UnfulfillableCapacityErrorCacheTTL, UnfulfillableCapacityErrorCacheCleanupInterval),
+		unavailableOfferings: cache.New(UnfulfillableCapacityErrorCacheTTL, CacheCleanupInterval),
 	}
 }
 

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 		Expect(opts.Validate()).To(Succeed(), "Failed to validate options")
 		ctx = injection.WithOptions(ctx, opts)
 		launchTemplateCache = cache.New(CacheTTL, CacheCleanupInterval)
-		unavailableOfferingsCache = cache.New(InsufficientCapacityErrorCacheTTL, InsufficientCapacityErrorCacheCleanupInterval)
+		unavailableOfferingsCache = cache.New(UnfulfillableCapacityErrorCacheTTL, UnfulfillableCapacityErrorCacheCleanupInterval)
 		securityGroupCache = cache.New(CacheTTL, CacheCleanupInterval)
 		subnetCache = cache.New(CacheTTL, CacheCleanupInterval)
 		amiCache = cache.New(CacheTTL, CacheCleanupInterval)

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 		Expect(opts.Validate()).To(Succeed(), "Failed to validate options")
 		ctx = injection.WithOptions(ctx, opts)
 		launchTemplateCache = cache.New(CacheTTL, CacheCleanupInterval)
-		unavailableOfferingsCache = cache.New(UnfulfillableCapacityErrorCacheTTL, UnfulfillableCapacityErrorCacheCleanupInterval)
+		unavailableOfferingsCache = cache.New(UnfulfillableCapacityErrorCacheTTL, CacheCleanupInterval)
 		securityGroupCache = cache.New(CacheTTL, CacheCleanupInterval)
 		subnetCache = cache.New(CacheTTL, CacheCleanupInterval)
 		amiCache = cache.New(CacheTTL, CacheCleanupInterval)


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Cache unfulfillable capacity due to Max Spot Instance Limit Exceed, vcpu limit exceeded, and generic unfulfillable capacity  (in addition to the existing insufficient capacity error) 
 - Added request-id on the fleet error returned to aid in future debugging and error reports. 
 - Raised the Unfulfillable cache TTL from 45 secs to 60 secs. This may need to go up slightly more, but the idea is to continue to make progress on different instance type options. I found 45 secs to be a little limiting. 


**3. How was this change tested?**
 - Default spot limits, restricted provisioner to r6i.metal:
```
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:02.881Z	INFO	controller	Batched 1 pod(s) in 1.000856504s	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:03.522Z	DEBUG	controller	Discovered 351 EC2 instance types	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:03.625Z	DEBUG	controller	Discovered EC2 instance types zonal offerings	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:03.673Z	DEBUG	controller	Discovered subnets: [subnet-0b5670c1be69d427d (us-east-2c) subnet-03cbace186b972d1c (us-east-2b) subnet-029d1f82316bbaef7 (us-east-2a) subnet-0b5d9d38bd738720b (us-east-2b) subnet-02866ed856628c7df (us-east-2c) subnet-0798525f163e67f71 (us-east-2a)]	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:03.806Z	DEBUG	controller	Discovered security groups: [sg-078c68766ddaea9b3 sg-0a1c167ebd315f9b6]	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:03.807Z	DEBUG	controller	Discovered kubernetes version 1.21	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:03.852Z	DEBUG	controller	Discovered ami-08f9680431ceabfe7 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:06.324Z	DEBUG	controller	MaxSpotInstanceCountExceeded for offering { instanceType: r6i.metal, zone: us-east-2a, capacityType: spot }, avoiding for 1m0s	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:06.324Z	DEBUG	controller	MaxSpotInstanceCountExceeded for offering { instanceType: r6i.metal, zone: us-east-2c, capacityType: spot }, avoiding for 1m0s	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:06.324Z	DEBUG	controller	UnfulfillableCapacity for offering { instanceType: r6i.metal, zone: us-east-2b, capacityType: spot }, avoiding for 1m0s	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:06.324Z	ERROR	controller	Launching node, creating cloud provider machine, with fleet error(s), MaxSpotInstanceCountExceeded: Max spot instance count exceeded; UnfulfillableCapacity: Unable to fulfill capacity due to your request configuration. Please adjust your request and try again.	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:06.324Z	INFO	controller	Waiting for unschedulable pods	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:12.325Z	INFO	controller	Batched 1 pod(s) in 1.000547863s	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:12.494Z	DEBUG	controller	Created launch template, Karpenter-wagnerbm-karpenter-demo-18277044170222877115	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:14.822Z	DEBUG	controller	VcpuLimitExceeded for offering { instanceType: r6i.metal, zone: us-east-2a, capacityType: on-demand }, avoiding for 1m0s	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:14.822Z	DEBUG	controller	VcpuLimitExceeded for offering { instanceType: r6i.metal, zone: us-east-2b, capacityType: on-demand }, avoiding for 1m0s	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:14.822Z	DEBUG	controller	VcpuLimitExceeded for offering { instanceType: r6i.metal, zone: us-east-2c, capacityType: on-demand }, avoiding for 1m0s	{"commit": "64fe6ef", "provisioner": "default"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:14.822Z	ERROR	controller	Launching node, creating cloud provider machine, with fleet error(s), VcpuLimitExceeded: You have requested more vCPU capacity than your current vCPU limit of 32 allows for the instance bucket that the specified instance type belongs to. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:14.822Z	INFO	controller	Waiting for unschedulable pods	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:20.824Z	INFO	controller	Batched 1 pod(s) in 1.000455581s	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:20.827Z	DEBUG	controller	Relaxing soft constraints for pod since it previously failed to schedule, adding: toleration for PreferNoSchedule taints	{"commit": "64fe6ef"}
karpenter-f4d59d8ff-nvf9v controller 2022-04-22T22:55:20.827Z	ERROR	controller	no instance type satisfied resources {"cpu":"1","memory":"256M","pods":"1"} and requirements node.kubernetes.io/instance-type DoesNotExist [], karpenter.sh/provisioner-name In [default], karpenter.sh/capacity-type In [on-demand spot], topology.kubernetes.io/zone In [us-east-2a us-east-2b us-east-2c], kubernetes.io/os In [linux], kubernetes.io/arch In [amd64], kubernetes.io/hostname In [hostname-placeholder-0004]{"commit": "64fe6ef", "pod": "default/spot-7cf8b75c76-jlwc5"}
```

 - Hard coded an invalid fleet request and watched for request id error:

```
karpenter-5b969c7bb4-r9s55 controller 2022-04-22T22:51:45.687Z	ERROR	controller	Launching node, creating cloud provider machine, creating fleet InvalidParameterValue: FleetType must be "request", "maintain" or "instant" (fc413064-89a5-4f35-96ba-b223f7bd139e)
```


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
