### PR TITLE
Reconciling Nodes on Provisioner Spec changes

### DIFF
--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -241,6 +241,9 @@ spec:
                   x-kubernetes-int-or-string: true
                 description: Resources is the list of resources that have been provisioned.
                 type: object
+              totalNodesProvisioned:
+                description: Total number of nodes provisioned by the provisioner
+                type: integer
             type: object
         type: object
     served: true

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -100,7 +100,7 @@ func main() {
 		state.NewPodController(manager.GetClient(), cluster),
 		persistentvolumeclaim.NewController(manager.GetClient()),
 		termination.NewController(ctx, manager.GetClient(), clientSet.CoreV1(), cloudProvider),
-		node.NewController(manager.GetClient()),
+		node.NewController(ctx, manager.GetClient(), clientSet.CoreV1()),
 		metricspod.NewController(manager.GetClient()),
 		metricsnode.NewController(manager.GetClient()),
 		counter.NewController(manager.GetClient()),

--- a/pkg/apis/provisioning/v1alpha5/provisioner_status.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_status.go
@@ -33,6 +33,9 @@ type ProvisionerStatus struct {
 
 	// Resources is the list of resources that have been provisioned.
 	Resources v1.ResourceList `json:"resources,omitempty"`
+
+	//Total number of nodes provisioned by the provisioner
+	TotalNodesProvisioned int `json:"totalNodesProvisioned,omitempty"`
 }
 
 func (p *Provisioner) StatusConditions() apis.ConditionManager {

--- a/pkg/apis/provisioning/v1alpha5/register.go
+++ b/pkg/apis/provisioning/v1alpha5/register.go
@@ -45,6 +45,7 @@ var (
 	DoNotEvictPodAnnotationKey      = Group + "/do-not-evict"
 	EmptinessTimestampAnnotationKey = Group + "/emptiness-timestamp"
 	TerminationFinalizer            = Group + "/termination"
+	ProvisionerVersionKey           = Group + "/provisioner-version"
 )
 
 const (

--- a/pkg/apis/provisioning/v1alpha5/util.go
+++ b/pkg/apis/provisioning/v1alpha5/util.go
@@ -15,6 +15,9 @@ limitations under the License.
 package v1alpha5
 
 import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -39,4 +42,9 @@ func GetCondition(conditions []v1.NodeCondition, match v1.NodeConditionType) v1.
 		}
 	}
 	return v1.NodeCondition{}
+}
+
+func GetProvisionerHash(provisioner *Provisioner) string {
+	currentProvisionerVersion, _ := hashstructure.Hash(provisioner.Spec, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	return fmt.Sprintf("provisioner-%d", currentProvisionerVersion)
 }

--- a/pkg/controllers/node/provisionerversion.go
+++ b/pkg/controllers/node/provisionerversion.go
@@ -1,0 +1,39 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+)
+
+type ProvisionerVersion struct {
+	TerminationQueue *TerminationQueue
+}
+
+func (r *ProvisionerVersion) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisioner, node *v1.Node) (reconcile.Result, error) {
+	nodeProvisionerHash := node.Labels[v1alpha5.ProvisionerVersionKey]
+	currentProvisionerHash := v1alpha5.GetProvisionerHash(provisioner)
+
+	if /*nodeProvisionerHash != ""&&*/ currentProvisionerHash != nodeProvisionerHash {
+		//Use the number of nodes Provisioned uptil now from Status of provisioner
+		r.TerminationQueue.Add(node, provisioner.Status.TotalNodesProvisioned)
+	}
+	return reconcile.Result{}, nil
+}

--- a/pkg/controllers/node/provisionerversion.go
+++ b/pkg/controllers/node/provisionerversion.go
@@ -31,7 +31,7 @@ func (r *ProvisionerVersion) Reconcile(ctx context.Context, provisioner *v1alpha
 	nodeProvisionerHash := node.Labels[v1alpha5.ProvisionerVersionKey]
 	currentProvisionerHash := v1alpha5.GetProvisionerHash(provisioner)
 
-	if /*nodeProvisionerHash != ""&&*/ currentProvisionerHash != nodeProvisionerHash {
+	if nodeProvisionerHash != "" && currentProvisionerHash != nodeProvisionerHash {
 		//Use the number of nodes Provisioned uptil now from Status of provisioner
 		r.TerminationQueue.Add(node, provisioner.Status.TotalNodesProvisioned)
 	}

--- a/pkg/controllers/node/terminationqueue.go
+++ b/pkg/controllers/node/terminationqueue.go
@@ -1,0 +1,113 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"math"
+	"time"
+
+	set "github.com/deckarep/golang-set"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/workqueue"
+	"knative.dev/pkg/logging"
+)
+
+const (
+	schedulateTerminationOfBatchAfter = 60
+	terminationPercentage             = 5
+)
+
+type TerminationQueue struct {
+	workqueue.DelayingInterface
+	set.Set
+
+	ctx          context.Context
+	coreV1Client corev1.CoreV1Interface
+}
+
+func NewTerminationQueue(ctx context.Context, coreV1Client corev1.CoreV1Interface) *TerminationQueue {
+	queue := &TerminationQueue{
+		DelayingInterface: workqueue.NewDelayingQueue(),
+		Set:               set.NewSet(),
+
+		ctx:          ctx,
+		coreV1Client: coreV1Client,
+	}
+	go queue.Start(logging.WithLogger(ctx, logging.FromContext(ctx).Named("terminatorQueue")))
+	return queue
+}
+
+// Add adds pods to the EvictionQueue
+func (e *TerminationQueue) Add(node *v1.Node, totalNodesProvisioned int) {
+	if totalNodesProvisioned == 0 {
+		//Let the status of the provisioner be reconciled first
+		return
+	}
+	currentTerminationQueueLength := float64(e.Set.Cardinality())
+	//compute batch depending upon the length of the queue and total number of provisioned
+	batchSize := math.Ceil(float64(terminationPercentage*totalNodesProvisioned) / 100)
+	var scheduleInBatch = int64(0)
+	if batchSize > 0 {
+		scheduleInBatch = int64(math.Ceil(currentTerminationQueueLength / batchSize))
+	}
+	logging.FromContext(e.ctx).With("name", node.GetName()).Debugf("Batchsize is %v , current lenght of queue is %v", batchSize, currentTerminationQueueLength)
+	if !e.Set.Contains(node.GetName()) {
+		e.Set.Add(node.GetName())
+		logging.FromContext(e.ctx).Infof("Added node for termination in DelayQueue in batch %v", scheduleInBatch)
+		//Adding length of queue + 5sec in duration to counter the scenario where the reconciles are not concurrent enough, the length of queue will always be 0, because the item will
+		//be processed by the queue almost instantaneously, which may result in all nodes going down together, rendering this queue as useless.
+		e.DelayingInterface.AddAfter(node.GetName(), (time.Duration(scheduleInBatch)*schedulateTerminationOfBatchAfter*time.Second)+5)
+	}
+}
+
+func (e *TerminationQueue) Start(ctx context.Context) {
+	for {
+		// Get pod from queue. This waits until queue is non-empty.
+		item, shutdown := e.DelayingInterface.Get()
+		if shutdown {
+			break
+		}
+		nn := item.(string)
+		logging.FromContext(ctx).With("name", nn).Debug("Popped from Delayed TerminationQueue, making Node for Deletion")
+		// Evict pod
+		if e.terminate(ctx, nn) {
+			e.Set.Remove(nn)
+			e.DelayingInterface.Done(nn)
+			logging.FromContext(ctx).With("name", nn).Info("Marked node for deletion from termination queue")
+			continue
+		}
+		e.DelayingInterface.Done(nn)
+		//Todo Just log that it can't be termintated with the reason, or do we again put in queue for some later duration ?
+	}
+	logging.FromContext(ctx).Errorf("TerminationQueue is broken and has shutdown")
+}
+
+func (e *TerminationQueue) terminate(ctx context.Context, name string) bool {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", name))
+	err := e.coreV1Client.Nodes().Delete(ctx, name, metav1.DeleteOptions{})
+	if errors.IsNotFound(err) { // 404
+		return true
+	}
+	if err != nil {
+		logging.FromContext(ctx).Error(err)
+		return false
+	}
+	logging.FromContext(ctx).Debug("Terminated node in TerminationQueue")
+	return true
+}

--- a/pkg/controllers/node/terminationqueue.go
+++ b/pkg/controllers/node/terminationqueue.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	schedulateTerminationOfBatchAfter = 60
+	schedulateTerminationOfBatchAfter = 600 //In seconds
 	terminationPercentage             = 5
 )
 

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -171,8 +171,10 @@ func (p *Provisioner) schedule(ctx context.Context, pods []*v1.Pod) ([]*scheduli
 		if err != nil {
 			return nil, fmt.Errorf("getting provider requirements, %w", err)
 		}
+		provisionerHashVersion := v1alpha5.GetProvisionerHash(provisioner)
+		provisioner.Spec.Labels = functional.UnionStringMaps(provisioner.Spec.Labels, map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+			v1alpha5.ProvisionerVersionKey: provisionerHashVersion})
 
-		provisioner.Spec.Labels = functional.UnionStringMaps(provisioner.Spec.Labels, map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner.Name})
 		provisioner.Spec.Requirements = v1alpha5.NewRequirements(provisioner.Spec.Requirements.Requirements...).
 			Add(v1alpha5.NewLabelRequirements(provisioner.Spec.Labels).Requirements...).
 			Add(cloudproviderRequirements.Requirements...).

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -311,6 +311,7 @@ var _ = Describe("Provisioning", func() {
 			for _, pod := range ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod()) {
 				node := ExpectScheduled(ctx, env.Client, pod)
 				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerVersionKey, v1alpha5.GetProvisionerHash(provisioner)))
 				Expect(node.Labels).To(HaveKeyWithValue("test-key", "test-value"))
 				Expect(node.Labels).To(HaveKeyWithValue("test-key-2", "test-value-2"))
 				Expect(node.Labels).To(HaveKey(v1.LabelTopologyZone))


### PR DESCRIPTION
**1. Issue, if available:**
https://github.com/aws/karpenter/issues/1457
https://github.com/aws/karpenter/issues/1018

**2. Description of changes:**
The implementation stamps a label on Node signifying the provisioner version, when the provisioner spec changes so does it's hash and as soon Nodes are reconciled, they are made to compare with the current provisioner hash. 

If the hash turns out to be different, they are put in a `DelayedQueue` which enables the scheduling of nodes in to batches for termination. So entire set of nodes doesn't go down at once, but only `5%` of nodes at one time, with a 10 minute interval between in each batch. (Can be also taken dynamically in the spec).

The same approach can also be used in `Expiration` Sub-reconciler, where all nodes are terminated at once. Instead they could be put in this delayed queue and terminated in batches thereafter.

To batch the nodes, the total number of nodes provisioned by a specific provisioner is needed, to enable that there is a new field on `ProvisionerStatus`. So let's suppose 100 nodes are provisioned, when they are reconciled, we consider putting first 5 nodes reconciles into first batch, and consequently others. `DelayedQueue` in the` client-go` allows us to put the items at a later point of time.

**3. How was this change tested?**
Through test cases and also on a live EKS cluster.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
