### PR TITLE
check for HostPort compatibility when scheduling

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2861,13 +2861,11 @@ var _ = Describe("Instance Type Compatibility", func() {
 
 var _ = Describe("Networking constraints", func() {
 	Context("HostPort", func() {
-		It("shouldn't co-locate pods that use the same HostPort and protocol", func() {
-			Skip("enable after scheduler is aware of hostport usage")
+		It("shouldn't co-locate pods that use the same HostPort and protocol (default protocol)", func() {
 			port := v1.ContainerPort{
 				Name:          "test-port",
 				HostPort:      80,
 				ContainerPort: 1234,
-				Protocol:      "TCP",
 			}
 			pod1 := test.UnschedulablePod()
 			pod1.Spec.Containers[0].Ports = append(pod1.Spec.Containers[0].Ports, port)
@@ -2877,6 +2875,85 @@ var _ = Describe("Networking constraints", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 			ExpectProvisioned(ctx, env.Client, controller, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
+			node2 := ExpectScheduled(ctx, env.Client, pod2)
+			Expect(node1.Name).ToNot(Equal(node2.Name))
+		})
+		It("shouldn't co-locate pods that use the same HostPort and protocol (specific protocol)", func() {
+			port := v1.ContainerPort{
+				Name:          "test-port",
+				HostPort:      80,
+				ContainerPort: 1234,
+				Protocol:      "UDP",
+			}
+			pod1 := test.UnschedulablePod()
+			pod1.Spec.Containers[0].Ports = append(pod1.Spec.Containers[0].Ports, port)
+			pod2 := test.UnschedulablePod()
+			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
+
+			ExpectApplied(ctx, env.Client, provisioner)
+			ExpectProvisioned(ctx, env.Client, controller, pod1, pod2)
+			node1 := ExpectScheduled(ctx, env.Client, pod1)
+			node2 := ExpectScheduled(ctx, env.Client, pod2)
+			Expect(node1.Name).ToNot(Equal(node2.Name))
+		})
+		It("shouldn't co-locate pods that use the same HostPort and IP (default (_))", func() {
+			port := v1.ContainerPort{
+				Name:          "test-port",
+				HostPort:      80,
+				ContainerPort: 1234,
+			}
+			pod1 := test.UnschedulablePod()
+			pod1.Spec.Containers[0].Ports = append(pod1.Spec.Containers[0].Ports, port)
+			port.HostIP = "1.2.3.4" // Defaulted "0.0.0.0" on pod1 should conflict
+			pod2 := test.UnschedulablePod()
+			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
+
+			ExpectApplied(ctx, env.Client, provisioner)
+			ExpectProvisioned(ctx, env.Client, controller, pod1, pod2)
+			node1 := ExpectScheduled(ctx, env.Client, pod1)
+			node2 := ExpectScheduled(ctx, env.Client, pod2)
+			Expect(node1.Name).ToNot(Equal(node2.Name))
+		})
+		It("shouldn't co-locate pods that use the same HostPort but a different IP, where one ip is 0.0.0.0", func() {
+			port := v1.ContainerPort{
+				Name:          "test-port",
+				HostPort:      80,
+				ContainerPort: 1234,
+				Protocol:      "TCP",
+				HostIP:        "1.2.3.4",
+			}
+			pod1 := test.UnschedulablePod()
+			pod1.Spec.Containers[0].Ports = append(pod1.Spec.Containers[0].Ports, port)
+			pod2 := test.UnschedulablePod()
+			port.HostIP = "0.0.0.0" // all interfaces
+			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
+
+			ExpectApplied(ctx, env.Client, provisioner)
+			ExpectProvisioned(ctx, env.Client, controller, pod1, pod2)
+			node1 := ExpectScheduled(ctx, env.Client, pod1)
+			node2 := ExpectScheduled(ctx, env.Client, pod2)
+			Expect(node1.Name).ToNot(Equal(node2.Name))
+		})
+		It("shouldn't co-locate pods that use the same HostPort but a different IP, where one ip is 0.0.0.0 (inflight)", func() {
+			port := v1.ContainerPort{
+				Name:          "test-port",
+				HostPort:      80,
+				ContainerPort: 1234,
+				Protocol:      "TCP",
+				HostIP:        "1.2.3.4",
+			}
+			pod1 := test.UnschedulablePod()
+			pod1.Spec.Containers[0].Ports = append(pod1.Spec.Containers[0].Ports, port)
+			pod2 := test.UnschedulablePod()
+			port.HostIP = "0.0.0.0" // all interfaces
+			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
+
+			ExpectApplied(ctx, env.Client, provisioner)
+			ExpectProvisioned(ctx, env.Client, controller, pod1)
+			node1 := ExpectScheduled(ctx, env.Client, pod1)
+			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
+
+			ExpectProvisioned(ctx, env.Client, controller, pod2)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).ToNot(Equal(node2.Name))
 		})
@@ -2891,6 +2968,26 @@ var _ = Describe("Networking constraints", func() {
 			pod1.Spec.Containers[0].Ports = append(pod1.Spec.Containers[0].Ports, port)
 			pod2 := test.UnschedulablePod()
 			port.Protocol = "UDP"
+			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
+
+			ExpectApplied(ctx, env.Client, provisioner)
+			ExpectProvisioned(ctx, env.Client, controller, pod1, pod2)
+			node1 := ExpectScheduled(ctx, env.Client, pod1)
+			node2 := ExpectScheduled(ctx, env.Client, pod2)
+			Expect(node1.Name).To(Equal(node2.Name))
+		})
+		It("should co-locate pods that use the same HostPort but a different IP", func() {
+			port := v1.ContainerPort{
+				Name:          "test-port",
+				HostPort:      80,
+				ContainerPort: 1234,
+				Protocol:      "TCP",
+				HostIP:        "1.2.3.4",
+			}
+			pod1 := test.UnschedulablePod()
+			pod1.Spec.Containers[0].Ports = append(pod1.Spec.Containers[0].Ports, port)
+			pod2 := test.UnschedulablePod()
+			port.HostIP = "4.5.6.7"
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)

--- a/pkg/controllers/state/hostportusage.go
+++ b/pkg/controllers/state/hostportusage.go
@@ -1,0 +1,120 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"fmt"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HostPortUsage tracks HostPort usage within a node. On a node, each <hostIP, hostPort, protocol> used by pods bound
+// to the node must be unique. We need to track this to keep an accurate concept of what pods can potentially schedule
+// together.
+type HostPortUsage struct {
+	reserved []entry
+}
+type entry struct {
+	podName  types.NamespacedName
+	ip       net.IP
+	port     int32
+	protocol v1.Protocol
+}
+
+func (e entry) String() string {
+	return fmt.Sprintf("IP=%s Port=%d Proto=%s", e.ip, e.port, e.protocol)
+}
+
+func (e entry) matches(rhs entry) bool {
+	if e.protocol != rhs.protocol {
+		return false
+	}
+	if e.port != rhs.port {
+		return false
+	}
+
+	// If IPs are unequal, they don't match unless one is an unspecified address "0.0.0.0" or the IPv6 address "::".
+	if !e.ip.Equal(rhs.ip) && !e.ip.IsUnspecified() && !rhs.ip.IsUnspecified() {
+		return false
+	}
+
+	return true
+}
+
+func NewHostPortUsage() *HostPortUsage {
+	return &HostPortUsage{}
+}
+
+// Add adds a port to the HostPortUsage, returning an error in the case of a conflict
+func (u *HostPortUsage) Add(pod *v1.Pod) error {
+	newUsage := getHostPorts(pod)
+	for _, newEntry := range newUsage {
+		for _, existing := range u.reserved {
+			if newEntry.matches(existing) {
+				return fmt.Errorf("%s conflicts with existing HostPort configuration %s", newEntry, existing)
+			}
+		}
+	}
+	u.reserved = append(u.reserved, newUsage...)
+	return nil
+}
+
+// DeletePod deletes all host port usage from the HostPortUsage that were created by the pod with the given name.
+func (u *HostPortUsage) DeletePod(key types.NamespacedName) {
+	var remaining []entry
+	for _, e := range u.reserved {
+		if e.podName != key {
+			remaining = append(remaining, e)
+		}
+	}
+	u.reserved = remaining
+}
+
+// Copy creates a copy of the HostPortUsage. It's not a deep copy as some of the internal state is reused, but that
+// state is read-only so changes made to the copy or the original don't affect each other.
+func (u *HostPortUsage) Copy() *HostPortUsage {
+	return &HostPortUsage{
+		reserved: append([]entry{}, u.reserved...),
+	}
+}
+
+func getHostPorts(pod *v1.Pod) []entry {
+	var usage []entry
+	podName := client.ObjectKeyFromObject(pod)
+	for _, c := range pod.Spec.Containers {
+		for _, p := range c.Ports {
+			if p.HostPort == 0 {
+				continue
+			}
+			// Per the K8s docs, "If you don't specify the hostIP and protocol explicitly, Kubernetes will use 0.0.0.0
+			// as the default hostIP and TCP as the default protocol." In testing, and looking at the code the protocol
+			// is defaulted to TCP, but it leaves the IP empty.
+			hostIP := p.HostIP
+			if hostIP == "" {
+				hostIP = "0.0.0.0"
+			}
+			usage = append(usage, entry{
+				podName:  podName,
+				ip:       net.ParseIP(hostIP),
+				port:     p.HostPort,
+				protocol: p.Protocol,
+			})
+		}
+	}
+	return usage
+}


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**

Ensure we don't bind or assume that pods will schedule with conflicting hostport configurations. 

**3. How was this change tested?**

Unit testing & deploying to EKS.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
