### PR TITLE
fix: hydrate lt cache on election win and invalidate LTs in the cache that do not exist in the CP

### DIFF
--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -108,6 +108,7 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *Cloud
 				amifamily.New(ctx, ssm.New(sess), cache.New(CacheTTL, CacheCleanupInterval), options.KubeClient),
 				NewSecurityGroupProvider(ec2api),
 				getCABundle(ctx),
+				options.StartAsync,
 			),
 		},
 		kubeClient: options.KubeClient,

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -81,11 +81,13 @@ func (e *EC2API) Reset() {
 	e.Instances = sync.Map{}
 	e.LaunchTemplates = sync.Map{}
 	e.InsufficientCapacityPools.Reset()
+	e.NextError.Reset()
 }
 
 // nolint: gocyclo
 func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFleetInput, _ ...request.Option) (*ec2.CreateFleetOutput, error) {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return nil, e.NextError.Get()
 	}
 	e.CalledWithCreateFleetInput.Add(input)
@@ -151,6 +153,7 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 
 func (e *EC2API) CreateLaunchTemplateWithContext(_ context.Context, input *ec2.CreateLaunchTemplateInput, _ ...request.Option) (*ec2.CreateLaunchTemplateOutput, error) {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return nil, e.NextError.Get()
 	}
 	e.CalledWithCreateLaunchTemplateInput.Add(input)
@@ -161,6 +164,7 @@ func (e *EC2API) CreateLaunchTemplateWithContext(_ context.Context, input *ec2.C
 
 func (e *EC2API) DescribeInstancesWithContext(_ context.Context, input *ec2.DescribeInstancesInput, _ ...request.Option) (*ec2.DescribeInstancesOutput, error) {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return nil, e.NextError.Get()
 	}
 	if !e.DescribeInstancesOutput.IsNil() {
@@ -180,6 +184,7 @@ func (e *EC2API) DescribeInstancesWithContext(_ context.Context, input *ec2.Desc
 
 func (e *EC2API) DescribeLaunchTemplatesWithContext(_ context.Context, input *ec2.DescribeLaunchTemplatesInput, _ ...request.Option) (*ec2.DescribeLaunchTemplatesOutput, error) {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return nil, e.NextError.Get()
 	}
 	if !e.DescribeLaunchTemplatesOutput.IsNil() {
@@ -201,6 +206,7 @@ func (e *EC2API) DescribeLaunchTemplatesWithContext(_ context.Context, input *ec
 
 func (e *EC2API) DescribeSubnetsWithContext(ctx context.Context, input *ec2.DescribeSubnetsInput, opts ...request.Option) (*ec2.DescribeSubnetsOutput, error) {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return nil, e.NextError.Get()
 	}
 	if !e.DescribeSubnetsOutput.IsNil() {
@@ -242,6 +248,7 @@ func (e *EC2API) DescribeSubnetsWithContext(ctx context.Context, input *ec2.Desc
 
 func (e *EC2API) DescribeSecurityGroupsWithContext(ctx context.Context, input *ec2.DescribeSecurityGroupsInput, opts ...request.Option) (*ec2.DescribeSecurityGroupsOutput, error) {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return nil, e.NextError.Get()
 	}
 	if !e.DescribeSecurityGroupsOutput.IsNil() {
@@ -276,6 +283,7 @@ func (e *EC2API) DescribeSecurityGroupsWithContext(ctx context.Context, input *e
 
 func (e *EC2API) DescribeAvailabilityZonesWithContext(context.Context, *ec2.DescribeAvailabilityZonesInput, ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return nil, e.NextError.Get()
 	}
 	if !e.DescribeAvailabilityZonesOutput.IsNil() {
@@ -290,6 +298,7 @@ func (e *EC2API) DescribeAvailabilityZonesWithContext(context.Context, *ec2.Desc
 
 func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2.DescribeInstanceTypesInput, fn func(*ec2.DescribeInstanceTypesOutput, bool) bool, _ ...request.Option) error {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return e.NextError.Get()
 	}
 	if !e.DescribeInstanceTypesOutput.IsNil() {
@@ -493,6 +502,7 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2
 
 func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context, _ *ec2.DescribeInstanceTypeOfferingsInput, fn func(*ec2.DescribeInstanceTypeOfferingsOutput, bool) bool, _ ...request.Option) error {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return e.NextError.Get()
 	}
 	if !e.DescribeInstanceTypeOfferingsOutput.IsNil() {
@@ -580,6 +590,7 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 
 func (e *EC2API) DescribeSpotPriceHistoryPagesWithContext(_ aws.Context, _ *ec2.DescribeSpotPriceHistoryInput, fn func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool, opts ...request.Option) error {
 	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
 		return e.NextError.Get()
 	}
 	if !e.DescribeSpotPriceHistoryOutput.IsNil() {

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -140,6 +140,11 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, provider *v1alpha
 	}
 	createFleetOutput, err := p.ec2api.CreateFleetWithContext(ctx, createFleetInput)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "InvalidLaunchTemplateName.NotFoundException" {
+				p.launchTemplateProvider.invalidate(ctx, provider, nodeRequest, map[string]string{v1alpha5.LabelCapacityType: capacityType})
+			}
+		}
 		var reqFailure awserr.RequestFailure
 		if errors.As(err, &reqFailure) {
 			return nil, fmt.Errorf("creating fleet %w (%s)", err, reqFailure.RequestID())

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -149,7 +149,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, provider *v1alpha
 			for _, lt := range launchTemplateConfigs {
 				p.launchTemplateProvider.Invalidate(ctx, aws.StringValue(lt.LaunchTemplateSpecification.LaunchTemplateName))
 			}
-			return nil, err
+			return nil, fmt.Errorf("creating fleet %w", err)
 		}
 		var reqFailure awserr.RequestFailure
 		if errors.As(err, &reqFailure) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - This change requires that Karpenter has the leader lease before hydrating the LT cache on startup. This is necessary since the LT provider in the AWS CP manages the deletion lifecycle of LTs. So if Karpenter is deployed in an HA setup, a Karpenter pod that is not the leader could hydrate the cache with existing LTs created by Karpenter and then they would be deleted once the TTL expires (currently 1 min). The other Karpenter pods would have the LT still in the cache and fail when trying to launch an instance.  
 - In the case where the cache would get out-of-sync due to an operator manually deleting an LT, this change will invalidate the LTs in the cache that have caused errors which will result in a retry and a new LT being generated. 

**How was this change tested?**

* Tested manually on an EKS cluster.
  * Deployed Karpenter with some existing LTs. Noted that hydration of the LT cache occurred after the lease had been acquired. 
  * Manually deleted the LTs in the AWS console and tried an inflate scale-up
  * Karpenter invalidated the LTs causing the errors in the LT cache and retried the provisioning.   

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
