### PR TITLE
fix: [AWS] treat Unsupported error code as unfulfillable fleet error in the ICE cache

### DIFF
--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -37,6 +37,7 @@ var (
 		"MaxSpotInstanceCountExceeded",
 		"VcpuLimitExceeded",
 		"UnfulfillableCapacity",
+		"Unsupported",
 	}
 )
 

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -363,7 +363,7 @@ func (p *InstanceProvider) filterInstanceTypes(instanceTypes []cloudprovider.Ins
 			continue
 		}
 		// deprioritize some older instance types including 1st/2nd gen burstable, compute and graviton
-		if functional.HasAnyPrefix(*it.InstanceType, "t1", "t2", "a1", "c1") {
+		if functional.HasAnyPrefix(*it.InstanceType, "t1", "t2", "a1", "c1", "u-") {
 			continue
 		}
 		// deprioritize metal


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - Unsupported configuration errors may be returned by fleet which in-large means that the capacity is not able to be fulfilled. The error can also be transient, so treat as unfulfillable capacity in the ICE cache. 

**How was this change tested?**

* `make test` && eks

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
