### PR TITLE
consider ephemeral-storage when bin-packing

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/al2.go
+++ b/pkg/cloudprovider/aws/amifamily/al2.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
@@ -78,7 +79,15 @@ func (a AL2) containerRuntime(instanceTypes []cloudprovider.InstanceType) string
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
 func (a AL2) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
 	return []*v1alpha1.BlockDeviceMapping{{
-		DeviceName: aws.String("/dev/xvda"),
-		EBS:        &defaultEBS,
+		DeviceName: a.EphemeralBlockDevice(),
+		EBS:        &DefaultEBS,
 	}}
+}
+
+func (a AL2) EphemeralBlockDevice() *string {
+	return aws.String("/dev/xvda")
+}
+
+func (a AL2) EphemeralBlockDeviceOverhead() resource.Quantity {
+	return resource.MustParse("5Gi")
 }

--- a/pkg/cloudprovider/aws/amifamily/bottlerocket.go
+++ b/pkg/cloudprovider/aws/amifamily/bottlerocket.go
@@ -64,7 +64,7 @@ func (b Bottlerocket) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, tai
 
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
 func (b Bottlerocket) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
-	xvdaEBS := defaultEBS
+	xvdaEBS := DefaultEBS
 	xvdaEBS.VolumeSize = resource.NewScaledQuantity(4, resource.Giga)
 	return []*v1alpha1.BlockDeviceMapping{
 		{
@@ -72,8 +72,16 @@ func (b Bottlerocket) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMappin
 			EBS:        &xvdaEBS,
 		},
 		{
-			DeviceName: aws.String("/dev/xvdb"),
-			EBS:        &defaultEBS,
+			DeviceName: b.EphemeralBlockDevice(),
+			EBS:        &DefaultEBS,
 		},
 	}
+}
+
+func (b Bottlerocket) EphemeralBlockDevice() *string {
+	return aws.String("/dev/xvdb")
+}
+
+func (b Bottlerocket) EphemeralBlockDeviceOverhead() resource.Quantity {
+	return resource.MustParse("5Gi")
 }

--- a/pkg/cloudprovider/aws/amifamily/ubuntu.go
+++ b/pkg/cloudprovider/aws/amifamily/ubuntu.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
@@ -53,7 +54,15 @@ func (u Ubuntu) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
 func (u Ubuntu) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
 	return []*v1alpha1.BlockDeviceMapping{{
-		DeviceName: aws.String("/dev/sda1"),
-		EBS:        &defaultEBS,
+		DeviceName: u.EphemeralBlockDevice(),
+		EBS:        &DefaultEBS,
 	}}
+}
+
+func (u Ubuntu) EphemeralBlockDevice() *string {
+	return aws.String("/dev/sda1")
+}
+
+func (u Ubuntu) EphemeralBlockDeviceOverhead() resource.Quantity {
+	return resource.MustParse("5Gi")
 }

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -111,8 +111,12 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 }
 
 // GetInstanceTypes returns all available InstanceTypes
-func (c *CloudProvider) GetInstanceTypes(ctx context.Context) ([]cloudprovider.InstanceType, error) {
-	return c.instanceTypeProvider.Get(ctx)
+func (c *CloudProvider) GetInstanceTypes(ctx context.Context, provider *v1alpha5.Provider) ([]cloudprovider.InstanceType, error) {
+	awsprovider, err := v1alpha1.Deserialize(provider)
+	if err != nil {
+		return nil, apis.ErrGeneric(err.Error())
+	}
+	return c.instanceTypeProvider.Get(ctx, awsprovider)
 }
 
 func (c *CloudProvider) Delete(ctx context.Context, node *v1.Node) error {
@@ -120,7 +124,7 @@ func (c *CloudProvider) Delete(ctx context.Context, node *v1.Node) error {
 }
 
 func (c *CloudProvider) GetRequirements(ctx context.Context, provider *v1alpha5.Provider) (scheduling.Requirements, error) {
-	instanceTypes, err := c.GetInstanceTypes(ctx)
+	instanceTypes, err := c.GetInstanceTypes(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("getting instance types, %w", err)
 	}

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Pallinder/go-randomdata"
 	"github.com/aws/amazon-vpc-resource-controller-k8s/pkg/aws/vpc"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
@@ -38,7 +39,6 @@ import (
 	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/options"
 
-	"github.com/Pallinder/go-randomdata"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo"
@@ -1015,9 +1015,89 @@ var _ = Describe("Allocation", func() {
 				pod := ExpectProvisioned(ctx, env.Client, controller,
 					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 						Requests: map[v1.ResourceName]resource.Quantity{
-							v1.ResourceEphemeralStorage: resource.MustParse("1Pi"),
+							v1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
 						}}}))
 				ExpectScheduled(ctx, env.Client, pod[0])
+			})
+			It("should not pack pods if the sum of pod ephemeral-storage and overhead exceeds node capacity", func() {
+				ExpectApplied(ctx, env.Client, provisioner)
+				pod := ExpectProvisioned(ctx, env.Client, controller,
+					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceEphemeralStorage: resource.MustParse("19Gi"),
+						}}}))
+				ExpectNotScheduled(ctx, env.Client, pod[0])
+			})
+			It("should launch multiple nodes if sum of pod ephemeral-storage requests exceeds a single nodes capacity", func() {
+				var nodes []*v1.Node
+				ExpectApplied(ctx, env.Client, provisioner)
+				pods := ExpectProvisioned(ctx, env.Client, controller,
+					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+						},
+					},
+					}),
+					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+						},
+					},
+					}),
+				)
+				for _, pod := range pods {
+					nodes = append(nodes, ExpectScheduled(ctx, env.Client, pod))
+				}
+				Expect(nodes).To(HaveLen(2))
+			})
+			It("should only pack pods with ephemeral-storage requests that will fit on an available node", func() {
+				ExpectApplied(ctx, env.Client, provisioner)
+				pods := ExpectProvisioned(ctx, env.Client, controller,
+					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+						},
+					},
+					}),
+					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceEphemeralStorage: resource.MustParse("150Gi"),
+						},
+					},
+					}),
+				)
+				ExpectScheduled(ctx, env.Client, pods[0])
+				ExpectNotScheduled(ctx, env.Client, pods[1])
+			})
+			It("should not pack pod if no available instance types have enough storage", func() {
+				ExpectApplied(ctx, env.Client, provisioner)
+				pod := ExpectProvisioned(ctx, env.Client, controller,
+					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceEphemeralStorage: resource.MustParse("150Gi"),
+						},
+					},
+					}))[0]
+				ExpectNotScheduled(ctx, env.Client, pod)
+			})
+			It("should pack pods using the blockdevicemappings from the provider spec when defined", func() {
+				provider, _ = v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					DeviceName: aws.String("/dev/xvda"),
+					EBS: &v1alpha1.BlockDevice{
+						VolumeSize: resource.NewScaledQuantity(50, resource.Giga),
+					},
+				}}
+				ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+				pod := ExpectProvisioned(ctx, env.Client, controller,
+					test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceEphemeralStorage: resource.MustParse("25Gi"),
+						},
+					},
+					}))[0]
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(node.Status.Capacity).To(HaveKeyWithValue(v1.ResourceEphemeralStorage, resource.MustParse("50G")))
 			})
 		})
 	})

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -89,7 +89,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 	}, nil
 }
 
-func (c *CloudProvider) GetInstanceTypes(_ context.Context) ([]cloudprovider.InstanceType, error) {
+func (c *CloudProvider) GetInstanceTypes(_ context.Context, provider *v1alpha5.Provider) ([]cloudprovider.InstanceType, error) {
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}
@@ -140,7 +140,7 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context) ([]cloudprovider.Ins
 }
 
 func (c *CloudProvider) GetRequirements(ctx context.Context, provider *v1alpha5.Provider) (scheduling.Requirements, error) {
-	instanceTypes, err := c.GetInstanceTypes(ctx)
+	instanceTypes, err := c.GetInstanceTypes(ctx, provider)
 	if err != nil {
 		return nil, fmt.Errorf("getting instance types, %w", err)
 	}

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -78,9 +78,9 @@ func (d *decorator) Delete(ctx context.Context, node *v1.Node) error {
 	return d.CloudProvider.Delete(ctx, node)
 }
 
-func (d *decorator) GetInstanceTypes(ctx context.Context) ([]cloudprovider.InstanceType, error) {
+func (d *decorator) GetInstanceTypes(ctx context.Context, provider *v1alpha5.Provider) ([]cloudprovider.InstanceType, error) {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "GetInstanceTypes", d.Name()))()
-	return d.CloudProvider.GetInstanceTypes(ctx)
+	return d.CloudProvider.GetInstanceTypes(ctx, provider)
 }
 
 func (d *decorator) GetRequirements(ctx context.Context, provider *v1alpha5.Provider) (scheduling.Requirements, error) {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -44,7 +44,7 @@ type CloudProvider interface {
 	Delete(context.Context, *v1.Node) error
 	// GetInstanceTypes returns instance types supported by the cloudprovider.
 	// Availability of types or zone may vary by provisioner or over time.
-	GetInstanceTypes(context.Context) ([]InstanceType, error)
+	GetInstanceTypes(context.Context, *v1alpha5.Provider) ([]InstanceType, error)
 	// GetRequirements for the provider, e.g. zones contrained by subnets or
 	// os constrained by machine image.
 	GetRequirements(context.Context, *v1alpha5.Provider) (scheduling.Requirements, error)

--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -485,6 +485,7 @@ var _ = Describe("Instance Type Selection", func() {
 			resourceHashes[it.Name()], err = hashstructure.Hash(it.Resources(), hashstructure.FormatV2, nil)
 			Expect(err).To(BeNil())
 			overheadHashes[it.Name()], err = hashstructure.Hash(it.Overhead(), hashstructure.FormatV2, nil)
+			Expect(err).To(BeNil())
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
 		// these values are constructed so that three of these pods can always fit on at least one of our instance types

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -108,13 +108,14 @@ func TestSchedulingProfile(t *testing.T) {
 func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 	// disable logging
 	ctx := logging.WithLogger(context.Background(), zap.NewNop().Sugar())
+	provisioner := test.Provisioner(test.ProvisionerOptions{Limits: map[v1.ResourceName]resource.Quantity{}})
 
 	instanceTypes := fake.InstanceTypes(instanceCount)
-	scheduler := NewScheduler([]*scheduling.NodeTemplate{scheduling.NewNodeTemplate(test.Provisioner(
-		test.ProvisionerOptions{Limits: map[v1.ResourceName]resource.Quantity{}}),
+	scheduler := NewScheduler([]*scheduling.NodeTemplate{scheduling.NewNodeTemplate(provisioner,
 		cloudprovider.InstanceTypeRequirements(instanceTypes))},
 		nil, state.NewCluster(ctx, nil),
-		&Topology{}, fake.InstanceTypes(instanceCount),
+		&Topology{},
+		map[string][]cloudprovider.InstanceType{provisioner.Name: fake.InstanceTypes(instanceCount)},
 		map[*scheduling.NodeTemplate]v1.ResourceList{},
 		test.NewEventRecorder())
 


### PR DESCRIPTION
**1. Issue, if available:**
#1467

**2. Description of changes:**
Prior to this change, Karpenter would report an arbitrarily large value for the `ephemeral-storage` resource when discovering AWS instanceTypes.  This can result in Pending pods and node churn if the sum of the `ephemeral-storage` resources for pods being bound to a node exceeds that of the disk size of the launched node.  This change accurately reflects storage attached to instanceTypes so that binpacking of pods based on the `ephemeral-storage` resource type functions as expected.

The amount of storage used for binpacking is based on the size of the ~~"root" device~~ the device where `/var/lib/kubelet` resides.  If a BlockDeviceMapping is defined for the device in the AWS Provider Spec, then Karpenter will use the given BlockDevice size, otherwise it will revert to the default size (20GB).  

Added:
`EphemeralBlockDeviceOverhead` method which returns values specific to the AMIFamily.  How we calculate this overhead is up in the air, so more discussion is needed as to what it should be set to.

**3. How was this change tested?**
Implemented automated testing and also tested manually.  

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
