### PR TITLE
deprioritize a1 (graviton 1) instance types

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -334,7 +334,7 @@ func (p *InstanceProvider) getCapacityType(nodeRequest *cloudprovider.NodeReques
 func (p *InstanceProvider) filterInstanceTypes(instanceTypes []cloudprovider.InstanceType) []cloudprovider.InstanceType {
 	var genericInstanceTypes []cloudprovider.InstanceType
 	for _, it := range instanceTypes {
-		if functional.HasAnyPrefix(*it.(*InstanceType).InstanceType, "t1", "t2") {
+		if functional.HasAnyPrefix(*it.(*InstanceType).InstanceType, "t1", "t2", "a1") {
 			continue
 		}
 		if aws.BoolValue(it.(*InstanceType).BareMetal) {


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
 - Deprioritize a1 (graviton 1) instance types


**3. How was this change tested?**
 - scaled up an inflate several times, observed a1s being provisioned
 - made change
 - scaled up an inflate, observed m6i's now

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
