### PR TITLE
Test: Added kubeconfig to test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ battletest: ## Run randomized, racing, code coveraged, tests
 		-tags random_test_delay
 
 e2etests: ## Run the e2e suite against your local cluster
-	go test -p 1 -timeout 60m -v ./test/suites/... -run=${TEST_FILTER} -environment-name=${CLUSTER_NAME}
+	go test -p 1 -timeout 60m -v ./test/suites/... -run=${TEST_FILTER} -cluster-name=${CLUSTER_NAME} -kubeconfig ${HOME}/.kube/config
 
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...
@@ -62,8 +62,8 @@ licenses: ## Verifies dependency licenses
 apply: ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
 	helm upgrade --create-namespace --install karpenter charts/karpenter --namespace karpenter \
 		$(HELM_OPTS) \
-		--set controller.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/controller) \
-		--set webhook.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/webhook)
+		--set controller.image=$(shell $(WITH_GOFLAGS) ko build --bare github.com/aws/karpenter/cmd/controller) \
+		--set webhook.image=$(shell $(WITH_GOFLAGS) ko build --bare github.com/aws/karpenter/cmd/webhook)
 
 install:  ## Deploy the latest released version into your ~/.kube/config cluster
 	@echo Upgrading to $(shell grep version charts/karpenter/Chart.yaml)

--- a/test/pkg/environment/environment.go
+++ b/test/pkg/environment/environment.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
-	"path"
 	"testing"
 	"time"
 
@@ -20,7 +18,7 @@ import (
 	"github.com/aws/karpenter/pkg/utils/env"
 )
 
-var EnvironmentName = flag.String("environment-name", env.WithDefaultString("ENVIRONMENT_NAME", ""), "Environment name enables discovery of the testing environment")
+var ClusterName = flag.String("cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "Cluster name enables discovery of the testing environment")
 
 type Environment struct {
 	context.Context
@@ -56,11 +54,7 @@ func NewLocalClient() (client.Client, error) {
 	if err := apis.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-	config, err := (&environment.ClientConfig{Kubeconfig: path.Join(home, ".kube/config")}).GetRESTConfig()
+	config, err := (&environment.ClientConfig{}).GetRESTConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +62,12 @@ func NewLocalClient() (client.Client, error) {
 }
 
 type Options struct {
-	EnvironmentName string
+	ClusterName string
 }
 
 func NewOptions() (*Options, error) {
 	options := &Options{
-		EnvironmentName: *EnvironmentName,
+		ClusterName: *ClusterName,
 	}
 	if err := options.Validate(); err != nil {
 		return nil, err
@@ -82,8 +76,8 @@ func NewOptions() (*Options, error) {
 }
 
 func (o Options) Validate() error {
-	if o.EnvironmentName == "" {
-		return fmt.Errorf("--environment-name must be defined")
+	if o.ClusterName == "" {
+		return fmt.Errorf("--cluster-name must be defined")
 	}
 	return nil
 }

--- a/test/pkg/environment/expectations.go
+++ b/test/pkg/environment/expectations.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	EnvironmentLabelName = "testing.karpenter.sh/environment-name"
-	CleanableObjects     = []client.Object{
+	ClusterLabelName = "testing.karpenter.sh/cluster-name"
+	CleanableObjects = []client.Object{
 		&v1alpha5.Provisioner{},
 		&v1.Pod{},
 		&appsv1.Deployment{},
@@ -62,7 +62,7 @@ func (env *Environment) BeforeEach() {
 
 func (env *Environment) ExpectCreated(objects ...client.Object) {
 	for _, object := range objects {
-		object.SetLabels(lo.Assign(object.GetLabels(), map[string]string{EnvironmentLabelName: env.Options.EnvironmentName}))
+		object.SetLabels(lo.Assign(object.GetLabels(), map[string]string{ClusterLabelName: env.Options.ClusterName}))
 		Expect(env.Client.Create(env, object)).To(Succeed())
 	}
 }
@@ -84,7 +84,7 @@ func (env *Environment) AfterEach() {
 			go func(object client.Object, namespace string) {
 				Expect(env.Client.DeleteAllOf(env, object,
 					client.InNamespace(namespace),
-					client.MatchingLabels(map[string]string{EnvironmentLabelName: env.Options.EnvironmentName}),
+					client.MatchingLabels(map[string]string{ClusterLabelName: env.Options.ClusterName}),
 				)).ToNot(HaveOccurred())
 				wg.Done()
 			}(object, namespace.Name)

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -39,8 +39,8 @@ var _ = AfterEach(func() {
 var _ = Describe("Sanity Checks", func() {
 	It("should provision nodes", func() {
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 		pod := test.Pod()
@@ -59,8 +59,8 @@ var _ = Describe("Sanity Checks", func() {
 	})
 	It("should provision for a deployment", func() {
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 
@@ -79,8 +79,8 @@ var _ = Describe("Sanity Checks", func() {
 	})
 	It("should provision a node for a self-afinity deployment", func() {
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 		// just two pods as they all need to land on the same node
@@ -110,8 +110,8 @@ var _ = Describe("Sanity Checks", func() {
 	})
 	It("should provision three nodes for a zonal topology spread", func() {
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 

--- a/test/suites/storage/suite_test.go
+++ b/test/suites/storage/suite_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
@@ -13,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	"github.com/aws/karpenter/test/pkg/environment"
 	. "github.com/onsi/ginkgo"
@@ -56,8 +57,8 @@ var _ = Describe("Dynamic PVC", func() {
 		}
 
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{
 			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
@@ -97,8 +98,8 @@ var _ = Describe("Dynamic PVC", func() {
 var _ = Describe("Static PVC", func() {
 	It("should run a pod with a static persistent volume", func() {
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.EnvironmentName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{
 			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Renamed environment name to align with upcoming PR for testing clusters. Now supports/requires --kubeconfig 

**How was this change tested?**

* `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
