### PR TITLE
add docs covering upgrade to v0.10.0

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -147,6 +147,7 @@ Not yet.
 See [Deprovisioning nodes]({{< ref "./tasks/deprovisioning" >}}) for information on how Karpenter deprovisions nodes.
 
 ## Upgrading
+
 ### How do I upgrade Karpenter?
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
@@ -156,5 +157,12 @@ To upgrade Karpenter to version `$VERSION`, make sure that the `KarpenterNode IA
 Next, locate `KarpenterController IAM Role` ARN (i.e., ARN of the resource created in [Create the KarpenterController IAM Role](../getting-started/getting-started-with-eksctl/#create-the-karpentercontroller-iam-role)) and the cluster endpoint, and pass them to the helm upgrade command
 {{% script file="./content/en/preview/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh" language="bash"%}}
 
-For information on upgrading Karpenter, see the [Upgrade Guide]({{< ref "./upgrade-guide/" >}})a.
+For information on upgrading Karpenter, see the [Upgrade Guide]({{< ref "./upgrade-guide/" >}}).
 
+### Why do I get an `unknown field "startupTaints"` error when creating a provisioner with startupTaints?
+
+```bash
+error: error validating "provisioner.yaml": error validating data: ValidationError(Provisioner.spec): unknown field "startupTaints" in sh.karpenter.v1alpha5.Provisioner.spec; if you choose to ignore these errors, turn validation off with --validate=false
+```
+
+The `startupTaints` parameter was added in v0.10.0.  Helm upgrades do not upgrade the CRD describing the provisioner, so it must be done manually. For specific details, see the [Upgrade Guide]({{< ref "./upgrade-guide/#upgrading-to-v0100" >}})

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -70,6 +70,16 @@ for a subset of older versions and deprecate the others.
 
 # Released Upgrade Notes
 
+## Upgrading to v0.10.0+
+
+v0.10.0 adds a new field, `startupTaints` to the provisioner spec.  Standard Helm upgrades [do not upgrade CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations) so the  field will not be available unless the CRD is manually updated.  This can be performed prior to the standard upgrade by applying the new CRD manually:
+
+```shell
+kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/v0.10.0/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+```
+
+📝 If you don't perform this manual CRD update, Karpenter will work correctly except for rejecting the creation/update of provisioners that use `startupTaints`.
+
 ## Upgrading to v0.6.2+
 
 If using Helm, the variable names have changed for the cluster's name and endpoint. You may need to update any configuration


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

Helm doesn't upgrade CRDs.  A Helm uninstall doesn't even remove CRDs,
so an uninstall/reinstall doesn't solve the problem.  As far as I can
tell, you need to  manually apply the CRDs to the cluster.


**3. How was this change tested?**

`make website` preview

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
