### PR TITLE
feat: require 10 instance types when falling back from spot to OD

### DIFF
--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -40,6 +40,18 @@ var (
 	}
 )
 
+type SpotFallbackError struct {
+	error
+}
+
+func (s *SpotFallbackError) Is(target error) bool {
+	switch target.(type) {
+	case SpotFallbackError:
+		return true
+	}
+	return errors.Is(s, target)
+}
+
 // isNotFound returns true if the err is an AWS error (even if it's
 // wrapped) and is a known to mean "not found" (as opposed to a more
 // serious or unexpected error)

--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -40,16 +40,14 @@ var (
 	}
 )
 
-type SpotFallbackError struct {
-	error
-}
+type SpotFallbackError error
 
-func (s SpotFallbackError) Is(target error) bool {
-	switch target.(type) {
-	case SpotFallbackError:
-		return true
+func isSpotFallback(err error) bool {
+	if err == nil {
+		return false
 	}
-	return false
+	var sfbErr SpotFallbackError
+	return errors.As(err, &sfbErr)
 }
 
 // isNotFound returns true if the err is an AWS error (even if it's

--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -44,12 +44,12 @@ type SpotFallbackError struct {
 	error
 }
 
-func (s *SpotFallbackError) Is(target error) bool {
+func (s SpotFallbackError) Is(target error) bool {
 	switch target.(type) {
 	case SpotFallbackError:
 		return true
 	}
-	return errors.Is(s, target)
+	return false
 }
 
 // isNotFound returns true if the err is an AWS error (even if it's

--- a/pkg/cloudprovider/aws/fake/atomic.go
+++ b/pkg/cloudprovider/aws/fake/atomic.go
@@ -168,3 +168,9 @@ func (a *AtomicSlice[T]) Set(values []T) {
 	defer a.mu.Unlock()
 	a.values = values
 }
+
+func (a *AtomicSlice[T]) Len() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.values)
+}

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -58,7 +58,6 @@ type EC2Behavior struct {
 }
 
 type EC2API struct {
-	sync.Mutex
 	ec2iface.EC2API
 	EC2Behavior
 }
@@ -69,8 +68,6 @@ var DefaultSupportedUsageClasses = aws.StringSlice([]string{"on-demand", "spot"}
 // Reset must be called between tests otherwise tests will pollute
 // each other.
 func (e *EC2API) Reset() {
-	e.Lock()
-	defer e.Unlock()
 	e.DescribeInstancesOutput.Reset()
 	e.DescribeLaunchTemplatesOutput.Reset()
 	e.DescribeSubnetsOutput.Reset()

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -58,6 +58,7 @@ type EC2Behavior struct {
 }
 
 type EC2API struct {
+	sync.Mutex
 	ec2iface.EC2API
 	EC2Behavior
 }
@@ -68,6 +69,8 @@ var DefaultSupportedUsageClasses = aws.StringSlice([]string{"on-demand", "spot"}
 // Reset must be called between tests otherwise tests will pollute
 // each other.
 func (e *EC2API) Reset() {
+	e.Lock()
+	defer e.Unlock()
 	e.DescribeInstancesOutput.Reset()
 	e.DescribeLaunchTemplatesOutput.Reset()
 	e.DescribeSubnetsOutput.Reset()
@@ -100,7 +103,6 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 	if input.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName == nil {
 		return nil, fmt.Errorf("missing launch template name")
 	}
-	var instances []*ec2.Instance
 	var instanceIds []*string
 	var skippedPools []CapacityPool
 	var spotInstanceRequestID *string
@@ -109,50 +111,49 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 		spotInstanceRequestID = aws.String(randomdata.SillyName())
 	}
 
-	for i := 0; i < int(*input.TargetCapacitySpecification.TotalTargetCapacity); i++ {
-		skipInstance := false
-		e.InsufficientCapacityPools.Range(func(pool CapacityPool) bool {
-			if pool.InstanceType == aws.StringValue(input.LaunchTemplateConfigs[0].Overrides[0].InstanceType) &&
-				pool.Zone == aws.StringValue(input.LaunchTemplateConfigs[0].Overrides[0].AvailabilityZone) &&
-				pool.CapacityType == aws.StringValue(input.TargetCapacitySpecification.DefaultTargetCapacityType) {
-				skippedPools = append(skippedPools, pool)
-				skipInstance = true
-				return false
+	for _, ltc := range input.LaunchTemplateConfigs {
+		for _, override := range ltc.Overrides {
+			skipInstance := false
+			e.InsufficientCapacityPools.Range(func(pool CapacityPool) bool {
+				if pool.InstanceType == aws.StringValue(override.InstanceType) &&
+					pool.Zone == aws.StringValue(override.AvailabilityZone) &&
+					pool.CapacityType == aws.StringValue(input.TargetCapacitySpecification.DefaultTargetCapacityType) {
+					skippedPools = append(skippedPools, pool)
+					skipInstance = true
+					return false
+				}
+				return true
+			})
+			if skipInstance {
+				continue
 			}
-			return true
-		})
-		if skipInstance {
-			continue
+			instance := &ec2.Instance{
+				InstanceId:            aws.String(randomdata.SillyName()),
+				Placement:             &ec2.Placement{AvailabilityZone: input.LaunchTemplateConfigs[0].Overrides[0].AvailabilityZone},
+				PrivateDnsName:        aws.String(randomdata.IpV4Address()),
+				InstanceType:          input.LaunchTemplateConfigs[0].Overrides[0].InstanceType,
+				SpotInstanceRequestId: spotInstanceRequestID,
+			}
+			e.Instances.Store(*instance.InstanceId, instance)
+			instanceIds = append(instanceIds, instance.InstanceId)
 		}
-		instances = append(instances, &ec2.Instance{
-			InstanceId:            aws.String(randomdata.SillyName()),
-			Placement:             &ec2.Placement{AvailabilityZone: input.LaunchTemplateConfigs[0].Overrides[0].AvailabilityZone},
-			PrivateDnsName:        aws.String(randomdata.IpV4Address()),
-			InstanceType:          input.LaunchTemplateConfigs[0].Overrides[0].InstanceType,
-			SpotInstanceRequestId: spotInstanceRequestID,
-		})
-		e.Instances.Store(*instances[i].InstanceId, instances[i])
-		instanceIds = append(instanceIds, instances[i].InstanceId)
 	}
 
-	result := &ec2.CreateFleetOutput{
-		Instances: []*ec2.CreateFleetInstance{{InstanceIds: instanceIds}}}
-	if len(skippedPools) > 0 {
-		for _, pool := range skippedPools {
-			result.Errors = append(result.Errors, &ec2.CreateFleetError{
-				ErrorCode: aws.String("InsufficientInstanceCapacity"),
-				LaunchTemplateAndOverrides: &ec2.LaunchTemplateAndOverridesResponse{
-					LaunchTemplateSpecification: &ec2.FleetLaunchTemplateSpecification{
-						LaunchTemplateId:   input.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateId,
-						LaunchTemplateName: input.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName,
-					},
-					Overrides: &ec2.FleetLaunchTemplateOverrides{
-						InstanceType:     aws.String(pool.InstanceType),
-						AvailabilityZone: aws.String(pool.Zone),
-					},
+	result := &ec2.CreateFleetOutput{Instances: []*ec2.CreateFleetInstance{{InstanceIds: instanceIds}}}
+	for _, pool := range skippedPools {
+		result.Errors = append(result.Errors, &ec2.CreateFleetError{
+			ErrorCode: aws.String("InsufficientInstanceCapacity"),
+			LaunchTemplateAndOverrides: &ec2.LaunchTemplateAndOverridesResponse{
+				LaunchTemplateSpecification: &ec2.FleetLaunchTemplateSpecification{
+					LaunchTemplateId:   input.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateId,
+					LaunchTemplateName: input.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName,
 				},
-			})
-		}
+				Overrides: &ec2.FleetLaunchTemplateOverrides{
+					InstanceType:     aws.String(pool.InstanceType),
+					AvailabilityZone: aws.String(pool.Zone),
+				},
+			},
+		})
 	}
 	return result, nil
 }

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -483,7 +483,7 @@ var _ = Describe("Allocation", func() {
 				Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "inf1.6xlarge"))
 			})
 			It("should launch on-demand capacity if flexible to both spot and on-demand, but spot if unavailable", func() {
-				odFallbackRequiredInstanceTypes = 5
+				safeSpotFallbackThreshold = 5
 				fakeEC2API.DescribeInstanceTypesPagesWithContext(ctx, &ec2.DescribeInstanceTypesInput{}, func(dito *ec2.DescribeInstanceTypesOutput, b bool) bool {
 					for _, it := range dito.InstanceTypes {
 						fakeEC2API.InsufficientCapacityPools.Add(fake.CapacityPool{CapacityType: v1alpha1.CapacityTypeSpot, InstanceType: aws.StringValue(it.InstanceType), Zone: "test-zone-1a"})

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -101,7 +101,7 @@ type Scheduler struct {
 }
 
 func (s *Scheduler) Solve(ctx context.Context, pods []*v1.Pod) ([]*Node, error) {
-	// We loop and retrying to schedule to unschedulable pods as long as we are making progress.  This solves a few
+	// We loop trying to schedule unschedulable pods as long as we are making progress.  This solves a few
 	// issues including pods with affinity to another pod in the batch. We could topo-sort to solve this, but it wouldn't
 	// solve the problem of scheduling pods where a particular order is needed to prevent a max-skew violation. E.g. if we
 	// had 5xA pods and 5xB pods were they have a zonal topology spread, but A can only go in one zone and B in another.

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -112,11 +112,11 @@ If the instance type is unavailable for some reason, then fleet will move on to 
 If you are using the spot capacity type, Karpenter uses the capacity-optimized-prioritized allocation strategy which tells fleet to find the instance type that EC2 has the most capacity of which will decrease the probability of a spot interruption happening in the near term.
 See [Choose the appropriate allocation strategy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html#ec2-fleet-allocation-use-cases) for information on fleet optimization.
 
-### What if there is no spot capacity? Will Karpenter fallback to on-demand?
+### What if there is no spot capacity? Will Karpenter use on-demand?
 
-Karpenter will fallback to on-demand, if your provisioner specifies both spot and on-demand and you are flexible to at least 10 instance types. 
+Karpenter will use on-demand, if your provisioner specifies both spot and on-demand and you are flexible to at least 10 instance types. 
 
-More specifically, Karpenter maintains a concept of "offerings" for each instance type, which is a combination of zone and capacity type (equivalent in the AWS cloud provider to an EC2 purchase option). Spot offerings are prioritized, if they're available. Whenever the Fleet API returns an insufficient capacity error for Spot instances, those particular offerings are temporarily removed from consideration (across the entire provisioner) so that Karpenter can make forward progress through fallback. The retry will happen immediately within milliseconds.
+More specifically, Karpenter maintains a concept of "offerings" for each instance type, which is a combination of zone and capacity type (equivalent in the AWS cloud provider to an EC2 purchase option). Spot offerings are prioritized, if they're available. Whenever the Fleet API returns an insufficient capacity error for Spot instances, those particular offerings are temporarily removed from consideration (across the entire provisioner) so that Karpenter can make forward progress with different options. The retry will happen immediately within milliseconds.
 
 ## Workloads
 

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -114,7 +114,7 @@ See [Choose the appropriate allocation strategy](https://docs.aws.amazon.com/AWS
 
 ### What if there is no spot capacity? Will Karpenter fallback to on-demand?
 
-Karpenter will fallback to on-demand, if your provisioner specifies both spot and on-demand. 
+Karpenter will fallback to on-demand, if your provisioner specifies both spot and on-demand and you are flexible to at least 10 instance types. 
 
 More specifically, Karpenter maintains a concept of "offerings" for each instance type, which is a combination of zone and capacity type (equivalent in the AWS cloud provider to an EC2 purchase option). Spot offerings are prioritized, if they're available. Whenever the Fleet API returns an insufficient capacity error for Spot instances, those particular offerings are temporarily removed from consideration (across the entire provisioner) so that Karpenter can make forward progress through fallback. The retry will happen immediately within milliseconds.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - When falling back from Spot to OD, require that the current provisioning request includes at least 10 instance types. This will prevent a case where a capacity pool is constrained and fallback causes other spot instances to be interrupted due to falling back to OD. 
 - Fixes the fake ec2api CreateFleet func to return the proper FleetErrors 
 - Adds a mutex to the fake ec2api to prevent a race when resetting.

**How was this change tested?**

* Unit test + manual on EKS

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
