### PR TITLE
feat: make emptiness controller aware of scheduling

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -112,14 +112,14 @@ func main() {
 	}
 
 	recorder := events.NewDedupeRecorder(events.NewRecorder(manager.GetEventRecorderFor(appName)))
-	cluster := state.NewCluster(manager.GetClient(), cloudProvider)
+	cluster := state.NewCluster(cfg, manager.GetClient(), cloudProvider)
 
 	if err := manager.RegisterControllers(ctx,
 		provisioning.NewController(ctx, cfg, manager.GetClient(), clientSet.CoreV1(), recorder, cloudProvider, cluster),
 		state.NewNodeController(manager.GetClient(), cluster),
 		state.NewPodController(manager.GetClient(), cluster),
 		termination.NewController(ctx, manager.GetClient(), clientSet.CoreV1(), cloudProvider),
-		node.NewController(manager.GetClient(), cloudProvider),
+		node.NewController(manager.GetClient(), cloudProvider, cluster),
 		metricspod.NewController(manager.GetClient()),
 		metricsnode.NewController(manager.GetClient()),
 		metricsprovisioner.NewController(manager.GetClient()),

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -139,9 +139,9 @@ var _ = BeforeSuite(func() {
 			},
 			kubeClient: e.Client,
 		}
-		cluster = state.NewCluster(e.Client, cloudProvider)
-		recorder = test.NewEventRecorder()
 		cfg = test.NewConfig()
+		cluster = state.NewCluster(cfg, e.Client, cloudProvider)
+		recorder = test.NewEventRecorder()
 		controller = provisioning.NewController(ctx, cfg, e.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
 	})
 

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/karpenter/pkg/cloudprovider"
-
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -35,17 +33,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/cloudprovider"
+	"github.com/aws/karpenter/pkg/controllers/state"
 	"github.com/aws/karpenter/pkg/utils/result"
 )
 
 const controllerName = "node"
 
 // NewController constructs a controller instance
-func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) *Controller {
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, cluster *state.Cluster) *Controller {
 	return &Controller{
 		kubeClient:     kubeClient,
 		initialization: &Initialization{kubeClient: kubeClient, cloudProvider: cloudProvider},
-		emptiness:      &Emptiness{kubeClient: kubeClient},
+		emptiness:      &Emptiness{kubeClient: kubeClient, cluster: cluster},
 		expiration:     &Expiration{kubeClient: kubeClient},
 	}
 }

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -16,6 +16,7 @@ package node_test
 
 import (
 	"context"
+	"github.com/aws/karpenter/pkg/controllers/state"
 	"strings"
 	"testing"
 	"time"
@@ -52,7 +53,9 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
-		controller = node.NewController(e.Client, &fake.CloudProvider{})
+		cp := &fake.CloudProvider{}
+		cluster := state.NewCluster(test.NewConfig(), e.Client, cp)
+		controller = node.NewController(e.Client, cp, cluster)
 	})
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")
 })

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -270,6 +270,7 @@ func (p *Provisioner) launch(ctx context.Context, node *scheduler.Node) error {
 		}
 	}
 	logging.FromContext(ctx).Infof("Created %s", node)
+	p.cluster.NominateNodeForPod(k8sNode.Name)
 	for _, pod := range node.Pods {
 		p.recorder.NominatePod(pod, k8sNode)
 	}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -139,7 +139,11 @@ func (s *Scheduler) recordSchedulingResults(ctx context.Context, pods []*v1.Pod,
 		logging.FromContext(ctx).With("pod", client.ObjectKeyFromObject(pod)).Errorf("Could not schedule pod, %s", errors[pod])
 		s.recorder.PodFailedToSchedule(pod, errors[pod])
 	}
+
 	for _, node := range s.inflight {
+		if len(node.Pods) > 0 {
+			s.cluster.NominateNodeForPod(node.Node.Name)
+		}
 		for _, pod := range node.Pods {
 			s.recorder.NominatePod(pod, node.Node)
 		}

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -116,7 +116,7 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 		nil,
 		[]*scheduling.NodeTemplate{scheduling.NewNodeTemplate(provisioner)},
 		nil,
-		state.NewCluster(nil, cloudProv),
+		state.NewCluster(test.NewConfig(), nil, cloudProv),
 		&Topology{},
 		map[string][]cloudprovider.InstanceType{provisioner.Name: instanceTypes},
 		map[*scheduling.NodeTemplate]v1.ResourceList{},

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 		for _, it := range instanceTypes {
 			instanceTypeMap[it.Name()] = it
 		}
-		cluster := state.NewCluster(e.Client, cloudProvider)
+		cluster := state.NewCluster(cfg, e.Client, cloudProvider)
 		controller = provisioning.NewController(ctx, cfg, e.Client, corev1.NewForConfigOrDie(e.Config), recorder, cloudProvider, cluster)
 	})
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -41,6 +41,7 @@ import (
 )
 
 var ctx context.Context
+var cfg *test.Config
 var env *test.Environment
 var cluster *state.Cluster
 var nodeController *state.NodeController
@@ -56,6 +57,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {})
+	cfg = test.NewConfig()
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")
 })
 
@@ -65,7 +67,7 @@ var _ = AfterSuite(func() {
 
 var _ = BeforeEach(func() {
 	cloudProvider = &fake.CloudProvider{InstanceTypes: fake.InstanceTypesAssorted()}
-	cluster = state.NewCluster(env.Client, cloudProvider)
+	cluster = state.NewCluster(cfg, env.Client, cloudProvider)
 	nodeController = state.NewNodeController(env.Client, cluster)
 	podController = state.NewPodController(env.Client, cluster)
 	provisioner = test.Provisioner(test.ProvisionerOptions{ObjectMeta: metav1.ObjectMeta{Name: "default"}})


### PR DESCRIPTION
**Description**

    This eliminates some problems seen with short emptiness TTL
    where we can delete the node too early (e.g. PVC binding) and
    the 'boucing' of the emptiness annotation for newly launched nodes.

**How was this change tested?**

* Unit tests & `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
