### PR TITLE
fix: restrict iam:PassRole to just the node role we create

### DIFF
--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -54,7 +54,8 @@ You can review these fields [in the code](https://github.com/aws/karpenter/blob{
 ### InstanceProfile
 An `InstanceProfile` is a way to pass a single IAM role to an EC2 instance. Karpenter will not create one automatically.
 A default profile may be specified on the controller, allowing it to be omitted here. If not specified as either a default
-or on the controller, node provisioning will fail.
+or on the controller, node provisioning will fail. The KarpenterControllerPolicy will also need to have permissions for 
+`iam:PassRole` to the role provided here or provisioning will fail.  
 
 ```
 spec:

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
@@ -62,4 +62,4 @@ Resources:
           - Effect: Allow
             Action:
               - iam:PassRole
-            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}"
+            Resource: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}"

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
@@ -46,7 +46,6 @@ Resources:
               - ec2:CreateFleet
               - ec2:RunInstances
               - ec2:CreateTags
-              - iam:PassRole
               - ec2:TerminateInstances
               - ec2:DeleteLaunchTemplate
               # Read Operations
@@ -60,3 +59,7 @@ Resources:
               - ec2:DescribeSpotPriceHistory
               - ssm:GetParameter
               - pricing:GetProducts
+          - Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}"


### PR DESCRIPTION
Fixes # <!-- issue number -->

**Description**

restrict iam:PassRole to just the node role we create
**How was this change tested?**

* Tested in a new cluster using this cloudformation template and was unable to launch instances using an instance profile that was not the default.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
