### PR TITLE
fix: record provisioner requirements as valid topology domains

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -199,9 +199,15 @@ func (p *Provisioner) schedule(ctx context.Context, pods []*v1.Pod) ([]*schedule
 			return nil, fmt.Errorf("getting instance types, %w", err)
 		}
 		instanceTypes[provisioner.Name] = append(instanceTypes[provisioner.Name], instanceTypeOptions...)
+
 		// Construct Topology Domains
 		for _, instanceType := range instanceTypeOptions {
 			for key, requirement := range instanceType.Requirements() {
+				domains[key] = domains[key].Union(requirement.Values())
+			}
+		}
+		for key, requirement := range scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...) {
+			if requirement.Type() == v1.NodeSelectorOpIn {
 				domains[key] = domains[key].Union(requirement.Values())
 			}
 		}


### PR DESCRIPTION
**Description**
This allows spreading across labels constructed via provisioner requirements.
**How was this change tested?**
Unit testing & deployed to EKS.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
