### PR TITLE
test: Adding basic tests to for TTLExpired and TTLEmpty

### DIFF
--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -32,16 +32,17 @@ import (
 // ProvisionerOptions customizes a Provisioner.
 type ProvisionerOptions struct {
 	metav1.ObjectMeta
-	Limits               v1.ResourceList
-	Provider             interface{}
-	ProviderRef          *v1alpha5.ProviderRef
-	Kubelet              *v1alpha5.KubeletConfiguration
-	Labels               map[string]string
-	Taints               []v1.Taint
-	StartupTaints        []v1.Taint
-	Requirements         []v1.NodeSelectorRequirement
-	Status               v1alpha5.ProvisionerStatus
-	TTLSecondsAfterEmpty *int64
+	Limits                 v1.ResourceList
+	Provider               interface{}
+	ProviderRef            *v1alpha5.ProviderRef
+	Kubelet                *v1alpha5.KubeletConfiguration
+	Labels                 map[string]string
+	Taints                 []v1.Taint
+	StartupTaints          []v1.Taint
+	Requirements           []v1.NodeSelectorRequirement
+	Status                 v1alpha5.ProvisionerStatus
+	TTLSecondsAfterEmpty   *int64
+	TTLSecondsUntilExpired *int64
 }
 
 // Provisioner creates a test provisioner with defaults that can be overridden by ProvisionerOptions.
@@ -63,14 +64,15 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 	provisioner := &v1alpha5.Provisioner{
 		ObjectMeta: ObjectMeta(options.ObjectMeta),
 		Spec: v1alpha5.ProvisionerSpec{
-			Requirements:         options.Requirements,
-			KubeletConfiguration: options.Kubelet,
-			ProviderRef:          options.ProviderRef,
-			Taints:               options.Taints,
-			StartupTaints:        options.StartupTaints,
-			Labels:               options.Labels,
-			Limits:               &v1alpha5.Limits{Resources: options.Limits},
-			TTLSecondsAfterEmpty: options.TTLSecondsAfterEmpty,
+			Requirements:           options.Requirements,
+			KubeletConfiguration:   options.Kubelet,
+			ProviderRef:            options.ProviderRef,
+			Taints:                 options.Taints,
+			StartupTaints:          options.StartupTaints,
+			Labels:                 options.Labels,
+			Limits:                 &v1alpha5.Limits{Resources: options.Limits},
+			TTLSecondsAfterEmpty:   options.TTLSecondsAfterEmpty,
+			TTLSecondsUntilExpired: options.TTLSecondsUntilExpired,
 		},
 		Status: options.Status,
 	}

--- a/test/pkg/environment/expectations.go
+++ b/test/pkg/environment/expectations.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo" //nolint:revive,stylecheck
 	. "github.com/onsi/gomega" //nolint:revive,stylecheck
@@ -14,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/pkg/logging"
@@ -23,6 +25,7 @@ import (
 	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/utils/pod"
+	"github.com/aws/karpenter/pkg/utils/sets"
 )
 
 var (
@@ -123,6 +126,31 @@ func (env *Environment) eventuallyExpectScaleDown() {
 		// expect the current node count to be what it was when the test started
 		g.Expect(env.Monitor.NodeCount()).To(Equal(env.Monitor.NodeCountAtReset()))
 	}).Should(Succeed(), fmt.Sprintf("expected scale down to %d nodes, had %d", env.Monitor.NodeCountAtReset(), env.Monitor.NodeCount()))
+}
+
+func (env *Environment) GetCreatedNodes(before []v1.Node, after []v1.Node) []*v1.Node {
+	createdNodes := []*v1.Node{}
+	oldList := sets.NewSet()
+	for _, node := range before {
+		oldList.Insert(node.Name)
+	}
+	for i := range after {
+		if !oldList.Has(after[i].Name) {
+			createdNodes = append(createdNodes, &after[i])
+		}
+	}
+	return createdNodes
+}
+
+func (env *Environment) ExpectNodesEventuallyDeleted(timeout time.Duration, nodes ...*v1.Node) {
+	for _, node := range nodes {
+		Eventually(func(g Gomega) {
+			n := &v1.Node{}
+			err := env.Client.Get(env, client.ObjectKeyFromObject(node), n)
+			g.Expect(err).ToNot(BeNil())
+			g.Expect(errors.IsNotFound(err)).To(BeTrue())
+		}).WithTimeout(timeout).Should(Succeed(), fmt.Sprintf("expcted nodes %s to be deleted", nodes))
+	}
 }
 
 func (env *Environment) ExpectCreatedNodeCount(comparator string, nodeCount int) {

--- a/test/pkg/environment/monitor.go
+++ b/test/pkg/environment/monitor.go
@@ -81,6 +81,15 @@ func (m *Monitor) RestartCount() map[string]int {
 	return restarts
 }
 
+// GetNodes returns the most recent recording of nodes
+func (m *Monitor) GetNodes() []v1.Node {
+	m.poll()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	last := m.recordings[len(m.recordings)-1]
+	return last.nodes.Items
+}
+
 // NodeCount returns the current number of nodes
 func (m *Monitor) NodeCount() int {
 	m.poll()

--- a/test/suites/node/ttl_test.go
+++ b/test/suites/node/ttl_test.go
@@ -1,0 +1,92 @@
+package nodettl_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"knative.dev/pkg/ptr"
+
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/karpenter/test/pkg/environment"
+)
+
+var env *environment.Environment
+
+func TestNodeTTL(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		var err error
+		env, err = environment.NewEnvironment(t)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	RunSpecs(t, "NodeTTL")
+}
+
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.AfterEach() })
+
+var _ = Describe("TTL Empty", func() {
+	It("should terminate an empty node", func() {
+		beforeNodes := env.Monitor.GetNodes()
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef:          &v1alpha5.ProviderRef{Name: provider.Name},
+			TTLSecondsAfterEmpty: ptr.Int64(0),
+		})
+
+		const numPods = 1
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
+
+		env.ExpectCreated(provider, provisioner, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), numPods)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		createdNodes := env.GetCreatedNodes(beforeNodes, env.Monitor.GetNodes())
+
+		persisted := deployment.DeepCopy()
+		deployment.Spec.Replicas = ptr.Int32(0)
+		Expect(env.Client.Patch(env, deployment, client.MergeFrom(persisted))).To(Succeed())
+
+		env.ExpectNodesEventuallyDeleted(120*time.Second, createdNodes...)
+	})
+})
+
+var _ = Describe("TTL Expired", func() {
+	It("should terminate an expired node", func() {
+		beforeNodes := env.Monitor.GetNodes()
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef:            &v1alpha5.ProviderRef{Name: provider.Name},
+		})
+
+		const numPods = 1
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: numPods})
+
+		env.ExpectCreated(provisioner, provider, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), numPods)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		createdNodes := env.GetCreatedNodes(beforeNodes, env.Monitor.GetNodes())
+
+		persisted := provisioner.DeepCopy()
+		provisioner.Spec.TTLSecondsUntilExpired = ptr.Int64(10)
+		Expect(env.Client.Patch(env, provisioner, client.MergeFrom(persisted))).To(Succeed())
+
+		env.ExpectNodesEventuallyDeleted(120 * time.Second, createdNodes...)
+	})
+})


### PR DESCRIPTION
**Description**
Tests that TTLSecondsUntilExpired and TTLSecondsAfterEmpty work at a basic level.
**How was this change tested?**
* Ran `go test -p 1 -timeout 60m -v ./test/suites/... -run=TestNodeTTL` locally.


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
