### PR TITLE
fix: consider pod density in memory overhead calc

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/al2.go
+++ b/pkg/cloudprovider/aws/amifamily/al2.go
@@ -93,3 +93,7 @@ func (a AL2) EphemeralBlockDevice() *string {
 func (a AL2) EphemeralBlockDeviceOverhead() resource.Quantity {
 	return resource.MustParse("5Gi")
 }
+
+func (a AL2) ENILimitedMemoryOverhead() bool {
+	return true
+}

--- a/pkg/cloudprovider/aws/amifamily/bottlerocket.go
+++ b/pkg/cloudprovider/aws/amifamily/bottlerocket.go
@@ -85,3 +85,7 @@ func (b Bottlerocket) EphemeralBlockDevice() *string {
 func (b Bottlerocket) EphemeralBlockDeviceOverhead() resource.Quantity {
 	return resource.MustParse("5Gi")
 }
+
+func (b Bottlerocket) ENILimitedMemoryOverhead() bool {
+	return false
+}

--- a/pkg/cloudprovider/aws/amifamily/resolver.go
+++ b/pkg/cloudprovider/aws/amifamily/resolver.go
@@ -75,6 +75,7 @@ type AMIFamily interface {
 	DefaultMetadataOptions() *v1alpha1.MetadataOptions
 	EphemeralBlockDevice() *string
 	EphemeralBlockDeviceOverhead() resource.Quantity
+	ENILimitedMemoryOverhead() bool
 }
 
 // New constructs a new launch template Resolver

--- a/pkg/cloudprovider/aws/amifamily/ubuntu.go
+++ b/pkg/cloudprovider/aws/amifamily/ubuntu.go
@@ -67,3 +67,7 @@ func (u Ubuntu) EphemeralBlockDevice() *string {
 func (u Ubuntu) EphemeralBlockDeviceOverhead() resource.Quantity {
 	return resource.MustParse("5Gi")
 }
+
+func (u Ubuntu) ENILimitedMemoryOverhead() bool {
+	return true
+}

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -372,7 +372,7 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2
 				},
 				NetworkInfo: &ec2.NetworkInfo{
 					MaximumNetworkInterfaces:  aws.Int64(4),
-					Ipv4AddressesPerInterface: aws.Int64(60),
+					Ipv4AddressesPerInterface: aws.Int64(15),
 				},
 			},
 			{

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -394,7 +394,7 @@ var _ = Describe("Allocation", func() {
 					Expect(err).To(BeNil())
 					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
 					overhead := it.Overhead()
-					Expect(overhead.Memory().String()).To(Equal("3073Mi"))
+					Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 				})
 				It("should calculate memory overhead based on eni limited pods when not ENI limited", func() {
 					opts.AWSENILimitedPodDensity = false
@@ -404,7 +404,7 @@ var _ = Describe("Allocation", func() {
 					Expect(err).To(BeNil())
 					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
 					overhead := it.Overhead()
-					Expect(overhead.Memory().String()).To(Equal("3073Mi"))
+					Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 				})
 			})
 			Context("Bottlerocket", func() {
@@ -416,7 +416,7 @@ var _ = Describe("Allocation", func() {
 					Expect(err).To(BeNil())
 					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
 					overhead := it.Overhead()
-					Expect(overhead.Memory().String()).To(Equal("3073Mi"))
+					Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 				})
 				It("should calculate memory overhead based on max pods when not ENI limited", func() {
 					opts.AWSENILimitedPodDensity = false

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -390,41 +389,21 @@ var _ = Describe("Allocation", func() {
 				It("should calculate memory overhead based on eni limited pods when ENI limited", func() {
 					opts.AWSENILimitedPodDensity = true
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
 					provider.AMIFamily = &v1alpha1.AMIFamilyAL2
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					newCtx := injection.WithOptions(ctx, opts)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider, ProviderRef: providerRef})
-					ExpectApplied(ctx, env.Client, newProvisioner)
-
-					instanceTypeCache.Flush()
-					instanceTypes, err := cloudProvider.GetInstanceTypes(newCtx, newProvisioner.Spec.Provider)
+					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
-					idx := slices.IndexFunc(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == "m5.xlarge" })
-					overhead := instanceTypes[idx].Overhead()
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
+					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("3073Mi"))
 				})
 				It("should calculate memory overhead based on eni limited pods when not ENI limited", func() {
 					opts.AWSENILimitedPodDensity = false
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
 					provider.AMIFamily = &v1alpha1.AMIFamilyAL2
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					newCtx := injection.WithOptions(ctx, opts)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider, ProviderRef: providerRef})
-					ExpectApplied(ctx, env.Client, newProvisioner)
-
-					instanceTypeCache.Flush()
-					instanceTypes, err := cloudProvider.GetInstanceTypes(newCtx, newProvisioner.Spec.Provider)
+					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
-					idx := slices.IndexFunc(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == "m5.xlarge" })
-					overhead := instanceTypes[idx].Overhead()
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
+					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("3073Mi"))
 				})
 			})
@@ -432,41 +411,21 @@ var _ = Describe("Allocation", func() {
 				It("should calculate memory overhead based on eni limited pods when ENI limited", func() {
 					opts.AWSENILimitedPodDensity = true
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
 					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					newCtx := injection.WithOptions(ctx, opts)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider, ProviderRef: providerRef})
-					ExpectApplied(ctx, env.Client, newProvisioner)
-
-					instanceTypeCache.Flush()
-					instanceTypes, err := cloudProvider.GetInstanceTypes(newCtx, newProvisioner.Spec.Provider)
+					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
-					idx := slices.IndexFunc(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == "m5.xlarge" })
-					overhead := instanceTypes[idx].Overhead()
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
+					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("3073Mi"))
 				})
 				It("should calculate memory overhead based on max pods when not ENI limited", func() {
 					opts.AWSENILimitedPodDensity = false
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
 					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					newCtx := injection.WithOptions(ctx, opts)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider, ProviderRef: providerRef})
-					ExpectApplied(ctx, env.Client, newProvisioner)
-
-					instanceTypeCache.Flush()
-					instanceTypes, err := cloudProvider.GetInstanceTypes(newCtx, newProvisioner.Spec.Provider)
+					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
-					idx := slices.IndexFunc(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == "m5.xlarge" })
-					overhead := instanceTypes[idx].Overhead()
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
+					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("1665Mi"))
 				})
 			})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #1959

**Description**
This change will take the pod density setting in account when calculating memory overhead. This is important to avoid scheduling mistakes and endless loops like described in the linked issue.

**How was this change tested?**

* Real EKS cluster using the manifests from the issue
* Newly added automated tests

See new logs when testing against the reproducible setup (as expected, the c5n.xlarge instance type is now considered to be too small):

```console
2022-06-21T07:09:04.372Z	DEBUG	controller.provisioning	Relaxing soft constraints for pod since it previously failed to schedule, removing: spec.topologySpreadConstraints = {"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway","labelSelector":{"matchLabels":{"app":"inflate"}}}	{"commit": "153d333"}
2022-06-21T07:09:04.376Z	DEBUG	controller.provisioning	Relaxing soft constraints for pod since it previously failed to schedule, adding: toleration for PreferNoSchedule taints	{"commit": "153d333"}
2022-06-21T07:09:04.379Z	ERROR	controller.provisioning	Could not schedule pod, incompatible with provisioner "default", no instance type satisfied resources {"cpu":"224m","memory":"8791517761","pods":"1"} and requirements karpenter.sh/capacity-type In [on-demand spot], kubernetes.io/arch In [amd64 arm64], node.kubernetes.io/instance-type In [c5n.xlarge], karpenter.sh/provisioner-name In [default]; incompatible with provisioner "long-running", did not tolerate idealo.de/long-running=true:NoSchedule	{"commit": "153d333", "pod": "inflate/inflate-5bb76d8549-rprbr"}
```

Once you remove the `nodeSelector` it picks a list of instance types correctly:

```console
2022-06-21T07:11:34.973Z	DEBUG	controller.provisioning.cloudprovider	Created launch template, Karpenter-terratest-u1q5gG-10432077704041859839	{"commit": "153d333", "provisioner": "default"}
2022-06-21T07:11:36.890Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-0e752dc6a294469a1, hostname: ip-172-16-66-212.eu-central-1.compute.internal, type: c6i.2xlarge, zone: eu-central-1b, capacityType: spot	{"commit": "153d333", "provisioner": "default"}
2022-06-21T07:11:36.922Z	INFO	controller.provisioning	Created node with 1 pods requesting {"cpu":"559m","memory":"9037933121","pods":"8"} from types m6i.xlarge, m5zn.xlarge, t3a.xlarge, t3.xlarge, m6a.xlarge and 193 other(s)	{"commit": "153d333", "provisioner": "default"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed calculation of allocatable memory when not using ENI-based pod density
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
