### PR TITLE
test: run e2etests serially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ battletest: ## Run randomized, racing, code coveraged, tests
 		-tags random_test_delay
 
 e2etests: ## Run the e2e suite against your local cluster
-	go test -timeout 60m -v ./test/suites/... -run=${TEST_FILTER} -environment-name=${CLUSTER_NAME}
+	go test -p 1 -timeout 60m -v ./test/suites/... -run=${TEST_FILTER} -environment-name=${CLUSTER_NAME}
 
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...


### PR DESCRIPTION
**Description**

By default, go runs tests in different packages in parallel.  This
makes the e2etests fail as they create specific provisioners,
count nodes launched, etc.

**How was this change tested?**

`make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
