### PR TITLE
fix: hostNetwork variable is not aligned with docs in Helm chart (#2043)

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8}}
       {{- end }}
-      {{- if .Values.webhook.hostNetwork }}
+      {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
       containers:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your 

-->

Fixes #2043

**Description**
When try to use custom CNI, we need to setup hostNetwork to true in deployment.yaml.
According the readme & values.yaml, the variable would be hostNetwork, but the variable is `webhook.hostNetwork` in the deployment.yaml.

Based on the logic of https://github.com/aws/karpenter/pull/1145, because the variable is not in the webhook container section, it should be `hostNetwork` instead of `webhook.hostNetwork`

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
