### PR TITLE
perf: add retry logic to image pull

### DIFF
--- a/hack/release_common.sh
+++ b/hack/release_common.sh
@@ -62,6 +62,18 @@ pullPrivateReplica(){
   RELEASE_TYPE=$1
   RELEASE_IDENTIFIER=$2
   PULL_THROUGH_CACHE_PATH="${PRIVATE_PULL_THROUGH_HOST}/ecr-public/karpenter/"
-  docker pull "${PULL_THROUGH_CACHE_PATH}controller:${RELEASE_IDENTIFIER}"
-  docker pull "${PULL_THROUGH_CACHE_PATH}webhook:${RELEASE_IDENTIFIER}"
+
+  pullWithRetry "${PULL_THROUGH_CACHE_PATH}controller:${RELEASE_IDENTIFIER}"
+  pullWithRetry "${PULL_THROUGH_CACHE_PATH}webhook:${RELEASE_IDENTIFIER}"
+}
+
+pullWithRetry(){
+  PULL_PATH=$1
+  n=0
+    until [ "$n" -ge 5 ]
+    do
+       docker pull "${PULL_PATH}" && break
+       n=$((n+1))
+       sleep 10
+    done
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
It seems like sometimes the pull fails, attempting a retry logic to see if it's because the image publishing process is not atomic.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
