### PR TITLE
fix: Added back lease creation permissions for Karpenter RBAC Role

### DIFF
--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -13,7 +13,7 @@ rules:
   # Read
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "watch"]
+    verbs: ["create", "get", "watch"]
   - apiGroups: [""]
     resources: ["configmaps", "namespaces", "secrets"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
**Description**
On a fresh install of Karpenter, Karpenter needs to create leases for initial leader election records. With a recent change to scope down RBAC permissions, the permission to create these leases were removed. If a user is upgrading from a previous installation, where the lease is already created, the pod doesn't run into this issue. 

**How was this change tested?**
I created a new cluster and received this error when installing version v0.12.0. The webhook container in the Karpenter pod never becomes healthy, and the Karpenter pod then crash loops.
```
E0623 05:08:32.044105       1 leaderelection.go:329] error initially creating leader election record: leases.coordination.k8s.io is forbidden: User "system:serviceaccount:karpenter:karpenter" cannot create resource "leases" in API group "coordination.k8s.io" in the namespace "karpenter"
```

Once deleting all Karpenter resources and the namespace, I reinstalled to v0.11.1 and had a successful install. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
