### PR TITLE
Updating doc for KubeletConfiguration

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -88,6 +88,8 @@ type ProviderRef struct {
 // KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.
 // They are a subset of the upstream types, recognizing not all options may be supported.
 // Wherever possible, the types and names should reflect the upstream kubelet types.
+// https://pkg.go.dev/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
+// https://github.com/kubernetes/kubernetes/blob/9f82d81e55cafdedab619ea25cabf5d42736dacf/cmd/kubelet/app/options/options.go#L53
 type KubeletConfiguration struct {
 	// clusterDNS is a list of IP addresses for the cluster DNS server.
 	// Note that not all providers may use all addresses.


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
Just updating the comment to make it clear that `containerRuntime` isn't a part of KubeletConfiguration and is a KubeletFlag.

**3. How was this change tested?**
None.


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
