### PR TITLE
docs: Update api_version in helm provider

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
@@ -276,7 +276,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     }
@@ -355,7 +355,7 @@ provider "kubectl" {
   load_config_file       = false
 
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_id]
   }

--- a/website/content/en/v0.13.1/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.13.1/getting-started/getting-started-with-terraform/_index.md
@@ -262,7 +262,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
     exec {
-      api_version = "client.authentication.k8s.io/v1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     }
@@ -341,7 +341,7 @@ provider "kubectl" {
   load_config_file       = false
 
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_id]
   }

--- a/website/content/en/v0.13.1/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.13.1/getting-started/getting-started-with-terraform/_index.md
@@ -262,7 +262,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     }

--- a/website/content/en/v0.13.2/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.13.2/getting-started/getting-started-with-terraform/_index.md
@@ -262,7 +262,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     }
@@ -341,7 +341,7 @@ provider "kubectl" {
   load_config_file       = false
 
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_id]
   }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2200

**Description**
The api_version in the 'exec' section of the 'helm' provider was obsolete. From the kubernetes documentation of [Authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#input-and-output-formats), it should be 'v1beta1' or 'v1'.
Using the v1alpĥa1 will return the error: "no kind "ExecCredential" is registered for version "client.authentication.k8s.io/v1alpha1" in scheme "pkg/runtime/scheme.go:100"
The aws cli creates a EKS cluster where the 'v1alpha1' was deprecated and will not deploy.

**How was this change tested?**
I modified the api_version from 'v1alpha1' to 'v1' and the _'terraform apply'_ command succeeded


**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [x] Yes, issue opened: #2200
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
"action required": Modify your terraform file to include this change and type 'terraform apply' again
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
