### PR TITLE
add the option to have dnsConfig and dnsPolicy set on the pod

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -45,6 +45,13 @@ spec:
       {{- with .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8}}
+      {{- end }}
       {{- if .Values.webhook.hostNetwork }}
       hostNetwork: true
       {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -48,6 +48,13 @@ terminationGracePeriodSeconds:
 # -- Bind the pod to the host network.
 # This is required when using a custom CNI.
 hostNetwork: false
+# -- Configure the DNS Policy for the pod
+dnsPolicy: ClusterFirst
+# -- Configure DNS Config for the pod
+dnsConfig: {}
+#  options:
+#    - name: ndots
+#      value: "1"
 # -- Node selectors to schedule the pod to nodes with labels.
 nodeSelector:
   kubernetes.io/os: linux


### PR DESCRIPTION
**1. Issue, if available:**
When running karpenter on fargate and there is no nodes except for karpenter pod , karpenter fails in EKS as there is no coredns running on the cluster and by default dnsPolicy is ClusterFirst, causing karpenter to restart endless
issue #1836 
**2. Description of changes:**
add an option to configure the dnsPolicy and dnsConfig for the helm chart.

**3. How was this change tested?**
running a EKS cluster with NO nodes only fargate pod for karpenter and have a provisioner setup, karpenter fails to start unless dnsPolicy is changed to 'Default'

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
