### PR TITLE
fix: Emit evictions as events

### DIFF
--- a/pkg/controllers/termination/eviction.go
+++ b/pkg/controllers/termination/eviction.go
@@ -112,5 +112,6 @@ func (e *EvictionQueue) evict(ctx context.Context, nn types.NamespacedName) bool
 		logging.FromContext(ctx).Errorf("evicting pod, %s", err)
 		return false
 	}
+	e.recorder.EvictPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace}})
 	return true
 }

--- a/pkg/events/dedupe.go
+++ b/pkg/events/dedupe.go
@@ -43,6 +43,15 @@ func (d *dedupe) NominatePod(pod *v1.Pod, node *v1.Node) {
 	d.rec.NominatePod(pod, node)
 }
 
+func (d *dedupe) EvictPod(pod *v1.Pod) {
+	key := fmt.Sprintf("evict-pod-%s", pod.Name)
+	if _, exists := d.cache.Get(key); exists {
+		return
+	}
+	d.cache.SetDefault(key, nil)
+	d.rec.EvictPod(pod)
+}
+
 func (d *dedupe) PodFailedToSchedule(pod *v1.Pod, err error) {
 	key := fmt.Sprintf("failed-to-schedule-%s-%s", pod.Name, err.Error())
 	if _, exists := d.cache.Get(key); exists {

--- a/pkg/events/recorder.go
+++ b/pkg/events/recorder.go
@@ -25,6 +25,8 @@ type Recorder interface {
 	// NominatePod is called when we have determined that a pod should schedule against an existing node and don't
 	// currently need to provision new capacity for the pod.
 	NominatePod(*v1.Pod, *v1.Node)
+	// EvictedPod is called when a pod is evicted
+	EvictPod(*v1.Pod)
 	// PodFailedToSchedule is called when a pod has failed to schedule entirely.
 	PodFailedToSchedule(*v1.Pod, error)
 	// NodeFailedToDrain is called when a pod causes a node draining to fail
@@ -40,7 +42,11 @@ func NewRecorder(rec record.EventRecorder) Recorder {
 }
 
 func (r recorder) NominatePod(pod *v1.Pod, node *v1.Node) {
-	r.rec.Eventf(pod, "Normal", "NominatePod", "Pod should schedule on %s", node.Name)
+	r.rec.Eventf(pod, "Normal", "Nominate", "Pod should schedule on %s", node.Name)
+}
+
+func (r recorder) EvictPod(pod *v1.Pod) {
+	r.rec.Eventf(pod, "Normal", "Evict", "Evicted pod")
 }
 
 func (r recorder) PodFailedToSchedule(pod *v1.Pod, err error) {

--- a/pkg/test/eventrecorder.go
+++ b/pkg/test/eventrecorder.go
@@ -41,6 +41,9 @@ func (e *EventRecorder) NominatePod(pod *v1.Pod, node *v1.Node) {
 	defer e.mu.Unlock()
 	e.bindings = append(e.bindings, Binding{pod, node})
 }
+
+func (e *EventRecorder) EvictPod(pod *v1.Pod) {}
+
 func (e *EventRecorder) PodFailedToSchedule(pod *v1.Pod, err error) {}
 
 func (e *EventRecorder) NodeFailedToDrain(node *v1.Node, err error) {}

--- a/test/suites/integration/cni_test.go
+++ b/test/suites/integration/cni_test.go
@@ -1,8 +1,6 @@
 package integration_test
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
Following up from a previous PR: Emit evictions as events instead of logging. Also renamed NominatePod to Nominate to be more in line with existing pod events (Pulled, Created, Started, etc), since they're already scoped to an object type

**How was this change tested?**

`16m         Normal    Evict                  pod/ogreveil-4-cjtyd9gst2-6d998fb8b6-z7xd8           Evicted pod`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
