### PR TITLE
log the number of pods that will schedule against existing capacity

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -110,10 +110,15 @@ func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) ([]*Node, error) 
 	}
 
 	// notify users of pods that can schedule to inflight capacity
+	inflightCount := 0
 	for _, node := range s.inflight {
+		inflightCount += len(node.Pods)
 		for _, pod := range node.Pods {
 			s.recorder.PodShouldSchedule(pod, node.Node)
 		}
+	}
+	if inflightCount != 0 {
+		logging.FromContext(ctx).Infof("%d pod(s) will schedule against existing capacity", len(pods))
 	}
 
 	// Any remaining pods have failed to schedule


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
This can make the provisioner log output less confusing as it
directly displays the number of pods that we expect to schedule against
existing capacity.


**3. How was this change tested?**

Deploying to EKS

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
