### PR TITLE
test: Add E2E test for consolidating from on-demand to spot instance

### DIFF
--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -238,9 +238,9 @@ var _ = Describe("Consolidation", func() {
 					Values:   []string{"on-demand"},
 				},
 				{
-					Key:      v1.LabelInstanceTypeStable,
+					Key:      awsv1alpha1.LabelInstanceSize,
 					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{"c4.large"},
+					Values:   []string{"large"},
 				},
 			},
 			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
@@ -292,9 +292,9 @@ var _ = Describe("Consolidation", func() {
 				Values:   []string{"on-demand", "spot"},
 			},
 			{
-				Key:      v1.LabelInstanceTypeStable,
+				Key:      awsv1alpha1.LabelInstanceSize,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"c4.large"},
+				Values:   []string{"large"},
 			},
 		}
 		env.ExpectUpdate(provisioner)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Adds a E2E test for consolidating from a on-demand instance to a spot instance of the same type

**How was this change tested?**

* `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
