### PR TITLE
don't panic on launch template hydration error

### DIFF
--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -226,7 +226,7 @@ func (p *LaunchTemplateProvider) hydrateCache(ctx context.Context) {
 		}
 		return true
 	}); err != nil {
-		panic(fmt.Sprintf("Unable to hydrate the AWS launch template cache, %s", err))
+		p.logger.Errorf(fmt.Sprintf("Unable to hydrate the AWS launch template cache, %s", err))
 	}
 	p.logger.Debugf("Finished hydrating the launch template cache with %d items", p.cache.ItemCount())
 }


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1743

**2. Description of changes:**
 - Don't panic on launch template hydration error

We may want to consider another initialization path for the cloud provider that does not use the constructor since the webhook instantiates a cloud provider but it doesn't really need to be hydrated...  

**3. How was this change tested?**
 - Removed "DescribeLaunchTemplate" permission and noticed webhook container crashing (reproducing #1743)
 - Removed panic on hydration error
 - redeployed and observed no crash loop 

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
