### PR TITLE
test: fix batcher test flake

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -108,8 +108,13 @@ func (p *Provisioner) Start(ctx context.Context) {
 func (p *Provisioner) Provision(ctx context.Context) error {
 	// Batch pods
 	p.batcher.Wait()
-	// wake any waiters on the cond
-	defer p.cond.Broadcast()
+	defer func() {
+		// wake any waiters on the cond, this is only used for unit testing to ensure we can sync on the
+		// provisioning loop for reliable tests
+		p.mu.Lock()
+		p.cond.Broadcast()
+		p.mu.Unlock()
+	}()
 
 	// Get pods, exit if nothing to do
 	pods, err := p.getPods(ctx)


### PR DESCRIPTION
**Description**

TriggerAndWait() is used in unit tests to immediately trigger the batcher
and then wait on the condition variable.  It locks the mutex, and then
waits which unlocks it.  By locking on the mutex before broadcasting,
we ensure that we don't broadcast until the unit test is already
waiting on the condition variable.

**How was this change tested?**

* Unit testing & deployed to EKS.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
