### PR TITLE
test: fix security groups used in tests

### DIFF
--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/karpenter/pkg/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 )
 
 var _ = Describe("Subnets", func() {
@@ -22,9 +24,10 @@ var _ = Describe("Subnets", func() {
 		securityGroups := getSecurityGroups(map[string]string{"karpenter.sh/discovery": env.ClusterName})
 		Expect(len(securityGroups)).ToNot(Equal(0))
 
+		ids := strings.Join(lo.Map(securityGroups, func(sg ec2.GroupIdentifier, _ int) string  {return *sg.GroupId}), ",")
 		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 			AWS: awsv1alpha1.AWS{
-				SecurityGroupSelector: map[string]string{"aws-ids": *securityGroups[0].GroupId},
+				SecurityGroupSelector: map[string]string{"aws-ids": ids},
 				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			},
 		})


### PR DESCRIPTION
**Description**
This changes our Security groups test to use all security group ids that fit the tag filters.

**How was this change tested?**

* ran `make e2etests` locally

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
