### PR TITLE
update provisioner status upon node creation

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -119,7 +119,7 @@ func main() {
 		metricspod.NewController(manager.GetClient()),
 		metricsnode.NewController(manager.GetClient()),
 		metricsprovisioner.NewController(manager.GetClient()),
-		counter.NewController(manager.GetClient()),
+		counter.NewController(manager.GetClient(), cluster),
 	).Start(ctx); err != nil {
 		panic(fmt.Sprintf("Unable to start manager, %s", err))
 	}

--- a/pkg/controllers/counter/controller.go
+++ b/pkg/controllers/counter/controller.go
@@ -16,10 +16,14 @@ package counter
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/aws/karpenter/pkg/controllers/state"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,12 +40,14 @@ import (
 // Controller for the resource
 type Controller struct {
 	kubeClient client.Client
+	cluster    *state.Cluster
 }
 
 // NewController is a constructor
-func NewController(kubeClient client.Client) *Controller {
+func NewController(kubeClient client.Client, cluster *state.Cluster) *Controller {
 	return &Controller{
 		kubeClient: kubeClient,
+		cluster:    cluster,
 	}
 }
 
@@ -55,8 +61,19 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 	persisted := provisioner.DeepCopy()
+
+	nodes := v1.NodeList{}
+	if err := c.kubeClient.List(ctx, &nodes, client.MatchingLabels{v1alpha5.ProvisionerNameLabelKey: provisioner.Name}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Nodes aren't synced yet, so retry quickly.  In testing this never fires more than once.
+	if !c.nodesSynced(nodes.Items, provisioner.Name) {
+		return reconcile.Result{RequeueAfter: 250 * time.Millisecond}, nil
+	}
+
 	// Determine resource usage and update provisioner.status.resources
-	resourceCounts, err := c.resourceCountsFor(ctx, provisioner.Name)
+	resourceCounts, err := c.resourceCountsFor(provisioner.Name)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("computing resource usage, %w", err)
 	}
@@ -67,25 +84,27 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{}, nil
 }
 
-func (c *Controller) resourceCountsFor(ctx context.Context, provisionerName string) (v1.ResourceList, error) {
-	nodes := v1.NodeList{}
-	if err := c.kubeClient.List(ctx, &nodes, client.MatchingLabels{v1alpha5.ProvisionerNameLabelKey: provisionerName}); err != nil {
-		return nil, err
-	}
+func (c *Controller) resourceCountsFor(provisionerName string) (v1.ResourceList, error) {
+	var provisioned []v1.ResourceList
+	// Record all resources provisioned by the provisioners, we look at the cluster state nodes as their capacity
+	// is accurately reported even for nodes that haven't fully started yet. This allows us to update our provisioner
+	// status immediately upon node creation instead of waiting for the node to become ready.
+	c.cluster.ForEachNode(func(n *state.Node) bool {
+		if n.Provisioner != nil && n.Provisioner.Name == provisionerName {
+			provisioned = append(provisioned, n.Capacity)
+		}
+		return true
+	})
 
-	// record all resources provisioned by the provisioners
-	provisioned := []v1.ResourceList{
-		{
-			// record some zero values so the status will display something even if no nodes are provisioned
-			v1.ResourceCPU:    resource.MustParse("0"),
-			v1.ResourceMemory: resource.MustParse("0"),
-		},
+	result := v1.ResourceList{}
+	// only report the non-zero resources
+	for key, value := range resources.Merge(provisioned...) {
+		if value.IsZero() {
+			continue
+		}
+		result[key] = value
 	}
-
-	for _, node := range nodes.Items {
-		provisioned = append(provisioned, node.Status.Capacity)
-	}
-	return resources.Merge(provisioned...), nil
+	return result, nil
 }
 
 // Register the controller to the manager
@@ -105,4 +124,33 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Complete(c)
+}
+
+// nodesSynced returns true if the cluster state is synced with the current list cache state with respect to the nodes
+// created by the specified provisioner. Since updates may occur for the counting controller at a different time than
+// the cluster state controller, we don't update the counter state until the states are synced.  An alternative solution
+// would be to add event support to cluster state and listen for those node events instead.
+func (c *Controller) nodesSynced(nodes []v1.Node, provisionerName string) bool {
+	extraNodes := sets.String{}
+	for _, n := range nodes {
+		extraNodes.Insert(n.Name)
+	}
+	missingNode := false
+	c.cluster.ForEachNode(func(n *state.Node) bool {
+		// skip any nodes not created by this provisioner
+		if n.Provisioner == nil || n.Provisioner.Name != provisionerName {
+			return true
+		}
+		if !extraNodes.Has(n.Node.Name) {
+			missingNode = true
+			return false
+		}
+		extraNodes.Delete(n.Node.Name)
+		return true
+	})
+
+	if !missingNode && len(extraNodes) == 0 {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
**1. Issue, if available:**
 N/A

**2. Description of changes:**

Instead of waiting for kubelet to become ready to report the allocated
resources on the provisioner status, pulll it from the cluster state
so it can be updated as soon as the node is launched.

**3. How was this change tested?**

Deployed to EKS and scale-up/scale-down/

**4. Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: *link to issue*
- [X] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
