### PR TITLE
feat: in the absence of instance-type/family filtering, provide a default

### DIFF
--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -255,6 +255,11 @@ var _ = Describe("Allocation", func() {
 				}
 			})
 			It("should launch on metal", func() {
+				// add a provisioner requirement for instance type exists to remove our default filter for metal sizes
+				provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{
+					Key:      v1.LabelInstanceTypeStable,
+					Operator: v1.NodeSelectorOpExists,
+				})
 				ExpectApplied(ctx, env.Client, provisioner)
 				for _, pod := range ExpectProvisioned(ctx, env.Client, controller,
 					test.UnschedulablePod(test.PodOptions{

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -100,7 +100,7 @@ By adopting this practice we allow our users who are early adopters to test out 
 ## Upgrading to v0.14.0+
 * v0.14.0 changes the way Karpenter discovers its dynamically generated AWS launch templates to use a tag rather than a Name scheme. The previous name scheme was `Karpenter-${CLUSTER_NAME}-*` which could collide with user created launch templates that Karpenter should not manage. The new scheme uses a tag on the launch template `karpenter.k8s.aws/cluster: ${CLUSTER_NAME}`. As a result, Karpenter will not clean-up dynamically generated launch templates using the old name scheme. You can manually clean these up with the following commands:
 
-```
+```bash
 ## Find launch templates that match the naming pattern and you do not want to keep
 aws ec2 describe-launch-templates --filters="Name=launch-template-name,Values=Karpenter-${CLUSTER_NAME}-*"
 
@@ -108,6 +108,11 @@ aws ec2 describe-launch-templates --filters="Name=launch-template-name,Values=Ka
 aws ec2 delete-launch-template --launch-template-id <LAUNCH_TEMPLATE_ID>
 ```
 
+* v0.14.0 introduces additional instance type filtering if there are no `node.kubernetes.io/instance-type` or `karpenter.k8s.aws/instance-family` requirements that restrict instance types specified on the provisioner. This prevents Karpenter from launching bare metal and some older non-current generation instance types unless the provisioner has been explicitly configured to allow them. If you specify an instance type or family requirement that supplies a list of instance-types or families, that list will be used regardless of filtering.  The filtering can also be completely eliminated by adding an `Exists` requirement for instance type or family.   
+```yaml
+  - key: node.kubernetes.io/instance-type
+    operator: Exists
+```
 ## Upgrading to v0.13.0+
 * v0.13.0 introduces a new CRD named `AWSNodeTemplate` which can be used to specify AWS Cloud Provider parameters. Everything that was previously specified under `spec.provider` in the Provisioner resource, can now be specified in the spec of the new resource. The use of `spec.provider` is deprecated but will continue to function to maintain backwards compatibility for the current API version (v1alpha5) of the Provisioner resource. v0.13.0 also introduces support for custom user data that doesn't require the use of a custom launch template. The user data can be specified in-line in the AWSNodeTemplate resource. Read the [UserData documentation here](../aws/user-data) to get started.
 


### PR DESCRIPTION
**Description**

Provide a more opinionated set of default instance types if the provisioner
doesn't supply its own list of instance types/families.


**How was this change tested?**

Unit testing & deployed to EKS.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
