### PR TITLE
test: add dynamic/static PVC E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
       		--set clusterName=${CLUSTER_NAME} \
 			--set clusterEndpoint=${CLUSTER_ENDPOINT} \
 			--set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME}
-
+TEST_FILTER ?= .*
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
@@ -24,17 +24,17 @@ dev: verify test ## Run all steps in the developer loop
 ci: toolchain verify licenses battletest coverage ## Run all steps used by continuous integration
 
 test: ## Run tests
-	go test ./pkg/...
+	go test -run=${TEST_FILTER} ./pkg/...
 
 battletest: ## Run randomized, racing, code coveraged, tests
-	go test ./pkg/... \
+	go test -run=${TEST_FILTER} ./pkg/... \
 		-race \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./pkg/... \
 		-ginkgo.randomizeAllSpecs \
 		-tags random_test_delay
 
 e2etests: ## Run the e2e suite against your local cluster
-	go test -timeout 60m -v ./test/... -environment-name=${CLUSTER_NAME}
+	go test -timeout 60m -v ./test/suites/... -run=${TEST_FILTER} -environment-name=${CLUSTER_NAME}
 
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...

--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -35,15 +35,16 @@ import (
 // ProvisionerOptions customizes a Provisioner.
 type ProvisionerOptions struct {
 	metav1.ObjectMeta
-	Limits        v1.ResourceList
-	Provider      interface{}
-	ProviderRef   *v1alpha5.ProviderRef
-	Kubelet       *v1alpha5.KubeletConfiguration
-	Labels        map[string]string
-	Taints        []v1.Taint
-	StartupTaints []v1.Taint
-	Requirements  []v1.NodeSelectorRequirement
-	Status        v1alpha5.ProvisionerStatus
+	Limits               v1.ResourceList
+	Provider             interface{}
+	ProviderRef          *v1alpha5.ProviderRef
+	Kubelet              *v1alpha5.KubeletConfiguration
+	Labels               map[string]string
+	Taints               []v1.Taint
+	StartupTaints        []v1.Taint
+	Requirements         []v1.NodeSelectorRequirement
+	Status               v1alpha5.ProvisionerStatus
+	TTLSecondsAfterEmpty *int64
 }
 
 // Provisioner creates a test provisioner with defaults that can be overridden by ProvisionerOptions.
@@ -61,6 +62,9 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 	if options.Limits == nil {
 		options.Limits = v1.ResourceList{v1.ResourceCPU: resource.MustParse("1000")}
 	}
+	if options.TTLSecondsAfterEmpty == nil {
+		options.TTLSecondsAfterEmpty = ptr.Int64(10)
+	}
 
 	provisioner := &v1alpha5.Provisioner{
 		ObjectMeta: ObjectMeta(options.ObjectMeta),
@@ -72,7 +76,7 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 			StartupTaints:        options.StartupTaints,
 			Labels:               options.Labels,
 			Limits:               &v1alpha5.Limits{Resources: options.Limits},
-			TTLSecondsAfterEmpty: ptr.Int64(30),
+			TTLSecondsAfterEmpty: options.TTLSecondsAfterEmpty,
 		},
 		Status: options.Status,
 	}

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -16,14 +16,14 @@ import (
 
 var env *environment.Environment
 
-func TestAPIs(t *testing.T) {
+func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	BeforeSuite(func() {
 		var err error
 		env, err = environment.NewEnvironment(t)
 		Expect(err).ToNot(HaveOccurred())
 	})
-	RunSpecs(t, "Integration Suite")
+	RunSpecs(t, "Integration")
 }
 
 var _ = BeforeEach(func() {

--- a/test/suites/storage/suite_test.go
+++ b/test/suites/storage/suite_test.go
@@ -1,0 +1,140 @@
+package storage
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+
+	"github.com/aws/karpenter/test/pkg/environment"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var env *environment.Environment
+
+func TestStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		var err error
+		env, err = environment.NewEnvironment(t)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	RunSpecs(t, "Storage")
+}
+
+var _ = BeforeEach(func() {
+	env.BeforeEach()
+})
+var _ = AfterEach(func() {
+	env.AfterEach()
+})
+
+// This test requires the EBS CSI driver to be installed
+var _ = Describe("Dynamic PVC", func() {
+	It("should run a pod with a dynamic persistent volume", func() {
+		// Ensure that the EBS driver is installed, or we can't run the test.
+		var ds appsv1.DaemonSet
+		if err := env.Client.Get(env.Context, client.ObjectKey{
+			Namespace: "kube-system",
+			Name:      "ebs-csi-node",
+		}, &ds); err != nil {
+			if errors.IsNotFound(err) {
+				Skip(fmt.Sprintf("skipping dynamic PVC test due to missing EBS driver %s", err))
+			} else {
+				Fail(fmt.Sprintf("determining EBS driver status, %s", err))
+			}
+		}
+
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+
+		storageClassName := "ebs-sc-test"
+		bindMode := storagev1.VolumeBindingWaitForFirstConsumer
+		sc := test.StorageClass(test.StorageClassOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: storageClassName,
+			},
+			Provisioner:       aws.String("ebs.csi.aws.com"),
+			VolumeBindingMode: &bindMode,
+		})
+
+		pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ebs-claim",
+			},
+			StorageClassName: aws.String(storageClassName),
+			Resources:        v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("5Gi")}},
+		})
+
+		pod := test.Pod(test.PodOptions{
+			PersistentVolumeClaims: []string{pvc.Name},
+		})
+
+		env.ExpectCreatedNodeCount("==", 0)
+		env.ExpectCreated(provisioner, provider, sc, pvc, pod)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+		env.ExpectDeleted(pod)
+		env.EventuallyExpectScaleDown()
+		env.ExpectNoCrashes()
+	})
+})
+
+var _ = Describe("Static PVC", func() {
+	It("should run a pod with a static persistent volume", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+
+		storageClassName := "nfs-test"
+		pv := test.PersistentVolume(test.PersistentVolumeOptions{
+			ObjectMeta:       metav1.ObjectMeta{Name: "nfs-test-volume"},
+			StorageClassName: "nfs-test",
+		})
+
+		// the server here doesn't need to actually exist for the pod to start running
+		pv.Spec.NFS = &v1.NFSVolumeSource{
+			Server: "fake.server",
+			Path:   "/some/path",
+		}
+		pv.Spec.CSI = nil
+
+		pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nfs-claim",
+			},
+			StorageClassName: aws.String(storageClassName),
+			VolumeName:       pv.Name,
+			Resources:        v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("5Gi")}},
+		})
+
+		pod := test.Pod(test.PodOptions{
+			PersistentVolumeClaims: []string{pvc.Name},
+		})
+
+		env.ExpectCreatedNodeCount("==", 0)
+		env.ExpectCreated(provisioner, provider, pv, pvc, pod)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+		env.ExpectDeleted(pod)
+		env.EventuallyExpectScaleDown()
+		env.ExpectNoCrashes()
+	})
+})


### PR DESCRIPTION
**Description**

Adds tests for provisioning nodes for pods with both static & dynamic persistent volume claims.

**How was this change tested?**

`E2E_TESTS=PVC make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
