### PR TITLE
fix: Enforced state sync to eventually converge instead of giving up

### DIFF
--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -20,11 +20,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/avast/retry-go"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,9 +34,9 @@ import (
 	"github.com/aws/karpenter/pkg/utils/resources"
 )
 
-// ClusterSyncRetries controls how many times we attempt to retry waiting on cluster state sync. This is exposed for
+// WaitForClusterSync controls whether or not we synchronize before scheduling. This is exposed for
 // unit testing purposes so we can avoid a lengthy delay in cluster sync.
-var ClusterSyncRetries uint = 5
+var WaitForClusterSync = true
 
 func NewScheduler(ctx context.Context, kubeClient client.Client, nodeTemplates []*scheduling.NodeTemplate, provisioners []v1alpha5.Provisioner, cluster *state.Cluster, topology *Topology, instanceTypes map[string][]cloudprovider.InstanceType, daemonOverhead map[*scheduling.NodeTemplate]v1.ResourceList, recorder events.Recorder) *Scheduler {
 	for provisioner := range instanceTypes {
@@ -70,7 +68,14 @@ func NewScheduler(ctx context.Context, kubeClient client.Client, nodeTemplates [
 	}
 
 	// wait to ensure that our cluster state is synced with the current known nodes to prevent over-shooting
-	s.waitForClusterStateSync(ctx)
+	for WaitForClusterSync {
+		if err := s.cluster.Synchronized(ctx); err != nil {
+			logging.FromContext(ctx).Infof("waiting for cluster state to catch up, %s", err)
+			time.Sleep(1 * time.Second)
+		} else {
+			break
+		}
+	}
 
 	// create our in-flight nodes
 	s.cluster.ForEachNode(func(node *state.Node) bool {
@@ -232,40 +237,6 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 		return nil
 	}
 	return errs
-}
-
-// waitForClusterStateSync ensures that our cluster state is aware of at least all of the nodes that our list cache has.
-// Since we launch nodes in parallel, we can create many node objects which may not all be reconciled by the cluster
-// state before we start trying to schedule again.  In this case, we would over-provision as we weren't aware of the
-// inflight nodes.
-func (s *Scheduler) waitForClusterStateSync(ctx context.Context) {
-	if err := retry.Do(func() error {
-		// collect the nodes known by the kube API server
-		var nodes v1.NodeList
-		if err := s.kubeClient.List(ctx, &nodes); err != nil {
-			return nil
-		}
-		unknownNodes := sets.NewString()
-		for _, n := range nodes.Items {
-			unknownNodes.Insert(n.Name)
-		}
-
-		// delete any that cluster state already knows about
-		s.cluster.ForEachNode(func(n *state.Node) bool {
-			delete(unknownNodes, n.Node.Name)
-			return true
-		})
-
-		// and we're left with nodes which exist, but haven't reconciled with cluster state yet
-		if len(unknownNodes) != 0 {
-			return fmt.Errorf("%d nodes not known to cluster state", len(unknownNodes))
-		}
-		return nil
-	}, retry.Delay(1*time.Second),
-		retry.Attempts(ClusterSyncRetries),
-	); err != nil {
-		logging.FromContext(ctx).Infof("nodes failed to sync, may launch too many nodes which should resolve")
-	}
 }
 
 // subtractMax returns the remaining resources after subtracting the max resource quantity per instance type. To avoid

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -66,7 +66,6 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	scheduling.ClusterSyncRetries = 0
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
 		cloudProv = &fake.CloudProvider{}
 		cfg = test.NewConfig()

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/aws/karpenter/pkg/apis"
+	"github.com/aws/karpenter/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter/pkg/utils/project"
 )
 
@@ -71,6 +72,8 @@ type Environment struct {
 type EnvironmentOption func(env *Environment)
 
 func NewEnvironment(ctx context.Context, options ...EnvironmentOption) *Environment {
+	scheduling.WaitForClusterSync = false
+
 	ctx, stop := context.WithCancel(ctx)
 	return &Environment{
 		Environment: envtest.Environment{

--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -57,7 +57,7 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 		options.Name = RandomName()
 	}
 	if options.Limits == nil {
-		options.Limits = v1.ResourceList{v1.ResourceCPU: resource.MustParse("1000")}
+		options.Limits = v1.ResourceList{v1.ResourceCPU: resource.MustParse("2000")}
 	}
 
 	provisioner := &v1alpha5.Provisioner{

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -32,11 +32,9 @@ var _ = Describe("Scheduling Conformance", func() {
 		}})
 		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 
-		const numPods = 50
-		deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
-
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: 50})
 		env.ExpectCreated(provisioner, provider, deployment)
-		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), numPods)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
 		env.ExpectCreatedNodeCount("<=", 2) // should probably all land on a single node, but at worst two depending on batching
 	})
 	It("should provision a node for a self-affinity deployment", func() {

--- a/test/suites/utilization/suite_test.go
+++ b/test/suites/utilization/suite_test.go
@@ -1,0 +1,53 @@
+package utilization_test
+
+import (
+	"testing"
+
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+	"github.com/aws/karpenter/test/pkg/environment"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var env *environment.Environment
+
+func TestUtilization(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		var err error
+		env, err = environment.NewEnvironment(t)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	RunSpecs(t, "Utilization")
+}
+
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.AfterEach() })
+
+var _ = Describe("Utilization", func() {
+	It("should provision one pod per node", func() {
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}, Requirements: []v1.NodeSelectorRequirement{{
+			Key:      v1.LabelInstanceTypeStable,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{"t3a.small"},
+		}}})
+
+		deployment := test.Deployment(test.DeploymentOptions{
+			Replicas:   500,
+			PodOptions: test.PodOptions{ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1.5")}}}})
+
+		env.ExpectCreated(provisioner, provider, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
+		env.ExpectCreatedNodeCount("==", int(*deployment.Spec.Replicas)) // One pod per node enforced by instance size
+	})
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2164

**Description**
Currently, tests have spurious logging: `scheduling/scheduler.go:267	nodes failed to sync, may launch too many nodes which should resolve` on every test. Additionally, tests outside of the scheduling suite were using the retry behavior. 

- No longer emits spurious logs during tests
- Disables synchronization on all tests via the test env
- Enforce convergence of state before making progress (removing bimodal system behavior)
e.g. 500 node scale up.
```
karpenter-7489d86697-nwhvn controller 2022-07-26T20:55:50.753Z	INFO	controller.provisioning	Waiting for unschedulable pods	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:01.354Z	INFO	controller.provisioning	waiting for cluster state to catch up, 227 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:02.364Z	INFO	controller.provisioning	waiting for cluster state to catch up, 206 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:03.448Z	INFO	controller.provisioning	waiting for cluster state to catch up, 181 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:04.476Z	INFO	controller.provisioning	waiting for cluster state to catch up, 157 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:05.543Z	INFO	controller.provisioning	waiting for cluster state to catch up, 133 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:06.580Z	INFO	controller.provisioning	waiting for cluster state to catch up, 110 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:07.601Z	INFO	controller.provisioning	waiting for cluster state to catch up, 91 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:08.606Z	INFO	controller.provisioning	waiting for cluster state to catch up, 67 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:09.615Z	INFO	controller.provisioning	waiting for cluster state to catch up, 40 nodes not known to cluster state	{"commit": "059ad60"}
karpenter-7489d86697-nwhvn controller 2022-07-26T20:56:10.648Z	INFO	controller.provisioning	waiting for cluster state to catch up, 17 nodes not known to cluster state	{"commit": "059ad60"}
```

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
