### PR TITLE
allow all instance types but deprioritize ones that are not the stand…

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -168,12 +168,7 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 	) {
 		return false
 	}
-
-	return functional.HasAnyPrefix(aws.StringValue(instanceType.InstanceType),
-		"m", "c", "r", "a", "t", // Standard
-		"i3",            // Storage-optimized
-		"p", "inf", "g", // Accelerators
-	)
+	return true
 }
 
 // CacheUnavailable allows the InstanceProvider to communicate recently observed temporary capacity shortages in


### PR DESCRIPTION
…ard set

**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1791

**2. Description of changes:**
 - Allow all instance types by default (with the exception of g2's and FPGAs) but deprioritize instance types that are not the "standard" set (m,c,r,t,a,i)  


**3. How was this change tested?**
 - EKS cluster w/ no instance-type constraint on the provisioner, observed an m6gi provisioned (i.e. was using one of the standard set)
 - Set a requirement with z1d.large and observed karpenter launching z1d.large 


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
