### PR TITLE
docs: helm version causing errors

### DIFF
--- a/website/content/en/v0.13.2/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.13.2/getting-started/getting-started-with-terraform/_index.md
@@ -60,7 +60,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.4"
+      version = "~> 2.5.1"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"


### PR DESCRIPTION
fixes the authentication error on api_version client.authentication.k8s.io/v1alpha1


**Description**

Based on issue mentioned [here](https://github.com/helm/helm/issues/10975). Need to update helm version to respect the `client.authentication.k8s.io/v1alpha1` api_version variable.

**Does this change impact docs?**
- 
- Yes, PR includes docs updates

**Release Note**

```release-note
- Updates docs to have an upgraded helm version to avoid failure caused due to helm `api_version` as shown [here](https://github.com/helm/helm/issues/10975)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
