### PR TITLE
fix: discovering generated aws launch templates under karpenter management

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -152,6 +152,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, provider *v1alpha
 		TagSpecifications: []*ec2.TagSpecification{
 			{ResourceType: aws.String(ec2.ResourceTypeInstance), Tags: tags},
 			{ResourceType: aws.String(ec2.ResourceTypeVolume), Tags: tags},
+			{ResourceType: aws.String(ec2.ResourceTypeFleet), Tags: tags},
 		},
 	}
 	if capacityType == v1alpha1.CapacityTypeSpot {

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -652,18 +652,21 @@ var _ = Describe("Allocation", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateFleetInput.Len()).To(Equal(1))
 				createFleetInput := fakeEC2API.CalledWithCreateFleetInput.Pop()
-				Expect(createFleetInput.TagSpecifications).To(HaveLen(2))
+				Expect(createFleetInput.TagSpecifications).To(HaveLen(3))
 
 				tags := map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: provisionerName,
 					"Name":                           fmt.Sprintf("%s/%s", v1alpha5.ProvisionerNameLabelKey, provisionerName),
 				}
-				// tags should be included in both the instance and volume tag specification
+				// tags should be included in instance, volume, and fleet tag specification
 				Expect(*createFleetInput.TagSpecifications[0].ResourceType).To(Equal(ec2.ResourceTypeInstance))
 				ExpectTags(createFleetInput.TagSpecifications[0].Tags, tags)
 
 				Expect(*createFleetInput.TagSpecifications[1].ResourceType).To(Equal(ec2.ResourceTypeVolume))
 				ExpectTags(createFleetInput.TagSpecifications[1].Tags, tags)
+
+				Expect(*createFleetInput.TagSpecifications[2].ResourceType).To(Equal(ec2.ResourceTypeFleet))
+				ExpectTags(createFleetInput.TagSpecifications[2].Tags, tags)
 			})
 			It("should request that tags be applied to both instances and volumes", func() {
 				provider.Tags = map[string]string{
@@ -675,14 +678,17 @@ var _ = Describe("Allocation", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateFleetInput.Len()).To(Equal(1))
 				createFleetInput := fakeEC2API.CalledWithCreateFleetInput.Pop()
-				Expect(createFleetInput.TagSpecifications).To(HaveLen(2))
+				Expect(createFleetInput.TagSpecifications).To(HaveLen(3))
 
-				// tags should be included in both the instance and volume tag specification
+				// tags should be included in instance, volume, and fleet tag specification
 				Expect(*createFleetInput.TagSpecifications[0].ResourceType).To(Equal(ec2.ResourceTypeInstance))
 				ExpectTags(createFleetInput.TagSpecifications[0].Tags, provider.Tags)
 
 				Expect(*createFleetInput.TagSpecifications[1].ResourceType).To(Equal(ec2.ResourceTypeVolume))
 				ExpectTags(createFleetInput.TagSpecifications[1].Tags, provider.Tags)
+
+				Expect(*createFleetInput.TagSpecifications[2].ResourceType).To(Equal(ec2.ResourceTypeFleet))
+				ExpectTags(createFleetInput.TagSpecifications[2].Tags, provider.Tags)
 			})
 
 			It("should override default tag names", func() {
@@ -698,14 +704,17 @@ var _ = Describe("Allocation", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateFleetInput.Len()).To(Equal(1))
 				createFleetInput := fakeEC2API.CalledWithCreateFleetInput.Pop()
-				Expect(createFleetInput.TagSpecifications).To(HaveLen(2))
+				Expect(createFleetInput.TagSpecifications).To(HaveLen(3))
 
-				// tags should be included in both the instance and volume tag specification
+				// tags should be included in instance, volume, and fleet tag specification
 				Expect(*createFleetInput.TagSpecifications[0].ResourceType).To(Equal(ec2.ResourceTypeInstance))
 				ExpectTags(createFleetInput.TagSpecifications[0].Tags, provider.Tags)
 
 				Expect(*createFleetInput.TagSpecifications[1].ResourceType).To(Equal(ec2.ResourceTypeVolume))
 				ExpectTags(createFleetInput.TagSpecifications[1].Tags, provider.Tags)
+
+				Expect(*createFleetInput.TagSpecifications[2].ResourceType).To(Equal(ec2.ResourceTypeFleet))
+				ExpectTags(createFleetInput.TagSpecifications[2].Tags, provider.Tags)
 			})
 			It("should default to a generated launch template", func() {
 				ExpectApplied(ctx, env.Client, provisioner)

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -92,6 +92,17 @@ By adopting this practice we allow our users who are early adopters to test out 
 
 # Released Upgrade Notes
 
+## Upgrading to v0.14.0+
+* v0.14.0 changes the way Karpenter discovers its dynamically generated AWS launch templates to use a tag rather than a Name scheme. The previous name scheme was `Karpenter-${CLUSTER_NAME}-*` which could collide with user created launch templates that Karpenter should not manage. The new scheme uses a tag on the launch template `karpenter.k8s.aws/cluster: ${CLUSTER_NAME}`. As a result, Karpenter will not clean-up dynamically generated launch templates using the old name scheme. You can manually clean these up with the following commands:
+
+```
+## Find launch templates that match the naming pattern and you do not want to keep
+aws ec2 describe-launch-templates --filters="Name=launch-template-name,Values=Karpenter-${CLUSTER_NAME}-*"
+
+## Delete launch template(s) that match the name but do not have the "karpenter.k8s.aws/cluster" tag
+aws ec2 delete-launch-template --launch-template-id <LAUNCH_TEMPLATE_ID>
+```
+
 ## Upgrading to v0.13.0+
 * v0.13.0 introduces a new CRD named `AWSNodeTemplate` which can be used to specify AWS Cloud Provider parameters. Everything that was previously specified under `spec.provider` in the Provisioner resource, can now be specified in the spec of the new resource. The use of `spec.provider` is deprecated but will continue to function to maintain backwards compatibility for the current API version (v1alpha5) of the Provisioner resource. v0.13.0 also introduces support for custom user data that doesn't require the use of a custom launch template. The user data can be specified in-line in the AWSNodeTemplate resource. Read the [UserData documentation here](../aws/user-data) to get started.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->
https://github.com/aws/karpenter/issues/2101

**Description**
 - Karpenter could hydrate the launch template cache w/ user created LTs if they used a naming pattern like `Karpenter-<cluster-name>-*`. This change adds a `karpenter.k8s.aws/managed-by` tag that is used for cache hydration instead of the name pattern. 
 - Add Fleet, Network Interface, and launch template tags. 

**How was this change tested?**
* Deployed to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Karpenter now discovers AWS Launch Templates generated by Karpenter via the `karpenter.k8s.aws/managed-by: <Cluster-Name>` tag rather than the previously used name pattern.  See the upgrade guide for cleaning up old launch templates that Karpenter generated. 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
