### PR TITLE
chore: consistently order pods/nodes

### DIFF
--- a/pkg/controllers/provisioning/scheduling/queue.go
+++ b/pkg/controllers/provisioning/scheduling/queue.go
@@ -83,6 +83,8 @@ func byCPUAndMemoryDescending(pods []*v1.Pod) func(i int, j int) bool {
 		} else if memCmp > 0 {
 			return true
 		}
-		return false
+
+		// provide a consistent ordering
+		return pods[i].UID < pods[j].UID
 	}
 }

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -82,6 +82,11 @@ func NewScheduler(ctx context.Context, kubeClient client.Client, nodeTemplates [
 		s.remainingResources[name] = resources.Subtract(s.remainingResources[name], node.Capacity)
 		return true
 	})
+
+	// we de-dupe events based on content, so we need a consistent ordering of inflight nodes to generate fewer events
+	sort.Slice(s.inflight, func(a, b int) bool {
+		return s.inflight[a].Node.UID < s.inflight[b].Node.UID
+	})
 	return s
 }
 


### PR DESCRIPTION
Fixes # <!-- issue number -->

**Description**

We de-dupe events by message contents, by ordering nodes/pods during
scheduling we ensure that we pseudo-assign the same pod to the same
node which reduces the number of events we emit.

**How was this change tested?**

* Deployed to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
