### PR TITLE
Snapshot PR - Try adding permissions under the job

### DIFF
--- a/.github/workflows/snapshot-pr-approval.yaml
+++ b/.github/workflows/snapshot-pr-approval.yaml
@@ -7,6 +7,9 @@ permissions:
   contents: read
 jobs:
   snapshotsOnPRs:
+    permissions:
+      id-token: write
+      contents: read
     if: github.repository == 'aws/karpenter' && github.event.review.state == 'approved' && startsWith(github.event.review.body, '/snapshot')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Try out adding the permission under the job itself.
This may be why the job starts with "Secret source: None" which leads to a failure. https://github.com/aws/karpenter/runs/6481950410?check_suite_focus=true

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
