### PR TITLE
[AWS] Allow instance type specifications to pass through filter

### DIFF
--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -35,9 +35,10 @@ import (
 	"github.com/aws/karpenter/pkg/utils/functional"
 	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/project"
+	"github.com/aws/karpenter/pkg/utils/sets"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
+	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/transport"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
@@ -110,8 +111,8 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 }
 
 // GetInstanceTypes returns all available InstanceTypes
-func (c *CloudProvider) GetInstanceTypes(ctx context.Context) ([]cloudprovider.InstanceType, error) {
-	return c.instanceTypeProvider.Get(ctx)
+func (c *CloudProvider) GetInstanceTypes(ctx context.Context, requestedInstanceTypes sets.Set) ([]cloudprovider.InstanceType, error) {
+	return c.instanceTypeProvider.Get(ctx, requestedInstanceTypes)
 }
 
 func (c *CloudProvider) Delete(ctx context.Context, node *v1.Node) error {
@@ -128,7 +129,7 @@ func (c *CloudProvider) GetRequirements(ctx context.Context, provider *v1alpha5.
 	if err != nil {
 		return v1alpha5.Requirements{}, err
 	}
-	zones := sets.NewString()
+	zones := utilsets.NewString()
 	for _, subnet := range subnets {
 		zones.Insert(aws.StringValue(subnet.AvailabilityZone))
 	}

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/Pallinder/go-randomdata"
 
-	"k8s.io/apimachinery/pkg/util/sets"
+	utilsets "k8s.io/apimachinery/pkg/util/sets"
 
 	"knative.dev/pkg/apis"
 
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/utils/sets"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
@@ -93,7 +94,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 	}, nil
 }
 
-func (c *CloudProvider) GetInstanceTypes(_ context.Context) ([]cloudprovider.InstanceType, error) {
+func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ sets.Set) ([]cloudprovider.InstanceType, error) {
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}
@@ -134,7 +135,7 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context) ([]cloudprovider.Ins
 		NewInstanceType(InstanceTypeOptions{
 			Name:             "arm-instance-type",
 			Architecture:     "arm64",
-			OperatingSystems: sets.NewString("ios", "linux", "windows", "darwin"),
+			OperatingSystems: utilsets.NewString("ios", "linux", "windows", "darwin"),
 			Resources: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:    resource.MustParse("16"),
 				v1.ResourceMemory: resource.MustParse("128Gi"),

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/metrics"
 	"github.com/aws/karpenter/pkg/utils/injection"
+	"github.com/aws/karpenter/pkg/utils/sets"
 )
 
 const (
@@ -77,9 +78,9 @@ func (d *decorator) Delete(ctx context.Context, node *v1.Node) error {
 	return d.CloudProvider.Delete(ctx, node)
 }
 
-func (d *decorator) GetInstanceTypes(ctx context.Context) ([]cloudprovider.InstanceType, error) {
+func (d *decorator) GetInstanceTypes(ctx context.Context, requestedInstanceTypes sets.Set) ([]cloudprovider.InstanceType, error) {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "GetInstanceTypes", d.Name()))()
-	return d.CloudProvider.GetInstanceTypes(ctx)
+	return d.CloudProvider.GetInstanceTypes(ctx, requestedInstanceTypes)
 }
 
 func (d *decorator) GetRequirements(ctx context.Context, provider *v1alpha5.Provider) (v1alpha5.Requirements, error) {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -18,11 +18,12 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
+	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/sets"
 )
 
 // Options are injected into cloud providers' factories
@@ -41,7 +42,7 @@ type CloudProvider interface {
 	Delete(context.Context, *v1.Node) error
 	// GetInstanceTypes returns instance types supported by the cloudprovider.
 	// Availability of types or zone may vary by provisioner or over time.
-	GetInstanceTypes(context.Context) ([]InstanceType, error)
+	GetInstanceTypes(context.Context, sets.Set) ([]InstanceType, error)
 	// GetRequirements for the provider, e.g. zones contrained by subnets or
 	// os constrained by machine image.
 	GetRequirements(context.Context, *v1alpha5.Provider) (v1alpha5.Requirements, error)
@@ -73,7 +74,7 @@ type InstanceType interface {
 	// Note that though this is an array it is expected that all the Offerings are unique from one another
 	Offerings() []Offering
 	Architecture() string
-	OperatingSystems() sets.String
+	OperatingSystems() utilsets.String
 	// Resources are the full allocatable resource capacities for this instance type
 	Resources() v1.ResourceList
 	// Overhead is the amount of resource overhead expected to be used by kubelet and any other system daemons outside

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -153,7 +153,7 @@ func (p *Provisioner) schedule(ctx context.Context, pods []*v1.Pod) ([]*scheduli
 	defer metrics.Measure(schedulingDuration.WithLabelValues(injection.GetNamespacedName(ctx).Name))()
 
 	// Get instance type options
-	var requestedInstanceTypes sets.Set
+	requestedInstanceTypes := sets.NewSet()
 	for _, pod := range pods {
 		reqs := v1alpha5.NewPodRequirements(pod)
 		podInstanceTypes := reqs.Get(v1.LabelInstanceTypeStable)


### PR DESCRIPTION
**1. Issue, if available:** #1791 


**2. Description of changes:** Bypass allow-list filter if instance types are specified by user in `node.kubernetes.io/instance-type`


**3. How was this change tested?** TODO: add unittest

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
