### PR TITLE
Fix: Support Region and Normalized Labels

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -58,6 +58,7 @@ var (
 	// the range of the corresponding values by either provisioner or pods.
 	WellKnownLabels = sets.NewString(
 		v1.LabelTopologyZone,
+		v1.LabelTopologyRegion,
 		v1.LabelInstanceTypeStable,
 		v1.LabelArchStable,
 		v1.LabelOSStable,
@@ -80,11 +81,6 @@ var (
 		v1.LabelInstanceType:            v1.LabelInstanceTypeStable,
 		v1.LabelFailureDomainBetaRegion: v1.LabelTopologyRegion,
 	}
-	// IgnoredLables are not considered in scheduling decisions
-	// and prevent validation errors when specified
-	IgnoredLabels = sets.NewString(
-		v1.LabelTopologyRegion,
-	)
 )
 
 // IsRestrictedLabel returns an error if the label is restricted.

--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -169,6 +169,9 @@ func (s *ProvisionerSpec) validateProvider() *apis.FieldError {
 
 func ValidateRequirement(requirement v1.NodeSelectorRequirement) error { //nolint:gocyclo
 	var errs error
+	if normalized, ok := NormalizedLabels[requirement.Key]; ok {
+		requirement.Key = normalized
+	}
 	if !SupportedNodeSelectorOps.Has(string(requirement.Operator)) {
 		errs = multierr.Append(errs, fmt.Errorf("key %s has an unsupported operator %s not in %s", requirement.Key, requirement.Operator, SupportedNodeSelectorOps.UnsortedList()))
 	}

--- a/pkg/cloudprovider/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudprovider/aws/apis/v1alpha1/register.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/samber/lo"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 )
@@ -72,16 +71,6 @@ var (
 	LabelInstanceGPUManufacturer = LabelDomain + "/instance-gpu-manufacturer"
 	LabelInstanceGPUCount        = LabelDomain + "/instance-gpu-count"
 	LabelInstanceGPUMemory       = LabelDomain + "/instance-gpu-memory"
-
-	// Deprecated labels. Use the - notation above instead. Very sad.
-	LabelInstanceFamilyDeprecated          = LabelDomain + "/instance.family"
-	LabelInstanceSizeDeprecated            = LabelDomain + "/instance.size"
-	LabelInstanceCPUDeprecated             = LabelDomain + "/instance.cpu"
-	LabelInstanceMemoryDeprecated          = LabelDomain + "/instance.memory"
-	LabelInstanceGPUNameDeprecated         = LabelDomain + "/instance.gpu.name"
-	LabelInstanceGPUManufacturerDeprecated = LabelDomain + "/instance.gpu.manufacturer"
-	LabelInstanceGPUCountDeprecated        = LabelDomain + "/instance.gpu.count"
-	LabelInstanceGPUMemoryDeprecated       = LabelDomain + "/instance.gpu.memory"
 )
 
 var (
@@ -107,14 +96,4 @@ func init() {
 		LabelInstanceGPUCount,
 		LabelInstanceGPUMemory,
 	)
-	v1alpha5.NormalizedLabels = lo.Assign(v1alpha5.NormalizedLabels, map[string]string{
-		LabelInstanceFamilyDeprecated:          LabelInstanceFamily,
-		LabelInstanceSizeDeprecated:            LabelInstanceSize,
-		LabelInstanceCPUDeprecated:             LabelInstanceCPU,
-		LabelInstanceMemoryDeprecated:          LabelInstanceMemory,
-		LabelInstanceGPUNameDeprecated:         LabelInstanceGPUName,
-		LabelInstanceGPUManufacturerDeprecated: LabelInstanceGPUManufacturer,
-		LabelInstanceGPUCountDeprecated:        LabelInstanceGPUCount,
-		LabelInstanceGPUMemoryDeprecated:       LabelInstanceGPUMemory,
-	})
 }

--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -71,7 +71,6 @@ var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)
 
 type CloudProvider struct {
 	instanceTypeProvider *InstanceTypeProvider
-	subnetProvider       *SubnetProvider
 	instanceProvider     *InstanceProvider
 	kubeClient           k8sClient.Client
 }
@@ -101,12 +100,9 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *Cloud
 		logging.FromContext(ctx).Errorf("Checking EC2 API connectivity, %s", err)
 	}
 	subnetProvider := NewSubnetProvider(ec2api)
-	pricingProvider := NewPricingProvider(ctx, NewPricingAPI(sess, *sess.Config.Region), ec2api, *sess.Config.Region,
-		injection.GetOptions(ctx).AWSIsolatedVPC, options.StartAsync)
-	instanceTypeProvider := NewInstanceTypeProvider(ec2api, subnetProvider, pricingProvider)
+	instanceTypeProvider := NewInstanceTypeProvider(ctx, sess, options, ec2api, subnetProvider)
 	cloudprovider := &CloudProvider{
 		instanceTypeProvider: instanceTypeProvider,
-		subnetProvider:       subnetProvider,
 		instanceProvider: NewInstanceProvider(ctx, ec2api, instanceTypeProvider, subnetProvider,
 			NewLaunchTemplateProvider(
 				ctx,

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -45,7 +45,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "knative.dev/pkg/logging/testing"
-	
+
 	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider"
@@ -129,7 +129,6 @@ var _ = BeforeSuite(func() {
 		}
 		clientSet = kubernetes.NewForConfigOrDie(e.Config)
 		cloudProvider = &CloudProvider{
-			subnetProvider:       subnetProvider,
 			instanceTypeProvider: instanceTypeProvider,
 			instanceProvider: NewInstanceProvider(ctx, fakeEC2API, instanceTypeProvider, subnetProvider, &LaunchTemplateProvider{
 				ec2api:                fakeEC2API,
@@ -392,7 +391,7 @@ var _ = Describe("Allocation", func() {
 				Expect(err).To(BeNil())
 				provisioner := test.Provisioner()
 				for _, info := range instanceInfo {
-					it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					resources := it.Resources()
 					Expect(resources.Pods().Value()).To(BeNumerically("==", 110))
 				}
@@ -403,7 +402,7 @@ var _ = Describe("Allocation", func() {
 				Expect(err).To(BeNil())
 				provisioner := test.Provisioner()
 				for _, info := range instanceInfo {
-					it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					resources := it.Resources()
 					Expect(resources.Pods().Value()).ToNot(BeNumerically("==", 110))
 				}
@@ -415,7 +414,7 @@ var _ = Describe("Allocation", func() {
 					provider.AMIFamily = &awsv1alpha1.AMIFamilyAL2
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
 					Expect(err).To(BeNil())
-					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 				})
@@ -425,7 +424,7 @@ var _ = Describe("Allocation", func() {
 					provider.AMIFamily = &awsv1alpha1.AMIFamilyAL2
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
 					Expect(err).To(BeNil())
-					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 				})
@@ -437,7 +436,7 @@ var _ = Describe("Allocation", func() {
 					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
 					Expect(err).To(BeNil())
-					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 				})
@@ -447,7 +446,7 @@ var _ = Describe("Allocation", func() {
 					provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
 					instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
 					Expect(err).To(BeNil())
-					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("1665Mi"))
 				})
@@ -463,7 +462,7 @@ var _ = Describe("Allocation", func() {
 							},
 						},
 					})
-					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					overhead := it.Overhead()
 					Expect(overhead.Cpu().String()).To(Equal("2080m"))
 				})
@@ -477,7 +476,7 @@ var _ = Describe("Allocation", func() {
 							},
 						},
 					})
-					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+					it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 					overhead := it.Overhead()
 					Expect(overhead.Memory().String()).To(Equal("21473Mi"))
 				})
@@ -486,7 +485,7 @@ var _ = Describe("Allocation", func() {
 					Expect(err).To(BeNil())
 					provisioner := test.Provisioner(test.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{MaxPods: ptr.Int32(10)}})
 					for _, info := range instanceInfo {
-						it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+						it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 						resources := it.Resources()
 						Expect(resources.Pods().Value()).To(BeNumerically("==", 10))
 					}
@@ -497,7 +496,7 @@ var _ = Describe("Allocation", func() {
 					Expect(err).To(BeNil())
 					provisioner := test.Provisioner(test.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{MaxPods: ptr.Int32(10)}})
 					for _, info := range instanceInfo {
-						it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, provider, nil)
+						it := NewInstanceType(injection.WithOptions(ctx, opts), info, provisioner.Spec.KubeletConfiguration, 0, "", provider, nil)
 						resources := it.Resources()
 						Expect(resources.Pods().Value()).To(BeNumerically("==", 10))
 					}

--- a/pkg/scheduling/requirement_test.go
+++ b/pkg/scheduling/requirement_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -39,6 +40,44 @@ var _ = Describe("Requirement", func() {
 	greaterThan9 := NewRequirement("key", v1.NodeSelectorOpGt, "9")
 	lessThan1 := NewRequirement("key", v1.NodeSelectorOpLt, "1")
 	lessThan9 := NewRequirement("key", v1.NodeSelectorOpLt, "9")
+
+	Context("NewRequirements", func() {
+		It("should normalize labels", func() {
+			nodeSelector := map[string]string{
+				v1.LabelFailureDomainBetaZone:   "test",
+				v1.LabelFailureDomainBetaRegion: "test",
+				"beta.kubernetes.io/arch":       "test",
+				"beta.kubernetes.io/os":         "test",
+				v1.LabelInstanceType:            "test",
+			}
+			requirements := lo.MapToSlice(nodeSelector, func(key string, value string) v1.NodeSelectorRequirement {
+				return v1.NodeSelectorRequirement{Key: key, Operator: v1.NodeSelectorOpIn, Values: []string{value}}
+			})
+			for _, r := range []Requirements{
+				NewLabelRequirements(nodeSelector),
+				NewNodeSelectorRequirements(requirements...),
+				NewPodRequirements(&v1.Pod{
+					Spec: v1.PodSpec{
+						NodeSelector: nodeSelector,
+						Affinity: &v1.Affinity{
+							NodeAffinity: &v1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{MatchExpressions: requirements}}},
+								PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{{Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: requirements}}},
+							},
+						},
+					},
+				}),
+			} {
+				Expect(r.Keys().List()).To(ConsistOf(
+					v1.LabelArchStable,
+					v1.LabelOSStable,
+					v1.LabelInstanceTypeStable,
+					v1.LabelTopologyRegion,
+					v1.LabelTopologyZone,
+				))
+			}
+		})
+	})
 
 	Context("Intersection", func() {
 		It("should intersect sets", func() {

--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -41,7 +41,7 @@ func NewRequirements(requirements ...*Requirement) Requirements {
 
 // NewRequirements constructs requirements from NodeSelectorRequirements
 func NewNodeSelectorRequirements(requirements ...v1.NodeSelectorRequirement) Requirements {
-	r := Requirements{}
+	r := NewRequirements()
 	for _, requirement := range requirements {
 		r.Add(NewRequirement(requirement.Key, requirement.Operator, requirement.Values...))
 	}
@@ -50,7 +50,7 @@ func NewNodeSelectorRequirements(requirements ...v1.NodeSelectorRequirement) Req
 
 // NewLabelRequirements constructs requirements from labels
 func NewLabelRequirements(labels map[string]string) Requirements {
-	requirements := Requirements{}
+	requirements := NewRequirements()
 	for key, value := range labels {
 		requirements.Add(NewRequirement(key, v1.NodeSelectorOpIn, value))
 	}

--- a/pkg/scheduling/requirements_test.go
+++ b/pkg/scheduling/requirements_test.go
@@ -15,7 +15,6 @@ limitations under the License.
 package scheduling
 
 import (
-	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -25,13 +24,8 @@ var _ = Describe("Requirements", func() {
 	Context("Compatibility", func() {
 		It("should normalize aliased labels", func() {
 			requirements := NewRequirements(NewRequirement(v1.LabelFailureDomainBetaZone, v1.NodeSelectorOpIn, "test"))
+			Expect(requirements.Has(v1.LabelFailureDomainBetaZone)).To(BeFalse())
 			Expect(requirements.Get(v1.LabelTopologyZone).Has("test")).To(BeTrue())
-		})
-		It("should ignore labels in IgnoredLabels", func() {
-			for label := range v1alpha5.IgnoredLabels {
-				requirements := NewRequirements(NewRequirement(v1.LabelFailureDomainBetaZone, v1.NodeSelectorOpIn, "test"))
-				Expect(requirements.Has(label)).To(BeFalse())
-			}
 		})
 
 		// Use a well known label like zone, because it behaves differently than custom labels

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -1,18 +1,70 @@
 package integration_test
 
 import (
+	"fmt"
+
 	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/test"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-
-var _ = Describe("Scheduling Conformance", func() {
+var _ = Describe("Scheduling", func() {
+	It("should support well known labels", func() {
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		nodeSelector := map[string]string{
+			// Well Known
+			v1.LabelTopologyRegion:     env.Region,
+			v1.LabelTopologyZone:       fmt.Sprintf("%sa", env.Region),
+			v1.LabelInstanceTypeStable: "g4dn.8xlarge",
+			v1.LabelOSStable:           "linux",
+			v1.LabelArchStable:         "amd64",
+			v1alpha5.LabelCapacityType: "on-demand",
+			// Well Known to AWS
+			awsv1alpha1.LabelInstanceHypervisor:      "nitro",
+			awsv1alpha1.LabelInstanceCategory:        "g",
+			awsv1alpha1.LabelInstanceGeneration:      "4",
+			awsv1alpha1.LabelInstanceFamily:          "g4dn",
+			awsv1alpha1.LabelInstanceSize:            "8xlarge",
+			awsv1alpha1.LabelInstanceCPU:             "32",
+			awsv1alpha1.LabelInstanceMemory:          "131072",
+			awsv1alpha1.LabelInstancePods:            "58", // May vary w/ environment
+			awsv1alpha1.LabelInstanceGPUName:         "t4",
+			awsv1alpha1.LabelInstanceGPUManufacturer: "nvidia",
+			awsv1alpha1.LabelInstanceGPUCount:        "1",
+			awsv1alpha1.LabelInstanceGPUMemory:       "16384",
+			awsv1alpha1.LabelInstanceLocalNVME:       "900",
+			// Deprecated Labels
+			v1.LabelFailureDomainBetaZone:   fmt.Sprintf("%sa", env.Region),
+			v1.LabelFailureDomainBetaRegion: env.Region,
+			"beta.kubernetes.io/arch":       "amd64",
+			"beta.kubernetes.io/os":         "linux",
+			v1.LabelInstanceType:            "g4dn.8xlarge",
+		}
+		requirements := lo.MapToSlice(nodeSelector, func(key string, value string) v1.NodeSelectorRequirement {
+			return v1.NodeSelectorRequirement{Key: key, Operator: v1.NodeSelectorOpIn, Values: []string{value}}
+		})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: 1, PodOptions: test.PodOptions{
+			NodeSelector: nodeSelector,
+			NodePreferences: requirements,
+			NodeRequirements: requirements,
+		}})
+		// Ensure that we're exercising all well known labels
+		Expect(lo.Keys(nodeSelector)).To(ContainElements(append(v1alpha5.WellKnownLabels.UnsortedList(), lo.Keys(v1alpha5.NormalizedLabels)...)))
+		env.ExpectCreated(provisioner, provider, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
+		env.ExpectCreatedNodeCount("==", 1)
+	})
 	It("should provision a node for naked pods", func() {
 		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},

--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -17,9 +17,6 @@ import (
 )
 
 var _ = Describe("Subnets", func() {
-	BeforeEach(func() {
-
-	})
 
 	It("should use the subnet-id selector", func() {
 		subnets := getSubnets(map[string]string{"karpenter.sh/discovery": env.ClusterName})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2289

**Description**

- Fixes an issue where validation logic didn't include normalization, preventing scheduling
- Removed the concept of IgnoredLabels, in favor of simply supporting them in the cloud provider
- From the test, I discovered that AWS deprecated have been broken for a while. They were only released for a few days, so I removed them entirely.
**How was this change tested?**

* `make test`
* `make e2etest`

```
• [SLOW TEST:97.744 seconds]
Scheduling
/Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:18
  should support well known labels
  /Users/etarn/workspaces/go/src/github.com/aws/karpenter/test/suites/integration/scheduling_test.go:19
------------------------------
SSSSSSSSSSSSS
Ran 1 of 21 Specs in 99.470 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 20 Skipped
PASS | FOCUSED
FAIL	github.com/aws/karpenter/test/suites/integration	100.198s
testing: warning: no tests to run
PASS
ok  	github.com/aws/karpenter/test/suites/utilization	0.707s [no tests to run]
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
