### PR TITLE
support affinity/anti-affinity/topology spead against arch

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -27,9 +27,6 @@ var (
 	ArchitectureArm64    = "arm64"
 	OperatingSystemLinux = "linux"
 
-	// ValidTopologyKeys are the topology keys that Karpenter allows for topology spread and pod affinity/anti-affinity
-	ValidTopologyKeys = sets.NewString(v1.LabelHostname, v1.LabelTopologyZone, LabelCapacityType)
-
 	// Karpenter specific domains and labels
 	KarpenterLabelDomain = "karpenter.sh"
 	LabelCapacityType    = KarpenterLabelDomain + "/capacity-type"

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -68,6 +68,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 			Labels: map[string]string{
 				v1.LabelTopologyZone:       zone,
 				v1.LabelInstanceTypeStable: instance.Name(),
+				v1.LabelArchStable:         instance.Architecture(),
 				v1alpha5.LabelCapacityType: capacityType,
 			},
 		},

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -106,30 +106,12 @@ func isProvisionable(p *v1.Pod) bool {
 func validate(p *v1.Pod) error {
 	return multierr.Combine(
 		validateAffinity(p),
-		validateTopology(p),
 	)
-}
-
-func validateTopology(pod *v1.Pod) (errs error) {
-	for _, constraint := range pod.Spec.TopologySpreadConstraints {
-		if !v1alpha5.ValidTopologyKeys.Has(constraint.TopologyKey) {
-			errs = multierr.Append(errs, fmt.Errorf("unsupported topology spread constraint key, %s not in %s", constraint.TopologyKey, v1alpha5.ValidTopologyKeys))
-		}
-	}
-	return errs
 }
 
 func validateAffinity(p *v1.Pod) (errs error) {
 	if p.Spec.Affinity == nil {
 		return nil
-	}
-	if p.Spec.Affinity.PodAffinity != nil {
-		for _, term := range p.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
-			errs = multierr.Append(errs, validatePodAffinityTerm(term))
-		}
-		for _, term := range p.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
-			errs = multierr.Append(errs, validatePodAffinityTerm(term.PodAffinityTerm))
-		}
 	}
 	if p.Spec.Affinity.NodeAffinity != nil {
 		for _, term := range p.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
@@ -142,13 +124,6 @@ func validateAffinity(p *v1.Pod) (errs error) {
 		}
 	}
 	return errs
-}
-
-func validatePodAffinityTerm(term v1.PodAffinityTerm) error {
-	if !v1alpha5.ValidTopologyKeys.Has(term.TopologyKey) {
-		return fmt.Errorf("unsupported topology key in pod affinity, %s not in %s", term.TopologyKey, v1alpha5.ValidTopologyKeys)
-	}
-	return nil
 }
 
 func validateNodeSelectorTerm(term v1.NodeSelectorTerm) (errs error) {

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -32,7 +32,6 @@ import (
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/utils/pod"
 	"github.com/aws/karpenter/pkg/utils/sets"
 )
@@ -66,7 +65,7 @@ func NewTopology(ctx context.Context, kubeClient client.Client, cluster *state.C
 	// all of the nodes here as these are passed on to topology spreads which
 	// can be limited by node selector/required node affinities.
 	for _, nodeTemplate := range nodeTemplates {
-		for topologyKey := range v1alpha5.ValidTopologyKeys {
+		for topologyKey := range nodeTemplate.Requirements.Keys() {
 			t.domains[topologyKey] = t.domains[topologyKey].Union(nodeTemplate.Requirements.Get(topologyKey).Values())
 		}
 	}


### PR DESCRIPTION
**1. Issue, if available:**

Fixes #1863

**2. Description of changes:**

Allows affinity/anti-affinity/topology spread over arch

**3. How was this change tested?**

Unit testing & EKS.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
