### PR TITLE
Fix example

### DIFF
--- a/examples/provisioner/general-purpose.yaml
+++ b/examples/provisioner/general-purpose.yaml
@@ -7,11 +7,11 @@ spec:
   provider:
     requirements:
       # Include general purpose instance families
-      - key: karpenter.k8s.aws/instance-family
+      - key: karpenter.k8s.aws/instance.family
         operator: In
         values: [c5, m5, r5]
       # Exclude small instance sizes
-      - key: karpenter.k8s.aws/instance-size
+      - key: karpenter.k8s.aws/instance.size
         operator: NotIn
         values: [nano, micro, small, large]
     subnetSelector:


### PR DESCRIPTION
`invalid value: label karpenter.k8s.aws/instance-family is restricted; specify a well known label: [karpenter.k8s.aws/instance.c
pu karpenter.k8s.aws/instance.family karpenter.k8s.aws/instance.gpu.count karpenter.k8s.aws/instance.gpu.manufacturer karpenter.k8s.aws/instance.gpu.memory karpenter.k8s.aws/instance.gpu.name ka
rpenter.k8s.aws/instance.memory karpenter.k8s.aws/instance.size karpenter.sh/capacity-type kubernetes.io/arch kubernetes.io/os node.kubernetes.io/instance-type topology.kubernetes.io/zone], or a
custom label that does use a restricted domain: [k8s.io karpenter.k8s.aws karpenter.sh kubernetes.io]`