### PR TITLE
Update set-resource-limits.md

### DIFF
--- a/website/content/en/v0.10.0/tasks/set-resource-limits.md
+++ b/website/content/en/v0.10.0/tasks/set-resource-limits.md
@@ -21,7 +21,7 @@ CPU limits are described with a `DecimalSI` value, usually a natural integer.
 Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
 
 {{% alert title="Note" color="primary" %}}
-If CPU or Memory limit are not set, then the default value is set as unlimited by Karpenter.
+If CPU or Memory limits are not set, then the default value is set as unlimited by Karpenter.
 {{% /alert %}}
 
 You can view the current consumption of cpu and memory on your cluster by running:

--- a/website/content/en/v0.10.0/tasks/set-resource-limits.md
+++ b/website/content/en/v0.10.0/tasks/set-resource-limits.md
@@ -20,6 +20,10 @@ CPU limits are described with a `DecimalSI` value, usually a natural integer.
 
 Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://github.com/kubernetes/apimachinery/blob/4427f8f31dfbac65d3a044d0168f84c51bfda440/pkg/api/resource/quantity.go#L31)
 
+{{% alert title="Note" color="primary" %}}
+If CPU or Memory limit are not set, then the default value is set as unlimited by Karpenter.
+{{% /alert %}}
+
 You can view the current consumption of cpu and memory on your cluster by running:
 ```
 kubectl get provisioner -o=jsonpath='{.items[0].status}'


### PR DESCRIPTION
Clarifying Karpenter behavior if the CPU and Memory limit are not set

**1. Issue, if available:**


**2. Description of changes:**
Clarifying karpenter default behavior if CPU and Memory limit are not set 

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ x ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
