### PR TITLE
fix: check instance state on termination failure

### DIFF
--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -43,12 +43,24 @@ var (
 
 type SpotFallbackError error
 
+type InstanceTerminatedError struct {
+	error
+}
+
 func isSpotFallback(err error) bool {
 	if err == nil {
 		return false
 	}
 	var sfbErr SpotFallbackError
 	return errors.As(err, &sfbErr)
+}
+
+func isInstanceTerminated(err error) bool {
+	if err == nil {
+		return false
+	}
+	var itErr InstanceTerminatedError
+	return errors.As(err, &itErr)
 }
 
 // isNotFound returns true if the err is an AWS error (even if it's

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -136,6 +136,7 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 			if skipInstance {
 				continue
 			}
+			instanceState := ec2.InstanceStateNameRunning
 			for i := 0; i < int(*input.TargetCapacitySpecification.TotalTargetCapacity); i++ {
 				instance := &ec2.Instance{
 					InstanceId:            aws.String(test.RandomName()),
@@ -143,6 +144,9 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 					PrivateDnsName:        aws.String(randomdata.IpV4Address()),
 					InstanceType:          input.LaunchTemplateConfigs[0].Overrides[0].InstanceType,
 					SpotInstanceRequestId: spotInstanceRequestID,
+					State: &ec2.InstanceState{
+						Name: &instanceState,
+					},
 				}
 				e.Instances.Store(*instance.InstanceId, instance)
 				instanceIds = append(instanceIds, instance.InstanceId)

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -125,6 +125,14 @@ func (p *InstanceProvider) Terminate(ctx context.Context, node *v1.Node) error {
 		if isNotFound(err) {
 			return nil
 		}
+		if _, errMsg := p.getInstance(ctx, aws.StringValue(id)); err != nil {
+			if isInstanceTerminated(errMsg) || isNotFound(errMsg) {
+				logging.FromContext(ctx).Debugf("Instance already terminated, %s", node.Name)
+				return nil
+			}
+			err = multierr.Append(err, errMsg)
+		}
+
 		return fmt.Errorf("terminating instance %s, %w", node.Name, err)
 	}
 	return nil
@@ -286,9 +294,12 @@ func (p *InstanceProvider) getInstance(ctx context.Context, id string) (*ec2.Ins
 		return nil, fmt.Errorf("failed to describe ec2 instances, %w", err)
 	}
 	if len(describeInstancesOutput.Reservations) != 1 || len(describeInstancesOutput.Reservations[0].Instances) != 1 {
-		return nil, fmt.Errorf("expected instance but got 0")
+		return nil, InstanceTerminatedError{fmt.Errorf("expected instance but got 0")}
 	}
 	instance := describeInstancesOutput.Reservations[0].Instances[0]
+	if *instance.State.Name == ec2.InstanceStateNameTerminated {
+		return nil, InstanceTerminatedError{fmt.Errorf("instance is in terminated state")}
+	}
 	if injection.GetOptions(ctx).GetAWSNodeNameConvention() == options.ResourceName {
 		return instance, nil
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

**Fixes** # <!-- issue number -->
#2100 and #1796

**Description**
If tag conditions are used in Karpenter IAM policies for the TerminateInstances action, Karpenter can get stuck in a loop trying to terminate instances which were previously terminated (and reaped) without Karpenter's knowledge.  This fix adds a step where if instance Termination fails, Karpenter will then try to call DescribeInstances to determine the instances state.  If the state is "terminated" or if the instance isn't found, then skip the TerminateInstance call and proceed with removing the node in K8S.

**How was this change tested?**
Manually reproduced the issue by adding tag conditions to the Karpenter IAM policies for the TerminateInstances action.  Then launched an instance with said tags.  Then, manually removed the tags from the instance.  This simulates the case where a terminated instance no longer has the tags required for Karpenter to terminate.

Next, manually deleted the node in K8S, which caused Karpenter to continuously attempt to delete the EC2 instance, but fails with an UnauthorizedException error (this is intended behavior).
```
2022-08-04T14:30:27.498Z	ERROR	controller.controller.termination	Reconciler error	{"commit": "d94b7ac", "reconciler group": "", "reconciler kind": "Node", "name": "ip-192-168-178-4.us-west-2.compute.internal", "namespace": "", "error": "terminating node ip-192-168-178-4.us-west-2.compute.internal, terminating cloudprovider instance, terminating instance ip-192-168-178-4.us-west-2.compute.internal, UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: <message>\n\tstatus code: 403, request id: <id>"}
```

Finally, manually terminated the EC2 instance, leaving it in "terminated" state.  The next time Karpenter tries to terminate the instance, it also calls DescribeInstances and sees the instance is "terminated".  Karpenter then skips the TerminateInstance call and removes the node object.
```
2022-08-04T14:32:20.144Z	DEBUG	controller.termination	Instance already terminated, ip-192-168-178-4.us-west-2.compute.internal	{"commit": "d94b7ac", "node": "ip-192-168-178-4.us-west-2.compute.internal"}
2022-08-04T14:32:20.162Z	INFO	controller.termination	Deleted node	{"commit": "d94b7ac", "node": "ip-192-168-178-4.us-west-2.compute.internal"}
2022-08-04T14:32:35.692Z	DEBUG	controller.aws.launchtemplate	Deleted launch template Karpenter-dewaard-karpenter-demo-9688201425030023995 (lt-0a942f88cae582d73)	{"commit": "d94b7ac"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds support for deleting a node for an EC2 instance which was manually Terminated without Karpenter's knowledge
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
