### PR TITLE
test: deflake consolidation replace e2e test

### DIFF
--- a/test/pkg/environment/monitor.go
+++ b/test/pkg/environment/monitor.go
@@ -12,6 +12,7 @@ import (
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/utils/resources"
 )
 
@@ -182,6 +183,10 @@ func (m *Monitor) nodeUtilization(resource v1.ResourceName) []float64 {
 	var utilization []float64
 	for nodeName, requests := range st.nodeRequests {
 		allocatable := st.nodes[nodeName].Status.Allocatable[resource]
+		// skip any nodes we didn't launch
+		if _, ok := st.nodes[nodeName].Labels[v1alpha5.ProvisionerNameLabelKey]; !ok {
+			continue
+		}
 		if allocatable.IsZero() {
 			continue
 		}

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -195,20 +195,29 @@ var _ = Describe("Consolidation", func() {
 		env.ExpectUpdate(provisioner)
 
 		// With consolidation enabled, we now must replace each node in turn to consolidate due to the anti-affinity
-		// rules on the smaller deployment.  The large nodes should go to a medium
-		env.EventuallyExpectAvgUtilization(v1.ResourceCPU, ">", 0.6)
+		// rules on the smaller deployment.  The 2xl nodes should go to a large
+		env.EventuallyExpectAvgUtilization(v1.ResourceCPU, ">", 0.8)
 
 		var nodes v1.NodeList
 		Expect(env.Client.List(env.Context, &nodes)).To(Succeed())
 		numLargeNodes := 0
+		numOtherNodes := 0
 		for _, n := range nodes.Items {
+			// only count the nodes created by the provisoiner
+			if n.Labels[v1alpha5.ProvisionerNameLabelKey] != provisioner.Name {
+				continue
+			}
 			if strings.HasSuffix(n.Labels[v1.LabelInstanceTypeStable], ".large") {
 				numLargeNodes++
+			} else {
+				numOtherNodes++
 			}
 		}
 
-		// all of the nodes should have been replaced with medium instance types
+		// all of the 2xlarge nodes should have been replaced with large instance types
 		Expect(numLargeNodes).To(Equal(3))
+		// and we should have no other nodes
+		Expect(numOtherNodes).To(Equal(0))
 
 		env.ExpectDeleted(largeDep, smallDep)
 	})


### PR DESCRIPTION
**Description**

The E2E test would fail if your system nodes happened to be .large types.  Filter on the provisioner name to avoid this.

**How was this change tested?**

* Ran the consolidation E2E tests multiple times.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
