### PR TITLE
Test: Fixed a testing bug that ignored --kubeconfig

### DIFF
--- a/test/pkg/environment/environment.go
+++ b/test/pkg/environment/environment.go
@@ -10,9 +10,9 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/pkg/environment"
 	loggingtesting "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/utils/env"
@@ -54,7 +54,7 @@ func NewLocalClient() (client.Client, error) {
 	if err := apis.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
-	config, err := (&environment.ClientConfig{}).GetRESTConfig()
+	config, err := config.GetConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Even if kubeconfig was supplied, it was using the kubeconfig of the local env.

**How was this change tested?**
```
❯ go test ./test/suites/integration -cluster-name test --kubeconfig ./kubeconfig
Running Suite: Integration
==========================
Random Seed: 1657834980
Will run 4 of 4 specs

Failure [0.001 seconds]
[BeforeSuite] BeforeSuite
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/suite_test.go:22

  Unexpected error:
      <*fs.PathError | 0xc0005ec030>: {
          Op: "stat",
          Path: "./kubeconfig",
          Err: <syscall.Errno>0x2,
      }
      stat ./kubeconfig: no such file or directory
  occurred

  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/suite_test.go:25
------------------------------
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
