### PR TITLE
Test: Implemented ginkgo test against local kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,20 +24,23 @@ dev: verify test ## Run all steps in the developer loop
 ci: toolchain verify licenses battletest ## Run all steps used by continuous integration
 
 test: ## Run tests
-	ginkgo -r
+	go test -v ./pkg/...
 
 strongertests:
 	# Run randomized, racing, code coveraged, tests
 	ginkgo -r \
 			-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./pkg/... \
-			--randomizeAllSpecs --randomizeSuites -race
+			--randomizeAllSpecs --randomizeSuites -race ./pkg/...
+
+e2etests: ## Run the e2e suite against your local cluster
+	go test -v ./test/... -environment-name=${CLUSTER_NAME}
 
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...
 
 deflake:
 	for i in $(shell seq 1 5); do make strongertests || exit 1; done
-	ginkgo -r -race -tags random_test_delay
+	ginkgo -r pkg -race -tags random_test_delay
 
 battletest: strongertests
 	go tool cover -html coverage.out -o coverage.html

--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -29,6 +29,12 @@ var (
 
 	// Karpenter specific domains and labels
 	KarpenterLabelDomain = "karpenter.sh"
+
+	ProvisionerNameLabelKey         = Group + "/provisioner-name"
+	DoNotEvictPodAnnotationKey      = Group + "/do-not-evict"
+	EmptinessTimestampAnnotationKey = Group + "/emptiness-timestamp"
+	TerminationFinalizer            = Group + "/termination"
+
 	LabelCapacityType    = KarpenterLabelDomain + "/capacity-type"
 	LabelNodeInitialized = KarpenterLabelDomain + "/initialized"
 

--- a/pkg/apis/provisioning/v1alpha5/register.go
+++ b/pkg/apis/provisioning/v1alpha5/register.go
@@ -40,10 +40,6 @@ var (
 		metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 		return nil
 	})
-	ProvisionerNameLabelKey         = Group + "/provisioner-name"
-	DoNotEvictPodAnnotationKey      = Group + "/do-not-evict"
-	EmptinessTimestampAnnotationKey = Group + "/emptiness-timestamp"
-	TerminationFinalizer            = Group + "/termination"
 )
 
 const (

--- a/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/provider.go
@@ -192,7 +192,7 @@ type BlockDevice struct {
 
 func Deserialize(provider *v1alpha5.Provider) (*AWS, error) {
 	if provider == nil {
-		return nil, fmt.Errorf("invariant violated: spec.provider is not defined. Is the defaulting webhook installed?")
+		return nil, fmt.Errorf("invariant violated: spec.provider is not defined. Is the validating webhook installed?")
 	}
 	a := &AWS{}
 	_, gvk, err := Codec.UniversalDeserializer().Decode(provider.Raw, nil, a)
@@ -207,7 +207,7 @@ func Deserialize(provider *v1alpha5.Provider) (*AWS, error) {
 
 func (a *AWS) Serialize(provider *v1alpha5.Provider) error {
 	if provider == nil {
-		return fmt.Errorf("invariant violated: spec.provider is not defined. Is the defaulting webhook installed?")
+		return fmt.Errorf("invariant violated: spec.provider is not defined. Is the validating webhook installed?")
 	}
 	bytes, err := json.Marshal(a)
 	if err != nil {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -982,7 +982,7 @@ var _ = Describe("Allocation", func() {
 					}
 					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
 						UserData:   aws.String(string(content)),
-						AWS:        provider,
+						AWS:        *provider,
 						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
@@ -1010,7 +1010,7 @@ var _ = Describe("Allocation", func() {
 					}
 					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
 						UserData:   nil,
-						AWS:        provider,
+						AWS:        *provider,
 						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
@@ -1049,7 +1049,7 @@ var _ = Describe("Allocation", func() {
 					}
 					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
 						UserData:   aws.String("#/bin/bash\n ./not-toml.sh"),
-						AWS:        provider,
+						AWS:        *provider,
 						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(ctx, cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
@@ -1071,7 +1071,7 @@ var _ = Describe("Allocation", func() {
 					}
 					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
 						UserData:   aws.String(string(content)),
-						AWS:        provider,
+						AWS:        *provider,
 						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
@@ -1095,7 +1095,7 @@ var _ = Describe("Allocation", func() {
 					}
 					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
 						UserData:   nil,
-						AWS:        provider,
+						AWS:        *provider,
 						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
@@ -1119,7 +1119,7 @@ var _ = Describe("Allocation", func() {
 					}
 					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
 						UserData:   aws.String("#/bin/bash\n ./not-mime.sh"),
-						AWS:        provider,
+						AWS:        *provider,
 						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)

--- a/pkg/test/awsnodetemplate.go
+++ b/pkg/test/awsnodetemplate.go
@@ -27,7 +27,7 @@ import (
 type AWSNodeTemplateOptions struct {
 	metav1.ObjectMeta
 	UserData *string
-	AWS      *aws.AWS
+	AWS      aws.AWS
 }
 
 func AWSNodeTemplate(overrides ...AWSNodeTemplateOptions) *v1alpha1.AWSNodeTemplate {
@@ -41,7 +41,7 @@ func AWSNodeTemplate(overrides ...AWSNodeTemplateOptions) *v1alpha1.AWSNodeTempl
 		ObjectMeta: ObjectMeta(options.ObjectMeta),
 		Spec: v1alpha1.AWSNodeTemplateSpec{
 			UserData: options.UserData,
-			AWS:      *options.AWS,
+			AWS:      options.AWS,
 		},
 	}
 }

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -24,9 +24,7 @@ import (
 	"github.com/aws/karpenter/pkg/test"
 
 	"github.com/onsi/ginkgo"
-
-	//nolint:revive,stylecheck
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:revive,stylecheck
 	prometheus "github.com/prometheus/client_model/go"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -75,7 +75,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 		}
 	}
 	if options.Image == "" {
-		options.Image = "public.ecr.aws/eks-distro/kubernetes/pause:3.2"
+		options.Image = "alpine"
 	}
 	volumes := []v1.Volume{}
 	for _, pvc := range options.PersistentVolumeClaims {
@@ -93,7 +93,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 			Tolerations:               options.Tolerations,
 			InitContainers: []v1.Container{{
 				Name:      strings.ToLower(sequentialRandomName()),
-				Image:     "alpine",
+				Image:     options.Image,
 				Resources: options.InitResourceRequirements,
 			}},
 			Containers: []v1.Container{{

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -75,7 +75,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 		}
 	}
 	if options.Image == "" {
-		options.Image = "k8s.gcr.io/pause"
+		options.Image = "public.ecr.aws/eks-distro/kubernetes/pause:3.2"
 	}
 	volumes := []v1.Volume{}
 	for _, pvc := range options.PersistentVolumeClaims {
@@ -93,7 +93,7 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 			Tolerations:               options.Tolerations,
 			InitContainers: []v1.Container{{
 				Name:      strings.ToLower(sequentialRandomName()),
-				Image:     options.Image,
+				Image:     "alpine",
 				Resources: options.InitResourceRequirements,
 			}},
 			Containers: []v1.Container{{

--- a/test/README.md
+++ b/test/README.md
@@ -13,3 +13,10 @@ Testing infrastructure will be divided up into three layers: Management Cluster,
 - `Clusters Under Test`: Rapid iteration [KIT](https://github.com/awslabs/kubernetes-iteration-toolkit) Guest Clusters and EKS Clusters where test suites will run.
 
 *Note: A more formal design discussing testing infrastructure will come soon.*
+
+## Developing
+Use the Tekton UI to manage and monitor resources and test-runs:
+```
+kubectl port-forward service/tekton-dashboard -n tekton-pipelines 9097&
+open http://localhost:9097
+```

--- a/test/infrastructure/management-cluster.cloudformation.yaml
+++ b/test/infrastructure/management-cluster.cloudformation.yaml
@@ -5,17 +5,17 @@ Parameters:
     Type: String
     Description: "Host cluster name"
 Resources:
-  KarpenterGuestClusterNodeInstanceProfile:
+  KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
-      InstanceProfileName: !Sub "KarpenterGuestClusterNodeInstanceProfile-${ClusterName}"
+      InstanceProfileName: !Sub "KarpenterNodeInstanceProfile-${ClusterName}"
       Path: "/"
       Roles:
-        - Ref: "KarpenterGuestClusterNodeRole"
-  KarpenterGuestClusterNodeRole:
+        - Ref: "KarpenterNodeRole"
+  KarpenterNodeRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: !Sub "KarpenterGuestClusterNodeRole-${ClusterName}"
+      RoleName: !Sub "KarpenterNodeRole-${ClusterName}"
       Path: /
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/test/infrastructure/scripts/step-01-config.sh
+++ b/test/infrastructure/scripts/step-01-config.sh
@@ -1,6 +1,5 @@
-export CLUSTER_NAME="${CLUSTER_NAME:-karpenter-test-cluster}"
+export CLUSTER_NAME="${CLUSTER_NAME:-karpenter-test-infrastructure}"
 export AWS_PROFILE="${AWS_PROFILE:-karpenter-ci}"
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 export AWS_REGION="${AWS_REGION:-us-west-2}"
-export KARPENTER_VERSION="${KARPENTER_VERSION:-v0.9.0}"
 export AWS_PAGER=""

--- a/test/infrastructure/scripts/step-02-eksctl-cluster.sh
+++ b/test/infrastructure/scripts/step-02-eksctl-cluster.sh
@@ -1,7 +1,7 @@
 cmd="create"
 K8S_VERSION="1.22"
 eksctl get cluster --name "${CLUSTER_NAME}" && cmd="upgrade"
-eksctl ${cmd} cluster -f - << EOF
+eksctl ${cmd} cluster -f - <<EOF
 ---
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
@@ -23,7 +23,11 @@ managedNodeGroups:
     name: ${CLUSTER_NAME}-system-pool
     desiredCapacity: 2
     minSize: 2
-    maxSize: 4
+    maxSize: 2
+    taints:
+      - key: CriticalAddonsOnly
+        value: "true"
+        effect: NoSchedule
 iam:
   withOIDC: true
 EOF

--- a/test/infrastructure/scripts/step-03-tekton-controllers.sh
+++ b/test/infrastructure/scripts/step-03-tekton-controllers.sh
@@ -1,7 +1,16 @@
 echo "Installing Tekton"
+
 kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.33.2/release.yaml
+kubectl patch configmap config-defaults -n tekton-pipelines --patch '{"data": { "default-task-run-workspace-binding": "emptyDir: {}" } }'
+kubectl patch deployment tekton-pipelines-controller -n tekton-pipelines --patch '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly", "operator":"Exists"}]}}}}'
+kubectl patch deployment tekton-pipelines-webhook -n tekton-pipelines --patch '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly", "operator":"Exists"}]}}}}'
 sleep 10
+
 kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/previous/v0.19.0/release.yaml
+kubectl patch deployment tekton-triggers-controller -n tekton-pipelines --patch '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly", "operator":"Exists"}]}}}}'
+kubectl patch deployment tekton-triggers-webhook -n tekton-pipelines --patch '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly", "operator":"Exists"}]}}}}'
 sleep 10
+
 kubectl apply -f https://github.com/tektoncd/dashboard/releases/download/v0.24.1/tekton-dashboard-release.yaml
+kubectl patch deployment tekton-dashboard -n tekton-pipelines --patch '{"spec":{"template":{"spec":{"tolerations":[{"key":"CriticalAddonsOnly", "operator":"Exists"}]}}}}'
 sleep 10

--- a/test/infrastructure/scripts/step-04-aws-load-balancer.sh
+++ b/test/infrastructure/scripts/step-04-aws-load-balancer.sh
@@ -25,5 +25,4 @@ helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-contro
   --set tolerations[0].key="CriticalAddonsOnly" \
   --set tolerations[0].operator="Exists" \
   --set replicaCount=1 \
-  --set serviceAccount.name=aws-load-balancer-controller \
-  eks/aws-load-balancer-controller
+  --set serviceAccount.name=aws-load-balancer-controller

--- a/test/infrastructure/scripts/step-04-aws-load-balancer.sh
+++ b/test/infrastructure/scripts/step-04-aws-load-balancer.sh
@@ -22,5 +22,8 @@ helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-contro
   -n kube-system \
   --set clusterName=${CLUSTER_NAME} \
   --set serviceAccount.create=false \
+  --set tolerations[0].key="CriticalAddonsOnly" \
+  --set tolerations[0].operator="Exists" \
   --set replicaCount=1 \
-  --set serviceAccount.name=aws-load-balancer-controller
+  --set serviceAccount.name=aws-load-balancer-controller \
+  eks/aws-load-balancer-controller

--- a/test/infrastructure/scripts/step-05-ebs-csi-driver.sh
+++ b/test/infrastructure/scripts/step-05-ebs-csi-driver.sh
@@ -9,17 +9,19 @@ if ! aws iam get-policy --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/Karpe
 fi
 
 eksctl create iamserviceaccount \
-    --name=ebs-csi-controller-sa \
-    --namespace=kube-system \
-    --cluster=${CLUSTER_NAME} \
-    --attach-policy-arn=arn:aws:iam::${AWS_ACCOUNT_ID}:policy/Karpenter-AmazonEBSCSIDriverServiceRolePolicy-${CLUSTER_NAME} \
-    --approve \
-    --override-existing-serviceaccounts
+  --name=ebs-csi-controller-sa \
+  --namespace=kube-system \
+  --cluster=${CLUSTER_NAME} \
+  --attach-policy-arn=arn:aws:iam::${AWS_ACCOUNT_ID}:policy/Karpenter-AmazonEBSCSIDriverServiceRolePolicy-${CLUSTER_NAME} \
+  --approve \
+  --override-existing-serviceaccounts
 
 helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
 helm repo update
 helm upgrade --install aws-ebs-csi-driver \
-    --namespace kube-system \
-    --set controller.replicaCount=1 \
-    --set controller.serviceAccount.create=false \
-    aws-ebs-csi-driver/aws-ebs-csi-driver
+  --namespace kube-system \
+  --set controller.replicaCount=1 \
+  --set controller.serviceAccount.create=false \
+  --set tolerations[0].key="CriticalAddonsOnly" \
+  --set tolerations[0].operator="Exists" \
+  aws-ebs-csi-driver/aws-ebs-csi-driver

--- a/test/infrastructure/scripts/step-06-karpenter.sh
+++ b/test/infrastructure/scripts/step-06-karpenter.sh
@@ -1,13 +1,13 @@
-echo "Installing Karpenter for Guest Clusters"
+echo "Installing Karpenter"
 
 aws cloudformation deploy \
-  --stack-name "KarpenterTesting-${CLUSTER_NAME}" \
+  --stack-name "KarpenterTestInfrastructure-${CLUSTER_NAME}" \
   --template-file ${SCRIPTPATH}/management-cluster.cloudformation.yaml \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameter-overrides "ClusterName=${CLUSTER_NAME}"
 
-ROLE="    - rolearn: arn:aws:iam::${AWS_ACCOUNT_ID}:role/KarpenterGuestClusterNodeRole-${CLUSTER_NAME}\n      username: system:node:{{EC2PrivateDNSName}}\n      groups:\n      - system:nodes\n      - system:bootstrappers"
-kubectl get -n kube-system configmap/aws-auth -o yaml | awk "/mapRoles: \|/{print;print \"${ROLE}\";next}1" > /tmp/aws-auth-patch.yml
+ROLE="    - rolearn: arn:aws:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}\n      username: system:node:{{EC2PrivateDNSName}}\n      groups:\n      - system:nodes\n      - system:bootstrappers"
+kubectl get -n kube-system configmap/aws-auth -o yaml | awk "/mapRoles: \|/{print;print \"${ROLE}\";next}1" >/tmp/aws-auth-patch.yml
 kubectl patch configmap/aws-auth -n kube-system --patch "$(cat /tmp/aws-auth-patch.yml)"
 
 eksctl create iamserviceaccount \
@@ -21,15 +21,16 @@ export KARPENTER_IAM_ROLE_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAM
 
 aws iam create-service-linked-role --aws-service-name spot.amazonaws.com || true
 
-if [ -z "$(helm repo list | grep karpenter)" ] ; then
+if [ -z "$(helm repo list | grep karpenter)" ]; then
   helm repo add karpenter https://charts.karpenter.sh
 fi
 helm repo update
-helm upgrade --install --namespace karpenter --create-namespace \
-  karpenter karpenter/karpenter \
-  --version ${KARPENTER_VERSION} \
+helm upgrade --install --namespace karpenter --create-namespace karpenter --version v0.13.1 \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-karpenter" \
   --set clusterName=${CLUSTER_NAME} \
-  --set clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json)  \
-  --set aws.defaultInstanceProfile=KarpenterGuestClusterNodeInstanceProfile-${CLUSTER_NAME} \
+  --set clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \
+  --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
+  --set tolerations[0].key="CriticalAddonsOnly" \
+  --set tolerations[0].operator="Exists" \
+  karpenter/karpenter \
   --wait

--- a/test/infrastructure/scripts/step-06-karpenter.sh
+++ b/test/infrastructure/scripts/step-06-karpenter.sh
@@ -25,7 +25,7 @@ if [ -z "$(helm repo list | grep karpenter)" ]; then
   helm repo add karpenter https://charts.karpenter.sh
 fi
 helm repo update
-helm upgrade --install --namespace karpenter --create-namespace karpenter --version v0.13.1 \
+helm upgrade --install --namespace karpenter --create-namespace karpenter --version v0.9.0 \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-karpenter" \
   --set clusterName=${CLUSTER_NAME} \
   --set clusterEndpoint=$(aws eks describe-cluster --name ${CLUSTER_NAME} --query "cluster.endpoint" --output json) \

--- a/test/infrastructure/scripts/step-07-provisioners.sh
+++ b/test/infrastructure/scripts/step-07-provisioners.sh
@@ -1,4 +1,4 @@
-# Provisioner for KIT Guest Clusters
+# General purpose provisioner for test execution
 cat <<EOF | kubectl apply -f -
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
@@ -10,32 +10,7 @@ spec:
     operator: Exists
   - key: kit.k8s.sh/control-plane-name
     operator: Exists
-  - key: "kubernetes.io/arch"
-    operator: NotIn
-    values: ["amd64"]
   ttlSecondsAfterEmpty: 180
-  provider:
-    instanceProfile: KarpenterGuestClusterNodeInstanceProfile-${CLUSTER_NAME}
-    tags:
-      kit.aws/substrate: ${CLUSTER_NAME}
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      kubernetes.io/cluster/${CLUSTER_NAME}: owned
-EOF
-
-# Provisioner for Tekton Pods
-cat << EOF | kubectl apply -f -
-apiVersion: karpenter.sh/v1alpha5
-kind: Provisioner
-metadata:
-  name: tekton-provisioner
-spec:
-  ttlSecondsAfterEmpty: 600
-  requirements:
-  - key: "kubernetes.io/arch"
-    operator: In
-    values: ["amd64"]
   provider:
     subnetSelector:
       karpenter.sh/discovery: ${CLUSTER_NAME}

--- a/test/infrastructure/scripts/step-08-prometheus.sh
+++ b/test/infrastructure/scripts/step-08-prometheus.sh
@@ -1,6 +1,7 @@
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 
-helm upgrade --install prometheus --namespace monitoring --create-namespace \
+helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace monitoring --create-namespace \
   --set tolerations[0].key="CriticalAddonsOnly" \
   --set tolerations[0].operator="Exists" \
   --set coreDns.enabled=false \
@@ -12,5 +13,4 @@ helm upgrade --install prometheus --namespace monitoring --create-namespace \
   --set kubeStateMetrics.enabled=false \
   --set kubeControllerManager.enabled=false \
   --set prometheus.serviceMonitor.selfMonitor=false \
-  --set prometheusOperator.serviceMonitor.selfMonitor=false \
-  prometheus-community/kube-prometheus-stack
+  --set prometheusOperator.serviceMonitor.selfMonitor=false

--- a/test/infrastructure/scripts/step-08-prometheus.sh
+++ b/test/infrastructure/scripts/step-08-prometheus.sh
@@ -1,7 +1,8 @@
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 
-helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
-  --namespace monitoring --create-namespace \
+helm upgrade --install prometheus --namespace monitoring --create-namespace \
+  --set tolerations[0].key="CriticalAddonsOnly" \
+  --set tolerations[0].operator="Exists" \
   --set coreDns.enabled=false \
   --set kubeProxy.enabled=false \
   --set kubeEtcd.enabled=false \
@@ -11,4 +12,5 @@ helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
   --set kubeStateMetrics.enabled=false \
   --set kubeControllerManager.enabled=false \
   --set prometheus.serviceMonitor.selfMonitor=false \
-  --set prometheusOperator.serviceMonitor.selfMonitor=false
+  --set prometheusOperator.serviceMonitor.selfMonitor=false \
+  prometheus-community/kube-prometheus-stack

--- a/test/infrastructure/scripts/step-10-tekton-permissions.sh
+++ b/test/infrastructure/scripts/step-10-tekton-permissions.sh
@@ -1,4 +1,4 @@
-if [ -z "$(kubectl get ns tekton-tests)" ] ; then
+if [ -z "$(kubectl get ns tekton-tests)" ]; then
   kubectl create ns tekton-tests
 fi
 
@@ -13,7 +13,7 @@ eksctl create iamserviceaccount \
   --approve
 
 ROLE="    - rolearn: arn:aws:sts::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-tekton\n      username: system:node:{{EC2PrivateDNSName}}\n      groups:\n      - tekton"
-kubectl get -n kube-system configmap/aws-auth -o yaml | awk "/mapRoles: \|/{print;print \"${ROLE}\";next}1" > /tmp/aws-auth-patch.yml
+kubectl get -n kube-system configmap/aws-auth -o yaml | awk "/mapRoles: \|/{print;print \"${ROLE}\";next}1" >/tmp/aws-auth-patch.yml
 kubectl patch configmap/aws-auth -n kube-system --patch "$(cat /tmp/aws-auth-patch.yml)"
 
 kubectl annotate --overwrite serviceaccount -n tekton-tests tekton "eks.amazonaws.com/role-arn=arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-tekton"

--- a/test/infrastructure/setup-management-cluster.sh
+++ b/test/infrastructure/setup-management-cluster.sh
@@ -25,4 +25,3 @@ for step in "${steps[@]}"; do
 done
 
 echo "✅ Successfully setup test infrastructure"
-

--- a/test/infrastructure/setup-management-cluster.sh
+++ b/test/infrastructure/setup-management-cluster.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+SCRIPTPATH="$(
+  cd "$(dirname "$0")"
+  pwd -P
+)"
 
 declare -a steps=(
   scripts/step-01-config.sh

--- a/test/pkg/environment/environment.go
+++ b/test/pkg/environment/environment.go
@@ -1,0 +1,84 @@
+package environment
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/pkg/environment"
+	loggingtesting "knative.dev/pkg/logging/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter/pkg/apis"
+	"github.com/aws/karpenter/pkg/utils/env"
+)
+
+var EnvironmentName = flag.String("environment-name", env.WithDefaultString("ENVIRONMENT_NAME", ""), "Environment name enables discovery of the testing environment")
+
+type Environment struct {
+	context.Context
+	Options *Options
+	Client  client.Client
+}
+
+func NewEnvironment(t *testing.T) (*Environment, error) {
+	ctx := loggingtesting.TestContextWithLogger(t)
+	client, err := NewLocalClient()
+	if err != nil {
+		return nil, err
+	}
+	options, err := NewOptions()
+	if err != nil {
+		return nil, err
+	}
+	gomega.SetDefaultEventuallyTimeout(10 * time.Minute)
+	gomega.SetDefaultEventuallyPollingInterval(1 * time.Second)
+	return &Environment{Context: ctx, Options: options, Client: client}, nil
+}
+
+func NewLocalClient() (client.Client, error) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := apis.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	config, err := (&environment.ClientConfig{Kubeconfig: path.Join(home, ".kube/config")}).GetRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	return client.New(config, client.Options{Scheme: scheme})
+}
+
+type Options struct {
+	EnvironmentName string
+}
+
+func NewOptions() (*Options, error) {
+	options := &Options{
+		EnvironmentName: *EnvironmentName,
+	}
+	if err := options.Validate(); err != nil {
+		return nil, err
+	}
+	return options, nil
+}
+
+func (o Options) Validate() error {
+	if o.EnvironmentName == "" {
+		return fmt.Errorf("--envronment-name must be defined")
+	}
+	return nil
+}

--- a/test/pkg/environment/environment.go
+++ b/test/pkg/environment/environment.go
@@ -78,7 +78,7 @@ func NewOptions() (*Options, error) {
 
 func (o Options) Validate() error {
 	if o.EnvironmentName == "" {
-		return fmt.Errorf("--envronment-name must be defined")
+		return fmt.Errorf("--environment-name must be defined")
 	}
 	return nil
 }

--- a/test/pkg/environment/expectations.go
+++ b/test/pkg/environment/expectations.go
@@ -1,0 +1,69 @@
+package environment
+
+import (
+	"sync"
+
+	. "github.com/onsi/gomega" //nolint:revive,stylecheck
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+)
+
+var (
+	EnvironmentLabelName = "testing.karpenter.sh/environment-name"
+	CleanableObjects     = []client.Object{
+		&v1alpha5.Provisioner{},
+		&v1.Pod{},
+		&appsv1.Deployment{},
+		&appsv1.DaemonSet{},
+		&v1beta1.PodDisruptionBudget{},
+		&v1.PersistentVolumeClaim{},
+		&v1.PersistentVolume{},
+		&storagev1.StorageClass{},
+		&v1alpha1.AWSNodeTemplate{},
+	}
+)
+
+func (env *Environment) ExpectCreated(objects ...client.Object) {
+	for _, object := range objects {
+		object.SetLabels(lo.Assign(object.GetLabels(), map[string]string{EnvironmentLabelName: env.Options.EnvironmentName}))
+		Expect(env.Client.Create(env, object)).To(Succeed())
+	}
+}
+
+func (env *Environment) ExpectCleaned() {
+	namespaces := &v1.NamespaceList{}
+	Expect(env.Client.List(env, namespaces)).To(Succeed())
+	wg := sync.WaitGroup{}
+	for _, object := range CleanableObjects {
+		for _, namespace := range namespaces.Items {
+			wg.Add(1)
+			go func(object client.Object, namespace string) {
+				Expect(env.Client.DeleteAllOf(env, object,
+					client.InNamespace(namespace),
+					client.MatchingLabels(map[string]string{EnvironmentLabelName: env.Options.EnvironmentName}),
+				)).ToNot(HaveOccurred())
+				wg.Done()
+			}(object, namespace.Name)
+		}
+	}
+	wg.Wait()
+}
+
+func (env *Environment) EventuallyExpectHealthy(pods ...*v1.Pod) {
+	for _, pod := range pods {
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+			g.Expect(pod.Status.Conditions).To(ContainElement(And(
+				HaveField("Type", Equal(v1.PodReady)),
+				HaveField("Status", Equal(v1.ConditionTrue)),
+			)))
+		}).Should(Succeed())
+	}
+}

--- a/test/suites/integration/pipeline.yaml
+++ b/test/suites/integration/pipeline.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: karpenter-integration-suite
+spec:
+  params:
+    - name: commit
+  tasks:
+  - name: github-action
+    taskRef:
+      name: github-action
+      kind: ClusterTask
+    params:
+      - name: repository
+        value: github.com/aws/karpenter
+      - name: commit
+        value: $(params.commit)
+      - name: command
+        value: go test ./test/suites/integration -environment-name=$(context.pipelineRun.name)

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -1,0 +1,41 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+	"github.com/aws/karpenter/test/pkg/environment"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var env *environment.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		var err error
+		env, err = environment.NewEnvironment(t)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	RunSpecs(t, "Integration Suite")
+}
+
+var _ = AfterEach(func() {
+	env.ExpectCleaned()
+})
+
+var _ = Describe("Sanity Checks", func() {
+	It("should provision nodes", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		pod := test.Pod()
+		env.ExpectCreated(provisioner, provider, pod)
+		env.EventuallyExpectHealthy(pod)
+	})
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
Enables e2e tests against a local cluster. 
- test resources are all tagged with a special label for cleanup
- Made progress on CI infra setup (critical addons only, role name, etc), but gaps remain

```
 ~/w/g/s/g/aws/karpenter │ on testinfra !1  make e2etests                                2 ✘ │ at 18:00:08
ginkgo -r test -- --environment-name=karpenter-test-infrastructure
Running Suite: Integration Suite
================================
Random Seed: 1656550823
Will run 1 of 1 specs

• [SLOW TEST:85.879 seconds]
Sanity Checks
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/suite_test.go:30
  should provision nodes
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/suite_test.go:31
------------------------------

Ran 1 of 1 Specs in 87.084 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 1m33.141041379s
Test Suite Passed
```

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
