### PR TITLE
Set namespace on PBD

### DIFF
--- a/charts/karpenter/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter/templates/poddisruptionbudget.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ include "karpenter.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: karpenter
+  namespace: {{ .Release.Namespace }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   selector:


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**

Aligns PDB template with the rest of the templates by setting `metadata.namespace`. Without this change [deployment guide](https://karpenter.sh/v0.10.1/getting-started/migrating-from-cas/#deploy-karpenter), followed as:
```
helm --namespace karpenter template ... > karpenter.yaml
kubectl apply -f karpenter.yaml
```
will land PBD into `default` namespace, unlike all other resources.

**3. How was this change tested?**

Ran `helm template --namespace karpenter .` on my branch and validated `namespace` is present in PDB template.

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
