### PR TITLE
track node capacity correctly before kubelet reports it

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -174,6 +174,11 @@ func (c *Cluster) newNode(node *v1.Node) *Node {
 
 	n.DaemonSetRequested = resources.Merge(daemonsetRequested...)
 	n.Capacity = n.Node.Status.Capacity
+	// if the capacity hasn't been reported yet, fall back to what the instance type reports so we can track
+	// limits
+	if len(n.Capacity) == 0 && n.InstanceType != nil {
+		n.Capacity = n.InstanceType.Resources()
+	}
 	n.Available = resources.Subtract(c.getNodeAllocatable(node, n.Provisioner), resources.Merge(requested...))
 	return n
 }


### PR DESCRIPTION
**1. Issue, if available:**
N/A

**2. Description of changes:**
track node capacity correctly before kubelet reports it

**3. How was this change tested?**
Running on EKS

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
