### PR TITLE
Upgrade golangci-lint to avoid error

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,8 +11,6 @@ run:
     - charts
     - designs
 
-  go: '1.18'
-
 linters:
   enable:
     - asciicheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,8 @@ run:
     - charts
     - designs
 
+  go: '1.18'
+
 linters:
   enable:
     - asciicheck

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -11,7 +11,7 @@ main() {
 
 tools() {
     go install github.com/google/go-licenses@v1.2.0
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.1
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
     go install github.com/google/ko@v0.11.2
     go install github.com/mikefarah/yq/v4@v4.24.5
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.8.1


### PR DESCRIPTION


**1. Issue, if available:**
```
V/w/w/k/karpenter (providerCrd) [127]> golangci-lint run
ERRO [runner] Panic: buildir: package "lo" (isInitialPkg: false, needAnalyzeSource: true): T: goroutine 12608 [running]:
```

**2. Description of changes:**

Fixes the above error that has started showing up. Looks like we need to upgrade.
https://github.com/golangci/golangci-lint/issues/2664

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
