### PR TITLE
Fix: Allow rollout to proceed when capacity is not available

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -32,7 +32,9 @@ replicas: 2
 # -- The number of old ReplicaSets to retain to allow rollback.
 revisionHistoryLimit: 10
 # -- Strategy for updating the pod.
-strategy: {}
+strategy:
+  rollingUpdate:
+    maxUnavailable: 1
 # -- Additional labels for the pod.
 podLabels: {}
 # -- Additional annotations for the pod.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

* Unconstrained pool, immediately rolls out two fresh replicas
* Constrained pool, waits for one pod to terminate, and rolls out one at a time

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
