### PR TITLE
chore: use "go test" instead of "ginkgo"

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -15,7 +15,6 @@ tools() {
     go install github.com/google/ko@v0.11.2
     go install github.com/mikefarah/yq/v4@v4.24.5
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.8.1
-    go install github.com/onsi/ginkgo/ginkgo@v1.16.5
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20220421205612-c162794a9b12
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0
     go install github.com/sigstore/cosign/cmd/cosign@v1.9.0


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
Uses go test instead of ginkgo cli. ginkgo is still used as a library.

**How was this change tested?**
Manually tested and injected failures.

- `make test`
- `make battletest`
- `make ci`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
