### PR TITLE
docs: ensure we don't list capacity type on our instance type docs

### DIFF
--- a/hack/docs/instancetypes_gen_docs.go
+++ b/hack/docs/instancetypes_gen_docs.go
@@ -104,8 +104,10 @@ below are the resources available with some assumptions and after the instance o
 	familyNames := lo.Keys(families)
 	sort.Strings(familyNames)
 
-	// we don't want to show the zone label that was applied based on our credentials
+	// we don't want to show a few labels that will vary amongst regions
 	delete(labelNameMap, v1.LabelTopologyZone)
+	delete(labelNameMap, v1alpha5.LabelCapacityType)
+
 	labelNames := lo.Keys(labelNameMap)
 
 	sort.Strings(labelNames)

--- a/website/content/en/preview/AWS/instance-types.md
+++ b/website/content/en/preview/AWS/instance-types.md
@@ -9510,7 +9510,6 @@ below are the resources available with some assumptions and after the instance o
  |karpenter.k8s.aws/instance-memory|512|
  |karpenter.k8s.aws/instance-pods|4|
  |karpenter.k8s.aws/instance-size|nano|
- |karpenter.sh/capacity-type|on-demand|
  |kubernetes.io/arch|amd64|
  |kubernetes.io/os|linux|
  |node.kubernetes.io/instance-type|t2.nano|


### PR DESCRIPTION
**Description**

Ensure we don't list the capacity-type label in our instance type docs.  Since we generate the labels based on if there is a single value per instance, this can sometimes appear if an instance type isn't available via spot.

**How was this change tested?**

* Generating docs

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
