### PR TITLE
fix: Separate zone caching by subnet selectors

### DIFF
--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -143,7 +143,7 @@ func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context, provide
 		}); err != nil {
 		return nil, fmt.Errorf("describing instance type zone offerings, %w", err)
 	}
-	logging.FromContext(ctx).Debugf("Discovered EC2 instance types zonal offerings for subnets %s, pretty.Concise(provider.SubnetSelector))
+	logging.FromContext(ctx).Debugf("Discovered EC2 instance types zonal offerings for subnets %s", pretty.Concise(provider.SubnetSelector))
 	p.cache.SetDefault(cacheKey, instanceTypeZones)
 	return instanceTypeZones, nil
 }

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -143,7 +143,7 @@ func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context, provide
 		}); err != nil {
 		return nil, fmt.Errorf("describing instance type zone offerings, %w", err)
 	}
-	logging.FromContext(ctx).Debugf("Discovered EC2 instance types zonal offerings (cache key: %v)", cacheKey)
+	logging.FromContext(ctx).Debugf("Discovered EC2 instance types zonal offerings for subnets %s, pretty.Concise(provider.SubnetSelector))
 	p.cache.SetDefault(cacheKey, instanceTypeZones)
 	return instanceTypeZones, nil
 }

--- a/pkg/cloudprovider/aws/instancetypes.go
+++ b/pkg/cloudprovider/aws/instancetypes.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/utils/functional"
+	"github.com/aws/karpenter/pkg/utils/pretty"
 )
 
 const (


### PR DESCRIPTION
Fixes #2228

**Description**

The set of zones for instance types was using the same cache key irrespective of the subnet selector. As a result, if two provisioners had distinct subnetSelectors that matched subnets in different availability zones, the karpenter controller would only see one of them and be unable to schedule nodes on some of the subnets.

**How was this change tested?**

Manually tested by patching this change on top of the v0.13.2-release branch in our cluster.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
Fix flakiness in setting up nodes in the right availability zone when provisioners target different subnets.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
