### PR TITLE
feat: add instance-hypervisor as an AWS node label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ codegen: ## Generate code. Must be run if changes are made to ./pkg/apis/...
 
 docgen: ## Generate docs
 	go run hack/docs/metrics_gen_docs.go pkg/ website/content/en/preview/tasks/metrics.md
-	go run hack/docs/instancetypes_gen_docs.go ${KARPENTER_SUBNET_SELECTOR} website/content/en/preview/AWS/instance-types.md
+	go run hack/docs/instancetypes_gen_docs.go website/content/en/preview/AWS/instance-types.md
      
 release: ## Generate release manifests and publish a versioned container image.
 	$(WITH_GOFLAGS) ./hack/release.sh

--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -57,6 +57,7 @@ var (
 	ResourceAWSNeuron v1.ResourceName = "aws.amazon.com/neuron"
 	ResourceAWSPodENI v1.ResourceName = "vpc.amazonaws.com/pod-eni"
 
+	LabelInstanceHypervisor      = LabelDomain + "/instance-hypervisor"
 	LabelInstanceFamily          = LabelDomain + "/instance-family"
 	LabelInstanceSize            = LabelDomain + "/instance-size"
 	LabelInstanceCPU             = LabelDomain + "/instance-cpu"
@@ -86,6 +87,7 @@ func init() {
 	Scheme.AddKnownTypes(schema.GroupVersion{Group: v1alpha5.ExtensionsGroup, Version: "v1alpha1"}, &AWS{})
 	v1alpha5.RestrictedLabelDomains = v1alpha5.RestrictedLabelDomains.Insert(RestrictedLabelDomains...)
 	v1alpha5.WellKnownLabels = v1alpha5.WellKnownLabels.Insert(
+		LabelInstanceHypervisor,
 		LabelInstanceFamily,
 		LabelInstanceSize,
 		LabelInstanceCPU,

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -353,7 +353,7 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2
 				SupportedVirtualizationTypes:  []*string{aws.String("hvm")},
 				BurstablePerformanceSupported: aws.Bool(false),
 				BareMetal:                     aws.Bool(false),
-				Hypervisor:                    aws.String("nitro"),
+				Hypervisor:                    aws.String("xen"),
 				ProcessorInfo: &ec2.ProcessorInfo{
 					SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
 				},

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -128,6 +128,7 @@ func (i *InstanceType) computeRequirements() scheduling.Requirements {
 		v1alpha1.LabelInstanceGPUManufacturer: sets.NewSet(),
 		v1alpha1.LabelInstanceGPUCount:        sets.NewSet(),
 		v1alpha1.LabelInstanceGPUMemory:       sets.NewSet(),
+		v1alpha1.LabelInstanceHypervisor:      sets.NewSet(aws.StringValue(i.Hypervisor)),
 	}
 	// Instance Type Labels
 	instanceTypeParts := strings.Split(aws.StringValue(i.InstanceType), ".")

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -192,6 +192,7 @@ var _ = Describe("Allocation", func() {
 				ExpectApplied(ctx, env.Client, provisioner)
 				var pods []*v1.Pod
 				for key, value := range map[string]string{
+					v1alpha1.LabelInstanceHypervisor:      "xen",
 					v1alpha1.LabelInstanceFamily:          "p3",
 					v1alpha1.LabelInstanceSize:            "xlarge",
 					v1alpha1.LabelInstanceCPU:             "32",
@@ -1384,6 +1385,7 @@ var _ = Describe("Allocation", func() {
 			})
 			It("should support well known labels", func() {
 				for _, label := range []string{
+					v1alpha1.LabelInstanceHypervisor,
 					v1alpha1.LabelInstanceFamily,
 					v1alpha1.LabelInstanceSize,
 					v1alpha1.LabelInstanceCPU,

--- a/website/content/en/preview/AWS/instance-types.md
+++ b/website/content/en/preview/AWS/instance-types.md
@@ -19,6 +19,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|a1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -37,6 +38,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|a1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -55,6 +57,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|a1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -73,6 +76,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|a1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -91,6 +95,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|a1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -109,6 +114,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|a1|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -128,6 +134,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|1740|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|amd64|
@@ -146,6 +153,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|7168|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -165,6 +173,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|3840|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -183,6 +192,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|7680|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -201,6 +211,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15360|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -219,6 +230,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|30720|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -237,6 +249,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|61440|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -256,6 +269,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|3840|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -274,6 +288,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|7680|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -292,6 +307,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15360|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -310,6 +326,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|30720|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -328,6 +345,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|36|
  |karpenter.k8s.aws/instance-family|c4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|61440|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -347,6 +365,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -365,6 +384,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -383,6 +403,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -401,6 +422,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -419,6 +441,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|36|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|73728|
  |karpenter.k8s.aws/instance-size|9xlarge|
  |kubernetes.io/arch|amd64|
@@ -437,6 +460,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -455,6 +479,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|72|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|147456|
  |karpenter.k8s.aws/instance-size|18xlarge|
  |kubernetes.io/arch|amd64|
@@ -473,6 +498,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -491,6 +517,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c5|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -510,6 +537,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -528,6 +556,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -546,6 +575,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -564,6 +594,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -582,6 +613,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -600,6 +632,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -618,6 +651,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -636,6 +670,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -655,6 +690,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -673,6 +709,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -691,6 +728,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -709,6 +747,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -727,6 +766,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -745,6 +785,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -763,6 +804,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -781,6 +823,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -800,6 +843,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -818,6 +862,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -836,6 +881,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -854,6 +900,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -872,6 +919,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|36|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|73728|
  |karpenter.k8s.aws/instance-size|9xlarge|
  |kubernetes.io/arch|amd64|
@@ -890,6 +938,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -908,6 +957,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|72|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|147456|
  |karpenter.k8s.aws/instance-size|18xlarge|
  |kubernetes.io/arch|amd64|
@@ -926,6 +976,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -944,6 +995,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c5d|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -963,6 +1015,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|5376|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -981,6 +1034,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|10752|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -999,6 +1053,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|21504|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -1017,6 +1072,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|43008|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -1035,6 +1091,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|36|
  |karpenter.k8s.aws/instance-family|c5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|9xlarge|
  |kubernetes.io/arch|amd64|
@@ -1053,6 +1110,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|72|
  |karpenter.k8s.aws/instance-family|c5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|18xlarge|
  |kubernetes.io/arch|amd64|
@@ -1071,6 +1129,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|72|
  |karpenter.k8s.aws/instance-family|c5n|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -1090,6 +1149,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -1108,6 +1168,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -1126,6 +1187,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -1144,6 +1206,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -1162,6 +1225,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -1180,6 +1244,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -1198,6 +1263,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -1216,6 +1282,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -1234,6 +1301,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -1252,6 +1320,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|192|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|48xlarge|
  |kubernetes.io/arch|amd64|
@@ -1270,6 +1339,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|192|
  |karpenter.k8s.aws/instance-family|c6a|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -1289,6 +1359,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -1307,6 +1378,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -1325,6 +1397,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -1343,6 +1416,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -1361,6 +1435,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -1379,6 +1454,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -1397,6 +1473,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -1415,6 +1492,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -1433,6 +1511,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6g|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -1452,6 +1531,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -1470,6 +1550,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -1488,6 +1569,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -1506,6 +1588,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -1524,6 +1607,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -1542,6 +1626,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -1560,6 +1645,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -1578,6 +1664,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -1596,6 +1683,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6gd|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -1615,6 +1703,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -1633,6 +1722,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -1651,6 +1741,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -1669,6 +1760,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -1687,6 +1779,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -1705,6 +1798,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -1723,6 +1817,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -1741,6 +1836,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -1760,6 +1856,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -1778,6 +1875,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -1796,6 +1894,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -1814,6 +1913,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -1832,6 +1932,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -1850,6 +1951,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -1868,6 +1970,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -1886,6 +1989,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -1904,6 +2008,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -1922,6 +2027,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|c6i|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -1941,6 +2047,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -1959,6 +2066,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -1977,6 +2085,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -1995,6 +2104,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -2013,6 +2123,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -2031,6 +2142,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -2049,6 +2161,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -2067,6 +2180,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -2085,6 +2199,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -2103,6 +2218,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|c6id|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -2122,6 +2238,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -2140,6 +2257,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -2158,6 +2276,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -2176,6 +2295,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -2194,6 +2314,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -2212,6 +2333,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -2230,6 +2352,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -2248,6 +2371,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|c7g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -2267,6 +2391,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|cc2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|61952|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |karpenter.sh/capacity-type|on-demand|
@@ -2287,6 +2412,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|d2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|31232|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -2305,6 +2431,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|d2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -2323,6 +2450,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|d2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -2341,6 +2469,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|36|
  |karpenter.k8s.aws/instance-family|d2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -2360,6 +2489,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|d3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -2378,6 +2508,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|d3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -2396,6 +2527,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|d3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -2414,6 +2546,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|d3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -2433,6 +2566,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|d3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -2451,6 +2585,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|d3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -2469,6 +2604,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|d3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -2487,6 +2623,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|24|
  |karpenter.k8s.aws/instance-family|d3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|6xlarge|
  |kubernetes.io/arch|amd64|
@@ -2505,6 +2642,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|d3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -2523,6 +2661,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|d3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -2546,6 +2685,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|habana|
  |karpenter.k8s.aws/instance-gpu-memory|32768|
  |karpenter.k8s.aws/instance-gpu-name|gaudi-hl-205|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -2569,6 +2709,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|m60|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -2592,6 +2733,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|m60|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -2615,6 +2757,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|m60|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -2639,6 +2782,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|m60|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|31232|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -2663,6 +2807,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -2686,6 +2831,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -2709,6 +2855,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -2732,6 +2879,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -2755,6 +2903,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
  |karpenter.k8s.aws/instance-gpu-memory|8192|
  |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -2779,6 +2928,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -2802,6 +2952,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -2825,6 +2976,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -2848,6 +3000,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -2871,6 +3024,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -2894,6 +3048,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -2917,6 +3072,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -2941,6 +3097,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -2964,6 +3121,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -2987,6 +3145,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -3010,6 +3169,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -3033,6 +3193,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -3056,6 +3217,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -3079,6 +3241,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -3102,6 +3265,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|24576|
  |karpenter.k8s.aws/instance-gpu-name|a10g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|48xlarge|
  |kubernetes.io/arch|amd64|
@@ -3126,6 +3290,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -3149,6 +3314,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -3172,6 +3338,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -3195,6 +3362,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -3218,6 +3386,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -3241,6 +3410,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|t4g|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -3261,6 +3431,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|h1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -3279,6 +3450,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|h1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -3297,6 +3469,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|h1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -3315,6 +3488,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|h1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -3334,6 +3508,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|i2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|31232|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -3352,6 +3527,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|i2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -3370,6 +3546,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|i2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -3388,6 +3565,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|i2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -3407,6 +3585,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|i3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15616|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -3425,6 +3604,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|i3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|31232|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -3443,6 +3623,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|i3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -3461,6 +3642,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|i3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -3479,6 +3661,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|i3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -3497,6 +3680,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|i3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -3515,6 +3699,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|72|
  |karpenter.k8s.aws/instance-family|i3|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -3534,6 +3719,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -3552,6 +3738,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -3570,6 +3757,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -3588,6 +3776,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|12|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|3xlarge|
  |kubernetes.io/arch|amd64|
@@ -3606,6 +3795,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|24|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|6xlarge|
  |kubernetes.io/arch|amd64|
@@ -3624,6 +3814,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -3642,6 +3833,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -3660,6 +3852,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|i3en|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -3679,6 +3872,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -3697,6 +3891,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -3715,6 +3910,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -3733,6 +3929,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -3751,6 +3948,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -3769,6 +3967,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -3787,6 +3986,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -3805,6 +4005,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|i4i|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -3824,6 +4025,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|im4gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -3842,6 +4044,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|im4gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -3860,6 +4063,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|im4gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -3878,6 +4082,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|im4gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -3896,6 +4101,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|im4gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -3914,6 +4120,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|im4gn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -3933,6 +4140,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|inf1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -3952,6 +4160,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|inf1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -3971,6 +4180,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|24|
  |karpenter.k8s.aws/instance-family|inf1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|49152|
  |karpenter.k8s.aws/instance-size|6xlarge|
  |kubernetes.io/arch|amd64|
@@ -3990,6 +4200,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|inf1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -4010,6 +4221,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|is4gen|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|6144|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -4028,6 +4240,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|is4gen|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|12288|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -4046,6 +4259,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|is4gen|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|24576|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -4064,6 +4278,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|is4gen|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|49152|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -4082,6 +4297,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|is4gen|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -4100,6 +4316,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|is4gen|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -4119,6 +4336,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|m1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|1740|
  |karpenter.k8s.aws/instance-size|small|
  |kubernetes.io/arch|amd64|
@@ -4137,6 +4355,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|m1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|3788|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|amd64|
@@ -4155,6 +4374,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|7680|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -4173,6 +4393,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15360|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4192,6 +4413,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|17510|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4210,6 +4432,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|35020|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -4228,6 +4451,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|70041|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -4247,6 +4471,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|m3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|3840|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|amd64|
@@ -4265,6 +4490,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|7680|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -4283,6 +4509,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15360|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4301,6 +4528,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|30720|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -4320,6 +4548,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -4338,6 +4567,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4356,6 +4586,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -4374,6 +4605,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -4392,6 +4624,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|40|
  |karpenter.k8s.aws/instance-family|m4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|163840|
  |karpenter.k8s.aws/instance-size|10xlarge|
  |kubernetes.io/arch|amd64|
@@ -4410,6 +4643,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -4429,6 +4663,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -4447,6 +4682,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4465,6 +4701,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -4483,6 +4720,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -4501,6 +4739,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -4519,6 +4758,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -4537,6 +4777,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -4555,6 +4796,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -4573,6 +4815,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -4592,6 +4835,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -4610,6 +4854,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4628,6 +4873,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -4646,6 +4892,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -4664,6 +4911,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -4682,6 +4930,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -4700,6 +4949,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -4718,6 +4968,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -4737,6 +4988,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -4755,6 +5007,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4773,6 +5026,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -4791,6 +5045,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -4809,6 +5064,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -4827,6 +5083,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -4845,6 +5102,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -4863,6 +5121,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -4882,6 +5141,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -4900,6 +5160,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -4918,6 +5179,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -4936,6 +5198,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -4954,6 +5217,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -4972,6 +5236,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -4990,6 +5255,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -5008,6 +5274,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -5026,6 +5293,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5d|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -5045,6 +5313,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -5063,6 +5332,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -5081,6 +5351,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -5099,6 +5370,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -5117,6 +5389,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -5135,6 +5408,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -5153,6 +5427,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -5171,6 +5446,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -5189,6 +5465,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5dn|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -5208,6 +5485,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -5226,6 +5504,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -5244,6 +5523,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -5262,6 +5542,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -5280,6 +5561,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -5298,6 +5580,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -5316,6 +5599,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -5334,6 +5618,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -5352,6 +5637,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m5n|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -5371,6 +5657,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m5zn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -5389,6 +5676,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m5zn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -5407,6 +5695,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m5zn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -5425,6 +5714,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|12|
  |karpenter.k8s.aws/instance-family|m5zn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|49152|
  |karpenter.k8s.aws/instance-size|3xlarge|
  |kubernetes.io/arch|amd64|
@@ -5443,6 +5733,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|24|
  |karpenter.k8s.aws/instance-family|m5zn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|6xlarge|
  |kubernetes.io/arch|amd64|
@@ -5461,6 +5752,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5zn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -5479,6 +5771,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m5zn|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -5498,6 +5791,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -5516,6 +5810,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -5534,6 +5829,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -5552,6 +5848,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -5570,6 +5867,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -5588,6 +5886,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -5606,6 +5905,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -5624,6 +5924,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -5642,6 +5943,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -5660,6 +5962,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|192|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|48xlarge|
  |kubernetes.io/arch|amd64|
@@ -5678,6 +5981,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|192|
  |karpenter.k8s.aws/instance-family|m6a|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -5697,6 +6001,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -5715,6 +6020,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -5733,6 +6039,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -5751,6 +6058,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -5769,6 +6077,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -5787,6 +6096,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -5805,6 +6115,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -5823,6 +6134,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -5841,6 +6153,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m6g|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -5860,6 +6173,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -5878,6 +6192,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -5896,6 +6211,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -5914,6 +6230,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -5932,6 +6249,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -5950,6 +6268,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -5968,6 +6287,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -5986,6 +6306,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -6004,6 +6325,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m6gd|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -6023,6 +6345,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -6041,6 +6364,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -6059,6 +6383,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -6077,6 +6402,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -6095,6 +6421,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -6113,6 +6440,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -6131,6 +6459,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -6149,6 +6478,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -6167,6 +6497,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -6185,6 +6516,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|m6i|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -6204,6 +6536,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -6222,6 +6555,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -6240,6 +6574,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -6258,6 +6593,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -6276,6 +6612,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -6294,6 +6631,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -6312,6 +6650,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -6330,6 +6669,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -6348,6 +6688,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -6366,6 +6707,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|m6id|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -6389,6 +6731,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|12288|
  |karpenter.k8s.aws/instance-gpu-name|k80|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -6412,6 +6755,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|12288|
  |karpenter.k8s.aws/instance-gpu-name|k80|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -6435,6 +6779,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|12288|
  |karpenter.k8s.aws/instance-gpu-name|k80|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|749568|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -6459,6 +6804,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|v100|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -6482,6 +6828,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|v100|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -6505,6 +6852,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|16384|
  |karpenter.k8s.aws/instance-gpu-name|v100|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -6529,6 +6877,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|32768|
  |karpenter.k8s.aws/instance-gpu-name|v100|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -6553,6 +6902,7 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
  |karpenter.k8s.aws/instance-gpu-memory|40960|
  |karpenter.k8s.aws/instance-gpu-name|a100|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1179648|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -6573,6 +6923,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15360|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -6591,6 +6942,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|31232|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -6609,6 +6961,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -6627,6 +6980,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -6645,6 +6999,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r3|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -6664,6 +7019,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15616|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -6682,6 +7038,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|31232|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -6700,6 +7057,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -6718,6 +7076,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -6736,6 +7095,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -6754,6 +7114,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r4|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -6773,6 +7134,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -6791,6 +7153,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -6809,6 +7172,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -6827,6 +7191,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -6845,6 +7210,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -6863,6 +7229,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -6881,6 +7248,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -6899,6 +7267,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -6917,6 +7286,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -6936,6 +7306,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -6954,6 +7325,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -6972,6 +7344,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -6990,6 +7363,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -7008,6 +7382,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -7026,6 +7401,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -7044,6 +7420,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -7062,6 +7439,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -7081,6 +7459,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -7099,6 +7478,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -7117,6 +7497,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -7135,6 +7516,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -7153,6 +7535,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -7171,6 +7554,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -7189,6 +7573,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -7207,6 +7592,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5ad|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -7226,6 +7612,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -7244,6 +7631,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -7262,6 +7650,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -7280,6 +7669,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -7298,6 +7688,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -7316,6 +7707,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -7334,6 +7726,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -7352,6 +7745,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -7370,6 +7764,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5b|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -7389,6 +7784,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -7407,6 +7803,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -7425,6 +7822,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -7443,6 +7841,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -7461,6 +7860,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -7479,6 +7879,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -7497,6 +7898,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -7515,6 +7917,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -7533,6 +7936,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5d|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -7552,6 +7956,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -7570,6 +7975,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -7588,6 +7994,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -7606,6 +8013,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -7624,6 +8032,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -7642,6 +8051,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -7660,6 +8070,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -7678,6 +8089,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -7696,6 +8108,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5dn|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -7715,6 +8128,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -7733,6 +8147,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -7751,6 +8166,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -7769,6 +8185,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -7787,6 +8204,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -7805,6 +8223,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -7823,6 +8242,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -7841,6 +8261,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -7859,6 +8280,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r5n|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -7878,6 +8300,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -7896,6 +8319,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -7914,6 +8338,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -7932,6 +8357,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -7950,6 +8376,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -7968,6 +8395,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -7986,6 +8414,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -8004,6 +8433,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -8022,6 +8452,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r6g|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -8041,6 +8472,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -8059,6 +8491,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -8077,6 +8510,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -8095,6 +8529,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -8113,6 +8548,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -8131,6 +8567,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -8149,6 +8586,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -8167,6 +8605,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -8185,6 +8624,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r6gd|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -8204,6 +8644,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -8222,6 +8663,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -8240,6 +8682,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -8258,6 +8701,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -8276,6 +8720,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -8294,6 +8739,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -8312,6 +8758,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -8330,6 +8777,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -8348,6 +8796,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -8366,6 +8815,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|r6i|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -8385,6 +8835,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -8403,6 +8854,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -8421,6 +8873,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -8439,6 +8892,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -8457,6 +8911,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -8475,6 +8930,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -8493,6 +8949,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -8511,6 +8968,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -8529,6 +8987,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -8547,6 +9006,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|r6id|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -8566,6 +9026,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|t1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|627|
  |karpenter.k8s.aws/instance-size|micro|
  |kubernetes.io/arch|amd64|
@@ -8585,6 +9046,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|t2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|512|
  |karpenter.k8s.aws/instance-size|nano|
  |karpenter.sh/capacity-type|on-demand|
@@ -8604,6 +9066,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|t2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|1024|
  |karpenter.k8s.aws/instance-size|micro|
  |kubernetes.io/arch|amd64|
@@ -8622,6 +9085,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|t2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|small|
  |kubernetes.io/arch|amd64|
@@ -8640,6 +9104,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|amd64|
@@ -8658,6 +9123,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -8676,6 +9142,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|t2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -8694,6 +9161,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|t2|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -8713,6 +9181,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|512|
  |karpenter.k8s.aws/instance-size|nano|
  |kubernetes.io/arch|amd64|
@@ -8731,6 +9200,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1024|
  |karpenter.k8s.aws/instance-size|micro|
  |kubernetes.io/arch|amd64|
@@ -8749,6 +9219,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|small|
  |kubernetes.io/arch|amd64|
@@ -8767,6 +9238,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|amd64|
@@ -8785,6 +9257,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -8803,6 +9276,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|t3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -8821,6 +9295,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|t3|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -8840,6 +9315,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|512|
  |karpenter.k8s.aws/instance-size|nano|
  |kubernetes.io/arch|amd64|
@@ -8858,6 +9334,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1024|
  |karpenter.k8s.aws/instance-size|micro|
  |kubernetes.io/arch|amd64|
@@ -8876,6 +9353,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|small|
  |kubernetes.io/arch|amd64|
@@ -8894,6 +9372,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|amd64|
@@ -8912,6 +9391,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t3a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -8930,6 +9410,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|t3a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -8948,6 +9429,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|t3a|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -8967,6 +9449,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|512|
  |karpenter.k8s.aws/instance-size|nano|
  |kubernetes.io/arch|arm64|
@@ -8985,6 +9468,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1024|
  |karpenter.k8s.aws/instance-size|micro|
  |kubernetes.io/arch|arm64|
@@ -9003,6 +9487,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2048|
  |karpenter.k8s.aws/instance-size|small|
  |kubernetes.io/arch|arm64|
@@ -9021,6 +9506,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4096|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -9039,6 +9525,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -9057,6 +9544,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -9075,6 +9563,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|t4g|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -9094,6 +9583,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|448|
  |karpenter.k8s.aws/instance-family|u-12tb1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|12582912|
  |karpenter.k8s.aws/instance-size|112xlarge|
  |karpenter.sh/capacity-type|on-demand|
@@ -9114,6 +9604,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|224|
  |karpenter.k8s.aws/instance-family|u-3tb1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|3145728|
  |karpenter.k8s.aws/instance-size|56xlarge|
  |karpenter.sh/capacity-type|on-demand|
@@ -9134,6 +9625,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|224|
  |karpenter.k8s.aws/instance-family|u-6tb1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|6291456|
  |karpenter.k8s.aws/instance-size|56xlarge|
  |karpenter.sh/capacity-type|on-demand|
@@ -9153,6 +9645,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|448|
  |karpenter.k8s.aws/instance-family|u-6tb1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|6291456|
  |karpenter.k8s.aws/instance-size|112xlarge|
  |karpenter.sh/capacity-type|on-demand|
@@ -9173,6 +9666,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|448|
  |karpenter.k8s.aws/instance-family|u-9tb1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|9437184|
  |karpenter.k8s.aws/instance-size|112xlarge|
  |karpenter.sh/capacity-type|on-demand|
@@ -9193,6 +9687,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|12|
  |karpenter.k8s.aws/instance-family|vt1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|24576|
  |karpenter.k8s.aws/instance-size|3xlarge|
  |kubernetes.io/arch|amd64|
@@ -9211,6 +9706,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|24|
  |karpenter.k8s.aws/instance-family|vt1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|49152|
  |karpenter.k8s.aws/instance-size|6xlarge|
  |kubernetes.io/arch|amd64|
@@ -9229,6 +9725,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|vt1|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -9248,6 +9745,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|x1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|999424|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -9266,6 +9764,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|x1|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|1998848|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -9285,6 +9784,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|x1e|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -9303,6 +9803,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|x1e|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -9321,6 +9822,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|x1e|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -9339,6 +9841,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|x1e|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|999424|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -9357,6 +9860,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|x1e|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|1998848|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -9375,6 +9879,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|x1e|
+ |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|3997696|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -9394,6 +9899,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|1|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|medium|
  |kubernetes.io/arch|arm64|
@@ -9412,6 +9918,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|arm64|
@@ -9430,6 +9937,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|arm64|
@@ -9448,6 +9956,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|arm64|
@@ -9466,6 +9975,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|arm64|
@@ -9484,6 +9994,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|arm64|
@@ -9502,6 +10013,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|arm64|
@@ -9520,6 +10032,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|arm64|
@@ -9538,6 +10051,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|x2gd|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|arm64|
@@ -9557,6 +10071,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|x2idn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -9575,6 +10090,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|x2idn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1572864|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -9593,6 +10109,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|x2idn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2097152|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -9611,6 +10128,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|x2idn|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|2097152|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -9630,6 +10148,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -9648,6 +10167,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -9666,6 +10186,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -9684,6 +10205,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -9702,6 +10224,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|2097152|
  |karpenter.k8s.aws/instance-size|16xlarge|
  |kubernetes.io/arch|amd64|
@@ -9720,6 +10243,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|3145728|
  |karpenter.k8s.aws/instance-size|24xlarge|
  |kubernetes.io/arch|amd64|
@@ -9738,6 +10262,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|4194304|
  |karpenter.k8s.aws/instance-size|32xlarge|
  |kubernetes.io/arch|amd64|
@@ -9756,6 +10281,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|128|
  |karpenter.k8s.aws/instance-family|x2iedn|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|4194304|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -9775,6 +10301,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|x2iezn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|262144|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -9793,6 +10320,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-family|x2iezn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|524288|
  |karpenter.k8s.aws/instance-size|4xlarge|
  |kubernetes.io/arch|amd64|
@@ -9811,6 +10339,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|24|
  |karpenter.k8s.aws/instance-family|x2iezn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|786432|
  |karpenter.k8s.aws/instance-size|6xlarge|
  |kubernetes.io/arch|amd64|
@@ -9829,6 +10358,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-family|x2iezn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1048576|
  |karpenter.k8s.aws/instance-size|8xlarge|
  |kubernetes.io/arch|amd64|
@@ -9847,6 +10377,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|x2iezn|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|1572864|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -9865,6 +10396,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|x2iezn|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|1572864|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|
@@ -9884,6 +10416,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|2|
  |karpenter.k8s.aws/instance-family|z1d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-size|large|
  |kubernetes.io/arch|amd64|
@@ -9902,6 +10435,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-family|z1d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-size|xlarge|
  |kubernetes.io/arch|amd64|
@@ -9920,6 +10454,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-family|z1d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-size|2xlarge|
  |kubernetes.io/arch|amd64|
@@ -9938,6 +10473,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|12|
  |karpenter.k8s.aws/instance-family|z1d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|98304|
  |karpenter.k8s.aws/instance-size|3xlarge|
  |kubernetes.io/arch|amd64|
@@ -9956,6 +10492,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|24|
  |karpenter.k8s.aws/instance-family|z1d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|196608|
  |karpenter.k8s.aws/instance-size|6xlarge|
  |kubernetes.io/arch|amd64|
@@ -9974,6 +10511,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|z1d|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|12xlarge|
  |kubernetes.io/arch|amd64|
@@ -9992,6 +10530,7 @@ below are the resources available with some assumptions and after the instance o
  |--|--|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-family|z1d|
+ |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|393216|
  |karpenter.k8s.aws/instance-size|metal|
  |kubernetes.io/arch|amd64|


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

 - Add instance-hypervisor label as an AWS node label so that you can filter for `xen` or `nitro` hypervisors. 

**How was this change tested?**

* `make test`
* manually tested on an EKS cluster 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add support for the AWS node label `karpenter.k8s.aws/instance-hypervisor` to select `nitro` or `xen` compatible instance types.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
