### PR TITLE
fix: termination latency dashboard unit set to seconds

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json
@@ -24,7 +24,8 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "iteration": 1658856621549,
+    "id": 7,
+    "iteration": 1659113139050,
     "links": [],
     "liveNow": true,
     "panels": [
@@ -79,7 +80,8 @@
                                 "value": 80
                             }
                         ]
-                    }
+                    },
+                    "unit": "s"
                 },
                 "overrides": []
             },
@@ -552,6 +554,6 @@
     "timezone": "",
     "title": "Karpenter Performance",
     "uid": "_bdgC2g4z",
-    "version": 1,
+    "version": 2,
     "weekStart": ""
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

**Description**
Sets the unit for the termination latency panel to seconds.

**How was this change tested?**

* Deployed dashboard to Grafana

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
