### PR TITLE
support awareness of in-flight nodes & startup taints

### DIFF
--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -106,6 +106,39 @@ spec:
                   - operator
                   type: object
                 type: array
+              startupTaints:
+                description: StartupTaints are taints that are applied to nodes upon
+                  startup but which are expected to be removed automatically within
+                  a short period of time, typically by a DaemonSet that tolerates
+                  the taint. These are commonly used by daemonsets to allow initialization
+                  and enforce startup ordering.  StartupTaints are ignored for provisioning
+                  purposes in that pods are not required to tolerate a StartupTaint
+                  in order to have nodes provisioned for them.
+                items:
+                  description: The node this Taint is attached to has the "effect"
+                    on any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: Required. The effect of the taint on pods that
+                        do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
+                        and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added. It is only written for NoExecute taints.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
               taints:
                 description: Taints will be applied to every node launched by the
                   Provisioner. If specified, the provisioner will not provision nodes

--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -108,9 +108,9 @@ spec:
                 type: array
               startupTaints:
                 description: StartupTaints are taints that are applied to nodes upon
-                  startup but which are expected to be removed automatically within
-                  a short period of time, typically by a DaemonSet that tolerates
-                  the taint. These are commonly used by daemonsets to allow initialization
+                  startup which are expected to be removed automatically within a
+                  short period of time, typically by a DaemonSet that tolerates the
+                  taint. These are commonly used by daemonsets to allow initialization
                   and enforce startup ordering.  StartupTaints are ignored for provisioning
                   purposes in that pods are not required to tolerate a StartupTaint
                   in order to have nodes provisioned for them.

--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -33,6 +33,12 @@ type Constraints struct {
 	// pod tolerations on a per-node basis.
 	// +optional
 	Taints Taints `json:"taints,omitempty"`
+	// StartupTaints are taints that are applied to nodes upon startup but which are expected to be removed automatically
+	// within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+	// daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+	// purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+	// +optional
+	StartupTaints Taints `json:"startupTaints,omitempty"`
 	// Requirements are layered with Labels and applied to every node.
 	Requirements Requirements `json:"requirements,inline,omitempty"`
 	// KubeletConfiguration are options passed to the kubelet when provisioning nodes
@@ -61,25 +67,28 @@ func (c *Constraints) ToNode() *v1.Node {
 			}
 		}
 	}
+
+	// both the taints and startup taints are applied to nodes we create
+	taints := append(c.Taints, c.StartupTaints...)
+
+	// Taint karpenter.sh/not-ready=NoSchedule to prevent the kube scheduler
+	// from scheduling pods before we're able to bind them ourselves. The kube
+	// scheduler has an eventually consistent cache of nodes and pods, so it's
+	// possible for it to see a provisioned node before it sees the pods bound
+	// to it. This creates an edge case where other pending pods may be bound to
+	// the node by the kube scheduler, causing OutOfCPU errors when the
+	// binpacked pods race to bind to the same node. The system eventually
+	// heals, but causes delays from additional provisioning (thrash). This
+	// taint will be removed by the node controller when a node is marked ready.
+	taints = append(taints, v1.Taint{Key: NotReadyTaintKey, Effect: v1.TaintEffectNoSchedule})
+
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:     labels,
 			Finalizers: []string{TerminationFinalizer},
 		},
 		Spec: v1.NodeSpec{
-			// Taint karpenter.sh/not-ready=NoSchedule to prevent the kube scheduler
-			// from scheduling pods before we're able to bind them ourselves. The kube
-			// scheduler has an eventually consistent cache of nodes and pods, so it's
-			// possible for it to see a provisioned node before it sees the pods bound
-			// to it. This creates an edge case where other pending pods may be bound to
-			// the node by the kube scheduler, causing OutOfCPU errors when the
-			// binpacked pods race to bind to the same node. The system eventually
-			// heals, but causes delays from additional provisioning (thrash). This
-			// taint will be removed by the node controller when a node is marked ready.
-			Taints: append(c.Taints, v1.Taint{
-				Key:    NotReadyTaintKey,
-				Effect: v1.TaintEffectNoSchedule,
-			}),
+			Taints: taints,
 		},
 	}
 }

--- a/pkg/apis/provisioning/v1alpha5/constraints.go
+++ b/pkg/apis/provisioning/v1alpha5/constraints.go
@@ -33,7 +33,7 @@ type Constraints struct {
 	// pod tolerations on a per-node basis.
 	// +optional
 	Taints Taints `json:"taints,omitempty"`
-	// StartupTaints are taints that are applied to nodes upon startup but which are expected to be removed automatically
+	// StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
 	// within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
 	// daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
 	// purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.

--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -85,13 +85,19 @@ func (s *ProvisionerSpec) validateLabels() (errs *apis.FieldError) {
 	return errs
 }
 
+type taintKeyEffect struct {
+	Key    string
+	Effect v1.TaintEffect
+}
+
 func (s *ProvisionerSpec) validateTaints() (errs *apis.FieldError) {
-	errs = errs.Also(s.validateTaintsField(s.Taints, "taints"))
-	errs = errs.Also(s.validateTaintsField(s.StartupTaints, "startupTaints"))
+	existing := map[taintKeyEffect]struct{}{}
+	errs = errs.Also(s.validateTaintsField(s.Taints, existing, "taints"))
+	errs = errs.Also(s.validateTaintsField(s.StartupTaints, existing, "startupTaints"))
 	return errs
 }
 
-func (s *ProvisionerSpec) validateTaintsField(taints Taints, fieldName string) *apis.FieldError {
+func (s *ProvisionerSpec) validateTaintsField(taints Taints, existing map[taintKeyEffect]struct{}, fieldName string) *apis.FieldError {
 	var errs *apis.FieldError
 	for i, taint := range taints {
 		// Validate Key
@@ -113,6 +119,14 @@ func (s *ProvisionerSpec) validateTaintsField(taints Taints, fieldName string) *
 		default:
 			errs = errs.Also(apis.ErrInvalidArrayValue(taint.Effect, "effect", i))
 		}
+
+		// Check for duplicate Key/Effect pairs
+		key := taintKeyEffect{Key: taint.Key, Effect: taint.Effect}
+		if _, ok := existing[key]; ok {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("duplicate taint Key/Effect pair %s=%s", taint.Key, taint.Effect), apis.CurrentField).
+				ViaFieldIndex("taints", i))
+		}
+		existing[key] = struct{}{}
 	}
 	return errs
 }

--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -86,18 +86,25 @@ func (s *ProvisionerSpec) validateLabels() (errs *apis.FieldError) {
 }
 
 func (s *ProvisionerSpec) validateTaints() (errs *apis.FieldError) {
-	for i, taint := range s.Taints {
+	errs = errs.Also(s.validateTaintsField(s.Taints, "taints"))
+	errs = errs.Also(s.validateTaintsField(s.StartupTaints, "startupTaints"))
+	return errs
+}
+
+func (s *ProvisionerSpec) validateTaintsField(taints Taints, fieldName string) *apis.FieldError {
+	var errs *apis.FieldError
+	for i, taint := range taints {
 		// Validate Key
 		if len(taint.Key) == 0 {
-			errs = errs.Also(apis.ErrInvalidArrayValue(errs, "taints", i))
+			errs = errs.Also(apis.ErrInvalidArrayValue(errs, fieldName, i))
 		}
 		for _, err := range validation.IsQualifiedName(taint.Key) {
-			errs = errs.Also(apis.ErrInvalidArrayValue(err, "taints", i))
+			errs = errs.Also(apis.ErrInvalidArrayValue(err, fieldName, i))
 		}
 		// Validate Value
 		if len(taint.Value) != 0 {
 			for _, err := range validation.IsQualifiedName(taint.Value) {
-				errs = errs.Also(apis.ErrInvalidArrayValue(err, "taints", i))
+				errs = errs.Also(apis.ErrInvalidArrayValue(err, fieldName, i))
 			}
 		}
 		// Validate effect

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -135,6 +135,27 @@ var _ = Describe("Validation", func() {
 			provisioner.Spec.Taints = []v1.Taint{{Key: "invalid-effect", Effect: "???"}}
 			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
+		It("should not fail for same key with different effects", func() {
+			provisioner.Spec.Taints = []v1.Taint{
+				{Key: "a", Effect: v1.TaintEffectNoSchedule},
+				{Key: "a", Effect: v1.TaintEffectNoExecute},
+			}
+			Expect(provisioner.Validate(ctx)).To(Succeed())
+		})
+		It("should fail for duplicate taint key/effect pairs", func() {
+			provisioner.Spec.Taints = []v1.Taint{
+				{Key: "a", Effect: v1.TaintEffectNoSchedule},
+				{Key: "a", Effect: v1.TaintEffectNoSchedule},
+			}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+			provisioner.Spec.Taints = []v1.Taint{
+				{Key: "a", Effect: v1.TaintEffectNoSchedule},
+			}
+			provisioner.Spec.StartupTaints = []v1.Taint{
+				{Key: "a", Effect: v1.TaintEffectNoSchedule},
+			}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+		})
 	})
 	Context("Validation", func() {
 		It("should allow supported ops", func() {

--- a/pkg/apis/provisioning/v1alpha5/util.go
+++ b/pkg/apis/provisioning/v1alpha5/util.go
@@ -18,7 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// NodeIsReady is returns true if the all of the startup taints have been removed from the node and it's current status
+// NodeIsReady returns true if all the startup taints have been removed from the node and its current status
 // is set to Ready
 func NodeIsReady(node *v1.Node, provisioner *Provisioner) bool {
 	for _, startupTaint := range provisioner.Spec.StartupTaints {

--- a/pkg/apis/provisioning/v1alpha5/util.go
+++ b/pkg/apis/provisioning/v1alpha5/util.go
@@ -12,13 +12,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package v1alpha5
 
 import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func IsReady(node *v1.Node) bool {
+// NodeIsReady is returns true if the all of the startup taints have been removed from the node and it's current status
+// is set to Ready
+func NodeIsReady(node *v1.Node, provisioner *Provisioner) bool {
+	for _, startupTaint := range provisioner.Spec.StartupTaints {
+		for i := 0; i < len(node.Spec.Taints); i++ {
+			// if the node still has a startup taint applied, it's not ready
+			if startupTaint.MatchTaint(&node.Spec.Taints[i]) {
+				return false
+			}
+		}
+	}
 	return GetCondition(node.Status.Conditions, v1.NodeReady).Status == v1.ConditionTrue
 }
 

--- a/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
@@ -43,6 +43,13 @@ func (in *Constraints) DeepCopyInto(out *Constraints) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.StartupTaints != nil {
+		in, out := &in.StartupTaints, &out.StartupTaints
+		*out = make(Taints, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Requirements.DeepCopyInto(&out.Requirements)
 	if in.KubeletConfiguration != nil {
 		in, out := &in.KubeletConfiguration, &out.KubeletConfiguration

--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/utils/functional"
 	"github.com/aws/karpenter/pkg/utils/injectabletime"
-	"github.com/aws/karpenter/pkg/utils/node"
 	"github.com/aws/karpenter/pkg/utils/pod"
 )
 
@@ -43,7 +42,7 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisi
 	if provisioner.Spec.TTLSecondsAfterEmpty == nil {
 		return reconcile.Result{}, nil
 	}
-	if !node.IsReady(n) {
+	if !v1alpha5.NodeIsReady(n, provisioner) {
 		return reconcile.Result{}, nil
 	}
 	// 2. Remove ttl if not empty

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/karpenter/pkg/events"
+
 	"github.com/aws/karpenter/pkg/controllers/state"
 
 	"github.com/aws/karpenter/pkg/cloudprovider"
@@ -44,14 +46,20 @@ const controllerName = "provisioning"
 type Controller struct {
 	kubeClient  client.Client
 	provisioner *Provisioner
+	recorder    events.Recorder
 }
 
 // NewController constructs a controller instance
-func NewController(ctx context.Context, kubeClient client.Client, coreV1Client corev1.CoreV1Interface, cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster) *Controller {
+func NewController(ctx context.Context, kubeClient client.Client, coreV1Client corev1.CoreV1Interface, recorder events.Recorder, cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster) *Controller {
 	return &Controller{
 		kubeClient:  kubeClient,
-		provisioner: NewProvisioner(ctx, kubeClient, coreV1Client, cloudProvider, cluster),
+		provisioner: NewProvisioner(ctx, kubeClient, coreV1Client, recorder, cloudProvider, cluster),
+		recorder:    recorder,
 	}
+}
+
+func (c *Controller) Recorder() events.Recorder {
+	return c.recorder
 }
 
 // Reconcile the resource

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/aws/karpenter/pkg/events"
+
 	"github.com/aws/karpenter/pkg/controllers/state"
 
 	"github.com/imdario/mergo"
@@ -42,7 +44,7 @@ import (
 	"github.com/aws/karpenter/pkg/utils/resources"
 )
 
-func NewProvisioner(ctx context.Context, kubeClient client.Client, coreV1Client corev1.CoreV1Interface, cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster) *Provisioner {
+func NewProvisioner(ctx context.Context, kubeClient client.Client, coreV1Client corev1.CoreV1Interface, recorder events.Recorder, cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster) *Provisioner {
 	running, stop := context.WithCancel(ctx)
 	p := &Provisioner{
 		Stop:           stop,
@@ -52,6 +54,7 @@ func NewProvisioner(ctx context.Context, kubeClient client.Client, coreV1Client 
 		coreV1Client:   coreV1Client,
 		volumeTopology: NewVolumeTopology(kubeClient),
 		cluster:        cluster,
+		recorder:       recorder,
 	}
 	p.cond = sync.NewCond(&p.mu)
 	go func() {
@@ -76,6 +79,7 @@ type Provisioner struct {
 	batcher        *Batcher
 	volumeTopology *VolumeTopology
 	cluster        *state.Cluster
+	recorder       events.Recorder
 
 	mu   sync.Mutex
 	cond *sync.Cond
@@ -191,7 +195,7 @@ func (p *Provisioner) schedule(ctx context.Context, pods []*v1.Pod) ([]*scheduli
 		return nil, fmt.Errorf("getting daemon overhead, %w", err)
 	}
 
-	return scheduling.NewScheduler(provisioners, topology, instanceTypes, daemonOverhead).Solve(ctx, pods)
+	return scheduling.NewScheduler(provisioners, p.cluster, topology, instanceTypes, daemonOverhead, p.recorder).Solve(ctx, pods)
 }
 
 func (p *Provisioner) launch(ctx context.Context, node *scheduling.Node) error {
@@ -203,12 +207,15 @@ func (p *Provisioner) launch(ctx context.Context, node *scheduling.Node) error {
 	if err := latest.Spec.Limits.ExceededBy(latest.Status.Resources); err != nil {
 		return err
 	}
+
+	// apply both the taints and startup taints to the node
+	taints := append(node.Provisioner.Spec.Taints, node.Provisioner.Spec.StartupTaints...)
 	k8sNode, err := p.cloudProvider.Create(ctx, &cloudprovider.NodeRequest{
 		InstanceTypeOptions: node.InstanceTypeOptions,
 		Template: &cloudprovider.NodeTemplate{
 			Provider:             node.Provisioner.Spec.Provider,
 			Labels:               node.Provisioner.Spec.Labels,
-			Taints:               node.Provisioner.Spec.Taints,
+			Taints:               taints,
 			Requirements:         node.Provisioner.Spec.Requirements,
 			KubeletConfiguration: node.Provisioner.Spec.KubeletConfiguration,
 		},
@@ -241,9 +248,33 @@ func (p *Provisioner) launch(ctx context.Context, node *scheduling.Node) error {
 
 func (p *Provisioner) bind(ctx context.Context, node *v1.Node, pods []*v1.Pod) (err error) {
 	defer metrics.Measure(bindTimeHistogram.WithLabelValues(injection.GetNamespacedName(ctx).Name))()
+
+	nodeTaints := v1alpha5.Taints(node.Spec.Taints)
+
+	notReadyTolerations := []v1.Toleration{
+		{
+			Key:      v1alpha5.NotReadyTaintKey,
+			Operator: v1.TolerationOpEqual,
+			Effect:   v1.TaintEffectNoSchedule,
+		}, {
+			Key:      v1.TaintNodeNotReady,
+			Operator: v1.TolerationOpEqual,
+			Effect:   v1.TaintEffectNoSchedule,
+		}}
+
 	workqueue.ParallelizeUntil(ctx, len(pods), len(pods), func(i int) {
-		if err := p.coreV1Client.Pods(pods[i].Namespace).Bind(ctx, &v1.Binding{TypeMeta: pods[i].TypeMeta, ObjectMeta: pods[i].ObjectMeta, Target: v1.ObjectReference{Name: node.Name}}, metav1.CreateOptions{}); err != nil {
-			logging.FromContext(ctx).Errorf("Failed to bind %s/%s to %s, %s", pods[i].Namespace, pods[i].Name, node.Name, err)
+		pod := pods[i]
+		// Don't bind pods that would immediately get evicted.  We tolerate the two standard taints that are applied for
+		// not ready nodes as we are binding pods to these not-ready nodes intentionally (currently).  Binding pods that get
+		// evicted can cause extra nodes to be launched as we don't see the in-flight capacity until the pod is fully deleted
+		// and controllers sometimes create replacement pods while the existing ones are deleting, but not fully deleted causing
+		// us to launch new capacity.
+		if nodeTaints.Tolerates(pod, notReadyTolerations...) != nil {
+			p.recorder.PodShouldSchedule(pod, node)
+			return
+		}
+		if err := p.coreV1Client.Pods(pods[i].Namespace).Bind(ctx, &v1.Binding{TypeMeta: pod.TypeMeta, ObjectMeta: pod.ObjectMeta, Target: v1.ObjectReference{Name: node.Name}}, metav1.CreateOptions{}); err != nil {
+			logging.FromContext(ctx).Errorf("Failed to bind %s/%s to %s, %s", pod.Namespace, pod.Name, node.Name, err)
 		}
 	})
 	return nil

--- a/pkg/controllers/provisioning/scheduling/inflightnode.go
+++ b/pkg/controllers/provisioning/scheduling/inflightnode.go
@@ -17,11 +17,10 @@ package scheduling
 import (
 	"fmt"
 
-	"github.com/aws/karpenter/pkg/controllers/state"
-
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/controllers/state"
 	"github.com/aws/karpenter/pkg/utils/resources"
 )
 

--- a/pkg/controllers/provisioning/scheduling/inflightnode.go
+++ b/pkg/controllers/provisioning/scheduling/inflightnode.go
@@ -1,0 +1,121 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"fmt"
+
+	"github.com/aws/karpenter/pkg/controllers/state"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/resources"
+)
+
+type InFlightNode struct {
+	Pods               []*v1.Pod
+	Node               *v1.Node
+	requests           v1.ResourceList
+	topology           *Topology
+	requirements       v1alpha5.Requirements
+	available          v1.ResourceList
+	startupTolerations []v1.Toleration
+}
+
+func NewInFlightNode(n *state.Node, topology *Topology, startupTaints []v1.Taint, daemonResources v1.ResourceList) *InFlightNode {
+	// the remaining daemonResources to schedule are the total daemonResources minus what has already scheduled
+	remainingDaemonResources := resources.Subtract(daemonResources, n.DaemonSetRequested)
+
+	node := &InFlightNode{
+		Node:         n.Node,
+		available:    n.Available,
+		topology:     topology,
+		requests:     remainingDaemonResources,
+		requirements: v1alpha5.NewLabelRequirements(n.Node.Labels),
+	}
+
+	// add a default toleration for the standard not ready and startup taints
+	node.startupTolerations = append(node.startupTolerations, v1.Toleration{
+		Key:      v1alpha5.NotReadyTaintKey,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	})
+	node.startupTolerations = append(node.startupTolerations, v1.Toleration{
+		Key:      v1.TaintNodeNotReady,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	})
+
+	for _, taint := range startupTaints {
+		node.startupTolerations = append(node.startupTolerations, v1alpha5.TaintToToleration(taint))
+	}
+
+	// If the in-flight node doesn't have a hostname yet, we treat it's unique name as the hostname.  This allows toppology
+	// with hostname keys to schedule correctly.
+	hostname := n.Node.Labels[v1.LabelHostname]
+	if hostname == "" {
+		hostname = n.Node.Name
+	}
+	node.requirements = node.requirements.Add(
+		v1.NodeSelectorRequirement{
+			Key:      v1.LabelHostname,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{hostname},
+		})
+	topology.Register(v1.LabelHostname, hostname)
+	return node
+}
+
+func (n *InFlightNode) Add(pod *v1.Pod) error {
+	taints := v1alpha5.Taints(n.Node.Spec.Taints)
+	if err := taints.Tolerates(pod, n.startupTolerations...); err != nil {
+		return err
+	}
+
+	// check resource requests first since that's a pretty likely reason the pod won't schedule on an in-flight
+	// node, which at this point can't be increased in size
+	requests := resources.Merge(n.requests, resources.RequestsForPods(pod))
+
+	if !resources.Fits(requests, n.available) {
+		return fmt.Errorf("exceeds node resources")
+	}
+
+	podRequirements := v1alpha5.NewPodRequirements(pod)
+	// Check initial compatibility
+	if err := n.requirements.Compatible(podRequirements); err != nil {
+		return err
+	}
+	nodeRequirements := n.requirements.Add(podRequirements.Requirements...)
+
+	// Include topology requirements
+	requirements, err := n.topology.AddRequirements(podRequirements, nodeRequirements, pod)
+	if err != nil {
+		return err
+	}
+	// Check node compatibility
+	if err = n.requirements.Compatible(requirements); err != nil {
+		return err
+	}
+	// Tighten requirements
+	requirements = n.requirements.Add(requirements.Requirements...)
+
+	// Update node
+	n.requests = requests
+	n.requirements = requirements
+	n.Pods = append(n.Pods, pod)
+	n.topology.Record(pod, requirements)
+	return nil
+}

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -126,9 +126,9 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 	}
 
 	kubeClient := testclient.NewClientBuilder().WithLists(&appsv1.DaemonSetList{}).Build()
-	provisioners = provisioning.NewController(ctx, kubeClient, nil, cloudProvider)
+	provisioners = provisioning.NewController(ctx, kubeClient, nil, recorder, cloudProvider)
 	provisioners.Apply(ctx, provisioner)
-	scheduler := scheduling.NewScheduler(kubeClient)
+	scheduler := scheduling.NewScheduler(kubeClient, recorder)
 
 	pods := makeDiversePods(podCount)
 

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -114,7 +114,9 @@ func (t *TopologyGroup) Counts(pod *v1.Pod, requirements v1alpha5.Requirements) 
 // Register ensures that the topology is aware of the given domain names.
 func (t *TopologyGroup) Register(domains ...string) {
 	for _, domain := range domains {
-		t.domains[domain] = 0
+		if _, ok := t.domains[domain]; !ok {
+			t.domains[domain] = 0
+		}
 	}
 }
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -128,7 +128,7 @@ func (c *Cluster) newNode(node *v1.Node) *Node {
 
 		n.podRequests[podKey] = requests
 		c.bindings[podKey] = n.Node.Name
-		if isOwnedByDaemonset(pod) {
+		if podutils.IsOwnedByDaemonSet(pod) {
 			daemonsetRequested = append(daemonsetRequested, requests)
 		}
 		requested = append(requested, requests)
@@ -137,15 +137,6 @@ func (c *Cluster) newNode(node *v1.Node) *Node {
 	n.DaemonSetRequested = resources.Merge(daemonsetRequested...)
 	n.Available = resources.Subtract(n.Node.Status.Allocatable, resources.Merge(requested...))
 	return n
-}
-
-func isOwnedByDaemonset(pod *v1.Pod) bool {
-	for _, ref := range pod.OwnerReferences {
-		if ref.Kind == "DaemonSet" {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *Cluster) deleteNode(nodeName string) {
@@ -260,7 +251,7 @@ func (c *Cluster) updateNodeUsageFromPod(pod *v1.Pod) {
 	// our available capacity goes down by the amount that the pod had requested
 	n.Available = resources.Subtract(n.Available, podRequests)
 	// if it's a daemonset, we track what it has requested separately
-	if isOwnedByDaemonset(pod) {
+	if podutils.IsOwnedByDaemonSet(pod) {
 		n.DaemonSetRequested = resources.Merge(n.DaemonSetRequested, podRequests)
 	}
 	n.podRequests[podKey] = podRequests

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -16,6 +16,7 @@ package state
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"knative.dev/pkg/logging"
@@ -59,6 +60,10 @@ type Node struct {
 	// Available is the total amount of resources that are available on the node.  This is the Allocatable minus the
 	// resources requested by all pods bound to the node.
 	Available v1.ResourceList
+	// DaemonSetRequested is the total amount of resources that have been requested by daemon sets.  This allows users
+	// of the Node to identify the remaining resources that we expect future daemonsets to consume.  This is already
+	// included in the calculation for Available.
+	DaemonSetRequested v1.ResourceList
 
 	podRequests map[types.NamespacedName]v1.ResourceList
 }
@@ -89,7 +94,16 @@ func (c *Cluster) ForPodsWithAntiAffinity(fn func(p *v1.Pod, n *v1.Node) bool) {
 func (c *Cluster) ForEachNode(f func(n *Node) bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	var nodes []*Node
 	for _, node := range c.nodes {
+		nodes = append(nodes, node)
+	}
+	// sort nodes by creation time so we provide a consistent ordering
+	sort.Slice(nodes, func(a, b int) bool {
+		return nodes[a].Node.CreationTimestamp.Time.Before(nodes[b].Node.CreationTimestamp.Time)
+	})
+
+	for _, node := range nodes {
 		if !f(node) {
 			return
 		}
@@ -106,16 +120,32 @@ func (c *Cluster) newNode(node *v1.Node) *Node {
 		logging.FromContext(c.ctx).Errorf("listing pods, %s", err)
 	}
 	var requested []v1.ResourceList
+	var daemonsetRequested []v1.ResourceList
 	for i := range pods.Items {
-		requests := resources.RequestsForPods(&pods.Items[i])
-		podKey := client.ObjectKeyFromObject(&pods.Items[i])
+		pod := &pods.Items[i]
+		requests := resources.RequestsForPods(pod)
+		podKey := client.ObjectKeyFromObject(pod)
 
 		n.podRequests[podKey] = requests
 		c.bindings[podKey] = n.Node.Name
+		if isOwnedByDaemonset(pod) {
+			daemonsetRequested = append(daemonsetRequested, requests)
+		}
 		requested = append(requested, requests)
 	}
+
+	n.DaemonSetRequested = resources.Merge(daemonsetRequested...)
 	n.Available = resources.Subtract(n.Node.Status.Allocatable, resources.Merge(requested...))
 	return n
+}
+
+func isOwnedByDaemonset(pod *v1.Pod) bool {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == "DaemonSet" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Cluster) deleteNode(nodeName string) {
@@ -156,6 +186,10 @@ func (c *Cluster) updateNodeUsageFromPodDeletion(podKey types.NamespacedName) {
 	// requested by the pod
 	n.Available = resources.Merge(n.Available, n.podRequests[podKey])
 	delete(n.podRequests, podKey)
+
+	// We can't easily track the changes to the DaemonsetRequested here as we no longer have the pod.  We could keep up
+	// with this separately, but if a daemonset pod is being deleted, it usually means the node is going down.  In the
+	// worst case we will resync to correct this.
 }
 
 // updatePod is called every time the pod is reconciled
@@ -225,6 +259,10 @@ func (c *Cluster) updateNodeUsageFromPod(pod *v1.Pod) {
 	podRequests := resources.RequestsForPods(pod)
 	// our available capacity goes down by the amount that the pod had requested
 	n.Available = resources.Subtract(n.Available, podRequests)
+	// if it's a daemonset, we track what it has requested separately
+	if isOwnedByDaemonset(pod) {
+		n.DaemonSetRequested = resources.Merge(n.DaemonSetRequested, podRequests)
+	}
 	n.podRequests[podKey] = podRequests
 	c.bindings[podKey] = n.Node.Name
 }

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -386,8 +386,8 @@ var _ = Describe("Node Resource Level", func() {
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(pod1))
 
 		// daemonset pod isn't bound yet
-		ExpectNodeDaemonsetRequested(node, v1.ResourceCPU, "0")
-		ExpectNodeDaemonsetRequested(node, v1.ResourceMemory, "0")
+		ExpectNodeDaemonSetRequested(node, v1.ResourceCPU, "0")
+		ExpectNodeDaemonSetRequested(node, v1.ResourceMemory, "0")
 		ExpectNodeResourceRequest(node, v1.ResourceCPU, "1.5")
 
 		ExpectApplied(ctx, env.Client, dsPod)
@@ -396,8 +396,8 @@ var _ = Describe("Node Resource Level", func() {
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(dsPod))
 
 		// just the DS request portion
-		ExpectNodeDaemonsetRequested(node, v1.ResourceCPU, "1")
-		ExpectNodeDaemonsetRequested(node, v1.ResourceMemory, "2Gi")
+		ExpectNodeDaemonSetRequested(node, v1.ResourceCPU, "1")
+		ExpectNodeDaemonSetRequested(node, v1.ResourceMemory, "2Gi")
 		// total request
 		ExpectNodeResourceRequest(node, v1.ResourceCPU, "2.5")
 		ExpectNodeResourceRequest(node, v1.ResourceMemory, "2Gi")
@@ -574,7 +574,7 @@ func ExpectNodeResourceRequest(node *v1.Node, resourceName v1.ResourceName, amou
 		return false
 	})
 }
-func ExpectNodeDaemonsetRequested(node *v1.Node, resourceName v1.ResourceName, amount string) {
+func ExpectNodeDaemonSetRequested(node *v1.Node, resourceName v1.ResourceName, amount string) {
 	cluster.ForEachNode(func(n *state.Node) bool {
 		if n.Node.Name != node.Name {
 			return true

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -17,15 +17,16 @@ package state_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/karpenter/pkg/controllers/state"
 	"github.com/aws/karpenter/pkg/utils/resources"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"math/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	"github.com/aws/karpenter/pkg/test"
 

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -17,6 +17,7 @@ package state_test
 import (
 	"context"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/karpenter/pkg/controllers/state"
 	"github.com/aws/karpenter/pkg/utils/resources"
 	v1 "k8s.io/api/core/v1"
@@ -300,14 +301,19 @@ var _ = Describe("Node Resource Level", func() {
 			}))
 		}
 		node := test.Node(test.NodeOptions{Allocatable: map[v1.ResourceName]resource.Quantity{
-			v1.ResourceCPU: resource.MustParse("200"),
+			v1.ResourceCPU:  resource.MustParse("200"),
+			v1.ResourcePods: resource.MustParse("500"),
 		}})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectNodeResourceRequest(node, v1.ResourceCPU, "0.0")
+		ExpectNodeResourceRequest(node, v1.ResourcePods, "0")
+
 		sum := 0.0
+		podCount := 0
 		for _, pod := range pods {
 			ExpectApplied(ctx, env.Client, pod)
 			ExpectManualBinding(ctx, env.Client, pod, node)
+			podCount++
 
 			// extra reconciles shouldn't cause it to be multiply counted
 			nReconciles := rand.Intn(3) + 1 // 1 to 3 reconciles
@@ -316,6 +322,7 @@ var _ = Describe("Node Resource Level", func() {
 			}
 			sum += pod.Spec.Containers[0].Resources.Requests.Cpu().AsApproximateFloat64()
 			ExpectNodeResourceRequest(node, v1.ResourceCPU, fmt.Sprintf("%1.1f", sum))
+			ExpectNodeResourceRequest(node, v1.ResourcePods, fmt.Sprintf("%d", podCount))
 		}
 
 		for _, pod := range pods {
@@ -326,9 +333,74 @@ var _ = Describe("Node Resource Level", func() {
 				ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(pod))
 			}
 			sum -= pod.Spec.Containers[0].Resources.Requests.Cpu().AsApproximateFloat64()
+			podCount--
 			ExpectNodeResourceRequest(node, v1.ResourceCPU, fmt.Sprintf("%1.1f", sum))
+			ExpectNodeResourceRequest(node, v1.ResourcePods, fmt.Sprintf("%d", podCount))
 		}
 		ExpectNodeResourceRequest(node, v1.ResourceCPU, "0.0")
+		ExpectNodeResourceRequest(node, v1.ResourcePods, "0")
+	})
+	It("should track daemonset requested resources separately", func() {
+		ds := test.DaemonSet(
+			test.DaemonSetOptions{PodOptions: test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("2Gi")}},
+			}},
+		)
+		ExpectApplied(ctx, env.Client, ds)
+		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(ds), ds)).To(Succeed())
+
+		pod1 := test.UnschedulablePod(test.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU: resource.MustParse("1.5"),
+				}},
+		})
+
+		dsPod := test.UnschedulablePod(test.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				}},
+		})
+		dsPod.OwnerReferences = append(dsPod.OwnerReferences, metav1.OwnerReference{
+			APIVersion:         "apps/v1",
+			Kind:               "DaemonSet",
+			Name:               ds.Name,
+			UID:                ds.UID,
+			Controller:         aws.Bool(true),
+			BlockOwnerDeletion: aws.Bool(true),
+		})
+
+		node := test.Node(test.NodeOptions{Allocatable: map[v1.ResourceName]resource.Quantity{
+			v1.ResourceCPU:    resource.MustParse("4"),
+			v1.ResourceMemory: resource.MustParse("8Gi"),
+		}})
+		ExpectApplied(ctx, env.Client, pod1, node)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+
+		ExpectManualBinding(ctx, env.Client, pod1, node)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(pod1))
+
+		// daemonset pod isn't bound yet
+		ExpectNodeDaemonsetRequested(node, v1.ResourceCPU, "0")
+		ExpectNodeDaemonsetRequested(node, v1.ResourceMemory, "0")
+		ExpectNodeResourceRequest(node, v1.ResourceCPU, "1.5")
+
+		ExpectApplied(ctx, env.Client, dsPod)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(dsPod))
+		ExpectManualBinding(ctx, env.Client, dsPod, node)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(dsPod))
+
+		// just the DS request portion
+		ExpectNodeDaemonsetRequested(node, v1.ResourceCPU, "1")
+		ExpectNodeDaemonsetRequested(node, v1.ResourceMemory, "2Gi")
+		// total request
+		ExpectNodeResourceRequest(node, v1.ResourceCPU, "2.5")
+		ExpectNodeResourceRequest(node, v1.ResourceMemory, "2Gi")
 	})
 })
 
@@ -502,12 +574,14 @@ func ExpectNodeResourceRequest(node *v1.Node, resourceName v1.ResourceName, amou
 		return false
 	})
 }
-func ExpectManualBinding(ctx context.Context, c client.Client, pod *v1.Pod, node *v1.Node) {
-	Expect(c.Create(ctx, &v1.Binding{
-		TypeMeta:   pod.TypeMeta,
-		ObjectMeta: pod.ObjectMeta,
-		Target: v1.ObjectReference{
-			Name: node.Name,
-		},
-	})).To(Succeed())
+func ExpectNodeDaemonsetRequested(node *v1.Node, resourceName v1.ResourceName, amount string) {
+	cluster.ForEachNode(func(n *state.Node) bool {
+		if n.Node.Name != node.Name {
+			return true
+		}
+		dsReq := n.DaemonSetRequested[resourceName]
+		expected := resource.MustParse(amount)
+		Expect(dsReq.AsApproximateFloat64()).To(BeNumerically("~", expected.AsApproximateFloat64(), 0.001))
+		return false
+	})
 }

--- a/pkg/events/recorder.go
+++ b/pkg/events/recorder.go
@@ -1,0 +1,35 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import v1 "k8s.io/api/core/v1"
+
+// Recorder is used to record events that occur about pods so they can be viewed by looking at the pod's events so our
+// actions are more observable without requiring log inspection
+type Recorder interface {
+	// PodShouldSchedule is called when we have determined that a pod should schedule against an existing node and don't
+	// currently need to provision new capacity for the pod.
+	PodShouldSchedule(pod *v1.Pod, node *v1.Node)
+	// PodFailedToSchedule is called when a pod has failed to schedule entirely.
+	PodFailedToSchedule(pod *v1.Pod, err error)
+}
+
+// TODO: Remove this type and actually record events onto pods as part of https://github.com/aws/karpenter/issues/1584
+// this will require some new permissions in order to create events
+type NoOpRecorder struct {
+}
+
+func (n *NoOpRecorder) PodShouldSchedule(pod *v1.Pod, node *v1.Node) {}
+func (n *NoOpRecorder) PodFailedToSchedule(pod *v1.Pod, err error)   {}

--- a/pkg/test/eventrecorder.go
+++ b/pkg/test/eventrecorder.go
@@ -1,0 +1,61 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// Binding is a potential binding that was reported through event recording.
+type Binding struct {
+	Pod  *v1.Pod
+	Node *v1.Node
+}
+
+// EventRecorder is a mock event recorder that is used to facilitate testing.
+type EventRecorder struct {
+	mu       sync.Mutex
+	bindings []Binding
+}
+
+func NewEventRecorder() *EventRecorder {
+	return &EventRecorder{}
+}
+
+func (e *EventRecorder) PodShouldSchedule(pod *v1.Pod, node *v1.Node) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.bindings = append(e.bindings, Binding{pod, node})
+}
+func (e *EventRecorder) PodFailedToSchedule(pod *v1.Pod, err error) {}
+
+func (e *EventRecorder) Reset() {
+	e.ResetBindings()
+}
+
+func (e *EventRecorder) ResetBindings() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.bindings = nil
+}
+func (e *EventRecorder) ForEachBinding(f func(pod *v1.Pod, node *v1.Node)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, b := range e.bindings {
+		f(b.Pod, b.Node)
+	}
+}

--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -33,13 +33,14 @@ import (
 // ProvisionerOptions customizes a Provisioner.
 type ProvisionerOptions struct {
 	metav1.ObjectMeta
-	Limits       v1.ResourceList
-	Provider     interface{}
-	Kubelet      *v1alpha5.KubeletConfiguration
-	Labels       map[string]string
-	Taints       []v1.Taint
-	Requirements []v1.NodeSelectorRequirement
-	Status       v1alpha5.ProvisionerStatus
+	Limits        v1.ResourceList
+	Provider      interface{}
+	Kubelet       *v1alpha5.KubeletConfiguration
+	Labels        map[string]string
+	Taints        []v1.Taint
+	StartupTaints []v1.Taint
+	Requirements  []v1.NodeSelectorRequirement
+	Status        v1alpha5.ProvisionerStatus
 }
 
 // Provisioner creates a test pod with defaults that can be overridden by ProvisionerOptions.
@@ -69,6 +70,7 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 				KubeletConfiguration: options.Kubelet,
 				Provider:             &runtime.RawExtension{Raw: provider},
 				Taints:               options.Taints,
+				StartupTaints:        options.StartupTaints,
 				Labels:               options.Labels,
 			},
 			Limits: &v1alpha5.Limits{Resources: options.Limits},

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -23,9 +23,17 @@ spec:
   ttlSecondsAfterEmpty: 30
 
   # Provisioned nodes will have these taints
-  # Taints may prevent pods from scheduling if they are not tolerated
+  # Taints may prevent pods from scheduling if they are not tolerated by the pod.
   taints:
     - key: example.com/special-taint
+      effect: NoSchedule
+      
+      
+  # Provisioned nodes will have these taints, but pods do not need to tolerate these taints to be provisioned by this 
+  # provisioner. These taints are expected to be temporary and some other entity (e.g. a DaemonSet) is responsible for
+  # removing the taint after it has finished initializing the node.
+  startupTaints:
+    - key: example.com/another-taint
       effect: NoSchedule
 
   # Labels are arbitrary key-values that are applied to all nodes

--- a/website/content/en/preview/tasks/provisioning.md
+++ b/website/content/en/preview/tasks/provisioning.md
@@ -83,7 +83,7 @@ In order for a pod to run on a node defined in this provisioner, it must tolerat
 
 ### Example: Adding the Cilium Startup Taint
 
-Per the Cilium [docs](https://docs.cilium.io/en/stable/gettingstarted/taints/),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the user of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+Per the Cilium [docs](https://docs.cilium.io/en/stable/gettingstarted/taints/),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5


### PR DESCRIPTION
**1. Issue, if available:**

Fixes #628 and #972

**2. Description of changes:**

- don't launch nodes if the pod can schedule on a recently launch
  node that hasn't become ready
- support startup taints

Co-authored-by: Bryan Stenson <bryan.stenson@okta.com>

**3. How was this change tested?**

Unit testing & scaling cluster on EKS. I tested with two EKS clusters, one using Cilium and one standard cluster.

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
