### PR TITLE
feat: Add the ability to manage Provisioners within the helm chart

### DIFF
--- a/charts/karpenter/templates/provisioner.yaml
+++ b/charts/karpenter/templates/provisioner.yaml
@@ -3,7 +3,6 @@ apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
   name: {{ .name }}
-  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "karpenter.labels" $ | nindent 4 }}
   {{- with $.Values.additionalAnnotations }}

--- a/charts/karpenter/templates/provisioner.yaml
+++ b/charts/karpenter/templates/provisioner.yaml
@@ -3,7 +3,13 @@ apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
   name: {{ .name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "karpenter.labels" $ | nindent 4 }}
+  {{- with $.Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- toYaml .spec | nindent 2 }}
 {{ end }}

--- a/charts/karpenter/templates/provisioner.yaml
+++ b/charts/karpenter/templates/provisioner.yaml
@@ -2,7 +2,7 @@
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
-  name: {{ .name }}
+  name: {{ .metadata.name }}
   labels:
     {{- include "karpenter.labels" $ | nindent 4 }}
   {{- with $.Values.additionalAnnotations }}

--- a/charts/karpenter/templates/provisioner.yaml
+++ b/charts/karpenter/templates/provisioner.yaml
@@ -1,0 +1,9 @@
+{{ range .Values.provisioners }}
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: {{ .name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- toYaml .spec | nindent 2 }}
+{{ end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -157,28 +157,8 @@ aws:
   # -- The default instance profile to use when launching nodes on AWS
   defaultInstanceProfile: ""
 
-# -- Provisioners definition
+# -- Provisioners definition, please check the [latest CRD definition](https://karpenter.sh/v0.11.1/provisioner/) for the `spec` field
 provisioners: {}
   # - metadata:
   #     name: sample-1
-  #   spec:
-  #     ttlSecondsUntilExpired: 2592000
-  #     ttlSecondsAfterEmpty: 30
-  #     requirements:
-  #       - key: "node.kubernetes.io/instance-type"
-  #         operator: In
-  #         values: ["m5.large", "m5.2xlarge"]
-  #       - key: "topology.kubernetes.io/zone"
-  #         operator: In
-  #         values: ["us-west-2a", "us-west-2b"]
-  #       - key: "kubernetes.io/arch"
-  #         operator: In
-  #         values: ["arm64", "amd64"]
-  #       - key: "karpenter.sh/capacity-type"
-  #         operator: In
-  #         values: ["spot", "on-demand"]
-  #     limits:
-  #       resources:
-  #         cpu: "1000"
-  #         memory: 1000Gi
-
+  #   spec: {}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -159,5 +159,25 @@ aws:
 
 # -- Provisioners definition
 provisioners: {}
-#  - name: default
-#    spec: {}
+  # - name: sample-1
+  #   spec:
+  #     ttlSecondsUntilExpired: 2592000
+  #     ttlSecondsAfterEmpty: 30
+  #     requirements:
+  #       - key: "node.kubernetes.io/instance-type"
+  #         operator: In
+  #         values: ["m5.large", "m5.2xlarge"]
+  #       - key: "topology.kubernetes.io/zone"
+  #         operator: In
+  #         values: ["us-west-2a", "us-west-2b"]
+  #       - key: "kubernetes.io/arch"
+  #         operator: In
+  #         values: ["arm64", "amd64"]
+  #       - key: "karpenter.sh/capacity-type"
+  #         operator: In
+  #         values: ["spot", "on-demand"]
+  #     limits:
+  #       resources:
+  #         cpu: "1000"
+  #         memory: 1000Gi
+

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -156,3 +156,8 @@ clusterEndpoint: ""
 aws:
   # -- The default instance profile to use when launching nodes on AWS
   defaultInstanceProfile: ""
+
+# -- Provisioners definition
+provisioners: {}
+#  - name: default
+#    spec: {}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -159,7 +159,8 @@ aws:
 
 # -- Provisioners definition
 provisioners: {}
-  # - name: sample-1
+  # - metadata:
+  #     name: sample-1
   #   spec:
   #     ttlSecondsUntilExpired: 2592000
   #     ttlSecondsAfterEmpty: 30


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

This PR adds the Provisioner template to the chart to render the Provisioners along the helm release and manage their lifecycle instead of having to handle plain manifests in another part of the CI.

Included a basic sample for the documentation, the `spec` key from the array will be passed as is.

```
$ cat -n tmpfiles/karpenter/templates/provisioner.yaml
     1  ---
     2  # Source: karpenter/templates/provisioner.yaml
     3  apiVersion: karpenter.sh/v1alpha5
     4  kind: Provisioner
     5  metadata:
     6    name: sample-1
     7    namespace: karpenter
     8    labels:
     9      helm.sh/chart: karpenter-0.11.1
    10      app.kubernetes.io/name: karpenter
    11      app.kubernetes.io/instance: release-name
    12      app.kubernetes.io/version: "0.11.1"
    13      app.kubernetes.io/managed-by: Helm
    14    annotations:
    15      test: toto
    16  spec:
    17    limits:
    18      resources:
    19        cpu: "1000"
    20        memory: 1000Gi
    21    requirements:
    22    - key: node.kubernetes.io/instance-type
    23      operator: In
    24      values:
    25      - m5.large
    26      - m5.2xlarge
    27    - key: topology.kubernetes.io/zone
    28      operator: In
    29      values:
    30      - us-west-2a
    31      - us-west-2b
    32    - key: kubernetes.io/arch
    33      operator: In
    34      values:
    35      - arm64
    36      - amd64
    37    - key: karpenter.sh/capacity-type
    38      operator: In
    39      values:
    40      - spot
    41      - on-demand
    42    ttlSecondsAfterEmpty: 30
    43    ttlSecondsUntilExpired: 2592000

```

**How was this change tested?**

* Locally by rendering the templates
* Compared templates against the ones actually used on production
* Deployed a template in a dummy cluster

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
