### PR TITLE
Docs update to run daemonset plugin on GPU nodes

### DIFF
--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -282,10 +282,11 @@ spec:
             nvidia.com/gpu: "1"
 ```
 {{% alert title="Note" color="primary" %}}
-If you are provisioning GPU nodes, such as the `g4dn.2xlarge` instance type, you should run `nvidia-device-plugin-daemonset` on those nodes.
-Without that daemonset running, Karpenter will not see those nodes as initialized.
-To install the daemonset plugin, run:
-
-`kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.12.2/nvidia-device-plugin.yml`
+If you are provisioning GPU nodes, you need to deploy an appropriate GPU device plugin daemonset for those nodes.
+Without the daemonset running, Karpenter will not see those nodes as initialized.
+Refer to general [Kubernetes GPU](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#deploying-amd-gpu-device-plugin) docs and the following specific GPU docs:
+* `nvidia.com/gpu`: [NVIDIA device plugin for Kubernetes](https://github.com/NVIDIA/k8s-device-plugin)
+* `amd.com/gpu`: [AMD GPU device plugin for Kubernetes](https://github.com/RadeonOpenCompute/k8s-device-plugin)
+* `aws.amazon.com/neuron`: [Kubernetes enviroment setup for Neuron](https://github.com/aws/aws-neuron-sdk/blob/master/neuron-deploy/tutorials/tutorial-k8s.rst)
 {{% /alert %}}
 

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -281,3 +281,11 @@ spec:
           limits:
             nvidia.com/gpu: "1"
 ```
+{{% alert title="Note" color="primary" %}}
+If you are provisioning GPU nodes, such as the `g4dn.2xlarge` instance type, you should run `nvidia-device-plugin-daemonset` on those nodes.
+Without that daemonset running, Karpenter will not see those nodes as initialized.
+To install the daemonset plugin, run:
+
+`kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.12.2/nvidia-device-plugin.yml`
+{{% /alert %}}
+


### PR DESCRIPTION
**Fixes**: [#2085](https://github.com/aws/karpenter/issues/2085)

**Description**
Added note to [Provisioning Configuration](https://karpenter.sh/preview/aws/provisioning/) docs that tells users provisioning GPUs to the NVIDIA daemonset (`nvidia-device-plugin-daemonset`).

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No
