### PR TITLE
Simplify set and requirements logic

### DIFF
--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -56,14 +56,14 @@ var (
 	ResourceAWSNeuron v1.ResourceName = "aws.amazon.com/neuron"
 	ResourceAWSPodENI v1.ResourceName = "vpc.amazonaws.com/pod-eni"
 
-	InstanceFamilyLabelKey          = LabelDomain + "/instance.family"
-	InstanceSizeLabelKey            = LabelDomain + "/instance.size"
-	InstanceCPULabelKey             = LabelDomain + "/instance.cpu"
-	InstanceMemoryLabelKey          = LabelDomain + "/instance.memory"
-	InstanceGPUNameLabelKey         = LabelDomain + "/instance.gpu.name"
-	InstanceGPUManufacturerLabelKey = LabelDomain + "/instance.gpu.manufacturer"
-	InstanceGPUCountLabelKey        = LabelDomain + "/instance.gpu.count"
-	InstanceGPUMemoryLabelKey       = LabelDomain + "/instance.gpu.memory"
+	LabelInstanceFamily          = LabelDomain + "/instance.family"
+	LabelInstanceSize            = LabelDomain + "/instance.size"
+	LabelInstanceCPU             = LabelDomain + "/instance.cpu"
+	LabelInstanceMemory          = LabelDomain + "/instance.memory"
+	LabelInstanceGPUName         = LabelDomain + "/instance.gpu.name"
+	LabelInstanceGPUManufacturer = LabelDomain + "/instance.gpu.manufacturer"
+	LabelInstanceGPUCount        = LabelDomain + "/instance.gpu.count"
+	LabelInstanceGPUMemory       = LabelDomain + "/instance.gpu.memory"
 )
 
 var (
@@ -75,13 +75,13 @@ func init() {
 	Scheme.AddKnownTypes(schema.GroupVersion{Group: v1alpha5.ExtensionsGroup, Version: "v1alpha1"}, &AWS{})
 	v1alpha5.RestrictedLabelDomains = v1alpha5.RestrictedLabelDomains.Insert(RestrictedLabelDomains...)
 	v1alpha5.WellKnownLabels = v1alpha5.WellKnownLabels.Insert(
-		InstanceFamilyLabelKey,
-		InstanceSizeLabelKey,
-		InstanceCPULabelKey,
-		InstanceMemoryLabelKey,
-		InstanceGPUNameLabelKey,
-		InstanceGPUManufacturerLabelKey,
-		InstanceGPUCountLabelKey,
-		InstanceGPUMemoryLabelKey,
+		LabelInstanceFamily,
+		LabelInstanceSize,
+		LabelInstanceCPU,
+		LabelInstanceMemory,
+		LabelInstanceGPUName,
+		LabelInstanceGPUManufacturer,
+		LabelInstanceGPUCount,
+		LabelInstanceGPUMemory,
 	)
 }

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -120,28 +120,28 @@ func (i *InstanceType) computeRequirements() scheduling.Requirements {
 		// Well Known to Karpenter
 		v1alpha5.LabelCapacityType: sets.NewSet(lo.Map(i.Offerings(), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
 		// Well Known to AWS
-		v1alpha1.InstanceCPULabelKey:             sets.NewSet(fmt.Sprint(aws.Int64Value(i.VCpuInfo.DefaultVCpus))),
-		v1alpha1.InstanceMemoryLabelKey:          sets.NewSet(fmt.Sprint(aws.Int64Value(i.MemoryInfo.SizeInMiB))),
-		v1alpha1.InstanceFamilyLabelKey:          sets.NewSet(),
-		v1alpha1.InstanceSizeLabelKey:            sets.NewSet(),
-		v1alpha1.InstanceGPUNameLabelKey:         sets.NewSet(),
-		v1alpha1.InstanceGPUManufacturerLabelKey: sets.NewSet(),
-		v1alpha1.InstanceGPUCountLabelKey:        sets.NewSet(),
-		v1alpha1.InstanceGPUMemoryLabelKey:       sets.NewSet(),
+		v1alpha1.LabelInstanceCPU:             sets.NewSet(fmt.Sprint(aws.Int64Value(i.VCpuInfo.DefaultVCpus))),
+		v1alpha1.LabelInstanceMemory:          sets.NewSet(fmt.Sprint(aws.Int64Value(i.MemoryInfo.SizeInMiB))),
+		v1alpha1.LabelInstanceFamily:          sets.NewSet(),
+		v1alpha1.LabelInstanceSize:            sets.NewSet(),
+		v1alpha1.LabelInstanceGPUName:         sets.NewSet(),
+		v1alpha1.LabelInstanceGPUManufacturer: sets.NewSet(),
+		v1alpha1.LabelInstanceGPUCount:        sets.NewSet(),
+		v1alpha1.LabelInstanceGPUMemory:       sets.NewSet(),
 	}
 	// Instance Type Labels
 	instanceTypeParts := strings.Split(aws.StringValue(i.InstanceType), ".")
 	if len(instanceTypeParts) == 2 {
-		requirements[v1alpha1.InstanceFamilyLabelKey].Insert(instanceTypeParts[0])
-		requirements[v1alpha1.InstanceSizeLabelKey].Insert(instanceTypeParts[1])
+		requirements[v1alpha1.LabelInstanceFamily].Insert(instanceTypeParts[0])
+		requirements[v1alpha1.LabelInstanceSize].Insert(instanceTypeParts[1])
 	}
 	// GPU Labels
 	if i.GpuInfo != nil && len(i.GpuInfo.Gpus) == 1 {
 		gpu := i.GpuInfo.Gpus[0]
-		requirements[v1alpha1.InstanceGPUNameLabelKey].Insert(lowerKabobCase(aws.StringValue(gpu.Name)))
-		requirements[v1alpha1.InstanceGPUManufacturerLabelKey].Insert(lowerKabobCase(aws.StringValue(gpu.Manufacturer)))
-		requirements[v1alpha1.InstanceGPUCountLabelKey].Insert(fmt.Sprint(aws.Int64Value(gpu.Count)))
-		requirements[v1alpha1.InstanceGPUMemoryLabelKey].Insert(fmt.Sprint(aws.Int64Value(gpu.MemoryInfo.SizeInMiB)))
+		requirements[v1alpha1.LabelInstanceGPUName].Insert(lowerKabobCase(aws.StringValue(gpu.Name)))
+		requirements[v1alpha1.LabelInstanceGPUManufacturer].Insert(lowerKabobCase(aws.StringValue(gpu.Manufacturer)))
+		requirements[v1alpha1.LabelInstanceGPUCount].Insert(fmt.Sprint(aws.Int64Value(gpu.Count)))
+		requirements[v1alpha1.LabelInstanceGPUMemory].Insert(fmt.Sprint(aws.Int64Value(gpu.MemoryInfo.SizeInMiB)))
 	}
 	return requirements
 }

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -117,29 +117,31 @@ func (i *InstanceType) computeRequirements() scheduling.Requirements {
 		v1.LabelArchStable:         sets.NewSet(i.architecture()),
 		v1.LabelOSStable:           sets.NewSet(v1alpha5.OperatingSystemLinux),
 		v1.LabelTopologyZone:       sets.NewSet(lo.Map(i.Offerings(), func(o cloudprovider.Offering, _ int) string { return o.Zone })...),
+		// Well Known to Karpenter
 		v1alpha5.LabelCapacityType: sets.NewSet(lo.Map(i.Offerings(), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
-		// Resources
-		v1alpha1.InstanceCPULabelKey:    sets.NewSet(fmt.Sprint(aws.Int64Value(i.VCpuInfo.DefaultVCpus))),
-		v1alpha1.InstanceMemoryLabelKey: sets.NewSet(fmt.Sprint(aws.Int64Value(i.MemoryInfo.SizeInMiB))),
+		// Well Known to AWS
+		v1alpha1.InstanceCPULabelKey:             sets.NewSet(fmt.Sprint(aws.Int64Value(i.VCpuInfo.DefaultVCpus))),
+		v1alpha1.InstanceMemoryLabelKey:          sets.NewSet(fmt.Sprint(aws.Int64Value(i.MemoryInfo.SizeInMiB))),
+		v1alpha1.InstanceFamilyLabelKey:          sets.NewSet(),
+		v1alpha1.InstanceSizeLabelKey:            sets.NewSet(),
+		v1alpha1.InstanceGPUNameLabelKey:         sets.NewSet(),
+		v1alpha1.InstanceGPUManufacturerLabelKey: sets.NewSet(),
+		v1alpha1.InstanceGPUCountLabelKey:        sets.NewSet(),
+		v1alpha1.InstanceGPUMemoryLabelKey:       sets.NewSet(),
 	}
 	// Instance Type Labels
 	instanceTypeParts := strings.Split(aws.StringValue(i.InstanceType), ".")
 	if len(instanceTypeParts) == 2 {
-		requirements.Add(scheduling.Requirements{
-			v1alpha1.InstanceFamilyLabelKey: sets.NewSet(instanceTypeParts[0]),
-			v1alpha1.InstanceSizeLabelKey:   sets.NewSet(instanceTypeParts[1]),
-		})
+		requirements[v1alpha1.InstanceFamilyLabelKey].Insert(instanceTypeParts[0])
+		requirements[v1alpha1.InstanceSizeLabelKey].Insert(instanceTypeParts[1])
 	}
 	// GPU Labels
 	if i.GpuInfo != nil && len(i.GpuInfo.Gpus) == 1 {
 		gpu := i.GpuInfo.Gpus[0]
-		requirements.Add(scheduling.Requirements{
-			v1alpha1.InstanceGPUNameLabelKey:         sets.NewSet(lowerKabobCase(aws.StringValue(gpu.Name))),
-			v1alpha1.InstanceGPUManufacturerLabelKey: sets.NewSet(lowerKabobCase(aws.StringValue(gpu.Manufacturer))),
-			v1alpha1.InstanceGPUCountLabelKey:        sets.NewSet(fmt.Sprint(aws.Int64Value(gpu.Count))),
-			v1alpha1.InstanceGPUMemoryLabelKey:       sets.NewSet(fmt.Sprint(aws.Int64Value(gpu.MemoryInfo.SizeInMiB))),
-		})
-
+		requirements[v1alpha1.InstanceGPUNameLabelKey].Insert(lowerKabobCase(aws.StringValue(gpu.Name)))
+		requirements[v1alpha1.InstanceGPUManufacturerLabelKey].Insert(lowerKabobCase(aws.StringValue(gpu.Manufacturer)))
+		requirements[v1alpha1.InstanceGPUCountLabelKey].Insert(fmt.Sprint(aws.Int64Value(gpu.Count)))
+		requirements[v1alpha1.InstanceGPUMemoryLabelKey].Insert(fmt.Sprint(aws.Int64Value(gpu.MemoryInfo.SizeInMiB)))
 	}
 	return requirements
 }

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -78,16 +78,16 @@ func (p *InstanceTypeProvider) Get(ctx context.Context, provider *v1alpha1.AWS) 
 	}
 	var result []cloudprovider.InstanceType
 	for _, i := range instanceTypes {
-		result = append(result, p.newInstanceType(ctx, i, provider, instanceTypeZones[*i.InstanceType]))
+		result = append(result, p.newInstanceType(ctx, i, provider, p.createOfferings(i, instanceTypeZones[aws.StringValue(i.InstanceType)])))
 	}
 	return result, nil
 }
 
-func (p *InstanceTypeProvider) newInstanceType(ctx context.Context, info *ec2.InstanceTypeInfo, provider *v1alpha1.AWS, zones sets.String) *InstanceType {
+func (p *InstanceTypeProvider) newInstanceType(ctx context.Context, info *ec2.InstanceTypeInfo, provider *v1alpha1.AWS, offerings []cloudprovider.Offering) *InstanceType {
 	instanceType := &InstanceType{
 		InstanceTypeInfo: info,
 		provider:         provider,
-		offerings:        p.createOfferings(info, zones),
+		offerings:        offerings,
 	}
 	// Precompute to minimize memory/compute overhead
 	instanceType.resources = instanceType.computeResources(injection.GetOptions(ctx).AWSEnablePodENI)

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -191,14 +191,14 @@ var _ = Describe("Allocation", func() {
 				ExpectApplied(ctx, env.Client, provisioner)
 				var pods []*v1.Pod
 				for key, value := range map[string]string{
-					v1alpha1.InstanceFamilyLabelKey:          "p3",
-					v1alpha1.InstanceSizeLabelKey:            "xlarge",
-					v1alpha1.InstanceCPULabelKey:             "32",
-					v1alpha1.InstanceMemoryLabelKey:          "249856",
-					v1alpha1.InstanceGPUNameLabelKey:         "nvidia-v100",
-					v1alpha1.InstanceGPUManufacturerLabelKey: "nvidia",
-					v1alpha1.InstanceGPUCountLabelKey:        "4",
-					v1alpha1.InstanceGPUMemoryLabelKey:       "16384",
+					v1alpha1.LabelInstanceFamily:          "p3",
+					v1alpha1.LabelInstanceSize:            "xlarge",
+					v1alpha1.LabelInstanceCPU:             "32",
+					v1alpha1.LabelInstanceMemory:          "249856",
+					v1alpha1.LabelInstanceGPUName:         "nvidia-v100",
+					v1alpha1.LabelInstanceGPUManufacturer: "nvidia",
+					v1alpha1.LabelInstanceGPUCount:        "4",
+					v1alpha1.LabelInstanceGPUMemory:       "16384",
 				} {
 					pods = append(pods, test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{key: value}}))
 				}
@@ -1322,14 +1322,14 @@ var _ = Describe("Allocation", func() {
 			})
 			It("should support well known labels", func() {
 				for _, label := range []string{
-					v1alpha1.InstanceFamilyLabelKey,
-					v1alpha1.InstanceSizeLabelKey,
-					v1alpha1.InstanceCPULabelKey,
-					v1alpha1.InstanceMemoryLabelKey,
-					v1alpha1.InstanceGPUNameLabelKey,
-					v1alpha1.InstanceGPUManufacturerLabelKey,
-					v1alpha1.InstanceGPUCountLabelKey,
-					v1alpha1.InstanceGPUMemoryLabelKey,
+					v1alpha1.LabelInstanceFamily,
+					v1alpha1.LabelInstanceSize,
+					v1alpha1.LabelInstanceCPU,
+					v1alpha1.LabelInstanceMemory,
+					v1alpha1.LabelInstanceGPUName,
+					v1alpha1.LabelInstanceGPUManufacturer,
+					v1alpha1.LabelInstanceGPUCount,
+					v1alpha1.LabelInstanceGPUMemory,
 				} {
 					provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
 					Expect(provisioner.Validate(ctx)).To(Succeed())

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -58,7 +58,9 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 	// Labels
 	labels := map[string]string{}
 	for key, values := range instanceType.Requirements() {
-		labels[key] = values.Any()
+		if values.Len() == 1 {
+			labels[key] = values.Any()
+		}
 	}
 	// Find Offering
 	for _, o := range instanceType.Offerings() {

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -201,13 +201,15 @@ func (i *InstanceType) Requirements() scheduling.Requirements {
 		v1.LabelOSStable:           sets.NewSet(i.options.OperatingSystems.List()...),
 		v1.LabelTopologyZone:       sets.NewSet(lo.Map(i.Offerings(), func(o cloudprovider.Offering, _ int) string { return o.Zone })...),
 		v1alpha5.LabelCapacityType: sets.NewSet(lo.Map(i.Offerings(), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
+		InstanceSizeLabelKey:       sets.NewSet(),
+		ExoticInstanceLabelKey:     sets.NewSet(),
 	}
 	if i.options.Resources.Cpu().Cmp(resource.MustParse("4")) > 0 &&
 		i.options.Resources.Memory().Cmp(resource.MustParse("8Gi")) > 0 {
-		requirements.Add(scheduling.Requirements{InstanceSizeLabelKey: sets.NewSet("large")})
-		requirements.Add(scheduling.Requirements{ExoticInstanceLabelKey: sets.NewSet("optional")})
+		requirements[InstanceSizeLabelKey] = sets.NewSet("large")
+		requirements[ExoticInstanceLabelKey] = sets.NewSet("optional")
 	} else {
-		requirements.Add(scheduling.Requirements{InstanceSizeLabelKey: sets.NewSet("small")})
+		requirements[InstanceSizeLabelKey] = sets.NewSet("small")
 	}
 	return requirements
 }

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -34,13 +34,13 @@ import (
 )
 
 const (
-	InstanceSizeLabelKey   = "size"
+	LabelInstanceSize      = "size"
 	ExoticInstanceLabelKey = "special"
 )
 
 func init() {
 	v1alpha5.WellKnownLabels.Insert(
-		InstanceSizeLabelKey,
+		LabelInstanceSize,
 		ExoticInstanceLabelKey,
 	)
 }
@@ -201,15 +201,15 @@ func (i *InstanceType) Requirements() scheduling.Requirements {
 		v1.LabelOSStable:           sets.NewSet(i.options.OperatingSystems.List()...),
 		v1.LabelTopologyZone:       sets.NewSet(lo.Map(i.Offerings(), func(o cloudprovider.Offering, _ int) string { return o.Zone })...),
 		v1alpha5.LabelCapacityType: sets.NewSet(lo.Map(i.Offerings(), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
-		InstanceSizeLabelKey:       sets.NewSet(),
+		LabelInstanceSize:          sets.NewSet(),
 		ExoticInstanceLabelKey:     sets.NewSet(),
 	}
 	if i.options.Resources.Cpu().Cmp(resource.MustParse("4")) > 0 &&
 		i.options.Resources.Memory().Cmp(resource.MustParse("8Gi")) > 0 {
-		requirements[InstanceSizeLabelKey] = sets.NewSet("large")
+		requirements[LabelInstanceSize] = sets.NewSet("large")
 		requirements[ExoticInstanceLabelKey] = sets.NewSet("optional")
 	} else {
-		requirements[InstanceSizeLabelKey] = sets.NewSet("small")
+		requirements[LabelInstanceSize] = sets.NewSet("small")
 	}
 	return requirements
 }

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -65,7 +65,7 @@ type InstanceType interface {
 	// Name of the instance type, must correspond to v1.LabelInstanceTypeStable
 	Name() string
 	// Requirements returns a flexible set of properties that may be selected
-	// for scheduling. Must be defined for every well known label.
+	// for scheduling. Must be defined for every well known label, even if empty.
 	Requirements() scheduling.Requirements
 	// Note that though this is an array it is expected that all the Offerings are unique from one another
 	Offerings() []Offering

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -162,7 +162,6 @@ func (p *Provisioner) getPods(ctx context.Context) ([]*v1.Pod, error) {
 	return pods, nil
 }
 
-//gocyclo:ignore
 func (p *Provisioner) schedule(ctx context.Context, pods []*v1.Pod) ([]*scheduler.Node, error) {
 	defer metrics.Measure(schedulingDuration.WithLabelValues(injection.GetNamespacedName(ctx).Name))()
 

--- a/pkg/controllers/provisioning/scheduling/node.go
+++ b/pkg/controllers/provisioning/scheduling/node.go
@@ -75,7 +75,7 @@ func (n *Node) Add(pod *v1.Pod) error {
 
 	// Check Node Affinity Requirements
 	if err := nodeRequirements.Compatible(podRequirements); err != nil {
-		return err
+		return fmt.Errorf("incompatible requirements, %w", err)
 	}
 	nodeRequirements.Add(podRequirements)
 

--- a/pkg/controllers/provisioning/scheduling/node.go
+++ b/pkg/controllers/provisioning/scheduling/node.go
@@ -127,7 +127,7 @@ func filterInstanceTypes(instanceTypes []cloudprovider.InstanceType, requirement
 }
 
 func compatible(instanceType cloudprovider.InstanceType, requirements scheduling.Requirements) bool {
-	return instanceType.Requirements().Intersects(requirements, v1alpha5.WellKnownLabels) == nil
+	return instanceType.Requirements().Intersects(requirements) == nil
 }
 
 func fits(instanceType cloudprovider.InstanceType, requests v1.ResourceList) bool {

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -408,7 +408,7 @@ var _ = Describe("Custom Constraints", func() {
 					{Key: "test-key", Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-value"}},
 				}}))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
-			Expect(node.Labels).ToNot(HaveKeyWithValue("test-key", "test-value"))
+			Expect(node.Labels).ToNot(HaveKey("test-key"))
 		})
 		It("should not schedule pods that have node selectors with Exists operator and undefined key", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
@@ -2948,8 +2948,8 @@ var _ = Describe("Instance Type Compatibility", func() {
 			cloudProv.InstanceTypes = fake.InstanceTypes(5)
 			ExpectApplied(ctx, env.Client, provisioner)
 			pods := ExpectProvisioned(ctx, env.Client, controller,
-				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.InstanceSizeLabelKey: "large"}}),
-				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.InstanceSizeLabelKey: "small"}}),
+				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.LabelInstanceSize: "large"}}),
+				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.LabelInstanceSize: "small"}}),
 			)
 			node := ExpectScheduled(ctx, env.Client, pods[0])
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "fake-it-4"))
@@ -2961,11 +2961,11 @@ var _ = Describe("Instance Type Compatibility", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 			pods := ExpectProvisioned(ctx, env.Client, controller,
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{
-					fake.InstanceSizeLabelKey:  "large",
+					fake.LabelInstanceSize:  "large",
 					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[0].Name(),
 				}}),
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{
-					fake.InstanceSizeLabelKey:  "small",
+					fake.LabelInstanceSize:  "small",
 					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[4].Name(),
 				}}),
 			)

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2948,8 +2948,8 @@ var _ = Describe("Instance Type Compatibility", func() {
 			cloudProv.InstanceTypes = fake.InstanceTypes(5)
 			ExpectApplied(ctx, env.Client, provisioner)
 			pods := ExpectProvisioned(ctx, env.Client, controller,
-				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{"size": "large"}}),
-				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{"size": "small"}}),
+				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.InstanceSizeLabelKey: "large"}}),
+				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.InstanceSizeLabelKey: "small"}}),
 			)
 			node := ExpectScheduled(ctx, env.Client, pods[0])
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "fake-it-4"))
@@ -2961,11 +2961,11 @@ var _ = Describe("Instance Type Compatibility", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 			pods := ExpectProvisioned(ctx, env.Client, controller,
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{
-					"size":                     "large",
+					fake.InstanceSizeLabelKey:  "large",
 					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[0].Name(),
 				}}),
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{
-					"size":                     "small",
+					fake.InstanceSizeLabelKey:  "small",
 					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[4].Name(),
 				}}),
 			)

--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -135,7 +135,7 @@ func (r Requirements) Compatible(requirements Requirements) (errs error) {
 		if operator := requirements.Get(key).Type(); r.Has(key) || operator == v1.NodeSelectorOpNotIn || operator == v1.NodeSelectorOpDoesNotExist {
 			continue
 		}
-		errs = multierr.Append(errs, fmt.Errorf("%s not in %s, key %s", requirements.Get(key), r.Get(key), key))
+		errs = multierr.Append(errs, fmt.Errorf("key %s does not have known values", key))
 	}
 	// Well Known Labels must intersect, but if not defined, are allowed.
 	return multierr.Append(errs, r.Intersects(requirements))
@@ -155,7 +155,7 @@ func (r Requirements) Intersects(requirements Requirements) (errs error) {
 					continue
 				}
 			}
-			errs = multierr.Append(errs, fmt.Errorf("%s not in %s, key %s", incoming, existing, key))
+			errs = multierr.Append(errs, fmt.Errorf("key %s, %s not in %s", key, incoming, existing))
 		}
 	}
 	return errs

--- a/pkg/utils/sets/suite_test.go
+++ b/pkg/utils/sets/suite_test.go
@@ -72,8 +72,5 @@ var _ = Describe("Set", func() {
 		It("A should not have B", func() {
 			Expect(setA.Has("B")).To(BeFalse())
 		})
-		It("Should panic when call A' values", func() {
-			Expect(func() { setAComplement.Values() }).To(Panic())
-		})
 	})
 })


### PR DESCRIPTION
**1. Issue, if available:**


**2. Description of changes:**

```
karpenter-6cf9b544fb-wn8sl controller 2022-06-06T21:01:48.488Z	ERROR	controller	Scheduling pod, incompatible with provisioner "default", incompatible requirements, for key karpenter.sh/capacity-type, [spot] not in [on-demand]	{"commit": "08998cb", "pod": "default/inflate-6776857d54-dmgn5"}
```
```
karpenter-6cf9b544fb-wn8sl controller 2022-06-06T21:05:08.529Z	ERROR	controller	Scheduling pod, incompatible with provisioner "default", no instance type satisfied resources {"cpu":"1","pods":"1"} and requirements karpenter.sh/provisioner-name In [default], karpenter.sh/capacity-type In [invalid], kubernetes.io/arch In [amd64], eks.amazonaws.com/nodegroup DoesNotExist []	{"commit": "08998cb", "pod": "default/inflate-57f4ccfb9f-fzmx6"}
```
```
karpenter-bd4dcc8b6-fht89 controller 2022-06-06T22:11:09.683Z	ERROR	controller	Scheduling pod, incompatible with provisioner "default", incompatible requirements, key foo does not have known values	{"commit": "3d0434a", "pod": "default/inflate-8c89655b-fqql4"}
```

**3. How was this change tested?**


**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
