### PR TITLE
[WIP] Implemented dependency injection via context

### DIFF
--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -69,7 +69,7 @@ type CloudProvider struct {
 	instanceProvider     *InstanceProvider
 }
 
-func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *CloudProvider {
+func NewCloudProvider(ctx context.Context) *CloudProvider {
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("aws"))
 	sess := withUserAgent(session.Must(session.NewSession(
 		request.WithRetryer(
@@ -92,7 +92,6 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *Cloud
 			NewLaunchTemplateProvider(
 				ctx,
 				ec2api,
-				options.ClientSet,
 				amifamily.New(ssm.New(sess), cache.New(CacheTTL, CacheCleanupInterval)),
 				NewSecurityGroupProvider(ec2api),
 				getCABundle(ctx),
@@ -199,7 +198,7 @@ func getCABundle(ctx context.Context) *string {
 	// have used the simpler client-go InClusterConfig() method.
 	// However, that only works when Karpenter is running as a Pod
 	// within the same cluster it's managing.
-	restConfig := injection.GetConfig(ctx)
+	restConfig := injection.GetRestConfig(ctx)
 	if restConfig == nil {
 		return nil
 	}

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -38,7 +38,6 @@ import (
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/utils/functional"
-	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/options"
 	"github.com/aws/karpenter/pkg/utils/resources"
 )
@@ -128,7 +127,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, provider *v1alpha
 		return nil, fmt.Errorf("getting launch template configs, %w", err)
 	}
 	// Create fleet
-	tags := v1alpha1.MergeTags(ctx, provider.Tags, map[string]string{fmt.Sprintf("kubernetes.io/cluster/%s", injection.GetOptions(ctx).ClusterName): "owned"})
+	tags := v1alpha1.MergeTags(ctx, provider.Tags, map[string]string{fmt.Sprintf("kubernetes.io/cluster/%s", options.Get(ctx).ClusterName): "owned"})
 	createFleetInput := &ec2.CreateFleetInput{
 		Type:                  aws.String(ec2.FleetTypeInstant),
 		LaunchTemplateConfigs: launchTemplateConfigs,
@@ -245,7 +244,7 @@ func (p *InstanceProvider) getInstance(ctx context.Context, id string) (*ec2.Ins
 		return nil, fmt.Errorf("expected instance but got 0")
 	}
 	instance := describeInstancesOutput.Reservations[0].Instances[0]
-	if injection.GetOptions(ctx).GetAWSNodeNameConvention() == options.ResourceName {
+	if options.Get(ctx).GetAWSNodeNameConvention() == options.ResourceName {
 		return instance, nil
 	}
 	if len(aws.StringValue(instance.PrivateDnsName)) == 0 {
@@ -258,7 +257,7 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 	for _, instanceType := range instanceTypes {
 		if instanceType.Name() == aws.StringValue(instance.InstanceType) {
 			nodeName := strings.ToLower(aws.StringValue(instance.PrivateDnsName))
-			if injection.GetOptions(ctx).GetAWSNodeNameConvention() == options.ResourceName {
+			if options.Get(ctx).GetAWSNodeNameConvention() == options.ResourceName {
 				nodeName = aws.StringValue(instance.InstanceId)
 			}
 

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/utils/functional"
-	"github.com/aws/karpenter/pkg/utils/injection"
+	"github.com/aws/karpenter/pkg/utils/options"
 )
 
 const (
@@ -81,7 +81,7 @@ func (p *InstanceTypeProvider) Get(ctx context.Context) ([]cloudprovider.Instanc
 			instanceType.AvailableOfferings = offerings
 			result = append(result, instanceType)
 		}
-		if !injection.GetOptions(ctx).AWSENILimitedPodDensity {
+		if !options.Get(ctx).AWSENILimitedPodDensity {
 			instanceType.MaxPods = ptr.Int32(110)
 		}
 	}

--- a/pkg/cloudprovider/injection.go
+++ b/pkg/cloudprovider/injection.go
@@ -1,5 +1,3 @@
-//go:build !aws
-
 /*
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,15 +12,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry
+package cloudprovider
 
 import (
 	"context"
 
-	"github.com/aws/karpenter/pkg/cloudprovider"
-	"github.com/aws/karpenter/pkg/cloudprovider/fake"
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
-func newCloudProvider(context.Context) cloudprovider.CloudProvider {
-	return &fake.CloudProvider{}
+type injectionKey struct{}
+
+func Inject(ctx context.Context, value CloudProvider) context.Context {
+	return context.WithValue(ctx, injectionKey{}, value)
+}
+
+func Get(ctx context.Context) CloudProvider {
+	return injection.Get(ctx, injectionKey{}).(CloudProvider)
 }

--- a/pkg/cloudprovider/registry/aws.go
+++ b/pkg/cloudprovider/registry/aws.go
@@ -23,6 +23,6 @@ import (
 	"github.com/aws/karpenter/pkg/cloudprovider/aws"
 )
 
-func newCloudProvider(ctx context.Context, options cloudprovider.Options) cloudprovider.CloudProvider {
-	return aws.NewCloudProvider(ctx, options)
+func newCloudProvider(ctx context.Context) cloudprovider.CloudProvider {
+	return aws.NewCloudProvider(ctx)
 }

--- a/pkg/cloudprovider/registry/register.go
+++ b/pkg/cloudprovider/registry/register.go
@@ -21,9 +21,9 @@ import (
 	"github.com/aws/karpenter/pkg/cloudprovider"
 )
 
-func NewCloudProvider(ctx context.Context, options cloudprovider.Options) cloudprovider.CloudProvider {
-	cloudProvider := newCloudProvider(ctx, options)
-	RegisterOrDie(ctx, cloudProvider)
+func NewCloudProvider(ctx context.Context) cloudprovider.CloudProvider {
+	cloudProvider := newCloudProvider(ctx)
+	RegisterOrDie(cloudProvider)
 	return cloudProvider
 }
 
@@ -31,7 +31,7 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) cloudp
 // architectures, and validation logic. This operation should only be called
 // once at startup time. Typically, this call is made by NewCloudProvider(), but
 // must be called if the cloud provider is constructed manually (e.g. tests).
-func RegisterOrDie(ctx context.Context, cloudProvider cloudprovider.CloudProvider) {
+func RegisterOrDie(cloudProvider cloudprovider.CloudProvider) {
 	v1alpha5.ValidateHook = cloudProvider.Validate
 	v1alpha5.DefaultHook = cloudProvider.Default
 }

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -19,17 +19,11 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/scheduling"
 )
-
-// Options are injected into cloud providers' factories
-type Options struct {
-	ClientSet *kubernetes.Clientset
-}
 
 // CloudProvider interface is implemented by cloud providers to support provisioning.
 type CloudProvider interface {

--- a/pkg/controllers/counter/controller.go
+++ b/pkg/controllers/counter/controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
 // Controller for the resource
@@ -41,9 +42,9 @@ type Controller struct {
 }
 
 // NewController is a constructor
-func NewController(kubeClient client.Client) *Controller {
+func NewController(ctx context.Context) *Controller {
 	return &Controller{
-		kubeClient: kubeClient,
+		kubeClient: injection.GetKubeClient(ctx),
 	}
 }
 

--- a/pkg/controllers/metrics/node/controller.go
+++ b/pkg/controllers/metrics/node/controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/injection"
 	podutil "github.com/aws/karpenter/pkg/utils/pod"
 	"github.com/aws/karpenter/pkg/utils/resources"
 )
@@ -135,9 +136,9 @@ type Controller struct {
 }
 
 // NewController constructs a controller instance
-func NewController(kubeClient client.Client) *Controller {
+func NewController(ctx context.Context) *Controller {
 	return &Controller{
-		kubeClient: kubeClient,
+		kubeClient: injection.GetKubeClient(ctx),
 	}
 }
 

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
 const (
@@ -86,9 +87,9 @@ func labelNames() []string {
 }
 
 // NewController constructs a controller instance
-func NewController(kubeClient client.Client) *Controller {
+func NewController(ctx context.Context) *Controller {
 	return &Controller{
-		kubeClient: kubeClient,
+		kubeClient: injection.GetKubeClient(ctx),
 	}
 }
 

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -33,18 +33,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/result"
 )
 
 const controllerName = "node"
 
 // NewController constructs a controller instance
-func NewController(kubeClient client.Client) *Controller {
+func NewController(ctx context.Context) *Controller {
 	return &Controller{
-		kubeClient:     kubeClient,
-		initialization: &Initialization{kubeClient: kubeClient},
-		emptiness:      &Emptiness{kubeClient: kubeClient},
-		expiration:     &Expiration{kubeClient: kubeClient},
+		kubeClient:     injection.GetKubeClient(ctx),
+		initialization: &Initialization{kubeClient: injection.GetKubeClient(ctx)},
+		emptiness:      &Emptiness{kubeClient: injection.GetKubeClient(ctx)},
+		expiration:     &Expiration{kubeClient: injection.GetKubeClient(ctx)},
 	}
 }
 

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/karpenter/pkg/controllers/node"
 	"github.com/aws/karpenter/pkg/test"
 	"github.com/aws/karpenter/pkg/utils/injectabletime"
+	"github.com/aws/karpenter/pkg/utils/injection"
 
 	. "github.com/aws/karpenter/pkg/test/expectations"
 	. "github.com/onsi/ginkgo"
@@ -49,7 +50,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
-		controller = node.NewController(e.Client)
+		ctx = injection.InjectKubeClient(ctx, e.Client)
+		controller = node.NewController(ctx)
 	})
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")
 })

--- a/pkg/controllers/persistentvolumeclaim/controller.go
+++ b/pkg/controllers/persistentvolumeclaim/controller.go
@@ -45,8 +45,8 @@ type Controller struct {
 }
 
 // NewController is a constructor
-func NewController(kubeClient client.Client) *Controller {
-	return &Controller{kubeClient: kubeClient}
+func NewController(ctx context.Context) *Controller {
+	return &Controller{kubeClient: injection.GetKubeClient(ctx)}
 }
 
 // Register the controller to the manager
@@ -62,8 +62,8 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 // Reconcile a control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named(controllerName).With("resource", req.String()))
-	ctx = injection.WithNamespacedName(ctx, req.NamespacedName)
-	ctx = injection.WithControllerName(ctx, controllerName)
+	ctx = injection.InjectNamespacedName(ctx, req.NamespacedName)
+	ctx = injection.InjectControllerName(ctx, controllerName)
 
 	pvc := &v1.PersistentVolumeClaim{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, pvc); err != nil {

--- a/pkg/controllers/persistentvolumeclaim/suite_test.go
+++ b/pkg/controllers/persistentvolumeclaim/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/karpenter/pkg/controllers/persistentvolumeclaim"
 	"github.com/aws/karpenter/pkg/test"
 	. "github.com/aws/karpenter/pkg/test/expectations"
+	"github.com/aws/karpenter/pkg/utils/injection"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -42,7 +43,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
-		controller = persistentvolumeclaim.NewController(e.Client)
+		ctx = injection.InjectKubeClient(ctx, e.Client)
+		controller = persistentvolumeclaim.NewController(ctx)
 	})
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")
 })

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -21,14 +21,9 @@ import (
 
 	"github.com/aws/karpenter/pkg/events"
 
-	"github.com/aws/karpenter/pkg/controllers/state"
-
-	"github.com/aws/karpenter/pkg/cloudprovider"
-
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/pod"
 )
 
@@ -50,11 +46,11 @@ type Controller struct {
 }
 
 // NewController constructs a controller instance
-func NewController(ctx context.Context, kubeClient client.Client, coreV1Client corev1.CoreV1Interface, recorder events.Recorder, cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster) *Controller {
+func NewController(ctx context.Context) *Controller {
 	return &Controller{
-		kubeClient:  kubeClient,
-		provisioner: NewProvisioner(ctx, kubeClient, coreV1Client, recorder, cloudProvider, cluster),
-		recorder:    recorder,
+		kubeClient:  injection.GetKubeClient(ctx),
+		provisioner: NewProvisioner(ctx),
+		recorder:    injection.GetEventRecorder(ctx),
 	}
 }
 

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/karpenter/pkg/events"
 	"github.com/aws/karpenter/pkg/scheduling"
+	"github.com/aws/karpenter/pkg/utils/injection"
 
 	"github.com/aws/karpenter/pkg/controllers/state"
 
@@ -34,16 +35,16 @@ import (
 	"github.com/aws/karpenter/pkg/cloudprovider"
 )
 
-func NewScheduler(nodeTemplates []*scheduling.NodeTemplate, cluster *state.Cluster, topology *Topology,
-	instanceTypes []cloudprovider.InstanceType, daemonOverhead map[*scheduling.NodeTemplate]v1.ResourceList, recorder events.Recorder) *Scheduler {
+func NewScheduler(ctx context.Context, nodeTemplates []*scheduling.NodeTemplate, topology *Topology,
+	instanceTypes []cloudprovider.InstanceType, daemonOverhead map[*scheduling.NodeTemplate]v1.ResourceList) *Scheduler {
 	sort.Slice(instanceTypes, func(i, j int) bool { return instanceTypes[i].Price() < instanceTypes[j].Price() })
 	s := &Scheduler{
 		nodeTemplates:  nodeTemplates,
 		topology:       topology,
-		cluster:        cluster,
+		cluster:        state.Get(ctx),
 		instanceTypes:  instanceTypes,
 		daemonOverhead: daemonOverhead,
-		recorder:       recorder,
+		recorder:       injection.GetEventRecorder(ctx),
 		preferences:    &Preferences{},
 	}
 

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/pod"
 	"github.com/aws/karpenter/pkg/utils/sets"
 )
@@ -53,10 +54,10 @@ type Topology struct {
 	cluster *state.Cluster
 }
 
-func NewTopology(ctx context.Context, kubeClient client.Client, cluster *state.Cluster, nodeTemplates []*scheduling.NodeTemplate, pods []*v1.Pod) (*Topology, error) {
+func NewTopology(ctx context.Context, nodeTemplates []*scheduling.NodeTemplate, pods []*v1.Pod) (*Topology, error) {
 	t := &Topology{
-		kubeClient:        kubeClient,
-		cluster:           cluster,
+		kubeClient:        injection.GetKubeClient(ctx),
+		cluster:           state.Get(ctx),
 		domains:           map[string]utilsets.String{},
 		topologies:        map[uint64]*TopologyGroup{},
 		inverseTopologies: map[uint64]*TopologyGroup{},

--- a/pkg/controllers/provisioning/scheduling/topologygroup.go
+++ b/pkg/controllers/provisioning/scheduling/topologygroup.go
@@ -165,7 +165,7 @@ func (t *TopologyGroup) nextDomainTopologySpread(pod *v1.Pod, podDomains, nodeDo
 		// but we can only choose from the node domains
 		if nodeDomains.Has(domain) {
 			// comment from kube-scheduler regarding the viable choices to schedule to based on skew is:
-			// 'existing matching num' + 'if self-match (1 or 0)' - 'global min matching num' <= 'maxSkew'
+			// 'existing matching num' + 'if self-match (1 or 0)' - 'options min matching num' <= 'maxSkew'
 			count := t.domains[domain]
 			if selfSelecting {
 				count++

--- a/pkg/controllers/provisioning/volumetopology.go
+++ b/pkg/controllers/provisioning/volumetopology.go
@@ -23,10 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
-func NewVolumeTopology(kubeClient client.Client) *VolumeTopology {
-	return &VolumeTopology{kubeClient: kubeClient}
+func NewVolumeTopology(ctx context.Context) *VolumeTopology {
+	return &VolumeTopology{kubeClient: injection.GetKubeClient(ctx)}
 }
 
 type VolumeTopology struct {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/karpenter/pkg/utils/injection"
 	podutils "github.com/aws/karpenter/pkg/utils/pod"
 	"github.com/aws/karpenter/pkg/utils/resources"
 )
@@ -43,10 +44,10 @@ type Cluster struct {
 	bindings map[types.NamespacedName]string // pod namespaced named -> node name
 }
 
-func NewCluster(ctx context.Context, client client.Client) *Cluster {
+func NewCluster(ctx context.Context) *Cluster {
 	return &Cluster{
 		ctx:        ctx,
-		kubeClient: client,
+		kubeClient: injection.GetKubeClient(ctx),
 		nodes:      map[string]*Node{},
 		bindings:   map[types.NamespacedName]string{},
 	}

--- a/pkg/controllers/state/injection.go
+++ b/pkg/controllers/state/injection.go
@@ -1,5 +1,3 @@
-//go:build !aws
-
 /*
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,15 +12,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry
+package state
 
 import (
 	"context"
 
-	"github.com/aws/karpenter/pkg/cloudprovider"
-	"github.com/aws/karpenter/pkg/cloudprovider/fake"
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
-func newCloudProvider(context.Context) cloudprovider.CloudProvider {
-	return &fake.CloudProvider{}
+type injectionKey struct{}
+
+func Inject(ctx context.Context, value *Cluster) context.Context {
+	return context.WithValue(ctx, injectionKey{}, value)
+}
+
+func Get(ctx context.Context) *Cluster {
+	return injection.Get(ctx, injectionKey{}).(*Cluster)
 }

--- a/pkg/controllers/state/node.go
+++ b/pkg/controllers/state/node.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
 const nodeControllerName = "node-state"
@@ -35,10 +37,10 @@ type NodeController struct {
 }
 
 // NewNodeController constructs a controller instance
-func NewNodeController(kubeClient client.Client, cluster *Cluster) *NodeController {
+func NewNodeController(ctx context.Context) *NodeController {
 	return &NodeController{
-		kubeClient: kubeClient,
-		cluster:    cluster,
+		kubeClient: injection.GetKubeClient(ctx),
+		cluster:    Get(ctx),
 	}
 }
 

--- a/pkg/controllers/state/pod.go
+++ b/pkg/controllers/state/pod.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
 var stateRetryPeriod = 1 * time.Minute
@@ -37,10 +39,10 @@ type PodController struct {
 	cluster    *Cluster
 }
 
-func NewPodController(kubeClient client.Client, cluster *Cluster) *PodController {
+func NewPodController(ctx context.Context) *PodController {
 	return &PodController{
-		kubeClient: kubeClient,
-		cluster:    cluster,
+		kubeClient: injection.GetKubeClient(ctx),
+		cluster:    Get(ctx),
 	}
 }
 

--- a/pkg/controllers/termination/eviction.go
+++ b/pkg/controllers/termination/eviction.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
 const (
@@ -42,12 +44,12 @@ type EvictionQueue struct {
 	coreV1Client corev1.CoreV1Interface
 }
 
-func NewEvictionQueue(ctx context.Context, coreV1Client corev1.CoreV1Interface) *EvictionQueue {
+func NewEvictionQueue(ctx context.Context) *EvictionQueue {
 	queue := &EvictionQueue{
 		RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(evictionQueueBaseDelay, evictionQueueMaxDelay)),
 		Set:                   set.NewSet(),
 
-		coreV1Client: coreV1Client,
+		coreV1Client: injection.GetKubernetesInterface(ctx).CoreV1(),
 	}
 	go queue.Start(logging.WithLogger(ctx, logging.FromContext(ctx).Named("eviction")))
 	return queue

--- a/pkg/utils/options/injection.go
+++ b/pkg/utils/options/injection.go
@@ -1,5 +1,3 @@
-//go:build !aws
-
 /*
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,15 +12,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package registry
+package options
 
 import (
 	"context"
 
-	"github.com/aws/karpenter/pkg/cloudprovider"
-	"github.com/aws/karpenter/pkg/cloudprovider/fake"
+	"github.com/aws/karpenter/pkg/utils/injection"
 )
 
-func newCloudProvider(context.Context) cloudprovider.CloudProvider {
-	return &fake.CloudProvider{}
+type injectionKey struct{}
+
+func Inject(ctx context.Context, value Options) context.Context {
+	return context.WithValue(ctx, injectionKey{}, value)
+}
+
+func Get(ctx context.Context) Options {
+	return injection.Get(ctx, injectionKey{}).(Options)
 }


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**
Been curious try something like this for a while. This pattern is used [across knative pkg](https://github.com/knative/pkg/tree/main/injection)

- For packages we own, we'll create an `inject.go` with `Inject` and `Get` methods that establish a singleton for the context
- For packages we don't own, we'll shim these interfaces into `injection/injection.go` with `InjectFoo` and `GetFoo` methods

Tradeoffs:
- (+) Packages are less aware of the dependency closure of their dependencies (standard benefits of DI)
- (-) We need to be a little cautious with the order that we wire them up, since injection order is no longer statically checked.

Thoughts?

**3. How was this change tested?**
`make test`
`make apply`

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
