### PR TITLE
fix: only count active pods towards node requests

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -255,10 +255,12 @@ func (c *Cluster) populateResourceRequests(ctx context.Context, node *v1.Node, n
 	var daemonsetLimits []v1.ResourceList
 	for i := range pods.Items {
 		pod := &pods.Items[i]
+		if podutils.IsTerminal(pod) {
+			continue
+		}
 		requests := resources.RequestsForPods(pod)
 		podLimits := resources.LimitsForPods(pod)
 		podKey := client.ObjectKeyFromObject(pod)
-
 		n.podRequests[podKey] = requests
 		n.podLimits[podKey] = podLimits
 		c.bindings[podKey] = n.Node.Name


### PR DESCRIPTION
**Description**
https://github.com/aws/karpenter/pull/2212

**How was this change tested?**

* Created a job with Resource requests and completions: 1000. Confirmed that resource metrics remained the same over the course of jobs completing.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
