### PR TITLE
fix: dynamically set go 1.19 runtime soft memory limit to better avoid OOM conditions

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -83,6 +83,12 @@ spec:
             - name: AWS_DEFAULT_INSTANCE_PROFILE
               value: {{ .Values.aws.defaultInstanceProfile }}
           {{- end }}
+            - name: MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: controller
+                  divisor: "0"
+                  resource: limits.memory
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -134,6 +140,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: webhook
+                  divisor: "0"
+                  resource: limits.memory
             {{- if .Values.aws.defaultInstanceProfile }}
             - name: AWS_DEFAULT_INSTANCE_PROFILE
               value: {{ .Values.aws.defaultInstanceProfile }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/karpenter
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -165,6 +165,7 @@ func (c *Controller) ProcessCluster(ctx context.Context) (ProcessResult, error) 
 }
 
 // candidateNodes returns nodes that appear to be currently consolidatable based off of their provisioner
+//
 //gocyclo:ignore
 func (c *Controller) candidateNodes(ctx context.Context) ([]candidateNode, error) {
 	provisioners, instanceTypesByProvisioner, err := c.buildProvisionerMap(ctx)

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -33,6 +33,20 @@ func WithDefaultInt(key string, def int) int {
 	return i
 }
 
+// WithDefaultInt64 returns the int value of the supplied environment variable or, if not present,
+// the supplied default value. If the int conversion fails, returns the default
+func WithDefaultInt64(key string, def int64) int64 {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	i, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return def
+	}
+	return i
+}
+
 // WithDefaultFloat64 returns the float64 value of the supplied environment variable or, if not present,
 // the supplied default value. If the float64 conversion fails, returns the default
 func WithDefaultFloat64(key string, def float64) float64 {

--- a/pkg/utils/options/options.go
+++ b/pkg/utils/options/options.go
@@ -42,6 +42,7 @@ type Options struct {
 	KubeClientQPS   int
 	KubeClientBurst int
 	EnableProfiling bool
+	MemoryLimit     int64
 	// AWS Specific
 	ClusterName               string
 	ClusterEndpoint           string
@@ -65,6 +66,7 @@ func New() Options {
 	f.IntVar(&opts.KubeClientQPS, "kube-client-qps", env.WithDefaultInt("KUBE_CLIENT_QPS", 200), "The smoothed rate of qps to kube-apiserver")
 	f.IntVar(&opts.KubeClientBurst, "kube-client-burst", env.WithDefaultInt("KUBE_CLIENT_BURST", 300), "The maximum allowed burst of queries to the kube-apiserver")
 	f.BoolVar(&opts.EnableProfiling, "enable-profiling", env.WithDefaultBool("ENABLE_PROFILING", false), "Enable the profiling on the metric endpoint")
+	f.Int64Var(&opts.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
 
 	// AWS Specific
 	f.StringVar(&opts.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "The kubernetes cluster name for resource discovery")
@@ -75,7 +77,6 @@ func New() Options {
 	f.StringVar(&opts.AWSDefaultInstanceProfile, "aws-default-instance-profile", env.WithDefaultString("AWS_DEFAULT_INSTANCE_PROFILE", ""), "The default instance profile to use when provisioning nodes in AWS")
 	f.BoolVar(&opts.AWSEnablePodENI, "aws-enable-pod-eni", env.WithDefaultBool("AWS_ENABLE_POD_ENI", false), "If true then instances that support pod ENI will report a vpc.amazonaws.com/pod-eni resource")
 	f.BoolVar(&opts.AWSIsolatedVPC, "aws-isolated-vpc", env.WithDefaultBool("AWS_ISOLATED_VPC", false), "If true then assume we can't reach AWS services which don't have a VPC endpoint")
-
 	return opts
 }
 


### PR DESCRIPTION
**Description**

This informs the go runtime of the amount of memory available to the
container.  It allows the runtime to sometimes delay GC when there is
plenty of headroom and to run GC more often to avoid exceeding the
container memory limit.


**How was this change tested?**

* 13k pod / 400 node scaleup

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
