### PR TITLE
test: Fixed node flakes

### DIFF
--- a/test/suites/integration/ttl_test.go
+++ b/test/suites/integration/ttl_test.go
@@ -68,9 +68,13 @@ var _ = Describe("TTL Expired", func() {
 
 		createdNodes := env.GetCreatedNodes(beforeNodes, env.Monitor.GetNodes())
 
-		persisted := provisioner.DeepCopy()
+		persistedDep := deployment.DeepCopy()
+		deployment.Spec.Replicas = ptr.Int32(0)
+		Expect(env.Client.Patch(env, deployment, client.MergeFrom(persistedDep))).To(Succeed())
+
+		persistedProv := provisioner.DeepCopy()
 		provisioner.Spec.TTLSecondsUntilExpired = ptr.Int64(10)
-		Expect(env.Client.Patch(env, provisioner, client.MergeFrom(persisted))).To(Succeed())
+		Expect(env.Client.Patch(env, provisioner, client.MergeFrom(persistedProv))).To(Succeed())
 
 		env.ExpectNodesEventuallyDeleted(120*time.Second, createdNodes...)
 	})


### PR DESCRIPTION
**Description**
Fixes flake for test/suites/integration TTL Expired test to prevent node recreation.
**How was this change tested?**

* `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
