### PR TITLE
fix: Fix broken command line arguments

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -96,7 +96,7 @@ func Initialize(injectCloudProvider func(context.Context, cloudprovider.Options)
 	cmw := informer.NewInformedWatcher(clientSet, system.Namespace())
 	ctx := LoggingContextOrDie(controllerRuntimeConfig, cmw)
 	ctx = injection.WithConfig(ctx, controllerRuntimeConfig)
-	ctx = injection.WithOptions(ctx, opts)
+	ctx = injection.WithOptions(ctx, *opts)
 
 	logging.FromContext(ctx).Infof("Initializing with version %s", project.Version)
 

--- a/pkg/utils/options/options.go
+++ b/pkg/utils/options/options.go
@@ -55,8 +55,8 @@ type Options struct {
 }
 
 // New creates an Options struct and registers CLI flags and environment variables to fill-in the Options struct fields
-func New() Options {
-	opts := Options{}
+func New() *Options {
+	opts := &Options{}
 	f := flag.NewFlagSet("karpenter", flag.ContinueOnError)
 	opts.FlagSet = f
 
@@ -82,7 +82,7 @@ func New() Options {
 
 // MustParse reads the user passed flags, environment variables, and default values.
 // Options are valided and panics if an error is returned
-func (o Options) MustParse() Options {
+func (o *Options) MustParse() *Options {
 	err := o.Parse(os.Args[1:])
 
 	if errors.Is(err, flag.ErrHelp) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Command line arguments were completely broken because `Options` was being returned by value instead of by reference

**How was this change tested?**

* Passed command line arguments 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
