### PR TITLE
docs: clarify use of prefix assignment mode

### DIFF
--- a/website/content/en/preview/tasks/pod-density.md
+++ b/website/content/en/preview/tasks/pod-density.md
@@ -20,13 +20,14 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node. 
+By default, the number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to an instance type. By running the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY=false` (or the argument  `--aws-eni-limited-pod-density=false`) you can set the maximum number of pods per node to 110 instead.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported. 
+Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
 
-Run the Karpenter controller with the enviornment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods. 
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows for a single ENI to provide IP addresses for multiple pods.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
-Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15). 
 
 ## Limit Pod Density
 


### PR DESCRIPTION
**Description**
Clarify how prefix assignment mode (AWS VPC CNI) can be used with Karpenter to increase pod densities per node.

**How was this change tested?**
`make website` and validated content.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
