### PR TITLE
feat: add network related bottlerocket userdata settings

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/bottlerocketsettings.go
@@ -29,6 +29,8 @@ type settings struct {
 	Metrics           *metrics           `toml:"metrics,omitempty"`
 	Kernel            *kernel            `toml:"kernel,omitempty"`
 	ContainerRegistry *containerRegistry `toml:"container-registry,omitempty"`
+	Network           *network           `toml:"network,omitempty"`
+	NTP               *ntp               `toml:"ntp,omitempty"`
 }
 
 // kubernetes specific configuration for bottlerocket api
@@ -44,7 +46,7 @@ type kubernetes struct {
 	EvictionHard              map[string]string    `toml:"eviction-hard,omitempty"`
 	KubeReserved              map[string]string    `toml:"kube-reserved,omitempty"`
 	SystemReserved            map[string]string    `toml:"system-reserved,omitempty"`
-	AllowedUnsafeSysctls      []*string            `toml:"allowed-unsafe-sysctls,omitempty"`
+	AllowedUnsafeSysctls      []string             `toml:"allowed-unsafe-sysctls,omitempty"`
 	ServerTLSBootstrap        *bool                `toml:"server-tls-bootstrap,omitempty"`
 	RegistryQPS               *int                 `toml:"registry-qps,omitempty"`
 	RegistryBurst             *int                 `toml:"registry-burst,omitempty"`
@@ -99,12 +101,23 @@ type control struct {
 }
 
 type metrics struct {
-	MetricsURL    *string   `toml:"metrics-url,omitempty"`
-	SendMetrics   *bool     `toml:"send-metrics,omitempty"`
-	ServiceChecks []*string `toml:"service-checks,omitempty"`
+	MetricsURL    *string  `toml:"metrics-url,omitempty"`
+	SendMetrics   *bool    `toml:"send-metrics,omitempty"`
+	ServiceChecks []string `toml:"service-checks,omitempty"`
 }
 
 type kernel struct {
 	Lockdown *string           `toml:"lockdown,omitempty"`
 	SysCtl   map[string]string `toml:"sysctl,omitempty"`
+}
+
+type network struct {
+	Hostname   *string         `toml:"hostname,omitempty"`
+	HTTPSProxy *string         `toml:"https-proxy,omitempty"`
+	NoProxy    []string        `toml:"no-proxy,omitempty"`
+	Hosts      [][]interface{} `toml:"hosts,omitempty"`
+}
+
+type ntp struct {
+	TimeServers []string `toml:"time-servers,omitempty"`
 }

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -414,8 +414,8 @@ var _ = Describe("Allocation", func() {
 				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
 					{
 						Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1a"}},
-					}},
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1a"}},
+						}},
 					},
 				}}}
 				ExpectApplied(ctx, env.Client, provisioner)

--- a/pkg/cloudprovider/aws/testdata/br_userdata_input.golden
+++ b/pkg/cloudprovider/aws/testdata/br_userdata_input.golden
@@ -1,4 +1,14 @@
 [settings.kubernetes.eviction-hard]
 "memory.available" = "12%"
+
 [settings.kubernetes]
 "unknown-setting" = "unknown"
+
+[settings.network]
+hostname = "test.local"
+https-proxy = "1.2.3.4:8080"
+no-proxy = ["localhost", "127.0.0.1"]
+hosts = [["10.0.0.0", ["test.example.com", "test1.example.com"]]]
+
+[settings.ntp]
+time-servers = ["169.254.169.123"]

--- a/pkg/cloudprovider/aws/testdata/br_userdata_merged.golden
+++ b/pkg/cloudprovider/aws/testdata/br_userdata_merged.golden
@@ -13,3 +13,12 @@ max-pods = 110
 
 [settings.kubernetes.eviction-hard]
 'memory.available' = '12%%'
+
+[settings.network]
+hostname = 'test.local'
+https-proxy = '1.2.3.4:8080'
+no-proxy = ['localhost', '127.0.0.1']
+hosts = [['10.0.0.0', ['test.example.com', 'test1.example.com']]]
+
+[settings.ntp]
+time-servers = ['169.254.169.123']


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->
https://github.com/aws/karpenter/issues/2059

**Description**

 - adds network and NTP settings to Karpenter's bottlerocket userdata settings.

**How was this change tested?**

* Unit tested 
* EKS cluster manually tested with AWSNodeTemplate:


``` 
spec:
   amiFamily: Bottlerocket
   securityGroupSelector:
     karpenter.sh/discovery: kdemo
   subnetSelector:
     karpenter.sh/discovery: kdemo
   userData: |
     [settings.network]
     no-proxy = ["localhost", "127.0.0.1"]
     hosts = [["100.0.0.0", ["test.example.com", "test1.example.com"]]]
     [settings.ntp]
     time-servers = ['169.254.169.123']
```

verified the node joins the cluster and that user-data matches in EC2. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
