### PR TITLE
test: unused import breaking e2etests

### DIFF
--- a/test/suites/integration/cni_test.go
+++ b/test/suites/integration/cni_test.go
@@ -1,8 +1,6 @@
 package integration_test
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
Our linter currently excludes test files so it doesn't catch things like unused imports. I tried adding test files but there were a 100 or so changes needed so rather decided to unblock our releases first.

**How was this change tested?**
`TEST_FILTER=TestIntegration make e2etests` succeeded

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
test: unused import breaking e2etests
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
