### PR TITLE
fix: permit custom device requests

### DIFF
--- a/pkg/controllers/provisioning/scheduling/inflightnode.go
+++ b/pkg/controllers/provisioning/scheduling/inflightnode.go
@@ -108,7 +108,8 @@ func (n *InFlightNode) Add(ctx context.Context, pod *v1.Pod) error {
 
 	// check resource requests first since that's a pretty likely reason the pod won't schedule on an in-flight
 	// node, which at this point can't be increased in size
-	requests := resources.Merge(n.requests, resources.RequestsForPods(pod))
+	podRequests := state.FilterWellKnownRequests(ctx, resources.RequestsForPods(pod))
+	requests := resources.Merge(n.requests, podRequests)
 
 	if !resources.Fits(requests, n.available) {
 		return fmt.Errorf("exceeds node resources")

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -196,8 +196,8 @@ func (c *Cluster) populateResourceRequests(ctx context.Context, node *v1.Node, n
 	var daemonsetLimits []v1.ResourceList
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		requests := resources.RequestsForPods(pod)
-		podLimits := resources.LimitsForPods(pod)
+		requests := FilterWellKnownRequests(ctx, resources.RequestsForPods(pod))
+		podLimits := FilterWellKnownRequests(ctx, resources.LimitsForPods(pod))
 		podKey := client.ObjectKeyFromObject(pod)
 
 		n.podRequests[podKey] = requests


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #1900

**Description**

Karpenter is negative towards custom device requests it is unaware of, erroneously assuming those cannot be scheduled. Instead, ignore unmanaged resources from Karpenter perspective in best effort.

This changes the request handling to be scoped only to resource request that Karpenter is actively managing. 
The reasoning here is that it cannot influence those resource requests anyways, they come into existence by means of other concepts such as the device plugin manager that might be late bound and thus out of Karpenter scope.
Hence, instead of being negative, it should be neutral regarding unknown resources.

It is related with the recent concept change _not to assign pods_ to a node but let control plane perform the final scheduling which takes into account runtime available resources.

**How was this change tested?**

* integration tests in AWS lab account

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
fix: supporting custom device requests
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
