### PR TITLE
feat: move to lease only elections

### DIFF
--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -27,7 +27,6 @@ rules:
     verbs: ["update", "patch", "delete"]
     resourceNames:
       - karpenter-global-settings
-      - karpenter-leader-election
       - config-logging
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -40,7 +39,7 @@ rules:
       - "webhook.webhookcertificates.00-of-01"
   # Cannot specify resourceNames on create
   # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
-  - apiGroups: ["coordinations.k8s.io"]
+  - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]
   - apiGroups: [""]

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -27,6 +27,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/flowcontrol"
 	"knative.dev/pkg/configmap/informer"
 	knativeinjection "knative.dev/pkg/injection"
@@ -84,12 +85,13 @@ func main() {
 	logging.FromContext(ctx).Infof("Initializing with version %s", project.Version)
 	// Set up controller runtime controller
 	manager := controllers.NewManagerOrDie(ctx, controllerRuntimeConfig, controllerruntime.Options{
-		Logger:                 zapr.NewLogger(logging.FromContext(ctx).Desugar()),
-		LeaderElection:         true,
-		LeaderElectionID:       "karpenter-leader-election",
-		Scheme:                 scheme,
-		MetricsBindAddress:     fmt.Sprintf(":%d", opts.MetricsPort),
-		HealthProbeBindAddress: fmt.Sprintf(":%d", opts.HealthProbePort),
+		Logger:                     zapr.NewLogger(logging.FromContext(ctx).Desugar()),
+		LeaderElection:             true,
+		LeaderElectionID:           "karpenter-leader-election",
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		Scheme:                     scheme,
+		MetricsBindAddress:         fmt.Sprintf(":%d", opts.MetricsPort),
+		HealthProbeBindAddress:     fmt.Sprintf(":%d", opts.HealthProbePort),
 	})
 
 	if opts.EnableProfiling {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

 - Switch to a `lease` only lock rather than a `ConfigMapLease` lock. 
   - controller-runtime switched from a configmap lease pre v0.7.0 and starting w/ v0.7.0 went to a `ConfigMapLease` lock that does both in order to support a migration to a `Lease` only lock. Karpenter adopted v0.7.0 starting with v0.1.0 https://github.com/aws/karpenter/commit/2e3a63063e0faf6f37ef23dd3423b78bdec9aaf0 so we should be safe to switch to Lease only locks. This will remove one of the configmaps that Karpenter creates and gives permissions to.  

**How was this change tested?**

* Installed in an EKS cluster and deleted all leases and configmaps (related to election) and saw that the Karpenter pod created the lease resources. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
