### PR TITLE
test: deflake config test by reiniting config

### DIFF
--- a/pkg/config/suite_test.go
+++ b/pkg/config/suite_test.go
@@ -39,6 +39,7 @@ var env *test.Environment
 var clientSet *kubernetes.Clientset
 var cfg config.Config
 var finished func()
+var cmw *informer.InformedWatcher
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -57,7 +58,7 @@ var _ = BeforeSuite(func() {
 		cm.Name = "karpenter-global-settings"
 		ExpectApplied(ctx, env.Client, &cm)
 
-		cmw := informer.NewInformedWatcher(clientSet, os.Getenv("SYSTEM_NAMESPACE"))
+		cmw = informer.NewInformedWatcher(clientSet, os.Getenv("SYSTEM_NAMESPACE"))
 		var err error
 		cfg, err = config.New(ctx, clientSet, cmw)
 		Expect(err).To(BeNil())
@@ -70,6 +71,9 @@ var _ = BeforeEach(func() {
 	var cm v1.ConfigMap
 	cm.Namespace = "default"
 	cm.Name = "karpenter-global-settings"
+	var err error
+	cfg, err = config.New(ctx, clientSet, cmw)
+	Expect(err).To(BeNil())
 	env.Client.Delete(ctx, &cm)
 	ExpectApplied(ctx, env.Client, &cm)
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

config was out-of-sync from out-of-order run causing assertion to fail sometimes:

https://github.com/aws/karpenter/runs/6990339852
```
------------------------------
• Failure [0.011 seconds]
Batch Parameter [It] should use default values if config map has invalid data 
/home/runner/work/karpenter/karpenter/pkg/config/suite_test.go:121
Expected
      <time.Duration>: 2000000000
  to equal
      <time.Duration>: 1000000000
  /home/runner/work/karpenter/karpenter/pkg/config/suite_test.go:122
------------------------------
•
Summarizing 1 Failure:
[Fail] Batch Parameter [It] should use default values if config map has invalid data 
/home/runner/work/karpenter/karpenter/pkg/config/suite_test.go:122
Ran 3 of 3 Specs in 11.611 seconds
```

test: deflake config test by reiniting config

**How was this change tested?**

`ginkgo -r pkg/config`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
