### PR TITLE
Fix unbound variable error

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -9,7 +9,7 @@ source "${SCRIPT_DIR}/release_common.sh"
 
 # TODO restore https://reproducible-builds.org/docs/source-date-epoch/
 DATE_FMT="+%Y-%m-%dT%H:%M:%SZ"
-if [ -z "$SOURCE_DATE_EPOCH" ]; then
+if [ -z "${SOURCE_DATE_EPOCH-}" ]; then
     BUILD_DATE=$(date -u ${DATE_FMT})
 else
     BUILD_DATE=$(date -u -d "${SOURCE_DATE_EPOCH}" "${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")


### PR DESCRIPTION
…set -u an undefined variable error shows up.

**1. Issue, if available:**
After enabling strict mode (set -u) this line would throw an unbound variable error. This hyphen allows bash to safely handle the variable.

**2. Description of changes:**


**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
