### PR TITLE
fix: de-prioritize bare metal instance types

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -214,6 +214,7 @@ func compressInstanceType(instanceType *ec2.InstanceTypeInfo) *ec2.InstanceTypeI
 		InstanceStorageInfo:      instanceType.InstanceStorageInfo,
 		MemoryInfo:               &ec2.MemoryInfo{SizeInMiB: instanceType.MemoryInfo.SizeInMiB},
 		ProcessorInfo:            &ec2.ProcessorInfo{SupportedArchitectures: instanceType.ProcessorInfo.SupportedArchitectures},
+		BareMetal:                instanceType.BareMetal,
 		NetworkInfo: &ec2.NetworkInfo{
 			Ipv4AddressesPerInterface: instanceType.NetworkInfo.Ipv4AddressesPerInterface,
 			MaximumNetworkInterfaces:  instanceType.NetworkInfo.MaximumNetworkInterfaces,


### PR DESCRIPTION
**Description**

Resolve issue where we failed to de-prioritize metal instance types.

**How was this change tested?**

Unit test & deployed to EKS where I inspected logs to see that the metal was now de-prioritized.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
