### PR TITLE
chore: add pod information to debug log

### DIFF
--- a/pkg/controllers/provisioning/scheduling/preferences.go
+++ b/pkg/controllers/provisioning/scheduling/preferences.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter/pkg/utils/pretty"
 )
@@ -38,7 +39,10 @@ func (p *Preferences) Relax(ctx context.Context, pod *v1.Pod) bool {
 		p.toleratePreferNoScheduleTaints,
 	} {
 		if reason := relaxFunc(pod); reason != nil {
-			logging.FromContext(ctx).Debugf("Relaxing soft constraints for pod since it previously failed to schedule, %s", ptr.StringValue(reason))
+
+			logging.FromContext(ctx).
+				With("pod", client.ObjectKeyFromObject(pod)).
+				Debugf("Relaxing soft constraints for pod since it previously failed to schedule, %s", ptr.StringValue(reason))
 			return true
 		}
 	}


### PR DESCRIPTION
**Description**

Record pod information in structured format with this log statement. When analyzing a log earlier it would have been helpful to know which pod this log referred to.

**How was this change tested?**
deployed to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
