### PR TITLE
Add capability to use custom podDisruptionBudget name

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -61,6 +61,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | nameOverride | string | `""` | Overrides the chart's name. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selectors to schedule the pod to nodes with labels. |
 | podAnnotations | object | `{}` | Additional annotations for the pod. |
+| podDisruptionBudget.name | string | `karpenter` | Custom PDB name. |
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podLabels | object | `{}` | Additional labels for the pod. |
 | podSecurityContext | object | `{"fsGroup":1000}` | SecurityContext for the pod. |

--- a/charts/karpenter/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter/templates/poddisruptionbudget.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "karpenter.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
-  name: karpenter
+  name: {{ .Values.podDisruptionBudget.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -39,7 +39,6 @@ podLabels: {}
 # -- Additional annotations for the pod.
 podAnnotations: {}
 podDisruptionBudget:
-# -- Allow custom PDB name to be used  
   name: karpenter
   maxUnavailable: 1
 # -- SecurityContext for the pod.

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -10,6 +10,7 @@ additionalLabels: {}
 additionalAnnotations: {}
 # -- Image pull policy for Docker images.
 imagePullPolicy: IfNotPresent
+# -- Image pull secrets for Docker images.
 imagePullSecrets: []
 serviceAccount:
   # -- Specifies if a ServiceAccount should be created.

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -10,7 +10,6 @@ additionalLabels: {}
 additionalAnnotations: {}
 # -- Image pull policy for Docker images.
 imagePullPolicy: IfNotPresent
-# -- Image pull secrets for Docker images.
 imagePullSecrets: []
 serviceAccount:
   # -- Specifies if a ServiceAccount should be created.
@@ -39,6 +38,8 @@ podLabels: {}
 # -- Additional annotations for the pod.
 podAnnotations: {}
 podDisruptionBudget:
+# -- Allow custom PDB name to be used  
+  name: karpenter
   maxUnavailable: 1
 # -- SecurityContext for the pod.
 podSecurityContext:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->
Add capability to use custom podDisruptionBudget name.

**Description**
Added podDisruptionBudget name as a Helm Value that the consumer can customise. This will help to satisfy Cluster constraints that have requirements of specific naming conventions. 

**How was this change tested?**

* Tested locally.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
