### PR TITLE
docs: fix misleading description on controller max-pods flag

### DIFF
--- a/website/content/en/preview/tasks/pod-density.md
+++ b/website/content/en/preview/tasks/pod-density.md
@@ -20,12 +20,14 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-By default, the number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to an instance type. By running the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY=false` (or the argument  `--aws-eni-limited-pod-density=false`) you can set the maximum number of pods per node to 110 instead.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
+
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
 
 {{% alert title="Note" color="primary" %}}
-When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows for a single ENI to provide IP addresses for multiple pods.  Much higher pod densities are supported as a result.
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
 {{% /alert %}}
 
 

--- a/website/content/en/v0.10.0/tasks/pod-density.md
+++ b/website/content/en/v0.10.0/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.10.1/tasks/pod-density.md
+++ b/website/content/en/v0.10.1/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.11.0/tasks/pod-density.md
+++ b/website/content/en/v0.11.0/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.11.1/tasks/pod-density.md
+++ b/website/content/en/v0.11.1/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.12.0/tasks/pod-density.md
+++ b/website/content/en/v0.12.0/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.12.1/tasks/pod-density.md
+++ b/website/content/en/v0.12.1/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.13.0/tasks/pod-density.md
+++ b/website/content/en/v0.13.0/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.13.1/tasks/pod-density.md
+++ b/website/content/en/v0.13.1/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.13.2/tasks/pod-density.md
+++ b/website/content/en/v0.13.2/tasks/pod-density.md
@@ -20,13 +20,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.7.0/tasks/pod-density.md
+++ b/website/content/en/v0.7.0/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.7.1/tasks/pod-density.md
+++ b/website/content/en/v0.7.1/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.7.2/tasks/pod-density.md
+++ b/website/content/en/v0.7.2/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.7.3/tasks/pod-density.md
+++ b/website/content/en/v0.7.3/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.8.0/tasks/pod-density.md
+++ b/website/content/en/v0.8.0/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.8.1/tasks/pod-density.md
+++ b/website/content/en/v0.8.1/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.8.2/tasks/pod-density.md
+++ b/website/content/en/v0.8.2/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.9.0/tasks/pod-density.md
+++ b/website/content/en/v0.9.0/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/v0.9.1/tasks/pod-density.md
+++ b/website/content/en/v0.9.1/tasks/pod-density.md
@@ -18,13 +18,15 @@ Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this va
 
 *☁️ AWS Specific*
 
-The number of pods on a node is limited by the number of networking interfaces (ENIs) that may be attached to a node.
+By default, the number of pods on a node is limited by both the number of networking interfaces (ENIs) that may be attached to an instance type and the number of IP addresses that can be assigned to each ENI.  See [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) for a more detailed information on these instance types' limits.
 
-[AWS VPC CNI v1.9 introduced prefix assignment.](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) In short, a single ENI can provide IP addresses for multiple pods. Much higher pod densities are now supported.
-
-Run the Karpenter controller with the environment variable `AWS_ENI_LIMITED_POD_DENSITY` (or the argument  `--aws-eni-limited-pod-density=true`) to enable nodes with more than 110 pods.
+Karpenter can be configured to disable nodes' ENI-based pod density.  This is specially useful for small to medium instance types which have a lower ENI-based pod density.  Set the environment variable `AWS_ENI_LIMITED_POD_DENSITY: "false"` (or the argument  `--aws-eni-limited-pod-density=false`) in the Karpenter controller to allow nodes to host up to 110 pods.
 
 Environment variables for the Karpenter controller may be specified as [helm chart values](https://github.com/aws/karpenter/blob/c73f425e924bb64c3f898f30ca5035a1d8591183/charts/karpenter/values.yaml#L15).
+
+{{% alert title="Note" color="primary" %}}
+When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to support 110 pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
+{{% /alert %}}
 
 ## Limit Pod Density
 


### PR DESCRIPTION
**Description**
Fixes a misleading description in the controller flag `aws-eni-limited-pod-density` which enables nodes to have a higher pod density, up to 110 pods.  Updating description to the current behaviour.

https://github.com/aws/karpenter/blob/e37909b223fd7625b57b59d28681561895643f09/pkg/cloudprovider/aws/launchtemplate.go#L364-L368

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
