### PR TITLE
fix: add in a grace period when checking if pods are stuck terminating

### DIFF
--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -329,7 +329,7 @@ var _ = Describe("Termination", func() {
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			// Simulate stuck terminating
-			injectabletime.Now = func() time.Time { return time.Now().Add(1 * time.Minute) }
+			injectabletime.Now = func() time.Time { return time.Now().Add(2 * time.Minute) }
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 			ExpectNotFound(ctx, env.Client, node)
 		})
@@ -494,7 +494,7 @@ var _ = Describe("Termination", func() {
 			ExpectEvicted(env.Client, pod)
 
 			// After grace period, node should delete
-			injectabletime.Now = func() time.Time { return time.Now().Add(30 * time.Second) }
+			injectabletime.Now = func() time.Time { return time.Now().Add(90 * time.Second) }
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 			ExpectNotFound(ctx, env.Client, node)
 		})

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -158,5 +159,5 @@ func IsStuckTerminating(pod *v1.Pod) bool {
 	if pod.DeletionTimestamp == nil {
 		return false
 	}
-	return injectabletime.Now().After(pod.DeletionTimestamp.Time)
+	return injectabletime.Now().After(pod.DeletionTimestamp.Time.Add(1 * time.Minute))
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
Currently Karpenter waits until pods are outside of their graceful termination period before terminating the instance. However, the kubelet doesn't start forcibly killing pods until this exact point in time, so Karpenter doesn't give the node the opportunity to force kill the pods. This causes the pods to become unowned and be cleaned up by the pod lifecycle controller's garbage collection mechanism.

I ran into this issue when testing large scale downs (50 pods) that would exceed the default 30 second grace period, and then the subsequent test would notice existing pods.

Long term, we probably should trigger node termination in EC2 without forcibly deleting the node object and build a mechanism for the instance to deregister from the API Server, but this change is outside of the scope of this fix.

**How was this change tested?**

* `make e2etest`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
