### PR TITLE
docs: document some advanced scheduling techniques

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/_index.md
@@ -53,7 +53,7 @@ Also set the following environment variables to store commonly used values.
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-eksctl/scripts/step01-config.sh" language="bash"%}}
 
-{{% alert title="Warning" color="primary" %}}
+{{% alert title="Warning" color="warning" %}}
 If you open a new shell to run steps in this procedure, you need to set some or all of the environment variables again.
 To remind yourself of these values, type:
 


### PR DESCRIPTION
**Description**

Documents the usage of `Exists` in provisioners and a method for a spot to on-demand split for a workload.


**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
