### PR TITLE
Make Helm clusterName and clusterEndpoint optionally rendered so that env vars can be passed instead

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -57,10 +57,14 @@ spec:
           image: {{ .Values.controller.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
+          {{- if .Values.clusterName }}
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName }}
+          {{- end }}
+          {{- if .Values.clusterEndpoint }}
             - name: CLUSTER_ENDPOINT
               value: {{ .Values.clusterEndpoint }}
+          {{- end }}
             - name: KARPENTER_SERVICE
               value: {{ include "karpenter.fullname" . }}
             - name: SYSTEM_NAMESPACE
@@ -105,12 +109,16 @@ spec:
           image: {{ .Values.webhook.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
+          {{- if .Values.clusterName }}
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName }}
+          {{- end }}
             - name: KUBERNETES_MIN_VERSION
               value: "1.19.0-0"
+          {{- if .Values.clusterEndpoint }}
             - name: CLUSTER_ENDPOINT
               value: {{ .Values.clusterEndpoint }}
+          {{- end }}
             - name: KARPENTER_SERVICE
               value: {{ include "karpenter.fullname" . }}
             - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
…CLUSTER_ENDPOINT env variables (eg. configMap), we need to make them optional, so we can redefine them in values file.

**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1539

**2. Description of changes:**
Added IF statement around CLUSTER_NAME and CLUSTER_ENDPOINT env variables, so we can redefine source of their values in values.yaml file

**3. How was this change tested?**
By deploying karpenter via terraform and passing CLUSTER_NAME and CLUSTER_ENDPOINT values as ConfigMap values.


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
