### PR TITLE
fix: use the correct number of pods when bin-packing if AWS_ENI_LIMITED_POD_DENSITY is false

### DIFF
--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -58,13 +58,14 @@ func NewInstanceType(ctx context.Context, info *ec2.InstanceTypeInfo, price floa
 		offerings:        offerings,
 		price:            price,
 	}
+	// set max pods before computing resources
+	if !injection.GetOptions(ctx).AWSENILimitedPodDensity {
+		instanceType.maxPods = ptr.Int32(110)
+	}
 	// Precompute to minimize memory/compute overhead
 	instanceType.resources = instanceType.computeResources(injection.GetOptions(ctx).AWSEnablePodENI)
 	instanceType.overhead = instanceType.computeOverhead(injection.GetOptions(ctx).VMMemoryOverhead)
 	instanceType.requirements = instanceType.computeRequirements()
-	if !injection.GetOptions(ctx).AWSENILimitedPodDensity {
-		instanceType.maxPods = ptr.Int32(110)
-	}
 	return instanceType
 }
 


### PR DESCRIPTION
**Description**
fix: use the correct number of pods when bin-packing if AWS_ENI_LIMITED_POD_DENSITY is false
**How was this change tested?**

* Unit testing and deploying a no-resource pod to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
