### PR TITLE
perf: Provisioner changes trigger consolidation to be re-considered

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -149,6 +149,7 @@ func Initialize(injectCloudProvider func(context.Context, cloudprovider.Options)
 		provisioning.NewController(manager.GetClient(), provisioner, recorder),
 		state.NewNodeController(manager.GetClient(), cluster),
 		state.NewPodController(manager.GetClient(), cluster),
+		state.NewProvisionerController(manager.GetClient(), cluster),
 		node.NewController(realClock, manager.GetClient(), cloudProvider, cluster),
 		termination.NewController(ctx, realClock, manager.GetClient(), clientSet.CoreV1(), recorder, cloudProvider),
 		metricspod.NewController(manager.GetClient()),

--- a/pkg/controllers/state/provisioner.go
+++ b/pkg/controllers/state/provisioner.go
@@ -1,0 +1,71 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"knative.dev/pkg/logging"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+)
+
+const provisionerControllerName = "provisioner-state"
+
+// ProvisionerController reconciles pods for the purpose of maintaining state regarding pods that is expensive to compute.
+type ProvisionerController struct {
+	kubeClient client.Client
+	cluster    *Cluster
+}
+
+func NewProvisionerController(kubeClient client.Client, cluster *Cluster) *ProvisionerController {
+	return &ProvisionerController{
+		kubeClient: kubeClient,
+		cluster:    cluster,
+	}
+}
+
+func (c *ProvisionerController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named(provisionerControllerName).With("provisioner", req.NamespacedName))
+	stored := &v1alpha5.Provisioner{}
+
+	// If the provisioner is deleted, no reason to re-consider consolidation at this point
+	if err := c.kubeClient.Get(ctx, req.NamespacedName, stored); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+	// Something changed in the provisioner so we should re-consider consolidation
+	c.cluster.recordConsolidationChange()
+	return reconcile.Result{}, nil
+}
+
+func (c *ProvisionerController) Register(ctx context.Context, m manager.Manager) error {
+	return controllerruntime.
+		NewControllerManagedBy(m).
+		Named(provisionerControllerName).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		For(&v1alpha5.Provisioner{}).
+		Complete(c)
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Allows consolidation to automatically be triggered if there is a change to the provisioner spec
- This allows immediate reconciliation when consolidation is turned on or when there is a change to provisioner requirements

**How was this change tested?**

* Manual validation of E2E
* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
