### PR TITLE
Pull released images through pull through cache

### DIFF
--- a/hack/add-snapshot-tag.sh
+++ b/hack/add-snapshot-tag.sh
@@ -29,4 +29,5 @@ tagRelease() {
 
 authenticate
 tagAllRepositories
+pullPrivateReplica $RELEASE_TYPE $NEW_TAG
 notifyRelease $RELEASE_TYPE $NEW_TAG

--- a/hack/release_common.sh
+++ b/hack/release_common.sh
@@ -64,10 +64,4 @@ pullPrivateReplica(){
   PULL_THROUGH_CACHE_PATH="${PRIVATE_PULL_THROUGH_HOST}/ecr-public/karpenter/"
   docker pull "${PULL_THROUGH_CACHE_PATH}controller:${RELEASE_IDENTIFIER}"
   docker pull "${PULL_THROUGH_CACHE_PATH}webhook:${RELEASE_IDENTIFIER}"
-
-  if [[ $RELEASE_TYPE == "snapshot" ]]; then
-      docker pull "${PULL_THROUGH_CACHE_PATH}karpenter:v${CURRENT_MAJOR_VERSION}-${RELEASE_IDENTIFIER}"
-  else
-      docker pull "${PULL_THROUGH_CACHE_PATH}karpenter:${RELEASE_IDENTIFIER}"
-  fi
 }

--- a/hack/snapshot.sh
+++ b/hack/snapshot.sh
@@ -33,5 +33,6 @@ authenticate
 buildImages $HELM_CHART_VERSION
 cosignImages
 publishHelmChart
-notifyRelease "snapshot" $HELM_CHART_VERSION
 notifyIfStableRelease
+notifyRelease "snapshot" $HELM_CHART_VERSION
+pullPrivateReplica "snapshot" $SNAPSHOT_TAG

--- a/hack/snapshot.sh
+++ b/hack/snapshot.sh
@@ -34,5 +34,5 @@ buildImages $HELM_CHART_VERSION
 cosignImages
 publishHelmChart
 notifyIfStableRelease
-notifyRelease "snapshot" $HELM_CHART_VERSION
 pullPrivateReplica "snapshot" $SNAPSHOT_TAG
+notifyRelease "snapshot" $HELM_CHART_VERSION


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Pulls the images that were published for verification and activating pull through cache: https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
