### PR TITLE
[docs] add provisioner examples with EBS

### DIFF
--- a/examples/provisioner/bottlerocket.yaml
+++ b/examples/provisioner/bottlerocket.yaml
@@ -30,4 +30,3 @@ spec:
         volumeType: gp3
         volumeSize: ${volumeSize} # replace with your required disk size
         deleteOnTermination: true
-  tags: ${tags}

--- a/examples/provisioner/bottlerocket.yaml
+++ b/examples/provisioner/bottlerocket.yaml
@@ -28,5 +28,5 @@ spec:
     - deviceName: /dev/xvdb
       ebs:
         volumeType: gp3
-        volumeSize: ${volumeSize} # replace with your required disk size
+        volumeSize: 20G # replace with your required disk size
         deleteOnTermination: true

--- a/examples/provisioner/multiple-ebs.yaml
+++ b/examples/provisioner/multiple-ebs.yaml
@@ -27,7 +27,7 @@ spec:
     karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelector:
     karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
-  amiFamily: Ubuntu
+  amiFamily: AL2
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:

--- a/examples/provisioner/multiple-ebs.yaml
+++ b/examples/provisioner/multiple-ebs.yaml
@@ -43,4 +43,4 @@ spec:
       ebs:
         volumeType: gp3
         volumeSize: 2000Gi
-        deleteOnTermination: false
+        deleteOnTermination: true

--- a/examples/provisioner/multiple-ebs.yaml
+++ b/examples/provisioner/multiple-ebs.yaml
@@ -1,11 +1,20 @@
 # This example provisioner will provision instances
-# running Bottlerocket OS
+# with multiple EBS attached
 
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
   name: default
 spec:
+  requirements:
+    # Include general purpose instance families
+    - key: karpenter.k8s.aws/instance-family
+      operator: In
+      values: [c6g, c7g, c6a, c6i, m6a, m6g, m6i, r6a, r6g, r6i]
+    # Exclude small instance sizes
+    - key: karpenter.k8s.aws/instance-size
+      operator: In
+      values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge]
   providerRef:
     name: my-provider
 ---
@@ -14,20 +23,24 @@ kind: AWSNodeTemplate
 metadata:
   name: my-provider
 spec:
-  amiFamily: Bottlerocket
   subnetSelector:
     karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelector:
     karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  amiFamily: Ubuntu
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:
         volumeType: gp3
-        volumeSize: 2Gi
+        volumeSize: 20Gi
         deleteOnTermination: true
     - deviceName: /dev/xvdb
       ebs:
         volumeType: gp3
-        volumeSize: ${volumeSize} # replace with your required disk size
+        volumeSize: 100Gi
         deleteOnTermination: true
-  tags: ${tags}
+    - deviceName: /dev/xvdc
+      ebs:
+        volumeType: gp3
+        volumeSize: 2000Gi
+        deleteOnTermination: false


### PR DESCRIPTION
Signed-off-by: Fernando Miguel <github@FernandoMiguel.net>

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

Fixes #1100

**Description**
adds provisioner examples with EBS

**How was this change tested?**

*

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds two examples of provisioner with EBS volumes. One for Bottlerocket (root and data) and one with multiple EBS
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
