### PR TITLE
fix: spot error type comparison

### DIFF
--- a/pkg/cloudprovider/aws/errors.go
+++ b/pkg/cloudprovider/aws/errors.go
@@ -41,7 +41,9 @@ var (
 	}
 )
 
-type SpotFallbackError error
+type SpotFallbackError struct {
+	error
+}
 
 type InstanceTerminatedError struct {
 	error

--- a/pkg/cloudprovider/aws/instance.go
+++ b/pkg/cloudprovider/aws/instance.go
@@ -207,8 +207,8 @@ func (p *InstanceProvider) checkODFallback(nodeRequest *cloudprovider.NodeReques
 		}
 	}
 	if len(instanceTypes) < safeSpotFallbackThreshold {
-		return SpotFallbackError(fmt.Errorf("at least %d instance types are required to perform spot to on-demand fallback, "+
-			"the current provisioning request only has %d instance type options", safeSpotFallbackThreshold, len(nodeRequest.InstanceTypeOptions)))
+		return SpotFallbackError{fmt.Errorf("at least %d instance types are required to perform spot to on-demand fallback, "+
+			"the current provisioning request only has %d instance type options", safeSpotFallbackThreshold, len(nodeRequest.InstanceTypeOptions))}
 	}
 	return nil
 }

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -555,7 +555,7 @@ var _ = Describe("Allocation", func() {
 				node := ExpectScheduled(ctx, env.Client, pod)
 				Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "inf1.6xlarge"))
 			})
-			It("should launch on-demand capacity if flexible to both spot and on-demand, but spot if unavailable", func() {
+			It("should launch on-demand capacity if flexible to both spot and on-demand, but spot is unavailable", func() {
 				safeSpotFallbackThreshold = 4
 				fakeEC2API.DescribeInstanceTypesPagesWithContext(ctx, &ec2.DescribeInstanceTypesInput{}, func(dito *ec2.DescribeInstanceTypesOutput, b bool) bool {
 					for _, it := range dito.InstanceTypes {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->
N/A

**Description**
 - Fixes an issue in the type comparison for identifying a spot flexibility error where the type was actually `errors.ErrorString` rather than SpotFallbackError. This would cause a `launchInstance` retry and constrain requirements to just spot even if on-demand was a valid requirement. This could also cause Spot to become a requirement if there was an error other than `LaunchTemplateNotFound` returned by `launchInstance` even if the provisioner was not flexible to Spot. 

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
