### PR TITLE
Fix: AWS Well Known Labels now use - instead of . to align with upstream

### DIFF
--- a/examples/provisioner/general-purpose.yaml
+++ b/examples/provisioner/general-purpose.yaml
@@ -7,11 +7,11 @@ spec:
   provider:
     requirements:
       # Include general purpose instance families
-      - key: karpenter.k8s.aws/instance.family
+      - key: karpenter.k8s.aws/instance-family
         operator: In
         values: [c5, m5, r5]
       # Exclude small instance sizes
-      - key: karpenter.k8s.aws/instance.size
+      - key: karpenter.k8s.aws/instance-size
         operator: NotIn
         values: [nano, micro, small, large]
     subnetSelector:

--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/samber/lo"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 )
@@ -56,14 +57,24 @@ var (
 	ResourceAWSNeuron v1.ResourceName = "aws.amazon.com/neuron"
 	ResourceAWSPodENI v1.ResourceName = "vpc.amazonaws.com/pod-eni"
 
-	LabelInstanceFamily          = LabelDomain + "/instance.family"
-	LabelInstanceSize            = LabelDomain + "/instance.size"
-	LabelInstanceCPU             = LabelDomain + "/instance.cpu"
-	LabelInstanceMemory          = LabelDomain + "/instance.memory"
-	LabelInstanceGPUName         = LabelDomain + "/instance.gpu.name"
-	LabelInstanceGPUManufacturer = LabelDomain + "/instance.gpu.manufacturer"
-	LabelInstanceGPUCount        = LabelDomain + "/instance.gpu.count"
-	LabelInstanceGPUMemory       = LabelDomain + "/instance.gpu.memory"
+	LabelInstanceFamily          = LabelDomain + "/instance-family"
+	LabelInstanceSize            = LabelDomain + "/instance-size"
+	LabelInstanceCPU             = LabelDomain + "/instance-cpu"
+	LabelInstanceMemory          = LabelDomain + "/instance-memory"
+	LabelInstanceGPUName         = LabelDomain + "/instance-gpu-name"
+	LabelInstanceGPUManufacturer = LabelDomain + "/instance-gpu-manufacturer"
+	LabelInstanceGPUCount        = LabelDomain + "/instance-gpu-count"
+	LabelInstanceGPUMemory       = LabelDomain + "/instance-gpu-memory"
+
+	// Deprecated labels. Use the - notation above instead. Very sad.
+	LabelInstanceFamilyDeprecated          = LabelDomain + "/instance.family"
+	LabelInstanceSizeDeprecated            = LabelDomain + "/instance.size"
+	LabelInstanceCPUDeprecated             = LabelDomain + "/instance.cpu"
+	LabelInstanceMemoryDeprecated          = LabelDomain + "/instance.memory"
+	LabelInstanceGPUNameDeprecated         = LabelDomain + "/instance.gpu.name"
+	LabelInstanceGPUManufacturerDeprecated = LabelDomain + "/instance.gpu.manufacturer"
+	LabelInstanceGPUCountDeprecated        = LabelDomain + "/instance.gpu.count"
+	LabelInstanceGPUMemoryDeprecated       = LabelDomain + "/instance.gpu.memory"
 )
 
 var (
@@ -84,4 +95,14 @@ func init() {
 		LabelInstanceGPUCount,
 		LabelInstanceGPUMemory,
 	)
+	v1alpha5.NormalizedLabels = lo.Assign(v1alpha5.NormalizedLabels, map[string]string{
+		LabelInstanceFamilyDeprecated:          LabelInstanceFamily,
+		LabelInstanceSizeDeprecated:            LabelInstanceSize,
+		LabelInstanceCPUDeprecated:             LabelInstanceCPU,
+		LabelInstanceMemoryDeprecated:          LabelInstanceMemory,
+		LabelInstanceGPUNameDeprecated:         LabelInstanceGPUName,
+		LabelInstanceGPUManufacturerDeprecated: LabelInstanceGPUManufacturer,
+		LabelInstanceGPUCountDeprecated:        LabelInstanceGPUCount,
+		LabelInstanceGPUMemoryDeprecated:       LabelInstanceGPUMemory,
+	})
 }

--- a/website/content/en/preview/tasks/scheduling.md
+++ b/website/content/en/preview/tasks/scheduling.md
@@ -85,14 +85,14 @@ The following labels are supported by Karpenter. They may be specified as provis
 | kubernetes.io/os                            | linux      | Operating systems are defined by [GOOS values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L10) on the instance        |
 | kubernetes.io/arch                          | amd64      | Architectures are defined by [GOARCH values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L50) on the instance          |
 | karpenter.sh/capacity-type                  | spot       | Capacity types include `spot`, `on-demand`                                                                                                  |
-| karpenter.k8s.aws/instance.family           | p3         | [AWS Specific] Instance types of similar properties but different resource quantities                                                       |
-| karpenter.k8s.aws/instance.size             | 8xlarge    | [AWS Specific] Instance types of similar resource quantities but different properties                                                       |
-| karpenter.k8s.aws/instance.cpu              | 32         | [AWS Specific] Number of CPUs on the instance                                                                                               |
-| karpenter.k8s.aws/instance.memory           | 249856     | [AWS Specific] Number of mebibytes of memory on the instance                                                                                |
-| karpenter.k8s.aws/instance.gpu.name         | v100       | [AWS Specific] Name of the GPU on the instance, if available                                                                                |
-| karpenter.k8s.aws/instance.gpu.manufacturer | nvidia     | [AWS Specific] Name of the GPU manufacturer                                                                                                 |
-| karpenter.k8s.aws/instance.gpu.count        | 4          | [AWS Specific] Number of GPUs on the instance                                                                                               |
-| karpenter.k8s.aws/instance.gpu.memory       | 16384      | [AWS Specific] Number of mebibytes of memory on the GPU                                                                                     |
+| karpenter.k8s.aws/instance-family           | p3         | [AWS Specific] Instance types of similar properties but different resource quantities                                                       |
+| karpenter.k8s.aws/instance-size             | 8xlarge    | [AWS Specific] Instance types of similar resource quantities but different properties                                                       |
+| karpenter.k8s.aws/instance-cpu              | 32         | [AWS Specific] Number of CPUs on the instance                                                                                               |
+| karpenter.k8s.aws/instance-memory           | 249856     | [AWS Specific] Number of mebibytes of memory on the instance                                                                                |
+| karpenter.k8s.aws/instance-gpu-name         | v100       | [AWS Specific] Name of the GPU on the instance, if available                                                                                |
+| karpenter.k8s.aws/instance-gpu-manufacturer | nvidia     | [AWS Specific] Name of the GPU manufacturer                                                                                                 |
+| karpenter.k8s.aws/instance-gpu-count        | 4          | [AWS Specific] Number of GPUs on the instance                                                                                               |
+| karpenter.k8s.aws/instance-gpu-memory       | 16384      | [AWS Specific] Number of mebibytes of memory on the GPU                                                                                     |
 
 ### Node selectors
 
@@ -195,7 +195,7 @@ metadata:
   name: gpu
 spec:
   requirements:
-  - key: karpenter.k8s.aws/instance.family
+  - key: karpenter.k8s.aws/instance-family
     operator: In
     values:
       - p3


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
See discussion thread: https://kubernetes.slack.com/archives/C02SFFZSA2K/p1655266249940299

**How was this change tested?**

* Unit, Manual

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
AWS Well Known Labels now use - instead of . to align with upstream
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
