### PR TITLE
docs: add more information about metrics

### DIFF
--- a/hack/docs/configuration_gen_docs.go
+++ b/hack/docs/configuration_gen_docs.go
@@ -40,7 +40,12 @@ func main() {
 	envVarsBlock := "| Environment Variable | CLI Flag | Description |\n"
 	envVarsBlock += "|--|--|--|\n"
 	opts.VisitAll(func(f *flag.Flag) {
-		envVarsBlock += fmt.Sprintf("| %s | %s | %s |\n", strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_"), "\\-\\-"+f.Name, f.Usage)
+		if f.DefValue == "" {
+			envVarsBlock += fmt.Sprintf("| %s | %s | %s|\n", strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_"), "\\-\\-"+f.Name, f.Usage)
+		} else {
+			envVarsBlock += fmt.Sprintf("| %s | %s | %s (default = %s)|\n", strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_"), "\\-\\-"+f.Name, f.Usage, f.DefValue)
+		}
+
 	})
 
 	log.Println("writing output to", outputFileName)

--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -114,7 +114,8 @@ description: >
 ---
 `)
 	fmt.Fprintf(f, "<!-- this document is generated from hack/docs/metrics_gen_docs.go -->\n")
-	fmt.Fprintf(f, "Karpenter writes several metrics to Prometheus to allow monitoring cluster provisioning status\n")
+	fmt.Fprintf(f, "Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. "+
+		"These metrics are available on the metrics port at `/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../configuration)\n")
 	previousSubsystem := ""
 	for _, metric := range allMetrics {
 		if metric.subsystem != previousSubsystem {

--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -115,7 +115,7 @@ description: >
 `)
 	fmt.Fprintf(f, "<!-- this document is generated from hack/docs/metrics_gen_docs.go -->\n")
 	fmt.Fprintf(f, "Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. "+
-		"These metrics are available on the metrics port at `/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../configuration)\n")
+		"These metrics are available by default at `karpenter.karpenter.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../configuration)\n")
 	previousSubsystem := ""
 	for _, metric := range allMetrics {
 		if metric.subsystem != previousSubsystem {

--- a/website/content/en/preview/tasks/configuration.md
+++ b/website/content/en/preview/tasks/configuration.md
@@ -14,19 +14,19 @@ There are two main configuration mechanisms that can be used to configure Karpen
 
 | Environment Variable | CLI Flag | Description |
 |--|--|--|
-| AWS_DEFAULT_INSTANCE_PROFILE | \-\-aws-default-instance-profile | The default instance profile to use when provisioning nodes in AWS |
-| AWS_ENABLE_POD_ENI | \-\-aws-enable-pod-eni | If true then instances that support pod ENI will report a vpc.amazonaws.com/pod-eni resource |
-| AWS_ENI_LIMITED_POD_DENSITY | \-\-aws-eni-limited-pod-density | Indicates whether new nodes should use ENI-based pod density |
-| AWS_ISOLATED_VPC | \-\-aws-isolated-vpc | If true then assume we can't reach AWS services which don't have a VPC endpoint |
-| AWS_NODE_NAME_CONVENTION | \-\-aws-node-name-convention | The node naming convention used by the AWS cloud provider. DEPRECATION WARNING: this field may be deprecated at any time |
-| CLUSTER_ENDPOINT | \-\-cluster-endpoint | The external kubernetes cluster endpoint for new nodes to connect with |
-| CLUSTER_NAME | \-\-cluster-name | The kubernetes cluster name for resource discovery |
-| ENABLE_PROFILING | \-\-enable-profiling | Enable the profiling on the metric endpoint |
-| HEALTH_PROBE_PORT | \-\-health-probe-port | The port the health probe endpoint binds to for reporting controller health |
-| KUBE_CLIENT_BURST | \-\-kube-client-burst | The maximum allowed burst of queries to the kube-apiserver |
-| KUBE_CLIENT_QPS | \-\-kube-client-qps | The smoothed rate of qps to kube-apiserver |
-| METRICS_PORT | \-\-metrics-port | The port the metric endpoint binds to for operating metrics about the controller itself |
-| VM_MEMORY_OVERHEAD | \-\-vm-memory-overhead | The VM memory overhead as a percent that will be subtracted from the total memory for all instance types |
+| AWS_DEFAULT_INSTANCE_PROFILE | \-\-aws-default-instance-profile | The default instance profile to use when provisioning nodes in AWS|
+| AWS_ENABLE_POD_ENI | \-\-aws-enable-pod-eni | If true then instances that support pod ENI will report a vpc.amazonaws.com/pod-eni resource (default = false)|
+| AWS_ENI_LIMITED_POD_DENSITY | \-\-aws-eni-limited-pod-density | Indicates whether new nodes should use ENI-based pod density (default = true)|
+| AWS_ISOLATED_VPC | \-\-aws-isolated-vpc | If true then assume we can't reach AWS services which don't have a VPC endpoint (default = false)|
+| AWS_NODE_NAME_CONVENTION | \-\-aws-node-name-convention | The node naming convention used by the AWS cloud provider. DEPRECATION WARNING: this field may be deprecated at any time (default = ip-name)|
+| CLUSTER_ENDPOINT | \-\-cluster-endpoint | The external kubernetes cluster endpoint for new nodes to connect with|
+| CLUSTER_NAME | \-\-cluster-name | The kubernetes cluster name for resource discovery|
+| ENABLE_PROFILING | \-\-enable-profiling | Enable the profiling on the metric endpoint (default = false)|
+| HEALTH_PROBE_PORT | \-\-health-probe-port | The port the health probe endpoint binds to for reporting controller health (default = 8081)|
+| KUBE_CLIENT_BURST | \-\-kube-client-burst | The maximum allowed burst of queries to the kube-apiserver (default = 300)|
+| KUBE_CLIENT_QPS | \-\-kube-client-qps | The smoothed rate of qps to kube-apiserver (default = 200)|
+| METRICS_PORT | \-\-metrics-port | The port the metric endpoint binds to for operating metrics about the controller itself (default = 8080)|
+| VM_MEMORY_OVERHEAD | \-\-vm-memory-overhead | The VM memory overhead as a percent that will be subtracted from the total memory for all instance types (default = 0.075)|
 
 [comment]: <> (end docs generated content from hack/docs/configuration_gen_docs.go)
 

--- a/website/content/en/preview/tasks/metrics.md
+++ b/website/content/en/preview/tasks/metrics.md
@@ -7,7 +7,7 @@ description: >
   Inspect Karpenter Metrics
 ---
 <!-- this document is generated from hack/docs/metrics_gen_docs.go -->
-Karpenter writes several metrics to Prometheus to allow monitoring cluster provisioning status
+Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available on the metrics port at `/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../configuration)
 ## Provisioner Metrics
 
 ### `karpenter_provisioner_limit`

--- a/website/content/en/preview/tasks/metrics.md
+++ b/website/content/en/preview/tasks/metrics.md
@@ -7,7 +7,7 @@ description: >
   Inspect Karpenter Metrics
 ---
 <!-- this document is generated from hack/docs/metrics_gen_docs.go -->
-Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available on the metrics port at `/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../configuration)
+Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.karpenter.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../configuration)
 ## Provisioner Metrics
 
 ### `karpenter_provisioner_limit`


### PR DESCRIPTION
Fixes #2042

**Description**

Add more information about the metrics endpoint and document the default
values for the command line parameters.

**How was this change tested?**

Website preview

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
