### PR TITLE
fix: add initial delay to liveness and let CP know it's run by the webhook

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -93,6 +93,7 @@ spec:
               containerPort: 8081
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 30
             httpGet:
               path: /healthz
               port: http
@@ -146,6 +147,7 @@ spec:
               containerPort: {{ .Values.webhook.port }}
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 30
             httpGet:
               port: https-webhook
               scheme: HTTPS

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -60,7 +60,10 @@ func main() {
 	})
 
 	// Register the cloud provider to attach vendor specific validation logic.
-	registry.NewCloudProvider(ctx, cloudprovider.Options{ClientSet: kubernetes.NewForConfigOrDie(config)})
+	registry.NewCloudProvider(ctx, cloudprovider.Options{
+		ClientSet:   kubernetes.NewForConfigOrDie(config),
+		WebhookOnly: true,
+	})
 
 	// Controllers and webhook
 	sharedmain.MainWithConfig(ctx, "webhook", config,

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -414,8 +414,8 @@ var _ = Describe("Allocation", func() {
 				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
 					{
 						Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1a"}},
-						}},
+						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1a"}},
+					}},
 					},
 				}}}
 				ExpectApplied(ctx, env.Client, provisioner)
@@ -1692,6 +1692,21 @@ var _ = Describe("Allocation", func() {
 					Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 				})
 			})
+		})
+	})
+
+	Context("Webhook", func() {
+		It("should validate when in webhook mode", func() {
+			cp := NewCloudProvider(ctx, cloudprovider.Options{WebhookOnly: true})
+			// just ensures that validation doesn't depend on anything as when created for the webhook
+			// we don't fully initialize the cloud provider
+			Expect(cp.Validate(ctx, provisioner)).To(Succeed())
+		})
+		It("should default when in webhookmode", func() {
+			cp := NewCloudProvider(ctx, cloudprovider.Options{WebhookOnly: true})
+			// just ensures that validation doesn't depend on anything as when created for the webhook
+			// we don't fully initialize the cloud provider
+			cp.Default(ctx, provisioner)
 		})
 	})
 })

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -30,6 +30,9 @@ import (
 type Options struct {
 	ClientSet  *kubernetes.Clientset
 	KubeClient client.Client
+	// WebhookOnly is true if the cloud provider is being used for its validation/defaulting only by the webhook.  In
+	// this case it may not need to perform some initialization and the StartAsync channel will not be closed.
+	WebhookOnly bool
 	// StartAsync is a channel that is closed when leader election has been won.  This is a signal to start any  async
 	// processing that should only occur while the cloud provider is the leader.
 	StartAsync <-chan struct{}


### PR DESCRIPTION
Fixes # <!-- issue number -->

**Description**

The webhook just needs the CP for Validate/Default, so let the CP know
this to allow it to skip some processing that isn't required if it
chooses to. Add an initial delay to our liveness probes to ensure that
any initial startup doesn't lead to restarts on the webhook/controller.


**How was this change tested?**

* Unit test & deployed to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
