### PR TITLE
chore: up the pipeline timeouts from the default 1-hr

### DIFF
--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -45,7 +45,6 @@ data:
        generateName: "$(echo ${suite} | tr '[:upper:]' '[:lower:]')-"
        namespace: karpenter-tests
      spec:
-       timeout: 180
        params:
        - name: test-filter
          value: "${suite}"

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -45,8 +45,7 @@ data:
        generateName: "$(echo ${suite} | tr '[:upper:]' '[:lower:]')-"
        namespace: karpenter-tests
      spec:
-       timeouts:
-         pipeline: "3h0m0s"
+       timeout: 180
        params:
        - name: test-filter
          value: "${suite}"

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -45,6 +45,8 @@ data:
        generateName: "$(echo ${suite} | tr '[:upper:]' '[:lower:]')-"
        namespace: karpenter-tests
      spec:
+       timeouts:
+         pipeline: "3h0m0s"
        params:
        - name: test-filter
          value: "${suite}"
@@ -61,6 +63,8 @@ data:
        generateName: "upgrade-suite"
        namespace: karpenter-tests
      spec:
+       timeouts:
+         pipeline: "3h0m0s"
        pipelineRef:
          name: upgrade
        serviceAccountName: karpenter-tests


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
 - Some tests timeout, specifically upgrade tests take > 1 hr.  Upped to 3hr since we run tests every 4 hours and 3 hrs should give plenty of time for tests speed variability. 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
