### PR TITLE
feat: Add a node liveness TTL that terminates NotReady nodes if optional field is set on provisioner

### DIFF
--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -218,6 +218,17 @@ spec:
                   not set."
                 format: int64
                 type: integer
+              ttlSecondsAfterNotReady:
+                description: 'TTLSecondsAfterNotReady is the number of seconds before
+                  a node that does not become Ready will be terminated. It is disabled
+                  if this field is not set, which means a node that joins the cluster
+                  but never become ready will cause pods assigned to the node to never
+                  start Running. Note: Seeing the TTL too low can hastily terminate
+                  nodes that otherwise would''ve joined given some time, especially
+                  for large clusters. It may also hinder debugging the underlying
+                  root problem of the node if it goes away too soon.'
+                format: int64
+                type: integer
               ttlSecondsUntilExpired:
                 description: "TTLSecondsUntilExpired is the number of seconds the
                   controller will wait before terminating a node, measured from when

--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -222,8 +222,8 @@ spec:
                 description: 'TTLSecondsAfterNotReady is the number of seconds before
                   a node that does not become Ready will be terminated. It is disabled
                   if this field is not set, which means a node that joins the cluster
-                  but never become ready will cause pods assigned to the node to never
-                  start Running. Note: Seeing the TTL too low can hastily terminate
+                  but never becomes Ready will cause pods assigned to the node to never
+                  start Running. Note: Setting the TTL too low can hastily terminate
                   nodes that otherwise would''ve joined given some time, especially
                   for large clusters. It may also hinder debugging the underlying
                   root problem of the node if it goes away too soon.'

--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -64,6 +64,15 @@ type ProvisionerSpec struct {
 	// Termination due to no utilization is disabled if this field is not set.
 	// +optional
 	TTLSecondsAfterEmpty *int64 `json:"ttlSecondsAfterEmpty,omitempty"`
+	// TTLSecondsAfterNotReady is the number of seconds before a node that does not
+	// become Ready will be terminated. It is disabled if this field is not set,
+	// which means a node that joins the cluster but never become ready will cause
+	// pods assigned to the node to never start Running.
+	// Note: Seeing the TTL too low can hastily terminate nodes that otherwise would've
+	// joined given some time, especially for large clusters. It may also hinder
+	// debugging the underlying root problem of the node if it goes away too soon.
+	// +optional
+	TTLSecondsAfterNotReady *int64 `json:"ttlSecondsAfterNotReady,omitempty"`
 	// TTLSecondsUntilExpired is the number of seconds the controller will wait
 	// before terminating a node, measured from when the node is created. This
 	// is useful to implement features like eventually consistent node upgrade,

--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -66,9 +66,9 @@ type ProvisionerSpec struct {
 	TTLSecondsAfterEmpty *int64 `json:"ttlSecondsAfterEmpty,omitempty"`
 	// TTLSecondsAfterNotReady is the number of seconds before a node that does not
 	// become Ready will be terminated. It is disabled if this field is not set,
-	// which means a node that joins the cluster but never become ready will cause
+	// which means a node that joins the cluster but never becomes Ready will cause
 	// pods assigned to the node to never start Running.
-	// Note: Seeing the TTL too low can hastily terminate nodes that otherwise would've
+	// Note: Setting the TTL too low can hastily terminate nodes that otherwise would've
 	// joined given some time, especially for large clusters. It may also hinder
 	// debugging the underlying root problem of the node if it goes away too soon.
 	// +optional

--- a/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
@@ -229,6 +229,11 @@ func (in *ProvisionerSpec) DeepCopyInto(out *ProvisionerSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.TTLSecondsAfterNotReady != nil {
+		in, out := &in.TTLSecondsAfterNotReady, &out.TTLSecondsAfterNotReady
+		*out = new(int64)
+		**out = **in
+	}
 	if in.TTLSecondsUntilExpired != nil {
 		in, out := &in.TTLSecondsUntilExpired, &out.TTLSecondsUntilExpired
 		*out = new(int64)

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -17,7 +17,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
@@ -37,7 +36,6 @@ import (
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/controllers/state"
-	"github.com/aws/karpenter/pkg/utils/injectabletime"
 	"github.com/aws/karpenter/pkg/utils/result"
 )
 
@@ -152,22 +150,4 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Complete(c)
-}
-
-// TriggerTerminationIfExpired is a helper function to be called by other controllers that want to trigger the
-// termination of nodes.
-func TriggerTerminationIfExpired(ctx context.Context, ttlSeconds int64, node *v1.Node, kubeClient client.Client,
-	reason string) (
-	time.Time, error) {
-	expirationTTL := time.Duration(ttlSeconds) * time.Second
-	expirationTime := node.CreationTimestamp.Add(expirationTTL)
-	if injectabletime.Now().After(expirationTime) {
-		logging.FromContext(ctx).Infof("Triggering termination for %s node after %s (+%s)",
-			reason, expirationTTL, time.Since(expirationTime))
-		if err := kubeClient.Delete(ctx, node); err != nil {
-			return expirationTime, fmt.Errorf("deleting node, %w", err)
-		}
-	}
-
-	return expirationTime, nil
 }

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -42,6 +42,7 @@ func (r *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 	if provisioner.Spec.TTLSecondsUntilExpired == nil {
 		return reconcile.Result{}, nil
 	}
+
 	// 2. Trigger termination workflow if expired
 	expirationTTL := time.Duration(ptr.Int64Value(provisioner.Spec.TTLSecondsUntilExpired)) * time.Second
 	expirationTime := node.CreationTimestamp.Add(expirationTTL)

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -51,6 +51,7 @@ func (r *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 			return reconcile.Result{}, fmt.Errorf("deleting node, %w", err)
 		}
 	}
+
 	// 3. Backoff until expired
 	return reconcile.Result{RequeueAfter: time.Until(expirationTime)}, nil
 }

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -19,25 +19,22 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
-
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
 	"golang.org/x/time/rate"
-	"knative.dev/pkg/logging"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/workqueue"
+	"knative.dev/pkg/logging"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/samber/lo"
 
 	provisioning "github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2021 

**Description**
A new optional field `TTLSecondsAfterNotReady` is added to the provisioner spec to provide an option to terminate nodes that never become ready after starting up within the TTL. 

**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
