### PR TITLE
Chore: Add a script to parse community contributors in each release

### DIFF
--- a/hack/github/community-contributors.sh
+++ b/hack/github/community-contributors.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -u
+
+TOKEN=$(cat $HOME/.git/token)
+
+RELEASES=$(
+    curl -s \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: token $TOKEN" \
+        https://api.github.com/repos/aws/karpenter/releases
+)
+LATEST=$(echo $RELEASES | jq -r ".[0].tag_name")
+PREVIOUS=$(echo $RELEASES | jq -r ".[1].tag_name")
+
+COMMITS=$(curl -s \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: token $TOKEN" \
+    https://api.github.com/repos/aws/karpenter/compare/$PREVIOUS...$LATEST)
+
+CONTRIBUTIONS=$(
+    echo $COMMITS | jq -r '
+    .commits
+    | sort_by(.commit.author.date)
+    | .[].commit
+    | {author: .author.name, message: (.message | split("\n")[0])}
+' | jq -s
+)
+NUM_CONTRIBUTIONS=$(echo $CONTRIBUTIONS | jq length)
+
+COMMUNITY_CONTRIBUTIONS=$(
+    echo $CONTRIBUTIONS | jq -r '
+    .[]
+    | select(
+        .author != "Ellis Tarn" and
+        .author != "Suket Sharma" and
+        .author != "Todd Neal" and
+        .author != "Nick Tran" and
+        .author != "Jason Deal" and
+        .author != "Ryan Maleki" and
+        .author != "Jonathan Innis" and
+        .author != "Brandon Wagner" and
+        .author != "Chris Negus" and
+        .author != "Jim DeWaard" and
+        .author != "dependabot[bot]"
+    )
+' | jq -s
+)
+
+NUM_COMMUNITY_CONTRIBUTIONS=$(echo $COMMUNITY_CONTRIBUTIONS | jq length)
+
+echo "Comparing $PREVIOUS and $LATEST"
+echo "Community members contributed $NUM_COMMUNITY_CONTRIBUTIONS/$NUM_CONTRIBUTIONS ($(awk "BEGIN {print (100*$NUM_COMMUNITY_CONTRIBUTIONS/$NUM_CONTRIBUTIONS)}")%) commits"
+echo $COMMUNITY_CONTRIBUTIONS | jq


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
```
./hack/github/community-contributors.sh
Comparing v0.13.2 and v0.14.0-rc.0
Community members contributed 13/134 (9.70149%)
[
  {
    "author": "flf2ko",
    "message": "fix: hostNetwork variable is not aligned with docs in Helm chart (#2043) (#2044)"
  },
  {
    "author": "Dan Shepard",
    "message": "docs: adding Omaze to list of adopters (#2068)"
  },
  {
    "author": "Vishal Vazkar",
    "message": "fix: helm version causing errors (#2096)"
  },
  {
    "author": "Ido Koren",
    "message": "add revisionHistoryLimit option to chart (#2102)"
  },
  {
    "author": "Bryant Biggs",
    "message": "feat: Update Terraform getting started guide to default to multi-cluster tagging scheme (#1668)"
  },
  {
    "author": "Shrikant Lavhate",
    "message": "Documentation update under 'getting started' section (#1788)"
  },
  {
    "author": "Fernando Miguel",
    "message": "typos (#2149)"
  },
  {
    "author": "Heiko Rothe",
    "message": "fix: consider pod density in memory overhead calc (#1960)"
  },
  {
    "author": "Shrikant Lavhate",
    "message": "Add capability to use custom podDisruptionBudget name (#2174)"
  },
  {
    "author": "gowtham",
    "message": "chore: add tyk cloud as an adopter (#2181)"
  },
  {
    "author": "juangascon",
    "message": "docs: Update api_version in helm provider (#2201)"
  },
  {
    "author": "James Wojewoda",
    "message": "docs: Update ADOPTERS file with Beeswax organization (#2208)"
  },
  {
    "author": "Enrique González",
    "message": "docs: fix misleading description on controller max-pods flag (#2148)"
  }
]
```
**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
