### PR TITLE
fix: de-prioritize c1

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -361,8 +361,8 @@ func (p *InstanceProvider) filterInstanceTypes(instanceTypes []cloudprovider.Ins
 		if !functional.HasAnyPrefix(*it.InstanceType, "m", "c", "r", "a", "t", "i") {
 			continue
 		}
-		// deprioritize 1st/2nd gen burstable and graviton 1
-		if functional.HasAnyPrefix(*it.InstanceType, "t1", "t2", "a1") {
+		// deprioritize some older instance types including 1st/2nd gen burstable, compute and graviton
+		if functional.HasAnyPrefix(*it.InstanceType, "t1", "t2", "a1", "c1") {
 			continue
 		}
 		// deprioritize metal


### PR DESCRIPTION
**Description**
C1 has odd #CPU <-> family mapping which can cause it to be preferred by bin-packing. De-prioritize to prevent this from occurring.

**How was this change tested?**

* Unit testing and `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
