### PR TITLE
fix provisioner name injection to cloud provider

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	"knative.dev/pkg/logging"
@@ -122,6 +123,7 @@ func (p *Provisioner) provision(ctx context.Context) error {
 
 	// Launch capacity and bind pods
 	workqueue.ParallelizeUntil(ctx, len(nodes), len(nodes), func(i int) {
+		ctx = injection.WithNamespacedName(ctx, types.NamespacedName{Name: nodes[i].Provisioner.Name})
 		if err := p.launch(logging.WithLogger(ctx, logging.FromContext(ctx).With("provisioner", nodes[i].Provisioner.Name)), nodes[i]); err != nil {
 			logging.FromContext(ctx).Errorf("Launching node, %s", err)
 		}

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -119,7 +119,7 @@ Select security groups by name using a wildcard:
 Karpenter adds tags to all resources it creates, including EC2 Instances, EBS volumes, and Launch Templates. The default set of AWS tags are listed below.
 
 ```
-Name: karpenter.sh/provisioner/<provisioner-name>
+Name: karpenter.sh/provisioner-name/<provisioner-name>
 karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1766

**2. Description of changes:**
- Fixes provisioner name ctx injection which is used in the cloud provider to tag instances with the provisioner name. 

**3. How was this change tested?**
 - observed node tagged properly:
```
Name: karpenter.sh/provisioner-name/default
karpenter.sh/provisioner-name: default
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
