### PR TITLE
fix: Drain terminated Pods without owner reference

### DIFF
--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -77,7 +77,7 @@ func (t *Terminator) drain(ctx context.Context, node *v1.Node) (bool, error) {
 	// Skip node due to pods that are not able to be evicted
 	for _, p := range pods {
 		// if a pod doesn't have owner references then we can't expect a controller to manage its lifecycle
-		if len(p.ObjectMeta.OwnerReferences) == 0 && !IsTerminatedStatus(p) {
+		if len(p.ObjectMeta.OwnerReferences) == 0 && !pod.IsTerminal(p) {
 			return false, NodeDrainErr(fmt.Errorf("pod %s/%s does not have any owner references", p.Namespace, p.Name))
 		} else if val := p.Annotations[v1alpha5.DoNotEvictPodAnnotationKey]; val == "true" {
 			return false, NodeDrainErr(fmt.Errorf("pod %s/%s has do-not-evict annotation", p.Namespace, p.Name))
@@ -160,11 +160,4 @@ func IsStuckTerminating(pod *v1.Pod) bool {
 		return false
 	}
 	return injectabletime.Now().After(pod.DeletionTimestamp.Time.Add(1 * time.Minute))
-}
-
-func IsTerminatedStatus(pod *v1.Pod) bool {
-	if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
**Description**

Since this https://github.com/aws/karpenter/pull/2092 Pods without owner reference are not drained but pods in terminated state should be safe to be evicted.

```
2022-07-28T11:21:43.167Z	DEBUG	controller.events	Warning	{"commit": "362ea52", "object": {"kind":"Node","name":"ip-172-21-98-19.eu-west-1.compute.internal","uid":"465876f3-6732-4e9e-a89c-a4fa3c1e6bae","apiVersion":"v1","resourceVersion":"1528597833"}, "reason": "FailedDraining", "message": "Failed to drain node, pod test/pod-name does not have any owner references"}
```
```
kubectl -n test get pods
NAME       READY   STATUS      RESTARTS   AGE
pod-name   0/1     Completed   0          16m
```
When a no long-running process Pod has no ownerReference but is in a Terminated state (Failed or Completed) Its expected that the lifecycle is ended so we can drain it to remove the node. In another case, we end with empty nodes that are not running any workload stuck to be removed 

**How was this change tested?**

* Deployed in a test cluster, created a test pod 

**Does this change impact docs?**
- [X] No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
