### PR TITLE
Remove UserData from docs

### DIFF
--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -241,13 +241,6 @@ spec:
           snapshotID: snap-0123456789
 ```
 
-### UserData
-
-You can control the UserData that needs to be applied to your worker nodes via the `spec.providerRef` field in your provisioner.
-Review the [Custom UserData documentation](../user-data/) to learn the necessary steps.
-
-If you need to specify a launch template in addition to UserData, then review the [Launch Template documentation](../launch-templates/) instead and utilize the `spec.provider.launchTemplate` field.
-
 ## Other Resources
 
 ### Accelerators, GPU

--- a/website/content/en/preview/AWS/user-data.md
+++ b/website/content/en/preview/AWS/user-data.md
@@ -1,11 +1,3 @@
----
-title: "User Data Configuration"
-linkTitle: "UserData"
-weight: 10
-description: >
-  Learn how to configure custom UserData with Karpenter
----
-
 This document describes how you can customize the UserData that will be specified on your EC2 worker nodes, without using a launch template.
 
 ## Configuration


### PR DESCRIPTION
- Remove UserData from docs

**1. Issue, if available:**
N/A

**2. Description of changes:**
* Removing UserData from docs so this will remain an undocumented feature until we complete the migration of all provider parameters to `providerRef`. 
* If anyone wants to try it out, I can just point them to a page that's not present in the left-nav like `http://localhost:1313/preview/aws/user-data/`.

**3. How was this change tested?**
I ran `make website` and ensured that UserData isn't present in the left-nav. 

**4. Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
