### PR TITLE
fix: login to Public ECR Should Occur at `public.ecr.aws`

### DIFF
--- a/hack/release_common.sh
+++ b/hack/release_common.sh
@@ -24,7 +24,7 @@ requireCloudProvider(){
 }
 
 authenticate() {
-  aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${RELEASE_REPO}
+  aws ecr-public get-login-password --region us-east-1 | ko login --username AWS --password-stdin public.ecr.aws
 }
 
 buildImages() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

`make snapshot` effectively expects two values:
1. The Registry path to the public repo where the images/chart will be published
2. The Public login endpoint for `docker login`

These values are currently under a single value `$RELEASE_REPO` which breaks some things when running `make snapshot`  

**How was this change tested?**

* Run `make snapshot` against a custom $RELEASE_REPO

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
