### PR TITLE
Support set private registry credential for CustomUserData with Bottl…

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/bottlerocketsettings.go
@@ -23,11 +23,12 @@ type config struct {
 // These settings apply across all K8s versions that karpenter supports.
 // This is currently an opinionated subset and can evolve over time
 type settings struct {
-	Kubernetes     kubernetes      `toml:"kubernetes"`
-	HostContainers *hostContainers `toml:"host-containers,omitempty"`
-	AWS            *awsConfig      `toml:"aws,omitempty"`
-	Metrics        *metrics        `toml:"metrics,omitempty"`
-	Kernel         *kernel         `toml:"kernel,omitempty"`
+	Kubernetes        kubernetes         `toml:"kubernetes"`
+	HostContainers    *hostContainers    `toml:"host-containers,omitempty"`
+	AWS               *awsConfig         `toml:"aws,omitempty"`
+	Metrics           *metrics           `toml:"metrics,omitempty"`
+	Kernel            *kernel            `toml:"kernel,omitempty"`
+	ContainerRegistry *containerRegistry `toml:"container-registry,omitempty"`
 }
 
 // kubernetes specific configuration for bottlerocket api
@@ -57,6 +58,17 @@ type kubernetes struct {
 	CPUManagerReconcilePeriod *string              `toml:"cpu-manager-reconcile-period,omitempty"`
 	TopologyManagerScope      *string              `toml:"topology-manager-scope,omitempty"`
 	TopologyManagerPolicy     *string              `toml:"topology-manager-policy,omitempty"`
+}
+
+type containerRegistry struct {
+	Credentials []*credential `toml:"credentials,omitempty"`
+}
+
+type credential struct {
+	Registry *string `toml:"registry,omitempty"`
+	Auth     *string `toml:"auth,omitempty"`
+	UserName *string `toml:"username,omitempty"`
+	Password *string `toml:"password,omitempty"`
 }
 
 type staticPod struct {


### PR DESCRIPTION

**1. Issue, if available:**
Issue: https://github.com/aws/karpenter/issues/1531
Pre-PR: https://github.com/aws/karpenter/pull/1726
Support set container registry credentials for CustomUserData with [Bottlerocket](https://github.com/bottlerocket-os/bottlerocket)

**2. Description of changes:**
It would config registry credentials in UserData by `AWSNodeTemplate` CR.

**3. How was this change tested?**
```yaml
apiVersion: karpenter.k8s.aws/v1alpha1
kind: AWSNodeTemplate
metadata:
  name: mynodetemplate
spec:
  userData:  |
    [settings.kubernetes]
    kube-api-qps = 30
    [settings.kubernetes.eviction-hard]
    "memory.available" = "20%"

    [[settings.container-registry.credentials]]
    registry = "registry.xxxx.io"
    auth = "<secret>"
```

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
