### PR TITLE
ENV variable warning in GS guide

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
@@ -53,6 +53,17 @@ Also set the following environment variables to store commonly used values.
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step01-config.sh" language="bash"%}}
 
+{{% alert title="Warning" color="primary" %}}
+If you open a new shell to run steps in this procedure, you need to set some or all of the environment variables again.
+To remind yourself of these values, type:
+
+```bash
+echo $KARPENTER_VERSION $CLUSTER_NAME $AWS_DEFAULT_REGION $AWS_ACCOUNT_ID
+```
+
+{{% /alert %}}
+
+
 ### Create a Cluster
 
 Create a basic cluster with `eksctl`.


### PR DESCRIPTION
While using the Karpenter getting started guide for eksctl, a few times I've run commands from a second shell and had them fail because I forgot to re-export environment variables. So I'm adding a warning to tell people they need to set those variables again if they go to another shell.
