### PR TITLE
during scheduling, filter instance types to those that won't violate limits

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -206,7 +206,7 @@ func (p *Provisioner) schedule(ctx context.Context, pods []*v1.Pod) ([]*schedule
 		return nil, fmt.Errorf("getting daemon overhead, %w", err)
 	}
 
-	return scheduler.NewScheduler(nodeTemplates, p.cluster, topology, instanceTypes, daemonOverhead, p.recorder).Solve(ctx, pods)
+	return scheduler.NewScheduler(nodeTemplates, provisionerList.Items, p.cluster, topology, instanceTypes, daemonOverhead, p.recorder).Solve(ctx, pods)
 }
 
 func (p *Provisioner) launch(ctx context.Context, node *scheduler.Node) error {

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -16,15 +16,10 @@ package scheduling
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/samber/lo"
-
-	"github.com/aws/karpenter/pkg/events"
-	"github.com/aws/karpenter/pkg/scheduling"
-
-	"github.com/aws/karpenter/pkg/controllers/state"
-
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/logging"
@@ -32,24 +27,34 @@ import (
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
+	"github.com/aws/karpenter/pkg/controllers/state"
+	"github.com/aws/karpenter/pkg/events"
+	"github.com/aws/karpenter/pkg/scheduling"
+	"github.com/aws/karpenter/pkg/utils/resources"
 )
 
-func NewScheduler(nodeTemplates []*scheduling.NodeTemplate, cluster *state.Cluster, topology *Topology,
-	instanceTypes []cloudprovider.InstanceType, daemonOverhead map[*scheduling.NodeTemplate]v1.ResourceList, recorder events.Recorder) *Scheduler {
+func NewScheduler(nodeTemplates []*scheduling.NodeTemplate, provisioners []v1alpha5.Provisioner, cluster *state.Cluster, topology *Topology, instanceTypes []cloudprovider.InstanceType, daemonOverhead map[*scheduling.NodeTemplate]v1.ResourceList, recorder events.Recorder) *Scheduler {
 	sort.Slice(instanceTypes, func(i, j int) bool { return instanceTypes[i].Price() < instanceTypes[j].Price() })
 	s := &Scheduler{
-		nodeTemplates:  nodeTemplates,
-		topology:       topology,
-		cluster:        cluster,
-		instanceTypes:  instanceTypes,
-		daemonOverhead: daemonOverhead,
-		recorder:       recorder,
-		preferences:    &Preferences{},
+		nodeTemplates:      nodeTemplates,
+		topology:           topology,
+		cluster:            cluster,
+		instanceTypes:      instanceTypes,
+		daemonOverhead:     daemonOverhead,
+		recorder:           recorder,
+		preferences:        &Preferences{},
+		remainingResources: map[string]v1.ResourceList{},
 	}
 
 	namedNodeTemplates := lo.KeyBy(s.nodeTemplates, func(nodeTemplate *scheduling.NodeTemplate) string {
 		return nodeTemplate.Requirements.Get(v1alpha5.ProvisionerNameLabelKey).Values().List()[0]
 	})
+
+	for _, provisioner := range provisioners {
+		if provisioner.Spec.Limits != nil {
+			s.remainingResources[provisioner.Name] = provisioner.Spec.Limits.Resources
+		}
+	}
 
 	// create our in-flight nodes
 	s.cluster.ForEachNode(func(node *state.Node) bool {
@@ -64,21 +69,27 @@ func NewScheduler(nodeTemplates []*scheduling.NodeTemplate, cluster *state.Clust
 			return true
 		}
 		s.inflight = append(s.inflight, NewInFlightNode(node, s.topology, nodeTemplate.StartupTaints, s.daemonOverhead[nodeTemplate]))
+
+		// We don't use the status field and instead recompute the remaining resources to ensure we have a consistent view
+		// of the cluster during scheduling.  Depending on how node creation falls out, this will also work for cases where
+		// we don't create Node resources.
+		s.remainingResources[name] = resources.Subtract(s.remainingResources[name], node.Capacity)
 		return true
 	})
 	return s
 }
 
 type Scheduler struct {
-	nodes          []*Node
-	inflight       []*InFlightNode
-	nodeTemplates  []*scheduling.NodeTemplate
-	instanceTypes  []cloudprovider.InstanceType
-	daemonOverhead map[*scheduling.NodeTemplate]v1.ResourceList
-	preferences    *Preferences
-	topology       *Topology
-	cluster        *state.Cluster
-	recorder       events.Recorder
+	nodes              []*Node
+	inflight           []*InFlightNode
+	nodeTemplates      []*scheduling.NodeTemplate
+	remainingResources map[string]v1.ResourceList // provisioner name -> remaining resources for that provisioner
+	instanceTypes      []cloudprovider.InstanceType
+	daemonOverhead     map[*scheduling.NodeTemplate]v1.ResourceList
+	preferences        *Preferences
+	topology           *Topology
+	cluster            *state.Cluster
+	recorder           events.Recorder
 }
 
 func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) ([]*Node, error) {
@@ -159,13 +170,67 @@ func (s *Scheduler) add(pod *v1.Pod) error {
 	// Create new node
 	var errs error
 	for _, nodeTemplate := range s.nodeTemplates {
-		node := NewNode(nodeTemplate, s.topology, s.daemonOverhead[nodeTemplate], s.instanceTypes)
+		instanceTypes := s.instanceTypes
+		// if limits have been applied to the provisioner, ensure we filter instance types to avoid violating those limits
+		if remaining, ok := s.remainingResources[nodeTemplate.ProvisionerName]; ok {
+			instanceTypes = filterByRemainingResources(s.instanceTypes, remaining)
+			if len(instanceTypes) == 0 {
+				errs = multierr.Append(errs, fmt.Errorf("all available instance types exceed provisioner limits"))
+				continue
+			}
+		}
+
+		node := NewNode(nodeTemplate, s.topology, s.daemonOverhead[nodeTemplate], instanceTypes)
 		err := node.Add(pod)
 		if err == nil {
 			s.nodes = append(s.nodes, node)
+			// we will launch this node and need to track its maximum possible resource usage against our remaining resources
+			s.remainingResources[nodeTemplate.ProvisionerName] = subtractMax(s.remainingResources[nodeTemplate.ProvisionerName], node.InstanceTypeOptions)
 			return nil
 		}
 		errs = multierr.Append(errs, err)
 	}
 	return errs
+}
+
+// subtractMax returns the remaining resources after subtracting the max resource quantity per instance type. To avoid
+// overshooting out, we need to pessimistically assume that if e.g. we request a 2, 4 or 8 CPU instance type
+// that the 8 CPU instance type is all that will be available.  This could cause a batch of pods to take multiple rounds
+// to schedule.
+func subtractMax(remaining v1.ResourceList, instanceTypes []cloudprovider.InstanceType) v1.ResourceList {
+	// shouldn't occur, but to be safe
+	if len(instanceTypes) == 0 {
+		return remaining
+	}
+	var allInstanceResources []v1.ResourceList
+	for _, it := range instanceTypes {
+		allInstanceResources = append(allInstanceResources, it.Resources())
+	}
+	result := v1.ResourceList{}
+	itResources := resources.MaxResources(allInstanceResources...)
+	for k, v := range remaining {
+		cp := v.DeepCopy()
+		cp.Sub(itResources[k])
+		result[k] = cp
+	}
+	return result
+}
+
+// filterByRemainingResources is used to filter out instance types that if launched would exceed the provisioner limits
+func filterByRemainingResources(instanceTypes []cloudprovider.InstanceType, remaining v1.ResourceList) []cloudprovider.InstanceType {
+	var filtered []cloudprovider.InstanceType
+	for _, it := range instanceTypes {
+		itResources := it.Resources()
+		viableInstance := true
+		for resourceName, remainingQuantity := range remaining {
+			// if the instance capacity is greater than the remaining quantity for this resource
+			if resources.Cmp(itResources[resourceName], remainingQuantity) > 0 {
+				viableInstance = false
+			}
+		}
+		if viableInstance {
+			filtered = append(filtered, it)
+		}
+	}
+	return filtered
 }

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -110,14 +110,13 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
 
 	instanceTypes := fake.InstanceTypes(instanceCount)
-	scheduler := NewScheduler(
-		[]*scheduling.NodeTemplate{scheduling.NewNodeTemplate(test.Provisioner(), cloudprovider.InstanceTypeRequirements(instanceTypes))},
-		state.NewCluster(ctx, nil),
-		&Topology{},
-		fake.InstanceTypes(instanceCount),
+	scheduler := NewScheduler([]*scheduling.NodeTemplate{scheduling.NewNodeTemplate(test.Provisioner(
+		test.ProvisionerOptions{Limits: map[v1.ResourceName]resource.Quantity{}}),
+		cloudprovider.InstanceTypeRequirements(instanceTypes))},
+		nil, state.NewCluster(ctx, nil),
+		&Topology{}, fake.InstanceTypes(instanceCount),
 		map[*scheduling.NodeTemplate]v1.ResourceList{},
-		test.NewEventRecorder(),
-	)
+		test.NewEventRecorder())
 
 	pods := makeDiversePods(podCount)
 

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/aws/karpenter/pkg/controllers/state"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
@@ -142,6 +144,90 @@ var _ = Describe("Provisioning", func() {
 				},
 			}))
 			pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
+			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should schedule if limits would be met", func() {
+			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{
+				Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+			}))
+			pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(
+				test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						// requires a 2 CPU node, but leaves room for overhead
+						v1.ResourceCPU: resource.MustParse("1.75"),
+					},
+				}}))[0]
+			// A 2 CPU node can be launched
+			ExpectScheduled(ctx, env.Client, pod)
+		})
+		It("should partially schedule if limits would be exceeded", func() {
+			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{
+				Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("3")},
+			}))
+
+			// prevent these pods from scheduling on the same node
+			opts := test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "foo"},
+				},
+				PodAntiRequirements: []v1.PodAffinityTerm{
+					{
+						TopologyKey: v1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": "foo",
+							},
+						},
+					},
+				},
+				ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("1.5"),
+					}}}
+			pods := ExpectProvisioned(ctx, env.Client, controller,
+				test.UnschedulablePod(opts),
+				test.UnschedulablePod(opts),
+			)
+			scheduledPodCount := 0
+			unscheduledPodCount := 0
+			pod0 := ExpectPodExists(ctx, env.Client, pods[0].Name, pods[0].Namespace)
+			pod1 := ExpectPodExists(ctx, env.Client, pods[1].Name, pods[1].Namespace)
+			if pod0.Spec.NodeName == "" {
+				unscheduledPodCount++
+			} else {
+				scheduledPodCount++
+			}
+			if pod1.Spec.NodeName == "" {
+				unscheduledPodCount++
+			} else {
+				scheduledPodCount++
+			}
+			Expect(scheduledPodCount).To(Equal(1))
+			Expect(unscheduledPodCount).To(Equal(1))
+		})
+		It("should not schedule if limits would be exceeded", func() {
+			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{
+				Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
+			}))
+			pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(
+				test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("2.1"),
+					},
+				}}))[0]
+			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should not schedule if limits would be exceeded (GPU)", func() {
+			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{
+				Limits: v1.ResourceList{v1.ResourcePods: resource.MustParse("1")},
+			}))
+			pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(
+				test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
+					},
+				}}))[0]
+			// only available instance type has 2 GPUs which would exceed the limit
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 	})

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -57,6 +57,9 @@ func NewCluster(ctx context.Context, client client.Client) *Cluster {
 // compute topology information.
 type Node struct {
 	Node *v1.Node
+	// Capacity is the total amount of resources on the node.  The available resources are the capacity minus overhead
+	// minus anything allocated to pods.
+	Capacity v1.ResourceList
 	// Available is the total amount of resources that are available on the node.  This is the Allocatable minus the
 	// resources requested by all pods bound to the node.
 	Available v1.ResourceList
@@ -135,6 +138,7 @@ func (c *Cluster) newNode(node *v1.Node) *Node {
 	}
 
 	n.DaemonSetRequested = resources.Merge(daemonsetRequested...)
+	n.Capacity = n.Node.Status.Capacity
 	n.Available = resources.Subtract(n.Node.Status.Allocatable, resources.Merge(requested...))
 	return n
 }

--- a/pkg/scheduling/nodetemplate.go
+++ b/pkg/scheduling/nodetemplate.go
@@ -27,6 +27,7 @@ import (
 // the fields in Provisioner. These structs are maintained separately in order
 // for fields like Requirements to be able to be stored more efficiently.
 type NodeTemplate struct {
+	ProvisionerName      string
 	Provider             *v1alpha5.Provider
 	Labels               map[string]string
 	Taints               Taints
@@ -38,6 +39,7 @@ type NodeTemplate struct {
 func NewNodeTemplate(provisioner *v1alpha5.Provisioner, requirements ...Requirements) *NodeTemplate {
 	provisioner.Spec.Labels = functional.UnionStringMaps(provisioner.Spec.Labels, map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner.Name})
 	return &NodeTemplate{
+		ProvisionerName:      provisioner.Name,
 		Provider:             provisioner.Spec.Provider,
 		KubeletConfiguration: provisioner.Spec.KubeletConfiguration,
 		Labels:               provisioner.Spec.Labels,

--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -56,7 +56,7 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 		options.Name = strings.ToLower(randomdata.SillyName())
 	}
 	if options.Limits == nil {
-		options.Limits = v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")}
+		options.Limits = v1.ResourceList{v1.ResourceCPU: resource.MustParse("1000")}
 	}
 	if options.Provider == nil {
 		options.Provider = struct{}{}

--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -193,13 +193,13 @@ spec:
 
 The provisioner spec includes a limits section (`spec.limits.resources`), which constrains the maximum amount of resources that the provisioner will manage. 
 
-Presently, Karpenter supports `memory` and `cpu` limits. 
+Karpenter supports limits of any resource type that is reported by your cloud provider.     
 
 CPU limits are described with a `DecimalSI` value. Note that the Kubernetes API will coerce this into a string, so we recommend against using integers to avoid GitOps skew.
 
 Memory limits are described with a [`BinarySI` value, such as 1000Gi.](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
 
-Karpenter stops allocating resources once at least one resource limit is met/exceeded.
+Karpenter limits instance types when scheduling to those that will not exceed the specified limits.  If a limit has been exceeded, nodes provisioning is prevented until some nodes have been terminated.
 
 Review the [resource limit task](../tasks/set-resource-limits) for more information.
 

--- a/website/content/en/preview/tasks/set-resource-limits.md
+++ b/website/content/en/preview/tasks/set-resource-limits.md
@@ -12,9 +12,7 @@ The provisioner spec includes a limits section (`spec.limits.resources`), which 
 
 For example, setting "spec.limits.resources.cpu" to "1000" limits the provisioner to a total of 1000 CPU cores across all instances. This prevents unwanted excessive growth of a cluster. 
 
-At this time, Karpenter only supports:
-- CPU
-- Memory
+Karpenter supports limits of any resource type that is reported by your cloud provider.
 
 CPU limits are described with a `DecimalSI` value, usually a natural integer. 
 
@@ -28,18 +26,6 @@ kubectl get provisioner -o=jsonpath='{.items[0].status}'
 Review the [Kubernetes core API](https://github.com/kubernetes/api/blob/37748cca582229600a3599b40e9a82a951d8bbbf/core/v1/resource.go#L23) (`k8s.io/api/core/v1`) for more information on `resources`.
 
 ### Implementation
-
-Karpenter refuses to allocate new resources while at least one resource limit is *exceeded*. In other words, resource limits aren't hard limits, they only apply once Karpenter detects that a limit has been crossed.
-
-**Example:**
-
-A resource limit of 1000 CPUs is set. 996 CPU cores are currently allocated. The resource limit is not met.
-
-In response to pending pods, Karpenter calculates a new 6 core instance is needed. Karpenter *creates* the instance.
-
-1002 CPU cores are now allocated. The resource limit is in now met/exceeded. 
-
-In response to a new set of pending pods, Karpenter calculates another 6 core instance is needed. Karpenter *does not create* the instance, because the resource limit has been met.
 
 {{% alert title="Note" color="primary" %}}
 Karpenter provisioning is highly parallel. Because of this, limit checking is eventually consistent, which can result in overrun during rapid scale outs.
@@ -61,4 +47,5 @@ spec:
     resources:
       cpu: 1000 
       memory: 1000Gi
+      nvidia.com/gpu: 2
 ```


### PR DESCRIPTION
**1. Issue, if available:**
Fixes #1728

**2. Description of changes:**

During the scheduling process, only provision from instance types that
won't violate limits.


**3. How was this change tested?**

Unit testing & deployed to EKS. I scaled up pods with an 8Gb memory limit set on my provisioner and the usage never exceeded 8Gb.

**4. Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
