### PR TITLE
feat: AMISelector uses most recently built AMI

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/ami.go
+++ b/pkg/cloudprovider/aws/amifamily/ami.go
@@ -17,6 +17,8 @@ package amifamily
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -109,6 +111,7 @@ func (p *AMIProvider) getAMIRequirements(ctx context.Context, providerRef *v1alp
 }
 
 func (p *AMIProvider) selectAMIs(ctx context.Context, amiSelector map[string]string) (map[string]scheduling.Requirements, error) {
+	var amis []*ec2.Image
 	ec2AMIs, err := p.fetchAMIsFromEC2(ctx, amiSelector)
 	if err != nil {
 		return nil, err
@@ -116,9 +119,16 @@ func (p *AMIProvider) selectAMIs(ctx context.Context, amiSelector map[string]str
 	if len(ec2AMIs) == 0 {
 		return nil, fmt.Errorf("no amis exist given constraints")
 	}
+	if _, exists := amiSelector["aws-ids"]; exists {
+		amis = ec2AMIs
+	} else {
+		mostRecentAMI := getMostRecentAMI(ec2AMIs)
+		amis = append(amis, mostRecentAMI)
+		logging.FromContext(ctx).Debugf("Using most recent image: %s", *mostRecentAMI.ImageId)
+	}
 	var amiIDs = map[string]scheduling.Requirements{}
-	for _, ec2AMI := range ec2AMIs {
-		amiIDs[*ec2AMI.ImageId] = p.getRequirementsFromImage(ec2AMI)
+	for _, ami := range amis {
+		amiIDs[*ami.ImageId] = p.getRequirementsFromImage(ami)
 	}
 	return amiIDs, nil
 }
@@ -152,6 +162,11 @@ func getFilters(amiSelector map[string]string) []*ec2.Filter {
 				Name:   aws.String("image-id"),
 				Values: aws.StringSlice(filterValues),
 			})
+		} else if key == "name" {
+			filters = append(filters, &ec2.Filter{
+				Name:   aws.String("name"),
+				Values: []*string{aws.String(value)},
+			})
 		} else {
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
@@ -160,6 +175,17 @@ func getFilters(amiSelector map[string]string) []*ec2.Filter {
 		}
 	}
 	return filters
+}
+
+func getMostRecentAMI(amis []*ec2.Image) *ec2.Image {
+	if len(amis) > 1 {
+		sort.Slice(amis, func(i, j int) bool {
+			itime, _ := time.Parse(time.RFC3339, aws.StringValue(amis[i].CreationDate))
+			jtime, _ := time.Parse(time.RFC3339, aws.StringValue(amis[j].CreationDate))
+			return itime.Unix() > jtime.Unix()
+		})
+	}
+	return amis[0]
 }
 
 func (p *AMIProvider) getRequirementsFromImage(ec2Image *ec2.Image) scheduling.Requirements {

--- a/pkg/cloudprovider/aws/amifamily/ami.go
+++ b/pkg/cloudprovider/aws/amifamily/ami.go
@@ -198,7 +198,7 @@ func getMostRecentCompatibleAMI(compatibleAMIs map[string][]cloudprovider.Instan
 	for _, ami := range amis {
 		if _, exists := compatibleAMIs[*ami.ImageId]; exists {
 			mostRecent[*ami.ImageId] = compatibleAMIs[*ami.ImageId]
-			return mostRecent
+			break
 		}
 	}
 	return mostRecent

--- a/pkg/cloudprovider/aws/amifamily/ami.go
+++ b/pkg/cloudprovider/aws/amifamily/ami.go
@@ -76,7 +76,7 @@ func (p *AMIProvider) Get(ctx context.Context, provider *awsv1alpha1.AWS, nodeRe
 		if _, exists := amiSelector["aws-ids"]; exists {
 			return amiIDs, nil
 		} else {
-			return getMostRecentCompatibleAMI(amiIDs, amis), nil
+			return getMostRecentCompatibleAMI(ctx, amiIDs, amis), nil
 		}
 	} else {
 		for _, instanceType := range nodeRequest.InstanceTypeOptions {
@@ -193,11 +193,12 @@ func sortAMIsByCreationDate(amis []*ec2.Image) []*ec2.Image {
 	return amis
 }
 
-func getMostRecentCompatibleAMI(compatibleAMIs map[string][]cloudprovider.InstanceType, amis []*ec2.Image) map[string][]cloudprovider.InstanceType {
+func getMostRecentCompatibleAMI(ctx context.Context, compatibleAMIs map[string][]cloudprovider.InstanceType, amis []*ec2.Image) map[string][]cloudprovider.InstanceType {
 	mostRecent := map[string][]cloudprovider.InstanceType{}
 	for _, ami := range amis {
 		if _, exists := compatibleAMIs[*ami.ImageId]; exists {
 			mostRecent[*ami.ImageId] = compatibleAMIs[*ami.ImageId]
+			logging.FromContext(ctx).Debugf("Using most recent compatible AMI: %s", *ami.ImageId)
 			break
 		}
 	}

--- a/pkg/cloudprovider/aws/launchtemplate_test.go
+++ b/pkg/cloudprovider/aws/launchtemplate_test.go
@@ -904,7 +904,7 @@ var _ = Describe("LaunchTemplates", func() {
 				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
 				Expect("special user data").To(Equal(string(userData)))
 			})
-			It("should correctly use ami selector with specific IDs in AWSNodeTemplate", func() {
+			It("should create multiple launch templates when multiple aws-ids specified in AWSNodeTemplate", func() {
 				opts.AWSENILimitedPodDensity = false
 				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
@@ -917,11 +917,13 @@ var _ = Describe("LaunchTemplates", func() {
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
 						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("t3.large")}},
+						CreationDate: aws.String("2022-08-05T12:00:00Z"),
 					},
 					{
 						ImageId:      aws.String("ami-456"),
 						Architecture: aws.String("x86_64"),
 						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
+						CreationDate: aws.String("2022-08-10T12:00:00Z"),
 					},
 				}})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
@@ -938,20 +940,31 @@ var _ = Describe("LaunchTemplates", func() {
 					},
 				}
 				Expect(actualFilter).To(Equal(expectedFilter))
+				expectedImageIds := sets.NewString("ami-123", "ami-456")
+				actualImageIds := sets.NewString(
+					*fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
+					*fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
+				)
+				Expect(expectedImageIds.Equal(actualImageIds)).To(BeTrue())
 			})
-			It("should create multiple launch templates when multiple amis are discovered", func() {
+			It("should create a launch template with the most recent AMI when multiple amis are discovered via tags", func() {
 				opts.AWSENILimitedPodDensity = false
 				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 					{
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
-						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("t3.large")}},
+						CreationDate: aws.String("2022-08-05T12:00:00Z"),
 					},
 					{
 						ImageId:      aws.String("ami-456"),
 						Architecture: aws.String("x86_64"),
-						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
+						CreationDate: aws.String("2022-08-10T12:00:00Z"),
+					},
+					{
+						ImageId:      aws.String("ami-789"),
+						Architecture: aws.String("x86_64"),
+						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 				}})
 				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
@@ -964,13 +977,51 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectApplied(ctx, env.Client, newProvisioner)
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				ExpectScheduled(ctx, env.Client, pod)
-				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(2))
-				expectedImageIds := sets.NewString("ami-123", "ami-456")
-				actualImageIds := sets.NewString(
-					*fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
-					*fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
-				)
-				Expect(expectedImageIds.Equal(actualImageIds)).To(BeTrue())
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
+				Expect("ami-789").To(Equal(*input.LaunchTemplateData.ImageId))
+			})
+			It("should create a launch template with the most recent AMI when multiple amis are discovered via name", func() {
+				opts.AWSENILimitedPodDensity = false
+				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
+				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
+					{
+						ImageId:      aws.String("ami-123"),
+						Architecture: aws.String("x86_64"),
+						CreationDate: aws.String("2022-08-05T12:00:00Z"),
+					},
+					{
+						ImageId:      aws.String("ami-456"),
+						Architecture: aws.String("x86_64"),
+						CreationDate: aws.String("2022-08-10T12:00:00Z"),
+					},
+					{
+						ImageId:      aws.String("ami-789"),
+						Architecture: aws.String("x86_64"),
+						CreationDate: aws.String("2022-08-15T12:00:00Z"),
+					},
+				}})
+				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					UserData:    nil,
+					AMISelector: map[string]string{"name": "eks*"},
+					AWS:         *provider,
+				})
+				ExpectApplied(ctx, env.Client, nodeTemplate)
+				newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
+				ExpectApplied(ctx, env.Client, newProvisioner)
+				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
+				ExpectScheduled(ctx, env.Client, pod)
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
+				actualFilter := fakeEC2API.CalledWithDescribeImagesInput.Pop().Filters
+				expectedFilter := []*ec2.Filter{
+					{
+						Name:   aws.String("name"),
+						Values: aws.StringSlice([]string{"eks*"}),
+					},
+				}
+				Expect(actualFilter).To(Equal(expectedFilter))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
+				Expect("ami-789").To(Equal(*input.LaunchTemplateData.ImageId))
 			})
 			It("should fail if no amis match selector.", func() {
 				opts.AWSENILimitedPodDensity = false

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -254,14 +254,14 @@ If you need to specify a launch template in addition to UserData, then review th
 
 ### AMISelector
 
-AMISelector is used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through [AWS tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html), similar to `subnetSelector`. This field is optional, and Karpenter will use the latest EKS-optimized AMIs if an amiSelector is not specified.
+AMISelector is used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through [AWS tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html), literal AWS IDs and the AMI name. This field is optional, and Karpenter will use the latest EKS-optimized AMIs if an amiSelector is not specified.
 
-EC2 AMIs may be specified by any AWS tag, including `Name`. Selecting tag values using wildcards (`*`) is supported.
+EC2 AMIs may be specified by any AWS tag or the AMI name. Selecting tag values using wildcards (`*`) is supported.
 
 EC2 AMI IDs may be specified by using the key `aws-ids` and then passing the IDs as a comma-separated string value.
 
 * When launching nodes, Karpenter automatically determines which architecture a custom AMI is compatible with and will use images that match an instanceType's requirements.
-* If multiple AMIs are found that can be used, Karpenter will randomly choose any one.
+* If multiple AMIs are found that can be used, Karpenter will select the most recently built one unless `aws-ids` is used in which case it will use one of the AMIs provided at random.
 * If no AMIs are found that can be used, then no nodes will be provisioned.
 
 For additional data on how UserData is configured for Custom AMIs, and how more requirements can be specified for custom AMIs, follow [this documentation](../user-data/#custom-amis).
@@ -277,7 +277,7 @@ Select all AMIs with a specified tag:
 Select AMIs by name:
 ```
   amiSelector:
-    Name: my-ami
+    name: eks*
 ```
 
 Select AMIs by an arbitrary AWS tag key/value pair:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

In this PR `AMISelector` will create a launch template with the most recently built AMI found matching using tags and/or name. If `aws-ids` key is used it will create a launch template for each matching AMI.

Relates to https://github.com/aws/karpenter/pull/2326#discussion_r950551896

**How was this change tested?**

* Unit tests
* Running make apply in cluster and ensuring that the most recently built AMI is chosen when using tags and/or name


**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
