### PR TITLE
Add one-line description to each docs page

### DIFF
--- a/website/content/en/preview/AWS/_index.md
+++ b/website/content/en/preview/AWS/_index.md
@@ -2,6 +2,8 @@
 title: "AWS"
 linkTitle: "AWS"
 weight: 70
+description: >
+  Use AWS cloud provider features with Karpenter
 ---
 
 Check out the [Karpenter EKS Best Practices](https://aws.github.io/aws-eks-best-practices/karpenter/) guide.

--- a/website/content/en/preview/AWS/launch-templates.md
+++ b/website/content/en/preview/AWS/launch-templates.md
@@ -2,6 +2,8 @@
 title: "Launch Templates and Custom Images"
 linkTitle: "Launch Templates"
 weight: 80
+description: >
+  Create custom launch templates for Karpenter
 ---
 
 By default, Karpenter generates launch templates with the following features:

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -2,6 +2,8 @@
 title: "Provisioning Configuration"
 linkTitle: "Provisioning"
 weight: 10
+description: >
+  Learn AWS-specific Karpenter provisioning settings
 ---
 
 ## spec.provider

--- a/website/content/en/preview/concepts/_index.md
+++ b/website/content/en/preview/concepts/_index.md
@@ -2,6 +2,8 @@
 title: "Concepts"
 linkTitle: "Concepts"
 weight: 35
+description: >
+  Understand key concepts of Karpenter
 ---
 
 Users fall under two basic roles: Kubernetes cluster administrators and application developers.

--- a/website/content/en/preview/development-guide.md
+++ b/website/content/en/preview/development-guide.md
@@ -2,6 +2,8 @@
 title: "Development Guide"
 linkTitle: "Development Guide"
 weight: 80
+description: >
+  Set up a Karpenter development environment
 ---
 
 ## Dependencies

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -2,6 +2,8 @@
 title: "FAQs"
 linkTitle: "FAQs"
 weight: 90
+description: >
+  Review Karpenter Frequently Asked Questions
 ---
 ## General
 

--- a/website/content/en/preview/getting-started/_index.md
+++ b/website/content/en/preview/getting-started/_index.md
@@ -2,6 +2,8 @@
 title: "Getting Started"
 linkTitle: "Getting Started"
 weight: 10
+description: >
+  Choose from different methods to get started with Karpenter
 cascade:
   type: docs
 ---

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
@@ -3,6 +3,8 @@
 title: "Getting Started with eksctl"
 linkTitle: "Getting Started with eksctl"
 weight: 10
+description: >
+  Set up Karpenter with an eksctl cluster
 ---
 
 Karpenter automatically provisions new nodes in response to unschedulable

--- a/website/content/en/preview/getting-started/getting-started-with-kops/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-kops/_index.md
@@ -3,6 +3,8 @@
 title: "Getting Started with kOps"
 linkTitle: "Getting Started with kOps"
 weight: 10
+description: >
+  Set up Karpenter with a kOps cluster
 ---
 
 In this example, the cluster will be running on Amazon Web Services (AWS) managed by [kOps](https://kops.sigs.k8s.io/).

--- a/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
@@ -3,6 +3,8 @@
 title: "Getting Started with Terraform"
 linkTitle: "Getting Started with Terraform"
 weight: 10
+description: >
+  Set up Karpenter with a Terraform cluster
 ---
 
 Karpenter automatically provisions new nodes in response to unschedulable

--- a/website/content/en/preview/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/preview/getting-started/migrating-from-cas/_index.md
@@ -184,6 +184,7 @@ kubectl logs -f -n karpenter -c controller -l app.kubernetes.io/name=karpenter
 ```
 
 You should also see new nodes created in your cluster as the old nodes are removed
+
 ```bash
 kubectl get nodes
 ```

--- a/website/content/en/preview/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/preview/getting-started/migrating-from-cas/_index.md
@@ -2,6 +2,8 @@
 title: "Migrating from Cluster Autoscaler"
 linkTitle: "Migrating from Cluster Autoscaler"
 weight: 10
+description: >
+  Migrate to Karpenter from Cluster Autoscaler 
 ---
 
 This guide will show you how to switch from the [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler) to Karpenter for automatic node provisioning.

--- a/website/content/en/preview/tasks/_index.md
+++ b/website/content/en/preview/tasks/_index.md
@@ -2,6 +2,8 @@
 title: "Tasks"
 linkTitle: "Tasks"
 weight: 45
+description: >
+  Perform tasks to create provisioners and schedule workloads
 ---
 
 Karpenter tasks can be divided into those for a cluster administrator who is managing the cluster itself and application developers who are deploying pod workloads on a cluster.

--- a/website/content/en/preview/tasks/deprovisioning.md
+++ b/website/content/en/preview/tasks/deprovisioning.md
@@ -2,6 +2,8 @@
 title: "Deprovisioning"
 linkTitle: "Deprovisioning"
 weight: 10
+description: >
+  Understand different ways Karpenter deprovisions nodes
 ---
 
 Karpenter sets a Kubernetes [finalizer](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) on each node it provisions.

--- a/website/content/en/preview/tasks/pod-density.md
+++ b/website/content/en/preview/tasks/pod-density.md
@@ -2,6 +2,8 @@
 title: "Control Pod Density"
 linkTitle: "Control Pod Density"
 weight: 20
+description: >
+  Learn ways to specify pod density with Karpenter
 ---
 
 Pod density is the number of pods per node. 

--- a/website/content/en/preview/tasks/provisioning.md
+++ b/website/content/en/preview/tasks/provisioning.md
@@ -2,6 +2,8 @@
 title: "Provisioning"
 linkTitle: "Provisioning"
 weight: 5
+description: >
+  Learn about Karpenter provisioners
 ---
 
 When you first installed Karpenter, you set up a default Provisioner.

--- a/website/content/en/preview/tasks/scheduling.md
+++ b/website/content/en/preview/tasks/scheduling.md
@@ -3,7 +3,7 @@ title: "Scheduling"
 linkTitle: "Scheduling"
 weight: 15
 description: >
-  Learn about scheduling workloads withKarpenter 
+  Learn about scheduling workloads with Karpenter 
 ---
 
 If your pods have no requirements for how or where to run, you can let Karpenter choose nodes from the full range of available cloud provider resources.

--- a/website/content/en/preview/tasks/scheduling.md
+++ b/website/content/en/preview/tasks/scheduling.md
@@ -2,6 +2,8 @@
 title: "Scheduling"
 linkTitle: "Scheduling"
 weight: 15
+description: >
+  Learn about scheduling workloads withKarpenter 
 ---
 
 If your pods have no requirements for how or where to run, you can let Karpenter choose nodes from the full range of available cloud provider resources.

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -2,6 +2,8 @@
 title: "Set Resource Limits"
 linkTitle: "Set Resource Limits"
 weight: 10
+description: >
+  Set resource limits with Karpenter
 ---
 
 Karpenter automatically provisions instances from the cloud provider. This often incurs hard costs. To control resource utilization and cluster size, use resource limits.

--- a/website/content/en/preview/testing-guide.md
+++ b/website/content/en/preview/testing-guide.md
@@ -1,7 +1,9 @@
 ---
-title: "Karpenter Testing Guide"
+title: "Testing Guide"
 linkTitle: "Testing Guide"
 weight: 80
+description: >
+  Learn about Karpenter testing
 ---
 Currently, users can only test Karpenter by adding to a list of integration tests run in a mock environment or installing and testing Karpenter on a real cluster. Users who want to run more comprehensive tests are limited by the lack of test automation and configurability.
 

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -2,6 +2,8 @@
 title: "Troubleshooting"
 linkTitle: "Troubleshooting"
 weight: 100
+description: >
+  Troubleshoot Karpenter problems
 ---
 
 ## Node NotReady

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -2,6 +2,8 @@
 title: "Upgrade Guide"
 linkTitle: "Upgrade Guide"
 weight: 10
+description: >
+  Learn about upgrading Karpenter
 ---
 
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.


### PR DESCRIPTION
**1. Description of changes:**
Description lines were missing from most of the Karpenter docs pages, so descriptions weren't displayed from _index pages (such as https://karpenter.sh/v0.9.1/). This PR adds a one-line description to each page where it was missing.

**2. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
