### PR TITLE
fix: Correct Grafana getting-started values to refer to proper release versions

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -20,6 +20,7 @@ chart() {
 website() {
     mkdir -p website/content/en/${RELEASE_VERSION} && cp -r website/content/en/preview/* website/content/en/${RELEASE_VERSION}/
     find website/content/en/${RELEASE_VERSION}/ -type f | xargs perl -i -p -e "s/{{< param \"latest_release_version\" >}}/${RELEASE_VERSION}/g;"
+    find website/content/en/${RELEASE_VERSION}/*/*/*.yaml -type f | xargs perl -i -p -e "s/preview/${RELEASE_VERSION}/g;"
 }
 
 requireCloudProvider

--- a/website/content/en/v0.10.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.10.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.10.0/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.10.0/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.10.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.10.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.10.1/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.10.1/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.11.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.11.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,8 +22,8 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.11.0/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.11.0/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
     provisioner-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-provisioner-metrics.json
+      url: https://karpenter.sh/v0.11.0/getting-started/getting-started-with-eksctl/karpenter-provisioner-metrics.json

--- a/website/content/en/v0.11.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.11.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,8 +22,8 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.11.1/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.11.1/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
     provisioner-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-provisioner-metrics.json
+      url: https://karpenter.sh/v0.11.1/getting-started/getting-started-with-eksctl/karpenter-provisioner-metrics.json

--- a/website/content/en/v0.12.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.12.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,8 +22,8 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.12.0/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.12.0/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
     provisioner-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-provisioner-metrics.json
+      url: https://karpenter.sh/v0.12.0/getting-started/getting-started-with-eksctl/karpenter-provisioner-metrics.json

--- a/website/content/en/v0.5.6/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.5.6/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.5.6/getting-started/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.5.6/getting-started/karpenter-pod-metrics.json

--- a/website/content/en/v0.6.0/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.0/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.6.0/getting-started/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.6.0/getting-started/karpenter-pod-metrics.json

--- a/website/content/en/v0.6.1/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.1/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.6.1/getting-started/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.6.1/getting-started/karpenter-pod-metrics.json

--- a/website/content/en/v0.6.2/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.2/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.6.2/getting-started/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.6.2/getting-started/karpenter-pod-metrics.json

--- a/website/content/en/v0.6.3/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.3/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.6.3/getting-started/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.6.3/getting-started/karpenter-pod-metrics.json

--- a/website/content/en/v0.6.4/getting-started/grafana-values.yaml
+++ b/website/content/en/v0.6.4/getting-started/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.6.4/getting-started/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.6.4/getting-started/karpenter-node-metrics.json

--- a/website/content/en/v0.6.5/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.6.5/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.6.5/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.6.5/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.7.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.7.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.7.0/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.7.0/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.7.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.7.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.7.1/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.7.1/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.7.2/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.7.2/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.7.2/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.7.2/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.7.3/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.7.3/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.7.3/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.7.3/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.8.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.8.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.8.0/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.8.0//getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.8.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.8.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.8.1/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.8.1/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.8.2/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.8.2/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.8.2/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.8.2/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.9.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.9.0/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.9.0/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.9.0/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json

--- a/website/content/en/v0.9.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
+++ b/website/content/en/v0.9.1/getting-started/getting-started-with-eksctl/grafana-values.yaml
@@ -22,6 +22,6 @@ dashboardProviders:
 dashboards:
   default:
     pod-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
+      url: https://karpenter.sh/v0.9.1/getting-started/getting-started-with-eksctl/karpenter-pod-metrics.json
     node-dashboard:
-      url: https://karpenter.sh/preview/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json
+      url: https://karpenter.sh/v0.9.1/getting-started/getting-started-with-eksctl/karpenter-node-metrics.json


### PR DESCRIPTION
**Description**
This adjusts the urls used for the grafana dashboards in the getting-started-with-eksctl guides to refer to the release versions that they're created at. Originally they were all pointing to preview.

This also changes future yamls to change preview to the proper release version. This has the potential downside of a comment that contains "preview" to be changed to the new version string, but this should be caught by PRs.

**How was this change tested?**


**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
