### PR TITLE
chore: lower spot to od threshold to 5

### DIFF
--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -45,7 +45,7 @@ import (
 )
 
 var (
-	safeSpotFallbackThreshold = 10 // falling back to on-demand without flexibility risks insufficient capacity errors
+	safeSpotFallbackThreshold = 5 // falling back to on-demand without flexibility risks insufficient capacity errors
 )
 
 type InstanceProvider struct {

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -114,7 +114,7 @@ See [Choose the appropriate allocation strategy](https://docs.aws.amazon.com/AWS
 
 ### What if there is no spot capacity? Will Karpenter use on-demand?
 
-Karpenter will use on-demand, if your provisioner specifies both spot and on-demand and you are flexible to at least 10 instance types. 
+Karpenter will use on-demand, if your provisioner specifies both spot and on-demand and you are flexible to at least 5 instance types. 
 
 More specifically, Karpenter maintains a concept of "offerings" for each instance type, which is a combination of zone and capacity type (equivalent in the AWS cloud provider to an EC2 purchase option). Spot offerings are prioritized, if they're available. Whenever the Fleet API returns an insufficient capacity error for Spot instances, those particular offerings are temporarily removed from consideration (across the entire provisioner) so that Karpenter can make forward progress with different options. The retry will happen immediately within milliseconds.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - Lower spot-to-od threshold from requiring 10 diverse instance types to only 5. 

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
