### PR TITLE
fix: reduce created event count

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -131,7 +131,11 @@ func (c *Cluster) ForEachNode(f func(n *Node) bool) {
 	}
 	// sort nodes by creation time so we provide a consistent ordering
 	sort.Slice(nodes, func(a, b int) bool {
-		return nodes[a].Node.CreationTimestamp.Time.Before(nodes[b].Node.CreationTimestamp.Time)
+		if nodes[a].Node.CreationTimestamp != nodes[b].Node.CreationTimestamp {
+			return nodes[a].Node.CreationTimestamp.Time.Before(nodes[b].Node.CreationTimestamp.Time)
+		}
+		// sometimes we get nodes created in the same second, so sort again by node UID to provide a consistent ordering
+		return nodes[a].Node.UID < nodes[b].Node.UID
 	})
 
 	for _, node := range nodes {

--- a/pkg/events/dedupe.go
+++ b/pkg/events/dedupe.go
@@ -25,7 +25,7 @@ import (
 func NewDedupeRecorder(r Recorder) Recorder {
 	return &dedupe{
 		rec:   r,
-		cache: cache.New(60*time.Second, 10*time.Second),
+		cache: cache.New(120*time.Second, 10*time.Second),
 	}
 }
 


### PR DESCRIPTION
**Description**

Creation timestamps are only 1 second resolution so also sort nodes
by UID to provide a consistent ordering.  Increase the de-dupe time
to 120 seconds before we re-post the same event. In a 100 pod scale-up
reduced event count by ~60%.

**How was this change tested?**

Unit testing & deployed to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
