### PR TITLE
correct faq on provisioner ordering

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -68,10 +68,11 @@ See [Provisioner API]({{< ref "./provisioner" >}}) for details.
 
 ### If multiple provisioners are defined, which will my pod use?
 
-By default, pods will use the rules defined by a provisioner named default.
-This is analogous to the default scheduler.
-To select an alternative provisioner, use the node selector `karpenter.sh/provisioner-name: alternative-provisioner`.
-You must either define a default provisioner or explicitly specify `karpenter.sh/provisioner-name node selector`.
+Pending pods will be handled by any Provisioner that matches the requirements of the pod.
+There is no ordering guarantee if multiple provisioners match pod requirements.
+We recommend that Provisioners are setup to be mutually exclusive. 
+Read more about this recommendation in the [EKS Best Practices Guide for Karpenter](https://aws.github.io/aws-eks-best-practices/karpenter/#create-provisioners-that-are-mutually-exclusive).
+To select a specific provisioner, use the node selector `karpenter.sh/provisioner-name: my-provisioner`.
 
 ### How can I configure Karpenter to only provision pods for a particular namespace?
 


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1758

**2. Description of changes:**
 - Correct FAQs about the default provisioner and provisioner ordering. 

https://deploy-preview-1765--karpenter-docs-prod.netlify.app/preview/faq/#if-multiple-provisioners-are-defined-which-will-my-pod-use

**3. How was this change tested?**
 - make website

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
