### PR TITLE
Add log captures to e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
       		--set clusterName=${CLUSTER_NAME} \
 			--set clusterEndpoint=${CLUSTER_ENDPOINT} \
 			--set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME}
-TEST_FILTER ?= TestIntegration
+TEST_FILTER ?= .*
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
       		--set clusterName=${CLUSTER_NAME} \
 			--set clusterEndpoint=${CLUSTER_ENDPOINT} \
 			--set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME}
-TEST_FILTER ?= .*
+TEST_FILTER ?= TestIntegration
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
@@ -34,7 +34,7 @@ battletest: ## Run randomized, racing, code coveraged, tests
 		-tags random_test_delay
 
 e2etests: ## Run the e2e suite against your local cluster
-	go test -p 1 -timeout 60m -v ./test/suites/... -run=${TEST_FILTER} -cluster-name=${CLUSTER_NAME} -kubeconfig ${HOME}/.kube/config
+	go test -p 1 -timeout 60m -v ./test/suites/... -run=${TEST_FILTER}
 
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -74,7 +74,9 @@ topologySpreadConstraints:
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
 # -- Tolerations to allow the pod to be scheduled to nodes with taints.
-tolerations: []
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
 # -- Additional volumes for the pod.
 extraVolumes: []
 # - name: aws-iam-token

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -30,10 +30,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/amifamily"
-	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/fake"
 	"github.com/aws/karpenter/pkg/cloudprovider/registry"
 	"github.com/aws/karpenter/pkg/controllers/provisioning"
@@ -155,11 +156,11 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("Allocation", func() {
 	var provisioner *v1alpha5.Provisioner
-	var provider *v1alpha1.AWS
+	var provider *awsv1alpha1.AWS
 
 	BeforeEach(func() {
-		provider = &v1alpha1.AWS{
-			AMIFamily:             aws.String(v1alpha1.AMIFamilyAL2),
+		provider = &awsv1alpha1.AWS{
+			AMIFamily:             aws.String(awsv1alpha1.AMIFamilyAL2),
 			SubnetSelector:        map[string]string{"foo": "bar"},
 			SecurityGroupSelector: map[string]string{"foo": "bar"},
 		}
@@ -205,19 +206,19 @@ var _ = Describe("Allocation", func() {
 				ExpectApplied(ctx, env.Client, provisioner)
 				var pods []*v1.Pod
 				for key, value := range map[string]string{
-					v1alpha1.LabelInstanceHypervisor:      "nitro",
-					v1alpha1.LabelInstanceCategory:        "g",
-					v1alpha1.LabelInstanceFamily:          "g4dn",
-					v1alpha1.LabelInstanceGeneration:      "4",
-					v1alpha1.LabelInstanceSize:            "8xlarge",
-					v1alpha1.LabelInstanceCPU:             "32",
-					v1alpha1.LabelInstanceMemory:          "131072",
-					v1alpha1.LabelInstancePods:            "58",
-					v1alpha1.LabelInstanceGPUName:         "t4",
-					v1alpha1.LabelInstanceGPUManufacturer: "nvidia",
-					v1alpha1.LabelInstanceGPUCount:        "1",
-					v1alpha1.LabelInstanceGPUMemory:       "16384",
-					v1alpha1.LabelInstanceLocalNVME:       "900",
+					awsv1alpha1.LabelInstanceHypervisor:      "nitro",
+					awsv1alpha1.LabelInstanceCategory:        "g",
+					awsv1alpha1.LabelInstanceFamily:          "g4dn",
+					awsv1alpha1.LabelInstanceGeneration:      "4",
+					awsv1alpha1.LabelInstanceSize:            "8xlarge",
+					awsv1alpha1.LabelInstanceCPU:             "32",
+					awsv1alpha1.LabelInstanceMemory:          "131072",
+					awsv1alpha1.LabelInstancePods:            "58",
+					awsv1alpha1.LabelInstanceGPUName:         "t4",
+					awsv1alpha1.LabelInstanceGPUManufacturer: "nvidia",
+					awsv1alpha1.LabelInstanceGPUCount:        "1",
+					awsv1alpha1.LabelInstanceGPUMemory:       "16384",
+					awsv1alpha1.LabelInstanceLocalNVME:       "900",
 				} {
 					pods = append(pods, test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{key: value}}))
 				}
@@ -233,8 +234,8 @@ var _ = Describe("Allocation", func() {
 							v1.LabelInstanceTypeStable: "t3.large",
 						},
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
 						},
 					})) {
 					ExpectNotScheduled(ctx, env.Client, pod)
@@ -292,8 +293,8 @@ var _ = Describe("Allocation", func() {
 				for _, pod := range ExpectProvisioned(cancelCtx, env.Client, provisionContoller,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
 						},
 					})) {
 					ExpectNotScheduled(cancelCtx, env.Client, pod)
@@ -304,8 +305,8 @@ var _ = Describe("Allocation", func() {
 				for _, pod := range ExpectProvisioned(ctx, env.Client, controller,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSPodENI: resource.MustParse("1")},
 						},
 					})) {
 					node := ExpectScheduled(ctx, env.Client, pod)
@@ -323,22 +324,22 @@ var _ = Describe("Allocation", func() {
 				for _, pod := range ExpectProvisioned(ctx, env.Client, controller,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
 						},
 					}),
 					// Should pack onto same instance
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("2")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("2")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("2")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("2")},
 						},
 					}),
 					// Should pack onto a separate instance
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("4")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("4")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("4")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("4")},
 						},
 					})) {
 					node := ExpectScheduled(ctx, env.Client, pod)
@@ -353,22 +354,22 @@ var _ = Describe("Allocation", func() {
 				for _, pod := range ExpectProvisioned(ctx, env.Client, controller,
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
 						},
 					}),
 					// Should pack onto same instance
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
 						},
 					}),
 					// Should pack onto a separate instance
 					test.UnschedulablePod(test.PodOptions{
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("4")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("4")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("4")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("4")},
 						},
 					}),
 				) {
@@ -402,7 +403,7 @@ var _ = Describe("Allocation", func() {
 				It("should calculate memory overhead based on eni limited pods when ENI limited", func() {
 					opts.AWSENILimitedPodDensity = true
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider.AMIFamily = &v1alpha1.AMIFamilyAL2
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyAL2
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
 					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
@@ -412,7 +413,7 @@ var _ = Describe("Allocation", func() {
 				It("should calculate memory overhead based on eni limited pods when not ENI limited", func() {
 					opts.AWSENILimitedPodDensity = false
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider.AMIFamily = &v1alpha1.AMIFamilyAL2
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyAL2
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
 					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
@@ -424,7 +425,7 @@ var _ = Describe("Allocation", func() {
 				It("should calculate memory overhead based on eni limited pods when ENI limited", func() {
 					opts.AWSENILimitedPodDensity = true
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
 					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
@@ -434,7 +435,7 @@ var _ = Describe("Allocation", func() {
 				It("should calculate memory overhead based on max pods when not ENI limited", func() {
 					opts.AWSENILimitedPodDensity = false
 					opts.VMMemoryOverhead = 0 // cutting a factor out of the equation
-					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx, provider)
 					Expect(err).To(BeNil())
 					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], 0, provider, nil)
@@ -445,21 +446,21 @@ var _ = Describe("Allocation", func() {
 		})
 		Context("Insufficient Capacity Error Cache", func() {
 			It("should launch instances of different type on second reconciliation attempt with Insufficient Capacity Error Cache fallback", func() {
-				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{{CapacityType: v1alpha1.CapacityTypeOnDemand, InstanceType: "inf1.6xlarge", Zone: "test-zone-1a"}})
+				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{{CapacityType: awsv1alpha1.CapacityTypeOnDemand, InstanceType: "inf1.6xlarge", Zone: "test-zone-1a"}})
 				ExpectApplied(ctx, env.Client, provisioner)
 				pods := ExpectProvisioned(ctx, env.Client, controller,
 					test.UnschedulablePod(test.PodOptions{
 						NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-1a"},
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
 						},
 					}),
 					test.UnschedulablePod(test.PodOptions{
 						NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-1a"},
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1")},
 						},
 					}),
 				)
@@ -476,12 +477,12 @@ var _ = Describe("Allocation", func() {
 				Expect(nodeNames.Len()).To(Equal(2))
 			})
 			It("should launch instances in a different zone on second reconciliation attempt with Insufficient Capacity Error Cache fallback", func() {
-				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{{CapacityType: v1alpha1.CapacityTypeOnDemand, InstanceType: "p3.8xlarge", Zone: "test-zone-1a"}})
+				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{{CapacityType: awsv1alpha1.CapacityTypeOnDemand, InstanceType: "p3.8xlarge", Zone: "test-zone-1a"}})
 				pod := test.UnschedulablePod(test.PodOptions{
 					NodeSelector: map[string]string{v1.LabelInstanceTypeStable: "p3.8xlarge"},
 					ResourceRequirements: v1.ResourceRequirements{
-						Requests: v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
-						Limits:   v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
+						Requests: v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
+						Limits:   v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
 					},
 				})
 				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
@@ -504,7 +505,7 @@ var _ = Describe("Allocation", func() {
 			})
 			It("should launch smaller instances than optimal if larger instance launch results in Insufficient Capacity Error", func() {
 				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{
-					{CapacityType: v1alpha1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "test-zone-1a"},
+					{CapacityType: awsv1alpha1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "test-zone-1a"},
 				})
 				provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{
 					Key:      v1.LabelInstanceType,
@@ -535,21 +536,21 @@ var _ = Describe("Allocation", func() {
 				}
 			})
 			It("should launch instances on later reconciliation attempt with Insufficient Capacity Error Cache expiry", func() {
-				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{{CapacityType: v1alpha1.CapacityTypeOnDemand, InstanceType: "inf1.6xlarge", Zone: "test-zone-1a"}})
+				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{{CapacityType: awsv1alpha1.CapacityTypeOnDemand, InstanceType: "inf1.6xlarge", Zone: "test-zone-1a"}})
 				ExpectApplied(ctx, env.Client, provisioner)
 				pod := ExpectProvisioned(ctx, env.Client, controller,
 					test.UnschedulablePod(test.PodOptions{
 						NodeSelector: map[string]string{v1.LabelInstanceTypeStable: "inf1.6xlarge"},
 						ResourceRequirements: v1.ResourceRequirements{
-							Requests: v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
-							Limits:   v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
+							Requests: v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
+							Limits:   v1.ResourceList{awsv1alpha1.ResourceAWSNeuron: resource.MustParse("2")},
 						},
 					}),
 				)[0]
 				ExpectNotScheduled(ctx, env.Client, pod)
 				// capacity shortage is over - expire the item from the cache and try again
 				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{})
-				unavailableOfferingsCache.Delete(UnavailableOfferingsCacheKey("inf1.6xlarge", "test-zone-1a", v1alpha1.CapacityTypeOnDemand))
+				unavailableOfferingsCache.Delete(UnavailableOfferingsCacheKey("inf1.6xlarge", "test-zone-1a", awsv1alpha1.CapacityTypeOnDemand))
 				pod = ExpectProvisioned(ctx, env.Client, controller, pod)[0]
 				node := ExpectScheduled(ctx, env.Client, pod)
 				Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "inf1.6xlarge"))
@@ -558,12 +559,12 @@ var _ = Describe("Allocation", func() {
 				safeSpotFallbackThreshold = 4
 				fakeEC2API.DescribeInstanceTypesPagesWithContext(ctx, &ec2.DescribeInstanceTypesInput{}, func(dito *ec2.DescribeInstanceTypesOutput, b bool) bool {
 					for _, it := range dito.InstanceTypes {
-						fakeEC2API.InsufficientCapacityPools.Add(fake.CapacityPool{CapacityType: v1alpha1.CapacityTypeSpot, InstanceType: aws.StringValue(it.InstanceType), Zone: "test-zone-1a"})
+						fakeEC2API.InsufficientCapacityPools.Add(fake.CapacityPool{CapacityType: awsv1alpha1.CapacityTypeSpot, InstanceType: aws.StringValue(it.InstanceType), Zone: "test-zone-1a"})
 					}
 					return true
 				})
 				provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot, v1alpha1.CapacityTypeOnDemand}},
+					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{awsv1alpha1.CapacityTypeSpot, awsv1alpha1.CapacityTypeOnDemand}},
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1a"}},
 				}
 				// Spot Unavailable
@@ -574,14 +575,14 @@ var _ = Describe("Allocation", func() {
 				pod = ExpectProvisioned(ctx, env.Client, controller, pod)[0]
 				// Fallback to OD
 				node := ExpectScheduled(ctx, env.Client, pod)
-				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelCapacityType, v1alpha1.CapacityTypeOnDemand))
+				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelCapacityType, awsv1alpha1.CapacityTypeOnDemand))
 			})
 			It("should return all instance types, even though with no offerings due to Insufficient Capacity Error", func() {
 				fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{
-					{CapacityType: v1alpha1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "test-zone-1a"},
-					{CapacityType: v1alpha1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "test-zone-1b"},
-					{CapacityType: v1alpha1.CapacityTypeSpot, InstanceType: "m5.xlarge", Zone: "test-zone-1a"},
-					{CapacityType: v1alpha1.CapacityTypeSpot, InstanceType: "m5.xlarge", Zone: "test-zone-1b"},
+					{CapacityType: awsv1alpha1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "test-zone-1a"},
+					{CapacityType: awsv1alpha1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "test-zone-1b"},
+					{CapacityType: awsv1alpha1.CapacityTypeSpot, InstanceType: "m5.xlarge", Zone: "test-zone-1a"},
+					{CapacityType: awsv1alpha1.CapacityTypeSpot, InstanceType: "m5.xlarge", Zone: "test-zone-1b"},
 				})
 				provisioner.Spec.Requirements = nil
 				provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{
@@ -596,7 +597,7 @@ var _ = Describe("Allocation", func() {
 				})
 
 				ExpectApplied(ctx, env.Client, provisioner)
-				for _, ct := range []string{v1alpha1.CapacityTypeOnDemand, v1alpha1.CapacityTypeSpot} {
+				for _, ct := range []string{awsv1alpha1.CapacityTypeOnDemand, awsv1alpha1.CapacityTypeSpot} {
 					for _, zone := range []string{"test-zone-1a", "test-zone-1b"} {
 						ExpectProvisioned(ctx, env.Client, controller,
 							test.UnschedulablePod(test.PodOptions{
@@ -630,19 +631,19 @@ var _ = Describe("Allocation", func() {
 				ExpectApplied(ctx, env.Client, provisioner)
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				node := ExpectScheduled(ctx, env.Client, pod)
-				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelCapacityType, v1alpha1.CapacityTypeOnDemand))
+				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelCapacityType, awsv1alpha1.CapacityTypeOnDemand))
 			})
 			It("should launch spot capacity if flexible to both spot and on demand", func() {
 				provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot, v1alpha1.CapacityTypeOnDemand}}}
+					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{awsv1alpha1.CapacityTypeSpot, awsv1alpha1.CapacityTypeOnDemand}}}
 				ExpectApplied(ctx, env.Client, provisioner)
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				node := ExpectScheduled(ctx, env.Client, pod)
-				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelCapacityType, v1alpha1.CapacityTypeSpot))
+				Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.LabelCapacityType, awsv1alpha1.CapacityTypeSpot))
 			})
 			It("should not launch spot capacity if flexible to both spot and on demand but only flexible to 1 instance types", func() {
 				provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot, v1alpha1.CapacityTypeOnDemand}},
+					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{awsv1alpha1.CapacityTypeSpot, awsv1alpha1.CapacityTypeOnDemand}},
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1a"}},
 					{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"m5.large"}},
 				}
@@ -657,7 +658,7 @@ var _ = Describe("Allocation", func() {
 				fakeEC2API.DescribeInstanceTypesOutput.Set(&ec2.DescribeInstanceTypesOutput{
 					InstanceTypes: []*ec2.InstanceTypeInfo{m5large},
 				})
-				unavailableOfferingsCache.SetDefault(UnavailableOfferingsCacheKey("m5.large", "test-zone-1a", v1alpha1.CapacityTypeSpot), struct{}{})
+				unavailableOfferingsCache.SetDefault(UnavailableOfferingsCacheKey("m5.large", "test-zone-1a", awsv1alpha1.CapacityTypeSpot), struct{}{})
 				ExpectApplied(ctx, env.Client, provisioner)
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				unscheduledPod := ExpectNotScheduled(ctx, env.Client, pod)
@@ -688,10 +689,10 @@ var _ = Describe("Allocation", func() {
 				// constrain the packer to a single launch template type
 				rr := v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceCPU:             resource.MustParse("24"),
-						v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
+						v1.ResourceCPU:                resource.MustParse("24"),
+						awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
 					},
-					Limits: v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
+					Limits: v1.ResourceList{awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")},
 				}
 
 				ExpectApplied(ctx, env.Client, provisioner)
@@ -1048,11 +1049,11 @@ var _ = Describe("Allocation", func() {
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(test.PodOptions{
 					ResourceRequirements: v1.ResourceRequirements{
 						Requests: map[v1.ResourceName]resource.Quantity{
-							v1.ResourceCPU:             resource.MustParse("1"),
-							v1alpha1.ResourceAWSNeuron: resource.MustParse("1"),
+							v1.ResourceCPU:                resource.MustParse("1"),
+							awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1"),
 						},
 						Limits: map[v1.ResourceName]resource.Quantity{
-							v1alpha1.ResourceAWSNeuron: resource.MustParse("1"),
+							awsv1alpha1.ResourceAWSNeuron: resource.MustParse("1"),
 						},
 					},
 				}))[0]
@@ -1067,11 +1068,11 @@ var _ = Describe("Allocation", func() {
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(test.PodOptions{
 					ResourceRequirements: v1.ResourceRequirements{
 						Requests: map[v1.ResourceName]resource.Quantity{
-							v1.ResourceCPU:             resource.MustParse("1"),
-							v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
+							v1.ResourceCPU:                resource.MustParse("1"),
+							awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
 						},
 						Limits: map[v1.ResourceName]resource.Quantity{
-							v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
+							awsv1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
 						},
 					},
 				}))[0]
@@ -1084,20 +1085,16 @@ var _ = Describe("Allocation", func() {
 			Context("Bottlerocket", func() {
 				It("should merge in custom user data", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
 					content, _ := ioutil.ReadFile("testdata/br_userdata_input.golden")
-					providerRefName := test.RandomName()
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
-						UserData:   aws.String(string(content)),
-						AWS:        *provider,
-						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+						UserData: aws.String(string(content)),
+						AWS:      *provider,
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					env.Client.Get(ctx, client.ObjectKeyFromObject(newProvisioner), newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
@@ -1113,19 +1110,15 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should bootstrap when custom user data is empty", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-					providerRefName := test.RandomName()
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
-						UserData:   nil,
-						AWS:        *provider,
-						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+						UserData: nil,
+						AWS:      *provider,
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1139,32 +1132,25 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should not bootstrap when provider ref points to a non-existent resource", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-					providerRef := &v1alpha5.ProviderRef{
-						Name: "doesnotexist",
-					}
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
 					controller := provisioning.NewController(ctx, cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: "doesnotexist"}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					// This will not be scheduled since we were pointed to a non-existent awsnodetemplate resource.
 					ExpectNotScheduled(ctx, env.Client, pod)
 				})
 				It("should not bootstrap on invalid toml user data", func() {
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-					providerRefName := test.RandomName()
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
-						UserData:   aws.String("#/bin/bash\n ./not-toml.sh"),
-						AWS:        *provider,
-						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+						UserData: aws.String("#/bin/bash\n ./not-toml.sh"),
+						AWS:      *provider,
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(ctx, cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					// This will not be scheduled since userData cannot be generated for the prospective node.
@@ -1174,19 +1160,15 @@ var _ = Describe("Allocation", func() {
 			Context("AL2 Custom UserData", func() {
 				It("should merge in custom user data", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					content, _ := ioutil.ReadFile("testdata/al2_userdata_input.golden")
-					providerRefName := test.RandomName()
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
-						UserData:   aws.String(string(content)),
-						AWS:        *provider,
-						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+						UserData: aws.String(string(content)),
+						AWS:      *provider,
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1199,18 +1181,14 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should handle empty custom user data", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := test.RandomName()
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
-						UserData:   nil,
-						AWS:        *provider,
-						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+						UserData: nil,
+						AWS:      *provider,
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1223,18 +1201,14 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should not bootstrap invalid MIME UserData", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := test.RandomName()
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
-						UserData:   aws.String("#/bin/bash\n ./not-mime.sh"),
-						AWS:        *provider,
-						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+						UserData: aws.String("#/bin/bash\n ./not-mime.sh"),
+						AWS:      *provider,
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
 					controller := provisioning.NewController(injection.WithOptions(ctx, opts), cfg, env.Client, clientSet.CoreV1(), recorder, cloudProvider, cluster)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					// This will not be scheduled since userData cannot be generated for the prospective node.
@@ -1244,21 +1218,17 @@ var _ = Describe("Allocation", func() {
 			Context("Custom AMI Selector", func() {
 				It("should use ami selector specified in AWSNodeTemplate", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 						UserData:    nil,
 						AMISelector: map[string]string{"karpenter.sh/discovery": "my-cluster"},
 						AWS:         *provider,
-						ObjectMeta:  metav1.ObjectMeta{Name: providerRefName}})
+					})
 					fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 						{ImageId: aws.String("ami-123"), Architecture: aws.String("x86_64")},
 					}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1268,22 +1238,18 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should copy over userData untouched when AMIFamily is Custom", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					provider.AMIFamily = &v1alpha1.AMIFamilyCustom
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider.AMIFamily = &awsv1alpha1.AMIFamilyCustom
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 						UserData:    aws.String("special user data"),
 						AMISelector: map[string]string{"karpenter.sh/discovery": "my-cluster"},
 						AWS:         *provider,
-						ObjectMeta:  metav1.ObjectMeta{Name: providerRefName}})
+					})
 					fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 						{ImageId: aws.String("ami-123"), Architecture: aws.String("x86_64")},
 					}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1294,16 +1260,12 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should correctly use ami selector with specific IDs in AWSNodeTemplate", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 						UserData:    nil,
 						AMISelector: map[string]string{"aws-ids": "ami-123,ami-456"},
 						AWS:         *provider,
-						ObjectMeta:  metav1.ObjectMeta{Name: providerRefName}})
+					})
 					fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 						{
 							ImageId:      aws.String("ami-123"),
@@ -1317,7 +1279,7 @@ var _ = Describe("Allocation", func() {
 						},
 					}})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1333,11 +1295,7 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should create multiple launch templates when multiple amis are discovered", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 						{
 							ImageId:      aws.String("ami-123"),
@@ -1350,13 +1308,13 @@ var _ = Describe("Allocation", func() {
 							Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
 						},
 					}})
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 						UserData:    nil,
 						AMISelector: map[string]string{"karpenter.sh/discovery": "my-cluster"},
 						AWS:         *provider,
-						ObjectMeta:  metav1.ObjectMeta{Name: providerRefName}})
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1370,19 +1328,15 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should fail if no amis match selector.", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{}})
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 						UserData:    nil,
 						AMISelector: map[string]string{"karpenter.sh/discovery": "my-cluster"},
 						AWS:         *provider,
-						ObjectMeta:  metav1.ObjectMeta{Name: providerRefName}})
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectNotScheduled(ctx, env.Client, pod)
@@ -1390,21 +1344,17 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should fail if no instanceType matches ami requirements.", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 						{ImageId: aws.String("ami-123"), Architecture: aws.String("newnew")},
 					}})
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 						UserData:    nil,
 						AMISelector: map[string]string{"karpenter.sh/discovery": "my-cluster"},
 						AWS:         *provider,
-						ObjectMeta:  metav1.ObjectMeta{Name: providerRefName}})
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectNotScheduled(ctx, env.Client, pod)
@@ -1412,17 +1362,13 @@ var _ = Describe("Allocation", func() {
 				})
 				It("should choose amis from SSM if no selector specified in AWSNodeTemplate", func() {
 					opts.AWSENILimitedPodDensity = false
-					provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-					providerRefName := strings.ToLower(randomdata.SillyName())
-					providerRef := &v1alpha5.ProviderRef{
-						Name: providerRefName,
-					}
-					nodeTemplate := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{
-						UserData:   nil,
-						AWS:        *provider,
-						ObjectMeta: metav1.ObjectMeta{Name: providerRefName}})
+					provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+					nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+						UserData: nil,
+						AWS:      *provider,
+					})
 					ExpectApplied(ctx, env.Client, nodeTemplate)
-					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: providerRef})
+					newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
 					ExpectApplied(ctx, env.Client, newProvisioner)
 					pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 					ExpectScheduled(ctx, env.Client, pod)
@@ -1477,9 +1423,9 @@ var _ = Describe("Allocation", func() {
 				Expect(*input.LaunchTemplateData.MetadataOptions.HttpTokens).To(Equal(ec2.LaunchTemplateHttpTokensStateRequired))
 			})
 			It("should set metadata options on generated launch template from provisioner configuration", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{
+				provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 					HTTPEndpoint:            aws.String(ec2.LaunchTemplateInstanceMetadataEndpointStateDisabled),
 					HTTPProtocolIPv6:        aws.String(ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled),
 					HTTPPutResponseHopLimit: aws.Int64(1),
@@ -1498,8 +1444,8 @@ var _ = Describe("Allocation", func() {
 		})
 		Context("Block Device Mappings", func() {
 			It("should default AL2 block device mappings", func() {
-				provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				provider.AMIFamily = &v1alpha1.AMIFamilyAL2
+				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.AMIFamily = &awsv1alpha1.AMIFamilyAL2
 				ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				ExpectScheduled(ctx, env.Client, pod)
@@ -1511,12 +1457,12 @@ var _ = Describe("Allocation", func() {
 				Expect(input.LaunchTemplateData.BlockDeviceMappings[0].Ebs.Iops).To(BeNil())
 			})
 			It("should use custom block device mapping", func() {
-				provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				provider.AMIFamily = &v1alpha1.AMIFamilyAL2
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{
+				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.AMIFamily = &awsv1alpha1.AMIFamilyAL2
+				provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{
 					{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							DeleteOnTermination: aws.Bool(true),
 							Encrypted:           aws.Bool(true),
 							VolumeType:          aws.String("io2"),
@@ -1540,8 +1486,8 @@ var _ = Describe("Allocation", func() {
 				Expect(*input.LaunchTemplateData.BlockDeviceMappings[0].Ebs.KmsKeyId).To(Equal("arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"))
 			})
 			It("should default bottlerocket second volume with root volume size", func() {
-				provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
+				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
 				ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				ExpectScheduled(ctx, env.Client, pod)
@@ -1558,8 +1504,8 @@ var _ = Describe("Allocation", func() {
 				Expect(input.LaunchTemplateData.BlockDeviceMappings[1].Ebs.Iops).To(BeNil())
 			})
 			It("should not default block device mappings for custom AMIFamilies", func() {
-				provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				provider.AMIFamily = &v1alpha1.AMIFamilyCustom
+				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.AMIFamily = &awsv1alpha1.AMIFamilyCustom
 				ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				ExpectScheduled(ctx, env.Client, pod)
@@ -1568,12 +1514,12 @@ var _ = Describe("Allocation", func() {
 				Expect(len(input.LaunchTemplateData.BlockDeviceMappings)).To(Equal(0))
 			})
 			It("should use custom block device mapping for custom AMIFamilies", func() {
-				provider, _ := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				provider.AMIFamily = &v1alpha1.AMIFamilyCustom
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{
+				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.AMIFamily = &awsv1alpha1.AMIFamilyCustom
+				provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{
 					{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							DeleteOnTermination: aws.Bool(true),
 							Encrypted:           aws.Bool(true),
 							VolumeType:          aws.String("io2"),
@@ -1690,10 +1636,10 @@ var _ = Describe("Allocation", func() {
 				ExpectNotScheduled(ctx, env.Client, pod)
 			})
 			It("should pack pods using the blockdevicemappings from the provider spec when defined", func() {
-				provider, _ = v1alpha1.Deserialize(provisioner.Spec.Provider)
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+				provider, _ = awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 					DeviceName: aws.String("/dev/xvda"),
-					EBS: &v1alpha1.BlockDevice{
+					EBS: &awsv1alpha1.BlockDevice{
 						VolumeSize: resource.NewScaledQuantity(50, resource.Giga),
 					},
 				}}
@@ -1710,18 +1656,18 @@ var _ = Describe("Allocation", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 			})
 			It("should pack pods using blockdevicemappings for Custom AMIFamily", func() {
-				provider, _ = v1alpha1.Deserialize(provisioner.Spec.Provider)
-				provider.AMIFamily = &v1alpha1.AMIFamilyCustom
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{
+				provider, _ = awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider.AMIFamily = &awsv1alpha1.AMIFamilyCustom
+				provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{
 					{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							VolumeSize: resource.NewScaledQuantity(20, resource.Giga),
 						},
 					},
 					{
 						DeviceName: aws.String("/dev/xvdb"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							VolumeSize: resource.NewScaledQuantity(40, resource.Giga),
 						},
 					},
@@ -1745,7 +1691,7 @@ var _ = Describe("Allocation", func() {
 		// Intent here is that if updates occur on the controller, the Provisioner doesn't need to be recreated
 		It("should not set the InstanceProfile with the default if none provided in Provisioner", func() {
 			provisioner.SetDefaults(ctx)
-			constraints, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+			constraints, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(constraints.InstanceProfile).To(BeNil())
 		})
@@ -1755,7 +1701,7 @@ var _ = Describe("Allocation", func() {
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1alpha1.CapacityTypeOnDemand},
+				Values:   []string{awsv1alpha1.CapacityTypeOnDemand},
 			}))
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1.LabelArchStable,
@@ -1775,7 +1721,7 @@ var _ = Describe("Allocation", func() {
 
 		Context("SubnetSelector", func() {
 			It("should not allow empty string keys or values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
 				for key, value := range map[string]string{
 					"":    "value",
@@ -1789,7 +1735,7 @@ var _ = Describe("Allocation", func() {
 		})
 		Context("SecurityGroupSelector", func() {
 			It("should not allow with a custom launch template", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
 				provider.LaunchTemplateName = aws.String("my-lt")
 				provider.SecurityGroupSelector = map[string]string{"key": "value"}
@@ -1797,7 +1743,7 @@ var _ = Describe("Allocation", func() {
 				Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 			})
 			It("should not allow empty string keys or values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
 				for key, value := range map[string]string{
 					"":    "value",
@@ -1811,7 +1757,7 @@ var _ = Describe("Allocation", func() {
 		})
 		Context("EC2 Context", func() {
 			It("should set context on the CreateFleet request if specified on the Provisioner", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
 				provider.Context = aws.String("context-1234")
 				provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -1835,20 +1781,20 @@ var _ = Describe("Allocation", func() {
 		})
 		Context("Labels", func() {
 			It("should not allow unrecognized labels with the aws label prefix", func() {
-				provisioner.Spec.Labels = map[string]string{v1alpha1.LabelDomain + "/" + randomdata.SillyName(): randomdata.SillyName()}
+				provisioner.Spec.Labels = map[string]string{awsv1alpha1.LabelDomain + "/" + randomdata.SillyName(): randomdata.SillyName()}
 				Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 			})
 			It("should support well known labels", func() {
 				for _, label := range []string{
-					v1alpha1.LabelInstanceHypervisor,
-					v1alpha1.LabelInstanceFamily,
-					v1alpha1.LabelInstanceSize,
-					v1alpha1.LabelInstanceCPU,
-					v1alpha1.LabelInstanceMemory,
-					v1alpha1.LabelInstanceGPUName,
-					v1alpha1.LabelInstanceGPUManufacturer,
-					v1alpha1.LabelInstanceGPUCount,
-					v1alpha1.LabelInstanceGPUMemory,
+					awsv1alpha1.LabelInstanceHypervisor,
+					awsv1alpha1.LabelInstanceFamily,
+					awsv1alpha1.LabelInstanceSize,
+					awsv1alpha1.LabelInstanceCPU,
+					awsv1alpha1.LabelInstanceMemory,
+					awsv1alpha1.LabelInstanceGPUName,
+					awsv1alpha1.LabelInstanceGPUManufacturer,
+					awsv1alpha1.LabelInstanceGPUCount,
+					awsv1alpha1.LabelInstanceGPUMemory,
 				} {
 					provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
 					Expect(provisioner.Validate(ctx)).To(Succeed())
@@ -1857,26 +1803,26 @@ var _ = Describe("Allocation", func() {
 		})
 		Context("MetadataOptions", func() {
 			It("should not allow with a custom launch template", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
 				provider.LaunchTemplateName = aws.String("my-lt")
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{}
+				provider.MetadataOptions = &awsv1alpha1.MetadataOptions{}
 				provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
 				Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 			})
 			It("should allow missing values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{}
+				provider.MetadataOptions = &awsv1alpha1.MetadataOptions{}
 				provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
 				Expect(provisioner.Validate(ctx)).To(Succeed())
 			})
 			Context("HTTPEndpoint", func() {
 				It("should allow enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
 					for _, value := range ec2.LaunchTemplateInstanceMetadataEndpointState_Values() {
-						provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 							HTTPEndpoint: &value,
 						}
 						provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -1884,9 +1830,9 @@ var _ = Describe("Allocation", func() {
 					}
 				})
 				It("should not allow non-enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+					provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 						HTTPEndpoint: aws.String(randomdata.SillyName()),
 					}
 					provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -1895,10 +1841,10 @@ var _ = Describe("Allocation", func() {
 			})
 			Context("HTTPProtocolIpv6", func() {
 				It("should allow enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
 					for _, value := range ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values() {
-						provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 							HTTPProtocolIPv6: &value,
 						}
 						provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -1906,9 +1852,9 @@ var _ = Describe("Allocation", func() {
 					}
 				})
 				It("should not allow non-enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+					provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 						HTTPProtocolIPv6: aws.String(randomdata.SillyName()),
 					}
 					provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -1917,18 +1863,18 @@ var _ = Describe("Allocation", func() {
 			})
 			Context("HTTPPutResponseHopLimit", func() {
 				It("should validate inside accepted range", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+					provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 						HTTPPutResponseHopLimit: aws.Int64(int64(randomdata.Number(1, 65))),
 					}
 					provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
 					Expect(provisioner.Validate(ctx)).To(Succeed())
 				})
 				It("should not validate outside accepted range", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{}
+					provider.MetadataOptions = &awsv1alpha1.MetadataOptions{}
 					// We expect to be able to invalidate any hop limit between
 					// [math.MinInt64, 1). But, to avoid a panic here, we can't
 					// exceed math.MaxInt for the difference between bounds of
@@ -1948,10 +1894,10 @@ var _ = Describe("Allocation", func() {
 			})
 			Context("HTTPTokens", func() {
 				It("should allow enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
 					for _, value := range ec2.LaunchTemplateHttpTokensState_Values() {
-						provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 							HTTPTokens: aws.String(value),
 						}
 						provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -1959,9 +1905,9 @@ var _ = Describe("Allocation", func() {
 					}
 				})
 				It("should not allow non-enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+					provider.MetadataOptions = &awsv1alpha1.MetadataOptions{
 						HTTPTokens: aws.String(randomdata.SillyName()),
 					}
 					provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -1970,12 +1916,12 @@ var _ = Describe("Allocation", func() {
 			})
 			Context("BlockDeviceMappings", func() {
 				It("should not allow with a custom launch template", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
 					provider.LaunchTemplateName = aws.String("my-lt")
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							VolumeSize: resource.NewScaledQuantity(1, resource.Giga),
 						},
 					}}
@@ -1983,11 +1929,11 @@ var _ = Describe("Allocation", func() {
 					Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 				})
 				It("should validate minimal device mapping", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							VolumeSize: resource.NewScaledQuantity(1, resource.Giga),
 						},
 					}}
@@ -1995,11 +1941,11 @@ var _ = Describe("Allocation", func() {
 					Expect(provisioner.Validate(ctx)).To(Succeed())
 				})
 				It("should validate ebs device mapping with snapshotID only", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							SnapshotID: aws.String("snap-0123456789"),
 						},
 					}}
@@ -2007,11 +1953,11 @@ var _ = Describe("Allocation", func() {
 					Expect(provisioner.Validate(ctx)).To(Succeed())
 				})
 				It("should not allow volume size below minimum", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							VolumeSize: resource.NewScaledQuantity(100, resource.Mega),
 						},
 					}}
@@ -2019,11 +1965,11 @@ var _ = Describe("Allocation", func() {
 					Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 				})
 				It("should not allow volume size above max", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS: &v1alpha1.BlockDevice{
+						EBS: &awsv1alpha1.BlockDevice{
 							VolumeSize: resource.NewScaledQuantity(65, resource.Tera),
 						},
 					}}
@@ -2031,10 +1977,10 @@ var _ = Describe("Allocation", func() {
 					Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 				})
 				It("should not allow nil device name", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-						EBS: &v1alpha1.BlockDevice{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
+						EBS: &awsv1alpha1.BlockDevice{
 							VolumeSize: resource.NewScaledQuantity(65, resource.Tera),
 						},
 					}}
@@ -2042,19 +1988,19 @@ var _ = Describe("Allocation", func() {
 					Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 				})
 				It("should not allow nil volume size", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
-						EBS:        &v1alpha1.BlockDevice{},
+						EBS:        &awsv1alpha1.BlockDevice{},
 					}}
 					provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})
 					Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 				})
 				It("should not allow empty ebs block", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 					Expect(err).ToNot(HaveOccurred())
-					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+					provider.BlockDeviceMappings = []*awsv1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
 					}}
 					provisioner := test.Provisioner(test.ProvisionerOptions{Provider: provider})

--- a/pkg/test/awsnodetemplate.go
+++ b/pkg/test/awsnodetemplate.go
@@ -15,35 +15,12 @@ limitations under the License.
 package test
 
 import (
-	"fmt"
-
-	"github.com/imdario/mergo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
-	aws "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 )
 
-type AWSNodeTemplateOptions struct {
-	metav1.ObjectMeta
-	UserData    *string
-	AMISelector map[string]string
-	AWS         aws.AWS
-}
-
-func AWSNodeTemplate(overrides ...AWSNodeTemplateOptions) *v1alpha1.AWSNodeTemplate {
-	options := AWSNodeTemplateOptions{}
-	for _, opts := range overrides {
-		if err := mergo.Merge(&options, opts, mergo.WithOverride); err != nil {
-			panic(fmt.Sprintf("Failed to merge aws node template options: %s", err))
-		}
-	}
+func AWSNodeTemplate(overrides ...v1alpha1.AWSNodeTemplateSpec) *v1alpha1.AWSNodeTemplate {
 	return &v1alpha1.AWSNodeTemplate{
-		ObjectMeta: ObjectMeta(options.ObjectMeta),
-		Spec: v1alpha1.AWSNodeTemplateSpec{
-			UserData:    options.UserData,
-			AMISelector: options.AMISelector,
-			AWS:         options.AWS,
-		},
+		ObjectMeta: ObjectMeta(),
+		Spec:       MustMerge(v1alpha1.AWSNodeTemplateSpec{}, overrides...),
 	}
 }

--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/ptr"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 )
@@ -59,9 +58,6 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 	}
 	if options.Limits == nil {
 		options.Limits = v1.ResourceList{v1.ResourceCPU: resource.MustParse("1000")}
-	}
-	if options.TTLSecondsAfterEmpty == nil {
-		options.TTLSecondsAfterEmpty = ptr.Int64(10)
 	}
 
 	provisioner := &v1alpha5.Provisioner{

--- a/test/pkg/environment/expectations.go
+++ b/test/pkg/environment/expectations.go
@@ -1,20 +1,25 @@
 package environment
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"io"
+	"strings"
 	"sync"
 
+	. "github.com/onsi/ginkgo" //nolint:revive,stylecheck
+	. "github.com/onsi/gomega" //nolint:revive,stylecheck
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	. "github.com/onsi/ginkgo" //nolint:revive,stylecheck
-	. "github.com/onsi/gomega" //nolint:revive,stylecheck
 
 	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
@@ -22,9 +27,8 @@ import (
 )
 
 var (
-	ClusterLabelName = "testing.karpenter.sh/cluster-name"
+	TestLabelName    = "testing.karpenter.sh/test-id"
 	CleanableObjects = []client.Object{
-		&v1alpha5.Provisioner{},
 		&v1.Pod{},
 		&appsv1.Deployment{},
 		&appsv1.DaemonSet{},
@@ -33,6 +37,7 @@ var (
 		&v1.PersistentVolume{},
 		&storagev1.StorageClass{},
 		&v1alpha1.AWSNodeTemplate{},
+		&v1alpha5.Provisioner{},
 	}
 )
 
@@ -53,16 +58,39 @@ func (env *Environment) BeforeEach() {
 		Expect(pods.Items[i].Namespace).ToNot(Equal("default"),
 			fmt.Sprintf("expected no pods in the `default` namespace, found %s/%s", pods.Items[i].Namespace, pods.Items[i].Name))
 	}
-
 	var provisioners v1alpha5.ProvisionerList
 	Expect(env.Client.List(env.Context, &provisioners)).To(Succeed())
 	Expect(provisioners.Items).To(HaveLen(0), "expected no provisioners to exist")
 	env.Monitor.Reset()
 }
 
+func (env *Environment) AfterEach() {
+	namespaces := &v1.NamespaceList{}
+	Expect(env.Client.List(env, namespaces)).To(Succeed())
+	wg := sync.WaitGroup{}
+	for _, object := range CleanableObjects {
+		for _, namespace := range namespaces.Items {
+			wg.Add(1)
+			go func(object client.Object, namespace string) {
+				defer GinkgoRecover()
+				Expect(env.Client.DeleteAllOf(env, object,
+					client.InNamespace(namespace),
+					client.HasLabels([]string{TestLabelName}),
+					client.PropagationPolicy(metav1.DeletePropagationForeground),
+				)).Should(Succeed())
+				wg.Done()
+			}(object, namespace.Name)
+		}
+	}
+	wg.Wait()
+	env.eventuallyExpectScaleDown()
+	env.expectNoCrashes()
+	env.printControllerLogs(&v1.PodLogOptions{Container: "controller"})
+}
+
 func (env *Environment) ExpectCreated(objects ...client.Object) {
 	for _, object := range objects {
-		object.SetLabels(lo.Assign(object.GetLabels(), map[string]string{ClusterLabelName: env.Options.ClusterName}))
+		object.SetLabels(lo.Assign(object.GetLabels(), map[string]string{TestLabelName: env.ClusterName}))
 		Expect(env.Client.Create(env, object)).To(Succeed())
 	}
 }
@@ -71,26 +99,6 @@ func (env *Environment) ExpectDeleted(objects ...client.Object) {
 	for _, object := range objects {
 		Expect(env.Client.Delete(env, object, &client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)})).To(Succeed())
 	}
-}
-
-func (env *Environment) AfterEach() {
-	defer GinkgoRecover()
-	namespaces := &v1.NamespaceList{}
-	Expect(env.Client.List(env, namespaces)).To(Succeed())
-	wg := sync.WaitGroup{}
-	for _, object := range CleanableObjects {
-		for _, namespace := range namespaces.Items {
-			wg.Add(1)
-			go func(object client.Object, namespace string) {
-				Expect(env.Client.DeleteAllOf(env, object,
-					client.InNamespace(namespace),
-					client.MatchingLabels(map[string]string{ClusterLabelName: env.Options.ClusterName}),
-				)).ToNot(HaveOccurred())
-				wg.Done()
-			}(object, namespace.Name)
-		}
-	}
-	wg.Wait()
 }
 
 func (env *Environment) EventuallyExpectHealthy(pods ...*v1.Pod) {
@@ -111,11 +119,12 @@ func (env *Environment) EventuallyExpectHealthyPodCount(selector labels.Selector
 	}).Should(Succeed())
 }
 
-func (env *Environment) EventuallyExpectScaleDown() {
+func (env *Environment) eventuallyExpectScaleDown() {
 	Eventually(func(g Gomega) {
 		// expect the current node count to be what it was when the test started
 		g.Expect(env.Monitor.NodeCount()).To(Equal(env.Monitor.NodeCountAtReset()))
 	}).Should(Succeed(), fmt.Sprintf("expected scale down to %d nodes, had %d", env.Monitor.NodeCountAtReset(), env.Monitor.NodeCount()))
+	logging.FromContext(context.Background()).Info(env.Monitor.NodeCountAtReset())
 }
 
 func (env *Environment) ExpectCreatedNodeCount(comparator string, nodeCount int) {
@@ -123,9 +132,35 @@ func (env *Environment) ExpectCreatedNodeCount(comparator string, nodeCount int)
 		fmt.Sprintf("expected %d created nodes, had %d", nodeCount, env.Monitor.CreatedNodes()))
 }
 
-func (env *Environment) ExpectNoCrashes() {
+func (env *Environment) expectNoCrashes() {
+	crashed := false
 	for name, restartCount := range env.Monitor.RestartCount() {
-		Expect(restartCount).To(Equal(0),
-			fmt.Sprintf("expected restart count of %s = 0, had %d", name, restartCount))
+		if restartCount > 0 {
+			crashed = true
+			env.printControllerLogs(&v1.PodLogOptions{Container: strings.Split(name, "/")[1], Previous: true})
+		}
 	}
+	Expect(crashed).To(BeFalse(), "expected karpenter containers to not crash")
+}
+
+var (
+	lastLogged = metav1.Now()
+)
+
+func (env *Environment) printControllerLogs(options *v1.PodLogOptions) {
+	if options.SinceTime == nil {
+		options.SinceTime = lastLogged.DeepCopy()
+		lastLogged = metav1.Now()
+	}
+	lease, err := env.KubeClient.CoordinationV1().Leases("karpenter").Get(env.Context, "karpenter-leader-election", metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(lease.Spec.HolderIdentity).ToNot(BeNil(), "lease has no holder")
+	nameid := strings.Split(*lease.Spec.HolderIdentity, "_")
+	Expect(nameid).To(HaveLen(2), fmt.Sprintf("invalid lease HolderIdentity, %s", *lease.Spec.HolderIdentity))
+	stream, err := env.KubeClient.CoreV1().Pods("karpenter").GetLogs(nameid[0], options).Stream(env.Context)
+	Expect(err).ToNot(HaveOccurred())
+	log := new(bytes.Buffer)
+	_, err = io.Copy(log, stream)
+	Expect(err).ToNot(HaveOccurred())
+	logging.FromContext(env.Context).Info(log)
 }

--- a/test/pkg/environment/monitor.go
+++ b/test/pkg/environment/monitor.go
@@ -29,7 +29,7 @@ type recording struct {
 	pods  v1.PodList
 }
 
-func NewClusterMonitor(ctx context.Context, kubeClient client.Client) *Monitor {
+func NewMonitor(ctx context.Context, kubeClient client.Client) *Monitor {
 	m := &Monitor{
 		ctx:        ctx,
 		kubeClient: kubeClient,
@@ -138,17 +138,12 @@ func (m *Monitor) poll() {
 	if err := m.kubeClient.List(m.ctx, &pods); err != nil {
 		logging.FromContext(m.ctx).Errorf("listing pods, %s", err)
 	}
-	m.record(nodes, pods)
-}
-
-func (m *Monitor) record(nodes v1.NodeList, pods v1.PodList) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.recordings = append(m.recordings, recording{
 		nodes: nodes,
 		pods:  pods,
 	})
-
 	for _, node := range nodes.Items {
 		m.nodesSeen.Insert(node.Name)
 	}

--- a/test/suites/common/run-test.yaml
+++ b/test/suites/common/run-test.yaml
@@ -10,8 +10,8 @@ spec:
   params:
     - name: cluster-name
       description: Name of the cluster under test.
-    - name: suite-path
-      description: Path to the test suite
+    - name: test-filter
+      description: Test filter passed to `go test -run`
     - name: git-ref
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
   workspaces:
@@ -30,4 +30,4 @@ spec:
     workingDir: $(workspaces.ws.path)
     script: |
       aws eks update-kubeconfig --name $(params.cluster-name)
-      go test -v $(params.suite-path) -cluster-name $(params.cluster-name) -kubeconfig /root/.kube/config
+      TEST_FILTER=$(params.test-filter) make e2etests

--- a/test/suites/common/setup.yaml
+++ b/test/suites/common/setup.yaml
@@ -97,8 +97,6 @@ spec:
         karpenter karpenter/karpenter \
         --version v0-$(git rev-parse HEAD) \
         --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::$(cat $(results.account-id.path)):role/$(params.cluster-name)-karpenter" \
-        --set tolerations[0].key="CriticalAddonsOnly" \
-        --set tolerations[0].operator="Exists" \
         --set clusterName=$(params.cluster-name) \
         --set clusterEndpoint=$(cat /root/.kube/config | grep server | awk '{print $2}') \
         --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-$(params.cluster-name) \

--- a/test/suites/common/suite.yaml
+++ b/test/suites/common/suite.yaml
@@ -11,8 +11,8 @@ spec:
     - name: git-ref
       default: HEAD
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
-    - name: suite-path
-      description: Path to the test suite from the git-ref root directory. (e.g. ./test/suites/...)
+    - name: test-filter
+      description: Test filter passed to `go test -run`
     - name: cleanup
       default: "true"
       description: If true, clean up resources
@@ -35,8 +35,8 @@ spec:
       value: $(params.cluster-name)
     - name: git-ref
       value: $(params.git-ref)
-    - name: suite-path
-      value: $(params.suite-path)
+    - name: test-filter
+      value: $(params.test-filter)
     runAfter:
     - setup
 

--- a/test/suites/integration/launchtemplates_test.go
+++ b/test/suites/integration/launchtemplates_test.go
@@ -1,0 +1,92 @@
+package integration_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var customAMI string
+
+var _ = Describe("LaunchTemplates", func() {
+	BeforeEach(func() {
+		customAMI = selectCustomAMI("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id")
+	})
+
+	It("should use the AMI defined by the AMI Selector", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			AMIFamily:             &v1alpha1.AMIFamilyAL2,
+		},
+			AMISelector: map[string]string{"aws-ids": customAMI},
+		})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		pod := test.Pod()
+
+		env.ExpectCreated(pod, provider, provisioner)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		ExpectInstance(pod.Spec.NodeName).To(HaveField("ImageId", BeEquivalentTo(customAMI)))
+	})
+	It("should support Custom AMIFamily with AMI Selectors", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			AMIFamily:             &v1alpha1.AMIFamilyCustom,
+		},
+			AMISelector: map[string]string{"aws-ids": customAMI},
+			UserData:    aws.String(fmt.Sprintf("#!/bin/bash\n/etc/eks/bootstrap.sh '%s'", env.ClusterName)),
+		})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		pod := test.Pod()
+
+		env.ExpectCreated(pod, provider, provisioner)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		ExpectInstance(pod.Spec.NodeName).To(HaveField("ImageId", BeEquivalentTo(customAMI)))
+	})
+})
+
+func ExpectInstance(nodeName string) Assertion {
+	var node v1.Node
+	Expect(env.Client.Get(env.Context, types.NamespacedName{Name: nodeName}, &node)).To(Succeed())
+	providerIDSplit := strings.Split(node.Spec.ProviderID, "/")
+	instanceID := providerIDSplit[len(providerIDSplit)-1]
+	instance, err := env.EC2API.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice([]string{instanceID}),
+	})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(instance.Reservations).To(HaveLen(1))
+	Expect(instance.Reservations[0].Instances).To(HaveLen(1))
+	return Expect(instance.Reservations[0].Instances[0])
+}
+
+func selectCustomAMI(amiPath string) string {
+	serverVersion, err := env.KubeClient.Discovery().ServerVersion()
+	Expect(err).To(BeNil())
+	minorVersion, err := strconv.Atoi(strings.TrimSuffix(serverVersion.Minor, "+"))
+	Expect(err).To(BeNil())
+	// Choose a minor version one lesser than the server's minor version. This ensures that we choose an AMI for
+	// this test that wouldn't be selected as Karpenter's SSM default (therefore avoiding false positives), and also
+	// ensures that we aren't violating version skew.
+	version := fmt.Sprintf("%s.%d", serverVersion.Major, minorVersion-1)
+	parameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
+		Name: aws.String(fmt.Sprintf(amiPath, version)),
+	})
+	Expect(err).To(BeNil())
+	return *parameter.Parameter.Value
+}

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -1,8 +1,9 @@
 package integration_test
 
 import (
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
-	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/test"
 	. "github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
@@ -13,7 +14,7 @@ import (
 
 var _ = Describe("Scheduling Conformance", func() {
 	It("should provision a node for naked pods", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
@@ -25,7 +26,7 @@ var _ = Describe("Scheduling Conformance", func() {
 		env.ExpectCreatedNodeCount("==", 1)
 	})
 	It("should provision a node for a deployment", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
@@ -39,7 +40,7 @@ var _ = Describe("Scheduling Conformance", func() {
 		env.ExpectCreatedNodeCount("<=", 2) // should probably all land on a single node, but at worst two depending on batching
 	})
 	It("should provision a node for a self-affinity deployment", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
@@ -66,7 +67,7 @@ var _ = Describe("Scheduling Conformance", func() {
 		env.ExpectCreatedNodeCount("==", 1)
 	})
 	It("should provision three nodes for a zonal topology spread", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -1,0 +1,98 @@
+package integration_test
+
+import (
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+	. "github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+
+var _ = Describe("Scheduling Conformance", func() {
+	It("should provision a node for naked pods", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		pod := test.Pod()
+
+		env.ExpectCreated(provisioner, provider, pod)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+	})
+	It("should provision a node for a deployment", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+
+		const numPods = 50
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
+
+		env.ExpectCreated(provisioner, provider, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), numPods)
+		env.ExpectCreatedNodeCount("<=", 2) // should probably all land on a single node, but at worst two depending on batching
+	})
+	It("should provision a node for a self-affinity deployment", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		// just two pods as they all need to land on the same node
+		podLabels := map[string]string{"test": "self-affinity"}
+		deployment := test.Deployment(test.DeploymentOptions{
+			Replicas: 2,
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				PodRequirements: []v1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: podLabels},
+						TopologyKey:   v1.LabelHostname,
+					},
+				},
+			},
+		})
+
+		env.ExpectCreated(provisioner, provider, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), 2)
+		env.ExpectCreatedNodeCount("==", 1)
+	})
+	It("should provision three nodes for a zonal topology spread", func() {
+		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+
+		// one pod per zone
+		podLabels := map[string]string{"test": "zonal-spread"}
+		deployment := test.Deployment(test.DeploymentOptions{
+			Replicas: 3,
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				TopologySpreadConstraints: []v1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       v1.LabelTopologyZone,
+						WhenUnsatisfiable: v1.DoNotSchedule,
+						LabelSelector:     &metav1.LabelSelector{MatchLabels: podLabels},
+					},
+				},
+			},
+		})
+
+		env.ExpectCreated(provisioner, provider, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(podLabels), 3)
+		env.ExpectCreatedNodeCount("==", 3)
+	})
+})

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -1,29 +1,14 @@
 package integration_test
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
-	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
-	"github.com/aws/karpenter/pkg/test"
 	"github.com/aws/karpenter/test/pkg/environment"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var env *environment.Environment
-var customAMI string
 
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -31,202 +16,9 @@ func TestIntegration(t *testing.T) {
 		var err error
 		env, err = environment.NewEnvironment(t)
 		Expect(err).ToNot(HaveOccurred())
-		customAMI = selectCustomAMI("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id")
 	})
 	RunSpecs(t, "Integration")
 }
 
-var _ = BeforeEach(func() {
-	// Sets up the test monitor so we can count nodes per test as well as performing some checks to ensure any
-	// existing nodes are tainted, there are no existing pods in the default namespace, etc.
-	env.BeforeEach()
-})
-var _ = AfterEach(func() {
-	env.AfterEach()
-})
-
-var _ = Describe("Sanity Checks", func() {
-	It("should provision nodes", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-		}})
-		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
-		pod := test.Pod()
-
-		// The 'CreatedNodeCount' doesn't count any nodes that are running when the test starts
-		env.ExpectCreatedNodeCount("==", 0)
-		env.ExpectCreated(provisioner, provider, pod)
-		env.EventuallyExpectHealthy(pod)
-		// should have a new node created to support the pod
-		env.ExpectCreatedNodeCount("==", 1)
-		env.ExpectDeleted(pod)
-		// all of the created nodes should be deleted
-		env.EventuallyExpectScaleDown()
-		// and neither the webhook or controller should have restarted during the test
-		env.ExpectNoCrashes()
-	})
-	It("should provision for a deployment", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-		}})
-		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
-
-		const numPods = 50
-		deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
-
-		selector := labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels)
-		env.ExpectCreatedNodeCount("==", 0)
-		env.ExpectCreated(provisioner, provider, deployment)
-		env.EventuallyExpectHealthyPodCount(selector, numPods)
-		// should probably all land on a single node, but at worst two depending on batching
-		env.ExpectCreatedNodeCount("<=", 2)
-		env.ExpectDeleted(deployment)
-		env.EventuallyExpectScaleDown()
-		env.ExpectNoCrashes()
-	})
-	It("should provision a node for a self-afinity deployment", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-		}})
-		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
-		// just two pods as they all need to land on the same node
-		podLabels := map[string]string{"test": "self-affinity"}
-		deployment := test.Deployment(test.DeploymentOptions{
-			Replicas: 2,
-			PodOptions: test.PodOptions{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: podLabels,
-				},
-				PodRequirements: []v1.PodAffinityTerm{
-					{
-						LabelSelector: &metav1.LabelSelector{MatchLabels: podLabels},
-						TopologyKey:   v1.LabelHostname,
-					},
-				},
-			},
-		})
-		selector := labels.SelectorFromSet(podLabels)
-		env.ExpectCreatedNodeCount("==", 0)
-		env.ExpectCreated(provisioner, provider, deployment)
-		env.EventuallyExpectHealthyPodCount(selector, 2)
-		env.ExpectCreatedNodeCount("==", 1)
-		env.ExpectDeleted(deployment)
-		env.EventuallyExpectScaleDown()
-		env.ExpectNoCrashes()
-	})
-	It("should provision three nodes for a zonal topology spread", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-		}})
-		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
-
-		// one pod per zone
-		podLabels := map[string]string{"test": "zonal-spread"}
-		deployment := test.Deployment(test.DeploymentOptions{
-			Replicas: 3,
-			PodOptions: test.PodOptions{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: podLabels,
-				},
-				TopologySpreadConstraints: []v1.TopologySpreadConstraint{
-					{
-						MaxSkew:           1,
-						TopologyKey:       v1.LabelTopologyZone,
-						WhenUnsatisfiable: v1.DoNotSchedule,
-						LabelSelector:     &metav1.LabelSelector{MatchLabels: podLabels},
-					},
-				},
-			},
-		})
-
-		selector := labels.SelectorFromSet(podLabels)
-		env.ExpectCreatedNodeCount("==", 0)
-		env.ExpectCreated(provisioner, provider, deployment)
-		env.EventuallyExpectHealthyPodCount(selector, 3)
-		env.ExpectCreatedNodeCount("==", 3)
-		env.ExpectDeleted(deployment)
-		env.EventuallyExpectScaleDown()
-		env.ExpectNoCrashes()
-	})
-	Context("LaunchTemplates", func() {
-		It("should use the AMI defined by the AMI Selector", func() {
-			provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-				AMIFamily:             &v1alpha1.AMIFamilyAL2,
-			},
-				AMISelector: map[string]string{"aws-ids": customAMI},
-			})
-			provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
-			pod := test.Pod()
-
-			env.ExpectCreatedNodeCount("==", 0)
-			env.ExpectCreated(pod, provider, provisioner)
-
-			env.EventuallyExpectHealthy(pod)
-			env.ExpectCreatedNodeCount("==", 1)
-
-			var node v1.Node
-			env.Client.Get(env.Context, types.NamespacedName{Name: pod.Spec.NodeName}, &node)
-			providerIDSplit := strings.Split(node.Spec.ProviderID, "/")
-			instanceID := providerIDSplit[len(providerIDSplit)-1]
-			instance, _ := env.Ec2API.DescribeInstances(&ec2.DescribeInstancesInput{
-				InstanceIds: aws.StringSlice([]string{instanceID}),
-			})
-			Expect(*instance.Reservations[0].Instances[0].ImageId).To(Equal(customAMI))
-			env.ExpectDeleted(pod)
-			env.EventuallyExpectScaleDown()
-			env.ExpectNoCrashes()
-		})
-		It("should support Custom AMIFamily with AMI Selectors", func() {
-			provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-				AMIFamily:             &v1alpha1.AMIFamilyCustom,
-			},
-				AMISelector: map[string]string{"aws-ids": customAMI},
-				UserData:    aws.String(fmt.Sprintf("#!/bin/bash\n/etc/eks/bootstrap.sh '%s'", env.Options.ClusterName)),
-			})
-			provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
-			pod := test.Pod()
-
-			env.ExpectCreatedNodeCount("==", 0)
-			env.ExpectCreated(pod, provider, provisioner)
-
-			env.EventuallyExpectHealthy(pod)
-			env.ExpectCreatedNodeCount("==", 1)
-
-			var node v1.Node
-			env.Client.Get(env.Context, types.NamespacedName{Name: pod.Spec.NodeName}, &node)
-			providerIDSplit := strings.Split(node.Spec.ProviderID, "/")
-			instanceID := providerIDSplit[len(providerIDSplit)-1]
-			instance, _ := env.Ec2API.DescribeInstances(&ec2.DescribeInstancesInput{
-				InstanceIds: aws.StringSlice([]string{instanceID}),
-			})
-			Expect(*instance.Reservations[0].Instances[0].ImageId).To(Equal(customAMI))
-			env.ExpectDeleted(pod)
-			env.EventuallyExpectScaleDown()
-			env.ExpectNoCrashes()
-		})
-	})
-})
-
-func selectCustomAMI(amiPath string) string {
-	serverVersion, err := env.KubeClient.Discovery().ServerVersion()
-	Expect(err).To(BeNil())
-	minorVersion, err := strconv.Atoi(strings.TrimSuffix(serverVersion.Minor, "+"))
-	Expect(err).To(BeNil())
-	// Choose a minor version one lesser than the server's minor version. This ensures that we choose an AMI for
-	// this test that wouldn't be selected as Karpenter's SSM default (therefore avoiding false positives), and also
-	// ensures that we aren't violating version skew.
-	version := fmt.Sprintf("%s.%d", serverVersion.Major, minorVersion-1)
-	parameter, err := env.SsmAPI.GetParameter(&ssm.GetParameterInput{
-		Name: aws.String(fmt.Sprintf(amiPath, version)),
-	})
-	Expect(err).To(BeNil())
-	return *parameter.Parameter.Value
-}
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.AfterEach() })

--- a/test/suites/storage/suite_test.go
+++ b/test/suites/storage/suite_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
-	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/test"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -52,7 +53,7 @@ var _ = Describe("Dynamic PVC", func() {
 			}
 		}
 
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
@@ -90,7 +91,7 @@ var _ = Describe("Dynamic PVC", func() {
 
 var _ = Describe("Static PVC", func() {
 	It("should run a pod with a static persistent volume", func() {
-		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})

--- a/test/suites/storage/suite_test.go
+++ b/test/suites/storage/suite_test.go
@@ -33,12 +33,8 @@ func TestStorage(t *testing.T) {
 	RunSpecs(t, "Storage")
 }
 
-var _ = BeforeEach(func() {
-	env.BeforeEach()
-})
-var _ = AfterEach(func() {
-	env.AfterEach()
-})
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.AfterEach() })
 
 // This test requires the EBS CSI driver to be installed
 var _ = Describe("Dynamic PVC", func() {
@@ -57,8 +53,8 @@ var _ = Describe("Dynamic PVC", func() {
 		}
 
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{
 			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
@@ -85,21 +81,18 @@ var _ = Describe("Dynamic PVC", func() {
 			PersistentVolumeClaims: []string{pvc.Name},
 		})
 
-		env.ExpectCreatedNodeCount("==", 0)
 		env.ExpectCreated(provisioner, provider, sc, pvc, pod)
 		env.EventuallyExpectHealthy(pod)
 		env.ExpectCreatedNodeCount("==", 1)
 		env.ExpectDeleted(pod)
-		env.EventuallyExpectScaleDown()
-		env.ExpectNoCrashes()
 	})
 })
 
 var _ = Describe("Static PVC", func() {
 	It("should run a pod with a static persistent volume", func() {
 		provider := test.AWSNodeTemplate(test.AWSNodeTemplateOptions{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.Options.ClusterName},
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{
 			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
@@ -130,12 +123,9 @@ var _ = Describe("Static PVC", func() {
 			PersistentVolumeClaims: []string{pvc.Name},
 		})
 
-		env.ExpectCreatedNodeCount("==", 0)
 		env.ExpectCreated(provisioner, provider, pv, pvc, pod)
 		env.EventuallyExpectHealthy(pod)
 		env.ExpectCreatedNodeCount("==", 1)
 		env.ExpectDeleted(pod)
-		env.EventuallyExpectScaleDown()
-		env.ExpectNoCrashes()
 	})
 })

--- a/test/suites/upgrade/pipeline.yaml
+++ b/test/suites/upgrade/pipeline.yaml
@@ -36,8 +36,8 @@ spec:
       value: $(params.cluster-name)
     - name: git-ref
       value: $(params.to-git-ref)
-    - name: suite-path
-      value: ./test/suites/integration
+    - name: test-filter
+      value: TestIntegration
     runAfter:
     - setup
 
@@ -60,8 +60,8 @@ spec:
       value: $(params.cluster-name)
     - name: git-ref
       value: $(params.to-git-ref)
-    - name: suite-path
-      value: ./test/suites/integration
+    - name: test-filter
+      value: TestIntegration
     runAfter:
     - upgrade
 

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -35,7 +35,7 @@ Users should therefore check to see if there is a breaking change every time the
 
 ## Custom Resource Definition (CRD) Upgrades
 
-Karpenter ships with a few Custom Resource Definitions (CRDs). These CRDs are part of the helm chart [here](https://github.com/aws/karpenter/blob/main/charts/karpenter/crds). Helm [does not manage the lifecycle of CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/), the tool will only install the CRD during the first installation of the helm chart. Subsequent chart upgrades will not add or remove CRDs, even if the CRDs have changed. When CRDs are changed, we will make a note in the version's upgrade guide. 
+Karpenter ships with a few Custom Resource Definitions (CRDs). These CRDs are part of the helm chart [here](https://github.com/aws/karpenter/blob/main/charts/karpenter/crds). Helm [does not manage the lifecycle of CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/), the tool will only install the CRD during the first installation of the helm chart. Subsequent chart upgrades will not add or remove CRDs, even if the CRDs have changed. When CRDs are changed, we will make a note in the version's upgrade guide.
 
 In general, you can reapply the CRDs in the `crds` directory of the Karpenter helm chart:
 
@@ -43,7 +43,7 @@ In general, you can reapply the CRDs in the `crds` directory of the Karpenter he
 kubectl replace -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}charts/karpenter/crds/karpenter.sh_provisioners.yaml
 
 kubectl replace -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}charts/karpenter/crds/karpenter.k8s.aws_awsnodetemplates.yaml
-``` 
+```
 
 ## How Do We Break Incompatibility?
 
@@ -108,11 +108,14 @@ aws ec2 describe-launch-templates --filters="Name=launch-template-name,Values=Ka
 aws ec2 delete-launch-template --launch-template-id <LAUNCH_TEMPLATE_ID>
 ```
 
-* v0.14.0 introduces additional instance type filtering if there are no `node.kubernetes.io/instance-type` or `karpenter.k8s.aws/instance-family` requirements that restrict instance types specified on the provisioner. This prevents Karpenter from launching bare metal and some older non-current generation instance types unless the provisioner has been explicitly configured to allow them. If you specify an instance type or family requirement that supplies a list of instance-types or families, that list will be used regardless of filtering.  The filtering can also be completely eliminated by adding an `Exists` requirement for instance type or family.   
+* v0.14.0 introduces additional instance type filtering if there are no `node.kubernetes.io/instance-type` or `karpenter.k8s.aws/instance-family` or `karpenter.k8s.aws/instance-category` requirements that restrict instance types specified on the provisioner. This prevents Karpenter from launching bare metal and some older non-current generation instance types unless the provisioner has been explicitly configured to allow them. If you specify an instance type or family requirement that supplies a list of instance-types or families, that list will be used regardless of filtering.  The filtering can also be completely eliminated by adding an `Exists` requirement for instance type or family.
 ```yaml
   - key: node.kubernetes.io/instance-type
     operator: Exists
 ```
+
+* v0.14.0 adds an an additional default toleration (CriticalAddonOnly=Exists) to the Karpenter helm chart. This may cause Karpenter to run on nodes with that use this Taint which previously would not have been schedulable. This can be overriden by using `--set tolerations[0]=null`.
+
 ## Upgrading to v0.13.0+
 * v0.13.0 introduces a new CRD named `AWSNodeTemplate` which can be used to specify AWS Cloud Provider parameters. Everything that was previously specified under `spec.provider` in the Provisioner resource, can now be specified in the spec of the new resource. The use of `spec.provider` is deprecated but will continue to function to maintain backwards compatibility for the current API version (v1alpha5) of the Provisioner resource. v0.13.0 also introduces support for custom user data that doesn't require the use of a custom launch template. The user data can be specified in-line in the AWSNodeTemplate resource. Read the [UserData documentation here](../aws/user-data) to get started.
 
@@ -121,7 +124,7 @@ aws ec2 delete-launch-template --launch-template-id <LAUNCH_TEMPLATE_ID>
   2. `kubectl delete crd awsnodetemplate`
   3. `kubectl apply -f https://raw.githubusercontent.com/aws/karpenter/v0.13.2/charts/karpenter/crds/karpenter.k8s.aws_awsnodetemplates.yaml`
   4. Perform the Karpenter upgrade to v0.13.x, which will install the new `awsnodetemplates` CRD.
-  5. Reapply the `awsnodetemplate` manifests you saved from step 1, if applicable. 
+  5. Reapply the `awsnodetemplate` manifests you saved from step 1, if applicable.
 * v0.13.0 also adds EC2/spot price fetching to Karpenter to allow making more accurate decisions regarding node deployments.  Our getting started guide documents this, but if you are upgrading Karpenter you will need to modify your Karpenter controller policy to add the `pricing:GetProducts` and `ec2:DescribeSpotPriceHistory` permissions.
 
 
@@ -132,7 +135,7 @@ aws ec2 delete-launch-template --launch-template-id <LAUNCH_TEMPLATE_ID>
   2. `kubectl delete crd awsnodetemplate`
   3. `kubectl apply -f https://raw.githubusercontent.com/aws/karpenter/v0.12.1/charts/karpenter/crds/karpenter.k8s.aws_awsnodetemplates.yaml`
   4. Perform the Karpenter upgrade to v0.12.x, which will install the new `awsnodetemplates` CRD.
-  5. Reapply the `awsnodetemplate` manifests you saved from step 1, if applicable. 
+  5. Reapply the `awsnodetemplate` manifests you saved from step 1, if applicable.
 
 ## Upgrading to v0.11.0+
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
- Print logs for each test
- Separated tests into logical files to keep things organized
- Made the tests generally more reliable

**How was this change tested?**

* `make e2etest`
```
❯ TEST_FILTER=TestIntegration make e2etests
go test -p 1 -timeout 60m -v ./test/suites/... -run=TestIntegration
=== RUN   TestIntegration
Running Suite: Integration
==========================
Random Seed: 1658530731
Will run 6 of 6 specs

{"level":"info","ts":1658530807.482953,"logger":"fallback","caller":"environment/expectations.go:127","msg":"2"}
    logger.go:130: 2022-07-22T16:00:07.722-0700	INFO	environment/expectations.go:165	2022-07-22T22:58:56.065Z	INFO	controller.provisioning	Found 1 provisionable pod(s)	{"commit": "f752ee0"}
        2022-07-22T22:58:56.065Z	INFO	controller.provisioning	Computed 1 new node(s) will fit 1 pod(s)	{"commit": "f752ee0"}
        2022-07-22T22:58:56.309Z	DEBUG	controller.provisioning.cloudprovider	Discovered subnets: [subnet-0b0cb59870e2a13a0 (us-west-2a) subnet-05c69c00f3c5bea19 (us-west-2d) subnet-0b4476a83d7f31e5c (us-west-2c) subnet-0c0e9602e87a5d00a (us-west-2d) subnet-05c4108aeefa7f2fa (us-west-2a) subnet-0e3ff9a206632cd4b (us-west-2c)]	{"commit": "f752ee0", "provisioner": "otterlavender-2-f0qvowzocw"}
        2022-07-22T22:58:56.426Z	DEBUG	controller.provisioning.cloudprovider	Discovered security groups: [sg-06617f6997ca930da sg-0af9e2723b4021a70]	{"commit": "f752ee0", "provisioner": "otterlavender-2-f0qvowzocw"}
        2022-07-22T22:58:56.429Z	DEBUG	controller.provisioning.cloudprovider	Discovered kubernetes version 1.21	{"commit": "f752ee0", "provisioner": "otterlavender-2-f0qvowzocw"}
        2022-07-22T22:58:56.488Z	DEBUG	controller.provisioning.cloudprovider	Discovered images: [ami-0aa4096ec49a62235]	{"commit": "f752ee0", "provisioner": "otterlavender-2-f0qvowzocw"}
        2022-07-22T22:58:56.663Z	DEBUG	controller.provisioning.cloudprovider	Created launch template, Karpenter-test-9718564430848386100	{"commit": "f752ee0", "provisioner": "otterlavender-2-f0qvowzocw"}
        2022-07-22T22:58:58.767Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-063df3e448acf9d7b, hostname: ip-192-168-104-187.us-west-2.compute.internal, type: t3a.micro, zone: us-west-2a, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "otterlavender-2-f0qvowzocw"}
        2022-07-22T22:58:58.780Z	INFO	controller.provisioning	Created node with 1 pods requesting {"cpu":"125m","pods":"3"} from types t3a.micro, t3.micro, t3a.small, t3.small, t3a.medium and 392 other(s)	{"commit": "f752ee0", "provisioner": "otterlavender-2-f0qvowzocw"}
        2022-07-22T22:58:58.780Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "f752ee0"}
        2022-07-22T22:58:58.780Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"flierbasalt-4-cedz37sj17","uid":"acf4686a-cc0d-41dc-9b29-a1e7e4dd3578","apiVersion":"v1","resourceVersion":"478547"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-104-187.us-west-2.compute.internal"}
        2022-07-22T23:00:02.879Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-104-187.us-west-2.compute.internal"}
        2022-07-22T23:00:02.890Z	DEBUG	controller.events	Warning	{"commit": "f752ee0", "object": {"kind":"Node","name":"ip-192-168-104-187.us-west-2.compute.internal","uid":"231180e5-1fc4-4e46-904a-5ae99f548023","apiVersion":"v1","resourceVersion":"479009"}, "reason": "FailedDraining", "message": "Failed to drain node, pod default/flierbasalt-4-cedz37sj17 does not have any owner references"}
        2022-07-22T23:00:03.024Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:03.030Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:03.041Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:03.061Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:03.071Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:03.102Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:03.262Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:03.583Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:04.224Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:05.504Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-104-187.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"beaksunset-1-u2gfmxp8n9\" not found"}
        2022-07-22T23:00:07.175Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-104-187.us-west-2.compute.internal"}
• [SLOW TEST:73.551 seconds]
LaunchTemplates
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/launchtemplates_test.go:23
  should use the AMI defined by the AMI Selector
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/launchtemplates_test.go:28
------------------------------
{"level":"info","ts":1658530892.161961,"logger":"fallback","caller":"environment/expectations.go:127","msg":"2"}
    logger.go:130: 2022-07-22T16:01:32.297-0700	INFO	environment/expectations.go:165	2022-07-22T23:00:07.175Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-104-187.us-west-2.compute.internal"}
        2022-07-22T23:00:10.022Z	DEBUG	controller.provisioning	Discovered 550 EC2 instance types	{"commit": "f752ee0"}
        2022-07-22T23:00:10.232Z	DEBUG	controller.provisioning	Discovered subnets: [subnet-0b0cb59870e2a13a0 (us-west-2a) subnet-05c69c00f3c5bea19 (us-west-2d) subnet-0b4476a83d7f31e5c (us-west-2c) subnet-0c0e9602e87a5d00a (us-west-2d) subnet-05c4108aeefa7f2fa (us-west-2a) subnet-0e3ff9a206632cd4b (us-west-2c)]	{"commit": "f752ee0"}
        2022-07-22T23:00:10.387Z	DEBUG	controller.provisioning	Discovered EC2 instance types zonal offerings	{"commit": "f752ee0"}
        2022-07-22T23:00:10.437Z	INFO	controller.provisioning	Found 1 provisionable pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:00:10.437Z	INFO	controller.provisioning	Computed 1 new node(s) will fit 1 pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:00:10.539Z	DEBUG	controller.provisioning.cloudprovider	Discovered security groups: [sg-06617f6997ca930da sg-0af9e2723b4021a70]	{"commit": "f752ee0", "provisioner": "dancerglen-7-krge4bi1h0"}
        2022-07-22T23:00:10.543Z	DEBUG	controller.provisioning.cloudprovider	Discovered kubernetes version 1.21	{"commit": "f752ee0", "provisioner": "dancerglen-7-krge4bi1h0"}
        2022-07-22T23:00:10.605Z	DEBUG	controller.provisioning.cloudprovider	Discovered images: [ami-0aa4096ec49a62235]	{"commit": "f752ee0", "provisioner": "dancerglen-7-krge4bi1h0"}
        2022-07-22T23:00:10.770Z	DEBUG	controller.provisioning.cloudprovider	Created launch template, Karpenter-test-11572500458206672709	{"commit": "f752ee0", "provisioner": "dancerglen-7-krge4bi1h0"}
        2022-07-22T23:00:12.960Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-09999a69b589cb4de, hostname: ip-192-168-15-152.us-west-2.compute.internal, type: t3a.micro, zone: us-west-2a, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "dancerglen-7-krge4bi1h0"}
        2022-07-22T23:00:13.021Z	INFO	controller.provisioning	Created node with 1 pods requesting {"cpu":"125m","pods":"3"} from types t3a.micro, t3.micro, t3a.small, t3.small, t3a.medium and 392 other(s)	{"commit": "f752ee0", "provisioner": "dancerglen-7-krge4bi1h0"}
        2022-07-22T23:00:13.024Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "f752ee0"}
        2022-07-22T23:00:13.024Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"wolfshadow-9-h6oo7dnppu","uid":"e19819a6-8f9f-4213-8eeb-07503ad83ac4","apiVersion":"v1","resourceVersion":"479055"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-15-152.us-west-2.compute.internal"}
        2022-07-22T23:01:19.692Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-15-152.us-west-2.compute.internal"}
        2022-07-22T23:01:19.694Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:19.694Z	DEBUG	controller.events	Warning	{"commit": "f752ee0", "object": {"kind":"Node","name":"ip-192-168-15-152.us-west-2.compute.internal","uid":"d443ace5-4284-4c97-84f3-f382d36c7c27","apiVersion":"v1","resourceVersion":"479539"}, "reason": "FailedDraining", "message": "Failed to drain node, pod default/wolfshadow-9-h6oo7dnppu does not have any owner references"}
        2022-07-22T23:01:19.706Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:19.710Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:19.719Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:19.756Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:19.759Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:19.920Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:20.241Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:20.882Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:22.163Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:24.724Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:29.845Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-15-152.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"healeriron-6-lxqtin7oii\" not found"}
        2022-07-22T23:01:31.222Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-15-152.us-west-2.compute.internal"}
• [SLOW TEST:84.575 seconds]
LaunchTemplates
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/launchtemplates_test.go:23
  should support Custom AMIFamily with AMI Selectors
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/launchtemplates_test.go:46
------------------------------
{"level":"info","ts":1658530995.909722,"logger":"fallback","caller":"environment/expectations.go:127","msg":"2"}
    logger.go:130: 2022-07-22T16:03:16.136-0700	INFO	environment/expectations.go:165	2022-07-22T23:01:33.718Z	INFO	controller.provisioning	Found 1 provisionable pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:01:33.718Z	INFO	controller.provisioning	Computed 1 new node(s) will fit 1 pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:01:33.775Z	DEBUG	controller.provisioning.cloudprovider	Discovered subnets: [subnet-0b0cb59870e2a13a0 (us-west-2a) subnet-05c69c00f3c5bea19 (us-west-2d) subnet-0b4476a83d7f31e5c (us-west-2c) subnet-0c0e9602e87a5d00a (us-west-2d) subnet-05c4108aeefa7f2fa (us-west-2a) subnet-0e3ff9a206632cd4b (us-west-2c)]	{"commit": "f752ee0", "provisioner": "fighterneon-12-ma6xmsafln"}
        2022-07-22T23:01:33.884Z	DEBUG	controller.provisioning.cloudprovider	Discovered security groups: [sg-06617f6997ca930da sg-0af9e2723b4021a70]	{"commit": "f752ee0", "provisioner": "fighterneon-12-ma6xmsafln"}
        2022-07-22T23:01:33.889Z	DEBUG	controller.provisioning.cloudprovider	Discovered kubernetes version 1.21	{"commit": "f752ee0", "provisioner": "fighterneon-12-ma6xmsafln"}
        2022-07-22T23:01:33.924Z	DEBUG	controller.provisioning.cloudprovider	Discovered ami-00cf63b12c53803a5 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"	{"commit": "f752ee0", "provisioner": "fighterneon-12-ma6xmsafln"}
        2022-07-22T23:01:34.198Z	DEBUG	controller.provisioning.cloudprovider	Created launch template, Karpenter-test-7790472763704559814	{"commit": "f752ee0", "provisioner": "fighterneon-12-ma6xmsafln"}
        2022-07-22T23:01:36.233Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-001730937cf87886d, hostname: ip-192-168-157-76.us-west-2.compute.internal, type: t3a.micro, zone: us-west-2c, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "fighterneon-12-ma6xmsafln"}
        2022-07-22T23:01:36.240Z	INFO	controller.provisioning	Created node with 1 pods requesting {"cpu":"125m","pods":"3"} from types t3a.micro, t3.micro, t3a.small, t3.small, t3a.medium and 392 other(s)	{"commit": "f752ee0", "provisioner": "fighterneon-12-ma6xmsafln"}
        2022-07-22T23:01:36.240Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "f752ee0"}
        2022-07-22T23:01:36.240Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"markhorn-14-qifzktcc5q","uid":"7b966b84-6ef9-4a43-99da-c10638c466f4","apiVersion":"v1","resourceVersion":"479636"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-157-76.us-west-2.compute.internal"}
        2022-07-22T23:01:37.081Z	DEBUG	controller.aws.launchtemplate	Deleted launch template Karpenter-test-13235907929358152321 (lt-0f95e2f6b8b0483af)	{"commit": "f752ee0"}
        2022-07-22T23:01:37.187Z	DEBUG	controller.aws.launchtemplate	Deleted launch template Karpenter-test-9718564430848386100 (lt-0ce4638b47fbfcfbb)	{"commit": "f752ee0"}
        2022-07-22T23:01:37.290Z	DEBUG	controller.aws.launchtemplate	Deleted launch template Karpenter-test-11572500458206672709 (lt-0b92e7b9efef6c2b4)	{"commit": "f752ee0"}
        2022-07-22T23:03:00.725Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-157-76.us-west-2.compute.internal"}
        2022-07-22T23:03:00.727Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:00.727Z	DEBUG	controller.events	Warning	{"commit": "f752ee0", "object": {"kind":"Node","name":"ip-192-168-157-76.us-west-2.compute.internal","uid":"f46bf549-e370-45d7-8315-efce6e8b6c5f","apiVersion":"v1","resourceVersion":"480204"}, "reason": "FailedDraining", "message": "Failed to drain node, pod default/markhorn-14-qifzktcc5q does not have any owner references"}
        2022-07-22T23:03:00.737Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:00.755Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:00.755Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:00.775Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:00.796Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:00.856Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:01.177Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:01.818Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:03.099Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:05.660Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:10.781Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:15.219Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:15.391Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-157-76.us-west-2.compute.internal"}
• [SLOW TEST:103.834 seconds]
Scheduling Conformance
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:15
  should provision a node for naked pods
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:16
------------------------------
{"level":"info","ts":1658531156.32271,"logger":"fallback","caller":"environment/expectations.go:127","msg":"2"}
    logger.go:130: 2022-07-22T16:05:56.591-0700	INFO	environment/expectations.go:165	2022-07-22T23:03:15.219Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-157-76.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"grabberlegend-11-hue8jnzrap\" not found"}
        2022-07-22T23:03:15.391Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-157-76.us-west-2.compute.internal"}
        2022-07-22T23:03:19.317Z	INFO	controller.provisioning	Found 50 provisionable pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:03:19.317Z	INFO	controller.provisioning	Computed 1 new node(s) will fit 50 pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:03:19.444Z	DEBUG	controller.provisioning.cloudprovider	Discovered subnets: [subnet-0b0cb59870e2a13a0 (us-west-2a) subnet-05c69c00f3c5bea19 (us-west-2d) subnet-0b4476a83d7f31e5c (us-west-2c) subnet-0c0e9602e87a5d00a (us-west-2d) subnet-05c4108aeefa7f2fa (us-west-2a) subnet-0e3ff9a206632cd4b (us-west-2c)]	{"commit": "f752ee0", "provisioner": "takerthread-17-hu4nhhxzio"}
        2022-07-22T23:03:19.536Z	DEBUG	controller.provisioning.cloudprovider	Discovered security groups: [sg-06617f6997ca930da sg-0af9e2723b4021a70]	{"commit": "f752ee0", "provisioner": "takerthread-17-hu4nhhxzio"}
        2022-07-22T23:03:19.538Z	DEBUG	controller.provisioning.cloudprovider	Discovered kubernetes version 1.21	{"commit": "f752ee0", "provisioner": "takerthread-17-hu4nhhxzio"}
        2022-07-22T23:03:19.580Z	DEBUG	controller.provisioning.cloudprovider	Discovered ami-00cf63b12c53803a5 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"	{"commit": "f752ee0", "provisioner": "takerthread-17-hu4nhhxzio"}
        2022-07-22T23:03:19.770Z	DEBUG	controller.provisioning.cloudprovider	Created launch template, Karpenter-test-7666294433840820489	{"commit": "f752ee0", "provisioner": "takerthread-17-hu4nhhxzio"}
        2022-07-22T23:03:21.879Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-06b36cb583655ac7b, hostname: ip-192-168-116-221.us-west-2.compute.internal, type: t3a.xlarge, zone: us-west-2a, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "takerthread-17-hu4nhhxzio"}
        2022-07-22T23:03:21.887Z	INFO	controller.provisioning	Created node with 50 pods requesting {"cpu":"125m","pods":"52"} from types t3a.xlarge, c6a.xlarge, c5a.xlarge, t3.xlarge, c6i.xlarge and 334 other(s)	{"commit": "f752ee0", "provisioner": "takerthread-17-hu4nhhxzio"}
        2022-07-22T23:03:21.888Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "f752ee0"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-2497c","uid":"0144dcdb-2426-4f0a-8f82-c0921e1e2212","apiVersion":"v1","resourceVersion":"480408"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-q44zk","uid":"04efa2fd-86a1-4320-b98e-9773e33bbb86","apiVersion":"v1","resourceVersion":"480415"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-fnkd2","uid":"192bf5e0-d675-4913-8a6b-3409bf3b8eac","apiVersion":"v1","resourceVersion":"480382"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-dvnwg","uid":"1e6a70a5-8b8c-4a5e-83fd-8fdcf86be9f6","apiVersion":"v1","resourceVersion":"480394"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-v2dnr","uid":"240a7706-afd4-4edb-b68b-d6b315db6280","apiVersion":"v1","resourceVersion":"480323"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-qxg4m","uid":"3a61aa81-5212-4c75-b9ea-adfd524a6ef2","apiVersion":"v1","resourceVersion":"480353"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-zbmlz","uid":"3c99ebf7-e444-43a6-9f0a-0f78dc6108ca","apiVersion":"v1","resourceVersion":"480328"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-6n559","uid":"4048bf33-bf5d-4a6e-b882-18fba0302584","apiVersion":"v1","resourceVersion":"480383"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-bz64w","uid":"48ab19ce-8da4-47fa-b548-eab511e119e1","apiVersion":"v1","resourceVersion":"480412"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-djfn4","uid":"4d244327-982a-49f7-8c04-56dbec4d6e8b","apiVersion":"v1","resourceVersion":"480319"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-tg9rg","uid":"5c677f9a-ed3c-4353-92d8-353559fb52c8","apiVersion":"v1","resourceVersion":"480418"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-zdv4g","uid":"5d8a645e-851e-408a-a53f-a4580c7644b4","apiVersion":"v1","resourceVersion":"480399"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-h69cl","uid":"5e838ebb-8e05-4417-8e1f-d733ee506978","apiVersion":"v1","resourceVersion":"480347"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-fz9k6","uid":"5eaf3f02-5816-49a8-92b8-684c1c03ef7e","apiVersion":"v1","resourceVersion":"480388"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-bmnpt","uid":"5ee7352d-bf87-44d4-b955-51bf33af05d6","apiVersion":"v1","resourceVersion":"480378"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-l8v79","uid":"6919c52d-8ae9-4fd6-bf7c-4c3ba2f071e0","apiVersion":"v1","resourceVersion":"480368"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-f8xms","uid":"787919c0-f91d-40a2-898e-e8a0f45101b2","apiVersion":"v1","resourceVersion":"480417"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-qt4tm","uid":"823a2d08-9104-46ca-ae3e-6f0146ba6e65","apiVersion":"v1","resourceVersion":"480390"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-569t5","uid":"89759a14-4ff6-45cd-9f7a-bd4c6f9f2f8d","apiVersion":"v1","resourceVersion":"480410"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-7f6dw","uid":"8ecc091d-474e-4709-8a39-20037fe37ea6","apiVersion":"v1","resourceVersion":"480333"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-ckc7h","uid":"a1c7dac7-2e54-478e-b07e-3670e3001e3e","apiVersion":"v1","resourceVersion":"480380"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-rjmz6","uid":"b237808e-1ab8-4fae-b54c-3df0b45a3f23","apiVersion":"v1","resourceVersion":"480354"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-zw5fj","uid":"b2e21649-84e0-4912-91e3-47b9838aa4a4","apiVersion":"v1","resourceVersion":"480401"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-c57dx","uid":"bf5e25e1-627e-4d12-be4a-62de41e577bd","apiVersion":"v1","resourceVersion":"480402"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-krqfd","uid":"c21c625a-112e-44ba-9164-4178d0f34462","apiVersion":"v1","resourceVersion":"480336"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-hhrmz","uid":"eb56c509-7102-4d75-b6d3-b11afff699e6","apiVersion":"v1","resourceVersion":"480405"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-79q66","uid":"f01f0053-b017-4583-b3bb-a008ca8b51bb","apiVersion":"v1","resourceVersion":"480396"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-fvjm7","uid":"f38ab78e-b17b-48e8-8422-9ce110964aeb","apiVersion":"v1","resourceVersion":"480375"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-mlr8k","uid":"fc99d3e1-e430-409c-9c8e-09c8a4d01251","apiVersion":"v1","resourceVersion":"480391"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-44hs9","uid":"fccc69b6-4a96-4ae2-ba81-8e993b92082a","apiVersion":"v1","resourceVersion":"480372"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-gv4hf","uid":"02d1f8db-24ce-4814-bdfd-91b26e0612f7","apiVersion":"v1","resourceVersion":"480446"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-9p52b","uid":"100b3dd1-5b26-475c-ae76-285c429eb039","apiVersion":"v1","resourceVersion":"480466"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-sl4d8","uid":"1f21cbfe-49a6-4f1d-9a6b-611b5927502b","apiVersion":"v1","resourceVersion":"480469"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-6sg2g","uid":"27302ceb-be4a-4848-b91a-3c90c13860dd","apiVersion":"v1","resourceVersion":"480424"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-lwg89","uid":"2df62a65-a2ed-469f-b859-9b89decba2f3","apiVersion":"v1","resourceVersion":"480481"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-5p5th","uid":"32b5fcf7-8de8-49d7-9b3b-9f86b3bc9398","apiVersion":"v1","resourceVersion":"480421"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-k775f","uid":"393de35e-be6b-4e38-b707-0ebe531116ce","apiVersion":"v1","resourceVersion":"480427"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-qsg2l","uid":"462b216c-b5ce-4b7e-b8ff-24ba82d3b5d3","apiVersion":"v1","resourceVersion":"480460"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-4p6z9","uid":"49abc313-c356-4f28-935e-4d6fb77da94d","apiVersion":"v1","resourceVersion":"480475"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-mjrpr","uid":"5d9ae8c1-bfd6-4a8c-8a33-962751c01522","apiVersion":"v1","resourceVersion":"480431"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-nrxtq","uid":"6220f83a-f8f9-4604-97f2-01093866135e","apiVersion":"v1","resourceVersion":"480433"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-qlm8l","uid":"653db59d-6c0c-4f59-9da4-f600664e6de6","apiVersion":"v1","resourceVersion":"480425"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-dcmkr","uid":"762fe205-3ad3-4ca7-b9a6-8f0e7989cf53","apiVersion":"v1","resourceVersion":"480456"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-mddmm","uid":"7eb4ad34-9817-4ba3-ab32-bf561f944cd2","apiVersion":"v1","resourceVersion":"480437"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-hh4fx","uid":"88fccb33-f919-476f-a6ca-d44f251112e9","apiVersion":"v1","resourceVersion":"480463"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-jc2mg","uid":"8a209534-141e-453a-ad8e-8658286864c9","apiVersion":"v1","resourceVersion":"480443"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-mvcn2","uid":"a5f592f3-4c00-4fde-a28b-5f8429f1c34d","apiVersion":"v1","resourceVersion":"480478"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-wcqgl","uid":"ad6c90f5-b407-44b9-a44b-cb15333709ec","apiVersion":"v1","resourceVersion":"480471"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-rbdwr","uid":"e9a71fc7-a744-4401-969b-041352335ded","apiVersion":"v1","resourceVersion":"480439"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:03:21.888Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"catchermud-19-uqtklurmtf-86b84c86cf-n9l75","uid":"71b03f55-2f62-426c-a7d5-0acfc783b1b5","apiVersion":"v1","resourceVersion":"480484"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:05:16.728Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:05:16.743Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-2497c"}
        2022-07-22T23:05:16.758Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-fnkd2"}
        2022-07-22T23:05:16.778Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-qt4tm"}
        2022-07-22T23:05:16.795Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-jc2mg"}
        2022-07-22T23:05:16.808Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-dcmkr"}
        2022-07-22T23:05:16.824Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-7f6dw"}
        2022-07-22T23:05:16.866Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-bmnpt"}
        2022-07-22T23:05:16.890Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-rjmz6"}
        2022-07-22T23:05:16.910Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-ckc7h"}
        2022-07-22T23:05:16.924Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-dvnwg"}
        2022-07-22T23:05:16.941Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-zdv4g"}
        2022-07-22T23:05:16.963Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-bz64w"}
        2022-07-22T23:05:17.004Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-q44zk"}
        2022-07-22T23:05:17.030Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-gv4hf"}
        2022-07-22T23:05:17.054Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-9p52b"}
        2022-07-22T23:05:17.068Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-4p6z9"}
        2022-07-22T23:05:17.080Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-44hs9"}
        2022-07-22T23:05:17.096Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-hhrmz"}
        2022-07-22T23:05:17.109Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-569t5"}
        2022-07-22T23:05:17.148Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-mlr8k"}
        2022-07-22T23:05:17.162Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-5p5th"}
        2022-07-22T23:05:17.181Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-mjrpr"}
        2022-07-22T23:05:17.196Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-h69cl"}
        2022-07-22T23:05:17.215Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-fz9k6"}
        2022-07-22T23:05:17.228Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-6n559"}
        2022-07-22T23:05:17.270Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-sl4d8"}
        2022-07-22T23:05:17.285Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-hh4fx"}
        2022-07-22T23:05:17.301Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-l8v79"}
        2022-07-22T23:05:17.317Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-c57dx"}
        2022-07-22T23:05:17.332Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-f8xms"}
        2022-07-22T23:05:17.350Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-qlm8l"}
        2022-07-22T23:05:17.365Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-6sg2g"}
        2022-07-22T23:05:17.408Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-mddmm"}
        2022-07-22T23:05:17.426Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-rbdwr"}
        2022-07-22T23:05:17.446Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-v2dnr"}
        2022-07-22T23:05:17.466Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-djfn4"}
        2022-07-22T23:05:17.497Z	DEBUG	controller.node-state	Discovered 550 EC2 instance types	{"commit": "f752ee0", "node": "ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:05:17.498Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-wcqgl"}
        2022-07-22T23:05:17.513Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-qxg4m"}
        2022-07-22T23:05:17.528Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-fvjm7"}
        2022-07-22T23:05:17.542Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-79q66"}
        2022-07-22T23:05:17.558Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-nrxtq"}
        2022-07-22T23:05:17.573Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-n9l75"}
        2022-07-22T23:05:17.582Z	DEBUG	controller.node-state	Discovered subnets: [subnet-0b0cb59870e2a13a0 (us-west-2a) subnet-05c69c00f3c5bea19 (us-west-2d) subnet-0b4476a83d7f31e5c (us-west-2c) subnet-0c0e9602e87a5d00a (us-west-2d) subnet-05c4108aeefa7f2fa (us-west-2a) subnet-0e3ff9a206632cd4b (us-west-2c)]	{"commit": "f752ee0", "node": "ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:05:17.587Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-lwg89"}
        2022-07-22T23:05:17.602Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-qsg2l"}
        2022-07-22T23:05:17.617Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-zbmlz"}
        2022-07-22T23:05:17.631Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-krqfd"}
        2022-07-22T23:05:17.645Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-zw5fj"}
        2022-07-22T23:05:17.661Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-tg9rg"}
        2022-07-22T23:05:17.673Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-k775f"}
        2022-07-22T23:05:17.689Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/catchermud-19-uqtklurmtf-86b84c86cf-mvcn2"}
        2022-07-22T23:05:17.726Z	DEBUG	controller.node-state	Discovered EC2 instance types zonal offerings	{"commit": "f752ee0", "node": "ip-192-168-116-221.us-west-2.compute.internal"}
        2022-07-22T23:05:17.740Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:17.746Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:17.757Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:17.778Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:17.819Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:17.901Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:17.904Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:18.063Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:18.704Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:19.985Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:22.547Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:27.668Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:37.909Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-116-221.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"deerrose-16-i0d3s7xvoj\" not found"}
        2022-07-22T23:05:55.843Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-116-221.us-west-2.compute.internal"}
• [SLOW TEST:160.453 seconds]
Scheduling Conformance
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:15
  should provision a node for a deployment
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:28
------------------------------
{"level":"info","ts":1658531274.931684,"logger":"fallback","caller":"environment/expectations.go:127","msg":"2"}
    logger.go:130: 2022-07-22T16:07:55.156-0700	INFO	environment/expectations.go:165	2022-07-22T23:05:58.205Z	INFO	controller.provisioning	Found 2 provisionable pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:05:58.205Z	INFO	controller.provisioning	Computed 1 new node(s) will fit 2 pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:05:58.435Z	DEBUG	controller.provisioning.cloudprovider	Discovered security groups: [sg-06617f6997ca930da sg-0af9e2723b4021a70]	{"commit": "f752ee0", "provisioner": "whalepollen-23-yuvsd98h2z"}
        2022-07-22T23:05:58.441Z	DEBUG	controller.provisioning.cloudprovider	Discovered kubernetes version 1.21	{"commit": "f752ee0", "provisioner": "whalepollen-23-yuvsd98h2z"}
        2022-07-22T23:05:58.484Z	DEBUG	controller.provisioning.cloudprovider	Discovered ami-00cf63b12c53803a5 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"	{"commit": "f752ee0", "provisioner": "whalepollen-23-yuvsd98h2z"}
        2022-07-22T23:05:58.656Z	DEBUG	controller.provisioning.cloudprovider	Created launch template, Karpenter-test-1173112556890079310	{"commit": "f752ee0", "provisioner": "whalepollen-23-yuvsd98h2z"}
        2022-07-22T23:06:00.689Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-08e300c45c359ac41, hostname: ip-192-168-187-183.us-west-2.compute.internal, type: t3a.micro, zone: us-west-2d, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "whalepollen-23-yuvsd98h2z"}
        2022-07-22T23:06:00.720Z	INFO	controller.provisioning	Created node with 2 pods requesting {"cpu":"125m","pods":"4"} from types t3a.micro, t3.micro, t3a.small, t3.small, t3a.medium and 392 other(s)	{"commit": "f752ee0", "provisioner": "whalepollen-23-yuvsd98h2z"}
        2022-07-22T23:06:00.720Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "f752ee0"}
        2022-07-22T23:06:00.731Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"raccoonring-25-7so9w6lpkn-5dbdbf9fc7-8nwqd","uid":"2db95799-c464-4867-8d4b-aa8b40ec3f58","apiVersion":"v1","resourceVersion":"482854"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-187-183.us-west-2.compute.internal"}
        2022-07-22T23:06:00.731Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"raccoonring-25-7so9w6lpkn-5dbdbf9fc7-t5pzd","uid":"8a493d2c-8c10-4888-a677-ba74102b6139","apiVersion":"v1","resourceVersion":"482859"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-187-183.us-west-2.compute.internal"}
        2022-07-22T23:07:35.572Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-187-183.us-west-2.compute.internal"}
        2022-07-22T23:07:35.589Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/raccoonring-25-7so9w6lpkn-5dbdbf9fc7-8nwqd"}
        2022-07-22T23:07:35.608Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/raccoonring-25-7so9w6lpkn-5dbdbf9fc7-t5pzd"}
        2022-07-22T23:07:35.610Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:35.616Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:35.627Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:35.647Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:35.657Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:35.688Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:35.849Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:36.170Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:36.811Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:37.195Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:38.092Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:43.212Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:53.453Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-187-183.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"burnbutter-22-rryoqoy4bz\" not found"}
        2022-07-22T23:07:53.844Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-187-183.us-west-2.compute.internal"}
• [SLOW TEST:118.564 seconds]
Scheduling Conformance
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:15
  should provision a node for a self-affinity deployment
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:42
------------------------------
{"level":"info","ts":1658531379.964473,"logger":"fallback","caller":"environment/expectations.go:127","msg":"2"}
    logger.go:130: 2022-07-22T16:09:40.309-0700	INFO	environment/expectations.go:165	2022-07-22T23:07:56.763Z	INFO	controller.provisioning	Found 3 provisionable pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:07:56.763Z	INFO	controller.provisioning	Computed 3 new node(s) will fit 3 pod(s)	{"commit": "f752ee0"}
        2022-07-22T23:07:56.954Z	DEBUG	controller.provisioning.cloudprovider	Discovered subnets: [subnet-0b0cb59870e2a13a0 (us-west-2a) subnet-05c69c00f3c5bea19 (us-west-2d) subnet-0b4476a83d7f31e5c (us-west-2c) subnet-0c0e9602e87a5d00a (us-west-2d) subnet-05c4108aeefa7f2fa (us-west-2a) subnet-0e3ff9a206632cd4b (us-west-2c)]	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:07:57.054Z	DEBUG	controller.provisioning.cloudprovider	Discovered security groups: [sg-06617f6997ca930da sg-0af9e2723b4021a70]	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:07:57.058Z	DEBUG	controller.provisioning.cloudprovider	Discovered kubernetes version 1.21	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:07:57.099Z	DEBUG	controller.provisioning.cloudprovider	Discovered ami-00cf63b12c53803a5 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:07:57.290Z	DEBUG	controller.provisioning.cloudprovider	Created launch template, Karpenter-test-12391984471153687911	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:07:59.279Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-00d46f3af8f26729b, hostname: ip-192-168-182-90.us-west-2.compute.internal, type: t3a.micro, zone: us-west-2d, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:07:59.290Z	INFO	controller.provisioning	Created node with 1 pods requesting {"cpu":"125m","pods":"3"} from types t3a.micro, t3.micro, t3a.small, t3.small, t3a.medium and 247 other(s)	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:07:59.290Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"bunnysly-31-eijkmc8jsm-6db9f7b7f-x9nd7","uid":"1ce37262-aa78-4052-bb83-bcb9d898aa46","apiVersion":"v1","resourceVersion":"483668"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-182-90.us-west-2.compute.internal"}
        2022-07-22T23:08:02.256Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-048a17949effb86bb, hostname: ip-192-168-129-147.us-west-2.compute.internal, type: t3a.micro, zone: us-west-2c, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:08:02.264Z	INFO	controller.provisioning	Created node with 1 pods requesting {"cpu":"125m","pods":"3"} from types t3a.micro, t3.micro, t3a.small, t3.small, t3a.medium and 369 other(s)	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:08:02.264Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"bunnysly-31-eijkmc8jsm-6db9f7b7f-xv2gc","uid":"3abfb20f-abb5-4f37-94bb-424cad5dac52","apiVersion":"v1","resourceVersion":"483670"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-129-147.us-west-2.compute.internal"}
        2022-07-22T23:08:03.284Z	INFO	controller.provisioning.cloudprovider	Launched instance: i-02930a2ecd510cf28, hostname: ip-192-168-10-83.us-west-2.compute.internal, type: t3a.micro, zone: us-west-2a, capacityType: on-demand	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:08:03.308Z	INFO	controller.provisioning	Created node with 1 pods requesting {"cpu":"125m","pods":"3"} from types t3a.micro, t3.micro, t3a.small, t3.small, t3a.medium and 392 other(s)	{"commit": "f752ee0", "provisioner": "falconbevel-29-ertseayklo"}
        2022-07-22T23:08:03.308Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "f752ee0"}
        2022-07-22T23:08:03.320Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"bunnysly-31-eijkmc8jsm-6db9f7b7f-dzwc9","uid":"4d76a2d1-bebb-49cf-8318-13ef54d34588","apiVersion":"v1","resourceVersion":"483662"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-10-83.us-west-2.compute.internal"}
        2022-07-22T23:08:35.055Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"bunnysly-31-eijkmc8jsm-6db9f7b7f-x9nd7","uid":"1ce37262-aa78-4052-bb83-bcb9d898aa46","apiVersion":"v1","resourceVersion":"483980"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-129-147.us-west-2.compute.internal"}
        2022-07-22T23:08:35.055Z	DEBUG	controller.events	Normal	{"commit": "f752ee0", "object": {"kind":"Pod","namespace":"default","name":"bunnysly-31-eijkmc8jsm-6db9f7b7f-xv2gc","uid":"3abfb20f-abb5-4f37-94bb-424cad5dac52","apiVersion":"v1","resourceVersion":"483987"}, "reason": "NominatePod", "message": "Pod should schedule on ip-192-168-10-83.us-west-2.compute.internal"}
        2022-07-22T23:09:18.584Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.586Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.590Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.591Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.595Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.601Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.601Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.601Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.602Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.603Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-10-83.us-west-2.compute.internal"}
        2022-07-22T23:09:18.608Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.609Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-182-90.us-west-2.compute.internal"}
        2022-07-22T23:09:18.610Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.610Z	INFO	controller.termination	Cordoned node	{"commit": "f752ee0", "node": "ip-192-168-129-147.us-west-2.compute.internal"}
        2022-07-22T23:09:18.611Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.616Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/bunnysly-31-eijkmc8jsm-6db9f7b7f-xv2gc"}
        2022-07-22T23:09:18.621Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.621Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.633Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.634Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/bunnysly-31-eijkmc8jsm-6db9f7b7f-dzwc9"}
        2022-07-22T23:09:18.652Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.652Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.660Z	DEBUG	controller.eviction	Evicted pod	{"commit": "f752ee0", "pod": "default/bunnysly-31-eijkmc8jsm-6db9f7b7f-x9nd7"}
        2022-07-22T23:09:18.663Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.702Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.702Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:18.732Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.023Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.023Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.053Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.240Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.591Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.646Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.664Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.664Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-182-90.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:19.694Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:21.314Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-182-90.us-west-2.compute.internal"}
        2022-07-22T23:09:22.224Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:22.255Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:27.345Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:27.376Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-129-147.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:27.668Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-129-147.us-west-2.compute.internal"}
        2022-07-22T23:09:37.586Z	ERROR	controller.controller.node-state	Reconciler error	{"commit": "f752ee0", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-10-83.us-west-2.compute.internal", "namespace": "", "error": "getting providerRef, AWSNodeTemplate.karpenter.k8s.aws \"palmred-28-pssxwl92sc\" not found"}
        2022-07-22T23:09:39.310Z	INFO	controller.termination	Deleted node	{"commit": "f752ee0", "node": "ip-192-168-10-83.us-west-2.compute.internal"}
• [SLOW TEST:105.152 seconds]
Scheduling Conformance
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:15
  should provision three nodes for a zonal topology spread
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:69
------------------------------

Ran 6 of 6 Specs in 648.452 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (648.45s)
PASS
ok  	github.com/aws/karpenter/test/suites/integration	649.334s
testing: warning: no tests to run
PASS
ok  	github.com/aws/karpenter/test/suites/storage	(cached) [no tests to run]
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
