### PR TITLE
Fix setting `karpenter.sh/provisioner-name` to nodeSelector causes an error

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -90,7 +90,7 @@ func IsRestrictedLabel(key string) error {
 		return nil
 	}
 	if IsRestrictedNodeLabel(key) {
-		return fmt.Errorf("label %s is restricted; specify a well known label: %v, or a custom label that does use a restricted domain: %v", key, WellKnownLabels.List(), RestrictedLabelDomains.List())
+		return fmt.Errorf("label %s is restricted; specify a well known label: %v, or a custom label that does not use a restricted domain: %v", key, WellKnownLabels.List(), RestrictedLabelDomains.List())
 	}
 	return nil
 }

--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -63,6 +63,7 @@ var (
 		v1.LabelArchStable,
 		v1.LabelOSStable,
 		LabelCapacityType,
+		ProvisionerNameLabelKey,
 	)
 
 	// RestrictedLabels are labels that should not be used

--- a/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner_validation.go
@@ -89,6 +89,9 @@ func (s *ProvisionerSpec) Validate(ctx context.Context) (errs *apis.FieldError) 
 
 func (s *ProvisionerSpec) validateLabels() (errs *apis.FieldError) {
 	for key, value := range s.Labels {
+		if key == ProvisionerNameLabelKey {
+			errs = errs.Also(apis.ErrInvalidKeyName(key, "labels", "restricted"))
+		}
 		for _, err := range validation.IsQualifiedName(key) {
 			errs = errs.Also(apis.ErrInvalidKeyName(key, "labels", err))
 		}
@@ -153,6 +156,9 @@ func (s *ProvisionerSpec) validateTaintsField(taints []v1.Taint, existing map[ta
 // Provisioner requirements only support well known labels.
 func (s *ProvisionerSpec) validateRequirements() (errs *apis.FieldError) {
 	for i, requirement := range s.Requirements {
+		if requirement.Key == ProvisionerNameLabelKey {
+			errs = errs.Also(apis.ErrInvalidArrayValue(fmt.Sprintf("%s is restricted", requirement.Key), "requirements", i))
+		}
 		if err := ValidateRequirement(requirement); err != nil {
 			errs = errs.Also(apis.ErrInvalidArrayValue(err, "requirements", i))
 		}

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -29,6 +29,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var ctx context.Context
@@ -112,6 +113,10 @@ var _ = Describe("Validation", func() {
 			provisioner.Spec.Labels = map[string]string{"spaces are not allowed": randomdata.SillyName()}
 			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
+		It("should fail for the provisioner name label", func() {
+			provisioner.Spec.Labels = map[string]string{ProvisionerNameLabelKey: randomdata.SillyName()}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+		})
 		It("should fail for invalid label values", func() {
 			provisioner.Spec.Labels = map[string]string{randomdata.SillyName(): "/ is not allowed"}
 			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
@@ -186,7 +191,13 @@ var _ = Describe("Validation", func() {
 			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
 	})
-	Context("Validation", func() {
+	Context("Requirements", func() {
+		It("should fail for the provisioner name label", func() {
+			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+				{Key: ProvisionerNameLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{randomdata.SillyName()}},
+			}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+		})
 		It("should allow supported ops", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
@@ -222,7 +233,7 @@ var _ = Describe("Validation", func() {
 			}
 		})
 		It("should allow well known label exceptions", func() {
-			for label := range WellKnownLabels {
+			for label := range WellKnownLabels.Difference(sets.NewString(ProvisionerNameLabelKey)) {
 				provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 					{Key: label, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
 				}

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -21,14 +21,16 @@ var _ = Describe("Scheduling", func() {
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ObjectMeta: metav1.ObjectMeta{Name: provider.Name}, ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 		nodeSelector := map[string]string{
 			// Well Known
-			v1.LabelTopologyRegion:     env.Region,
-			v1.LabelTopologyZone:       fmt.Sprintf("%sa", env.Region),
-			v1.LabelInstanceTypeStable: "g4dn.8xlarge",
-			v1.LabelOSStable:           "linux",
-			v1.LabelArchStable:         "amd64",
-			v1alpha5.LabelCapacityType: "on-demand",
+			v1.LabelTopologyRegion:           env.Region,
+			v1.LabelTopologyZone:             fmt.Sprintf("%sa", env.Region),
+			v1.LabelInstanceTypeStable:       "g4dn.8xlarge",
+			v1.LabelOSStable:                 "linux",
+			v1.LabelArchStable:               "amd64",
+			v1alpha5.LabelCapacityType:       "on-demand",
+			v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 			// Well Known to AWS
 			awsv1alpha1.LabelInstanceHypervisor:      "nitro",
 			awsv1alpha1.LabelInstanceCategory:        "g",
@@ -53,7 +55,6 @@ var _ = Describe("Scheduling", func() {
 		requirements := lo.MapToSlice(nodeSelector, func(key string, value string) v1.NodeSelectorRequirement {
 			return v1.NodeSelectorRequirement{Key: key, Operator: v1.NodeSelectorOpIn, Values: []string{value}}
 		})
-		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 		deployment := test.Deployment(test.DeploymentOptions{Replicas: 1, PodOptions: test.PodOptions{
 			NodeSelector: nodeSelector,
 			NodePreferences: requirements,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2320

**Description**

We got an error when we upgraded Karpenter to v0.14.0 from v0.13.2. (Also v0.15.0 shows the same error)

```
controller 2022-08-19T04:45:17.747Z    DEBUG    controller.provisioning    Ignoring pod, label karpenter.sh/provisioner-name is restricted; specify a well known label: [karpenter.k8s.aws/instance-category karpenter.k8s.aws/instance-cpu karpenter.k8s.aws/instance-family karpenter.k8s.aws/instance-generation karpenter.k8s.aws/instance-gpu-count karpenter.k8s.aws/instance-gpu-manufacturer karpenter.k8s.aws/instance-gpu-memory karpenter.k8s.aws/instance-gpu-name karpenter.k8s.aws/instance-hypervisor karpenter.k8s.aws/instance-local-nvme karpenter.k8s.aws/instance-memory karpenter.k8s.aws/instance-pods karpenter.k8s.aws/instance-size karpenter.sh/capacity-type kubernetes.io/arch kubernetes.io/os node.kubernetes.io/instance-type topology.kubernetes.io/region topology.kubernetes.io/zone], ora custom label that does use a restricted domain: [k8s.io karpenter.k8s.aws karpenter.sh kubernetes.io]    {"commit": "3d87474", "pod": "XXX"}
```

We uses a feature to use specific provisioner by setting `karpenter.sh/provisioner-name` label to nodeAffinity of the pods.
The feature is described in FAQs: https://karpenter.sh/v0.15.0/faq/#if-multiple-provisioners-are-defined-which-will-my-pod-use .


- Fix: allow setting `karpenter.sh/provisioner-name` to nodeAffinity
- Fix typo in error message

**How was this change tested?**

* Tested and confirmed that the problem is fixed on our EKS cluster

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
fix: Fix setting `karpenter.sh/provisioner-name` to nodeAffinity blocks node creation
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
