### PR TITLE
Fix: Fix managed policy for karpenter

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
@@ -151,7 +151,7 @@ module "eks" {
 
       iam_role_additional_policies = [
         # Required by Karpenter
-        "arn:${local.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+        "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       ]
     }
   }

--- a/website/content/en/v0.10.0/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.10.0/getting-started/getting-started-with-terraform/_index.md
@@ -151,7 +151,7 @@ module "eks" {
 
       iam_role_additional_policies = [
         # Required by Karpenter
-        "arn:${local.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+        "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       ]
     }
   }


### PR DESCRIPTION
**1. Issue, if available:**

N/A

**2. Description of changes:**

Using the Policy `AmazonSSMManagedInstanceCore` as described in the documentation led me to an error when applying the terraform plan. See error below

```
InvalidInput: ARN arn:${account_id}:iam::aws:policy/AmazonSSMManagedInstanceCore is not valid. status code: 400, request id: 7da46312-c3cb-4992-8fa8-af908d3fa64e
```
As the policy is a managed policy, replacing the `${local.partition}` by `aws` worked fine

**3. How was this change tested?**

after updating this value my terraform plan applied just fine.

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
