### PR TITLE
Revert "fix: login to Public ECR Should Occur at `public.ecr.aws`"

### DIFF
--- a/hack/release_common.sh
+++ b/hack/release_common.sh
@@ -24,7 +24,7 @@ requireCloudProvider(){
 }
 
 authenticate() {
-  aws ecr-public get-login-password --region us-east-1 | ko login --username AWS --password-stdin public.ecr.aws
+  aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${RELEASE_REPO}
 }
 
 buildImages() {


### PR DESCRIPTION
Reverts aws/karpenter#2204

This breaks the nightlies https://github.com/aws/karpenter/actions/runs/2753842941 let's revert and do it in a way that doesn't break the nightly builds if we need to.