### PR TITLE
filter out the G2 instance types

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -161,6 +161,14 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	if instanceType.FpgaInfo != nil {
 		return false
 	}
+	if functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
+		// G2 instances have an older GPU not supported by the nvidia plugin. This causes the allocatable # of gpus
+		// to be set to zero on startup as the plugin considers the GPU unhealthy.
+		"g2",
+	) {
+		return false
+	}
+
 	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
 		"m", "c", "r", "a", "t", // Standard
 		"i3",            // Storage-optimized


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

Filter out the G2 instance types as they use the K520 GPU which is not supported by the nvidia device plugin daemonset.

**3. How was this change tested?**

Launching on EKS.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
