### PR TITLE
Test: Remove validation from test.Provisioner() since some tests test validation

### DIFF
--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"knative.dev/pkg/logging"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 )
@@ -85,13 +84,10 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 		}
 		provider, err := json.Marshal(options.Provider)
 		if err != nil {
-			panic(err)
+			panic(err.Error())
 		}
 		provisioner.Spec.Provider = &runtime.RawExtension{Raw: provider}
 	}
 	provisioner.SetDefaults(context.Background())
-	if err := provisioner.Validate(context.Background()); err != nil {
-		logging.FromContext(context.TODO()).Info("TODO: Fix the tests that cause this")
-	}
 	return provisioner
 }


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Some tests themselves test validation, so don't test inside of object construction. It's up to the test authors to construct valid test cases.

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
