### PR TITLE
fix: ensure cluster state is synced prior to scheduling

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -66,6 +66,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	scheduling.ClusterSyncRetries = 0
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
 		cloudProv = &fake.CloudProvider{}
 		cfg = test.NewConfig()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -292,9 +292,11 @@ func (c *Cluster) deleteNode(nodeName string) {
 
 // updateNode is called for every node reconciliation
 func (c *Cluster) updateNode(ctx context.Context, node *v1.Node) error {
+	// perform node lookup before we lock so that the slower operation can occur in parallel
+	n, err := c.newNode(ctx, node)
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	n, err := c.newNode(ctx, node)
 	if err != nil {
 		// ensure that the out of date node is forgotten
 		delete(c.nodes, node.Name)

--- a/pkg/controllers/state/node.go
+++ b/pkg/controllers/state/node.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -65,5 +66,6 @@ func (c *NodeController) Register(ctx context.Context, m manager.Manager) error 
 		NewControllerManagedBy(m).
 		Named(nodeControllerName).
 		For(&v1.Node{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Complete(c)
 }

--- a/pkg/controllers/state/pod.go
+++ b/pkg/controllers/state/pod.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -66,6 +67,7 @@ func (c *PodController) Register(ctx context.Context, m manager.Manager) error {
 	return controllerruntime.
 		NewControllerManagedBy(m).
 		Named(podControllerName).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		For(&v1.Pod{}).
 		Complete(c)
 }


### PR DESCRIPTION
Fixes #2164 

**Description**
This prevents an issue where we can over-shoot if many nodes are launched.

**How was this change tested?**

* Unit testing & deployed to EKS with a sleep call in the updateNode function.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
