### PR TITLE
fix: ignore pods that have an invalid storage class

### DIFF
--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -506,10 +506,30 @@ var _ = Describe("Volume Topology Requirements", func() {
 		}))[0]
 		ExpectNotScheduled(ctx, env.Client, pod)
 	})
-	It("should schedule valid pods when a pod with an invalid pvc is encountered", func() {
+	It("should schedule with an empty storage class", func() {
+		storageClass := ""
+		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass})
+		ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
+		pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(test.PodOptions{
+			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+		}))[0]
+		ExpectScheduled(ctx, env.Client, pod)
+	})
+	It("should schedule valid pods when a pod with an invalid pvc is encountered (pvc)", func() {
 		ExpectApplied(ctx, env.Client, test.Provisioner())
 		invalidPod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(test.PodOptions{
 			PersistentVolumeClaims: []string{"invalid"},
+		}))[0]
+		pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(test.PodOptions{}))[0]
+		ExpectNotScheduled(ctx, env.Client, invalidPod)
+		ExpectScheduled(ctx, env.Client, pod)
+	})
+	It("should schedule valid pods when a pod with an invalid pvc is encountered (storage class)", func() {
+		invalidStorageClass := "invalid-storage-class"
+		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &invalidStorageClass})
+		ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
+		invalidPod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(test.PodOptions{
+			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
 		}))[0]
 		pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(test.PodOptions{}))[0]
 		ExpectNotScheduled(ctx, env.Client, invalidPod)


### PR DESCRIPTION
Fixes #2189

**Description**

Validate storage class on pod and ignore any that can't be validated.

**How was this change tested?**

* Unit testing & deployed to EKS where I verified the fix.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
