### PR TITLE
docs: do not tag managed nodegroup

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
@@ -168,11 +168,6 @@ module "eks" {
         # Required by Karpenter
         "arn:${local.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
       ]
-
-      tags = {
-        # This will tag the launch template created for use by Karpenter
-        "karpenter.sh/discovery/${local.cluster_name}" = local.cluster_name
-      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
IMHO, this should not be required because Karpenter creates its own launch template.

**How was this change tested?**

* I actually do not set this tag and it works.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Do not tag initial managed nodegroup with Karpenter discovery tag in reference documentation for Terraform.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
