### PR TITLE
fix: static pod and unschedulable toleration evictions

### DIFF
--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -64,7 +64,7 @@ func ExpectNotFound(ctx context.Context, c client.Client, objects ...client.Obje
 		Eventually(func() bool {
 			return errors.IsNotFound(c.Get(ctx, types.NamespacedName{Name: object.GetName(), Namespace: object.GetNamespace()}, object))
 		}, ReconcilerPropagationTime, RequestInterval).Should(BeTrue(), func() string {
-			return fmt.Sprintf("expected %s to be deleted, but it still exists", object.GetSelfLink())
+			return fmt.Sprintf("expected %s to be deleted, but it still exists", client.ObjectKeyFromObject(object))
 		})
 	}
 }

--- a/pkg/test/metadata.go
+++ b/pkg/test/metadata.go
@@ -45,13 +45,5 @@ func ObjectMeta(options metav1.ObjectMeta) metav1.ObjectMeta {
 	if options.Namespace == "" {
 		options.Namespace = "default"
 	}
-	if options.OwnerReferences == nil {
-		options.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: "v1",
-			Kind:       "Namespace",
-			Name:       "default",
-			UID:        "58953756-099e-47ad-bc6f-0486b690ea12",
-		}}
-	}
 	return options
 }

--- a/pkg/test/pods.go
+++ b/pkg/test/pods.go
@@ -62,10 +62,6 @@ func Pod(overrides ...PodOptions) *v1.Pod {
 		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
 			panic(fmt.Sprintf("Failed to merge pod options: %s", err))
 		}
-		// need this since mergo won't override a nil slice with an empty slice
-		if len(opts.ObjectMeta.OwnerReferences) == 0 && opts.ObjectMeta.OwnerReferences != nil {
-			options.OwnerReferences = []metav1.OwnerReference{}
-		}
 	}
 	if options.Image == "" {
 		options.Image = "public.ecr.aws/eks-distro/kubernetes/pause:3.2"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - Fixes a bug where:
   - static pods with do-not-evict labels would still result in node termination
   - pods that have an unschedulable toleration and a do-not-evict label would still result in termination
 - Cleaned up owner refs in the Termination controller suite tests 

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
