### PR TITLE
Remove extra steps from release GA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
           branch: gh-pages
           folder: charts
           target-folder: charts
-      - run: make toolchain
       - run: make stablerelease
         env:
           CLOUD_PROVIDER: aws


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
This is very similar to nightlies in what it does, hence it doesn't require the toolchain. The toolchain inclusion was failing because it would require Go runtime.

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
