### PR TITLE
fix: remove instance type compression

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -161,7 +161,7 @@ func (p *InstanceTypeProvider) getInstanceTypes(ctx context.Context, provider *v
 	}, func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {
 		for _, instanceType := range page.InstanceTypes {
 			if p.filter(instanceType) {
-				instanceTypes[aws.StringValue(instanceType.InstanceType)] = compressInstanceType(instanceType)
+				instanceTypes[aws.StringValue(instanceType.InstanceType)] = instanceType
 			}
 		}
 		return true
@@ -201,25 +201,6 @@ func (p *InstanceTypeProvider) CacheUnavailable(ctx context.Context, fleetErr *e
 		UnfulfillableCapacityErrorCacheTTL)
 	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
 	p.unavailableOfferings.SetDefault(UnavailableOfferingsCacheKey(instanceType, zone, capacityType), struct{}{})
-}
-
-func compressInstanceType(instanceType *ec2.InstanceTypeInfo) *ec2.InstanceTypeInfo {
-	return &ec2.InstanceTypeInfo{
-		InstanceType:             instanceType.InstanceType,
-		Hypervisor:               instanceType.Hypervisor,
-		SupportedUsageClasses:    instanceType.SupportedUsageClasses,
-		VCpuInfo:                 &ec2.VCpuInfo{DefaultVCpus: instanceType.VCpuInfo.DefaultVCpus},
-		GpuInfo:                  instanceType.GpuInfo,
-		InferenceAcceleratorInfo: instanceType.InferenceAcceleratorInfo,
-		InstanceStorageInfo:      instanceType.InstanceStorageInfo,
-		MemoryInfo:               &ec2.MemoryInfo{SizeInMiB: instanceType.MemoryInfo.SizeInMiB},
-		ProcessorInfo:            &ec2.ProcessorInfo{SupportedArchitectures: instanceType.ProcessorInfo.SupportedArchitectures},
-		BareMetal:                instanceType.BareMetal,
-		NetworkInfo: &ec2.NetworkInfo{
-			Ipv4AddressesPerInterface: instanceType.NetworkInfo.Ipv4AddressesPerInterface,
-			MaximumNetworkInterfaces:  instanceType.NetworkInfo.MaximumNetworkInterfaces,
-		},
-	}
 }
 
 func UnavailableOfferingsCacheKey(instanceType string, zone string, capacityType string) string {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - Remove unneeded instance type compression that is surprising to use since some fields are removed from the regular ec2.InstanceTypeInfo type. 

**How was this change tested?**

 * `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
