### PR TITLE
docs: add instance-hypervisor label to scheduling docs

### DIFF
--- a/website/content/en/preview/tasks/scheduling.md
+++ b/website/content/en/preview/tasks/scheduling.md
@@ -85,6 +85,7 @@ The following labels are supported by Karpenter. They may be specified as provis
 | kubernetes.io/os                            | linux      | Operating systems are defined by [GOOS values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L10) on the instance        |
 | kubernetes.io/arch                          | amd64      | Architectures are defined by [GOARCH values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L50) on the instance          |
 | karpenter.sh/capacity-type                  | spot       | Capacity types include `spot`, `on-demand`                                                                                                  |
+| karpenter.k8s.aws/instance-hypervisor       | xen        | [AWS Specific] Instance types that use a specific hypervisor                                                                                |
 | karpenter.k8s.aws/instance-family           | p3         | [AWS Specific] Instance types of similar properties but different resource quantities                                                       |
 | karpenter.k8s.aws/instance-size             | 8xlarge    | [AWS Specific] Instance types of similar resource quantities but different properties                                                       |
 | karpenter.k8s.aws/instance-cpu              | 32         | [AWS Specific] Number of CPUs on the instance                                                                                               |


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - Add instance-hypervisor AWS label to scheduling docs

**How was this change tested?**

* `make website`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
