### PR TITLE
test: fix upgrade tests

### DIFF
--- a/test/suites/upgrade/pipeline.yaml
+++ b/test/suites/upgrade/pipeline.yaml
@@ -9,7 +9,7 @@ spec:
       default: $(context.pipelineRun.namespace)-$(context.pipelineRun.name)
       description: Uniquely identifies a cluster name for the suite.
     - name: from-git-ref
-      default: v0.13.2
+      default: v0.15.0
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
     - name: to-git-ref
       default: HEAD
@@ -35,7 +35,7 @@ spec:
     - name: cluster-name
       value: $(params.cluster-name)
     - name: git-ref
-      value: $(params.to-git-ref)
+      value: $(params.from-git-ref)
     - name: test-filter
       value: TestIntegration
     runAfter:


### PR DESCRIPTION
**Description**
Fixes the upgrade tests to run the from-git-ref tests first
**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
