### PR TITLE
fix: correctly handle static volumes

### DIFF
--- a/pkg/test/storage.go
+++ b/pkg/test/storage.go
@@ -30,6 +30,7 @@ type PersistentVolumeOptions struct {
 	metav1.ObjectMeta
 	Zones            []string
 	StorageClassName string
+	Driver           string
 }
 
 func PersistentVolume(overrides ...PersistentVolumeOptions) *v1.PersistentVolume {
@@ -39,10 +40,13 @@ func PersistentVolume(overrides ...PersistentVolumeOptions) *v1.PersistentVolume
 			panic(fmt.Sprintf("Failed to merge options: %s", err))
 		}
 	}
+	if options.Driver == "" {
+		options.Driver = "test.driver"
+	}
 	return &v1.PersistentVolume{
 		ObjectMeta: ObjectMeta(metav1.ObjectMeta{}),
 		Spec: v1.PersistentVolumeSpec{
-			PersistentVolumeSource: v1.PersistentVolumeSource{CSI: &v1.CSIPersistentVolumeSource{Driver: "test-driver", VolumeHandle: "test-handle"}},
+			PersistentVolumeSource: v1.PersistentVolumeSource{CSI: &v1.CSIPersistentVolumeSource{Driver: options.Driver, VolumeHandle: "test-handle"}},
 			StorageClassName:       options.StorageClassName,
 			AccessModes:            []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			Capacity:               v1.ResourceList{v1.ResourceStorage: resource.MustParse("100Gi")},


### PR DESCRIPTION

Fixes #1998

**Description**

For static volumes, we pull the CSI driver name off of the PV
after it's bound instead of from the SC named on the PVC.  The SC
may not even exist in these cases and is informational.

**How was this change tested?**

* Unit testing & deploying a PVC/PV to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
