### PR TITLE
Fix: Don't attempt to drain terminal pods

### DIFF
--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -124,6 +124,10 @@ func (t *Terminator) getPods(ctx context.Context, node *v1.Node) ([]*v1.Pod, err
 	}
 	pods := []*v1.Pod{}
 	for _, p := range podList.Items {
+		// Ignore if the pod is complete and doesn't need to be evicted
+		if pod.IsTerminal(ptr.Pod(p)) {
+			continue
+		}
 		// Ignore if kubelet is partitioned and pods are beyond graceful termination window
 		if IsStuckTerminating(ptr.Pod(p)) {
 			continue


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Do not attempt to drain terminal pods. This helps resolve an issue where a disconnected node with terminal pods can get stuck.

Helping to merge @ese's change https://github.com/aws/karpenter/pull/2205

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
