### PR TITLE
chore: Add `make build` target alongside `make apply`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ build: ## Build the Karpenter controller and webhook images using ko build
 apply: build ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
 	helm upgrade --create-namespace --install karpenter charts/karpenter --namespace karpenter \
 		$(HELM_OPTS) \
-		--set controller.image=$(WEBHOOK_IMG) \
-		--set webhook.image=$(CONTROLLER_IMG)
+		--set controller.image=$(CONTROLLER_IMG) \
+		--set webhook.image=$(WEBHOOK_IMG)
 
 install:  ## Deploy the latest released version into your ~/.kube/config cluster
 	@echo Upgrading to $(shell grep version charts/karpenter/Chart.yaml)

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,15 @@ licenses: ## Verifies dependency licenses
 setup: ## Sets up the IAM roles needed prior to deploying the karpenter-controller. This command only needs to be run once
 	hack/setup-roles.sh
 
-apply: ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
+build: ## Build the Karpenter controller and webhook images using ko build
+	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/controller))
+	$(eval WEBHOOK_IMG=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/webhook))
+
+apply: build ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
 	helm upgrade --create-namespace --install karpenter charts/karpenter --namespace karpenter \
 		$(HELM_OPTS) \
-		--set controller.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/controller) \
-		--set webhook.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/webhook)
+		--set controller.image=$(WEBHOOK_IMG) \
+		--set webhook.image=$(CONTROLLER_IMG)
 
 install:  ## Deploy the latest released version into your ~/.kube/config cluster
 	@echo Upgrading to $(shell grep version charts/karpenter/Chart.yaml)

--- a/website/content/en/preview/contributing/development-guide.md
+++ b/website/content/en/preview/contributing/development-guide.md
@@ -48,6 +48,12 @@ make apply # quickly deploy changes to your cluster
 make dev # run codegen, lint, and tests
 ```
 
+If you are only interested in building the Karpenter images and not deploying the updated release to your cluster immediately with Helm, you can run
+
+```bash
+make build # build and push the karpenter images
+```
+
 ### Testing
 
 ```bash


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2225  <!-- issue number -->

**Description**

Adds another target for only building the controller and webhook images and pushing them without using helm to update the existing manifests 

**How was this change tested?**

* Running `make build` locally
* Running `make apply` locally

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
