### PR TITLE
fix: wait for node deletion before continuing consolidation

### DIFF
--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -324,7 +324,7 @@ func (c *Controller) waitForDeletion(ctx context.Context, node *v1.Node) {
 	if err := retry.Do(func() error {
 		var n v1.Node
 		nerr := c.kubeClient.Get(ctx, client.ObjectKey{Name: node.Name}, &n)
-		// We expect the node found error, at which point we know the node is deleted.
+		// We expect the not node found error, at which point we know the node is deleted.
 		if errors.IsNotFound(nerr) {
 			return nil
 		}

--- a/pkg/controllers/consolidation/suite_test.go
+++ b/pkg/controllers/consolidation/suite_test.go
@@ -623,8 +623,8 @@ var _ = Describe("Replace Nodes", func() {
 
 		// fetch the latest node object and remove the finalizer
 		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
-		node.Finalizers = nil
-		ExpectApplied(ctx, env.Client, node)
+		node.SetFinalizers([]string{})
+		Expect(env.Client.Update(ctx, node)).To(Succeed())
 
 		// consolidation should complete now that the finalizer on the node is gone and it can
 		// was actually deleted

--- a/pkg/controllers/consolidation/suite_test.go
+++ b/pkg/controllers/consolidation/suite_test.go
@@ -621,7 +621,8 @@ var _ = Describe("Replace Nodes", func() {
 		// and consolidation should still be running waiting on the node's deletion
 		Expect(consolidationFinished.Load()).To(BeFalse())
 
-		// remove the finalizer
+		// fetch the latest node object and remove the finalizer
+		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
 		node.Finalizers = nil
 		ExpectApplied(ctx, env.Client, node)
 

--- a/pkg/events/dedupe.go
+++ b/pkg/events/dedupe.go
@@ -34,8 +34,15 @@ type dedupe struct {
 	cache *cache.Cache
 }
 
+func (d *dedupe) WaitingOnDeletionForConsolidation(node *v1.Node) {
+	if !d.shouldCreateEvent(fmt.Sprintf("wait-node-consolidate-delete-%s", node.UID)) {
+		return
+	}
+	d.rec.WaitingOnDeletionForConsolidation(node)
+}
+
 func (d *dedupe) WaitingOnReadinessForConsolidation(node *v1.Node) {
-	if !d.shouldCreateEvent(fmt.Sprintf("wait-node-consolidate-%s", node.UID)) {
+	if !d.shouldCreateEvent(fmt.Sprintf("wait-node-consolidate-ready-%s", node.UID)) {
 		return
 	}
 	d.rec.WaitingOnReadinessForConsolidation(node)

--- a/pkg/events/recorder.go
+++ b/pkg/events/recorder.go
@@ -39,6 +39,9 @@ type Recorder interface {
 	// WaitingOnReadinessForConsolidation is called when consolidation is waiting on a node to become ready prior to
 	// continuing consolidation
 	WaitingOnReadinessForConsolidation(v *v1.Node)
+	// WaitingOnDeletionForConsolidation is called when consolidation is waiting on a node to be deleted prior to
+	// continuing consolidation
+	WaitingOnDeletionForConsolidation(oldnode *v1.Node)
 }
 
 type recorder struct {
@@ -49,6 +52,9 @@ func NewRecorder(rec record.EventRecorder) Recorder {
 	return &recorder{rec: rec}
 }
 
+func (r recorder) WaitingOnDeletionForConsolidation(node *v1.Node) {
+	r.rec.Eventf(node, "Normal", "ConsolidateWaiting", "Waiting on deletion to continue consolidation")
+}
 func (r recorder) WaitingOnReadinessForConsolidation(node *v1.Node) {
 	r.rec.Eventf(node, "Normal", "ConsolidateWaiting", "Waiting on readiness to continue consolidation")
 }

--- a/pkg/test/eventrecorder.go
+++ b/pkg/test/eventrecorder.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter/pkg/events"
 )
 
 // Binding is a potential binding that was reported through event recording.
@@ -32,6 +34,8 @@ type EventRecorder struct {
 	bindings []Binding
 }
 
+var _ events.Recorder = (*EventRecorder)(nil)
+
 func NewEventRecorder() *EventRecorder {
 	return &EventRecorder{}
 }
@@ -39,6 +43,7 @@ func NewEventRecorder() *EventRecorder {
 func (e *EventRecorder) WaitingOnReadinessForConsolidation(v *v1.Node)                {}
 func (e *EventRecorder) TerminatingNodeForConsolidation(node *v1.Node, reason string) {}
 func (e *EventRecorder) LaunchingNodeForConsolidation(node *v1.Node, reason string)   {}
+func (e *EventRecorder) WaitingOnDeletionForConsolidation(node *v1.Node)              {}
 
 func (e *EventRecorder) NominatePod(pod *v1.Pod, node *v1.Node) {
 	e.mu.Lock()

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -61,7 +61,7 @@ func ExpectNodeExists(ctx context.Context, c client.Client, name string) *v1.Nod
 
 func ExpectNotFound(ctx context.Context, c client.Client, objects ...client.Object) {
 	for _, object := range objects {
-		Eventually(func() bool {
+		EventuallyWithOffset(1, func() bool {
 			return errors.IsNotFound(c.Get(ctx, types.NamespacedName{Name: object.GetName(), Namespace: object.GetNamespace()}, object))
 		}, ReconcilerPropagationTime, RequestInterval).Should(BeTrue(), func() string {
 			return fmt.Sprintf("expected %s to be deleted, but it still exists", client.ObjectKeyFromObject(object))
@@ -89,20 +89,20 @@ func ExpectApplied(ctx context.Context, c client.Client, objects ...client.Objec
 		// Create or Update
 		if err := c.Get(ctx, client.ObjectKeyFromObject(current), current); err != nil {
 			if errors.IsNotFound(err) {
-				Expect(c.Create(ctx, object)).To(Succeed())
+				ExpectWithOffset(1, c.Create(ctx, object)).To(Succeed())
 			} else {
-				Expect(err).ToNot(HaveOccurred())
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			}
 		} else {
 			object.SetResourceVersion(current.GetResourceVersion())
-			Expect(c.Update(ctx, object)).To(Succeed())
+			ExpectWithOffset(1, c.Update(ctx, object)).To(Succeed())
 		}
 		// Update status
 		statuscopy.SetResourceVersion(object.GetResourceVersion())
-		Expect(c.Status().Update(ctx, statuscopy)).To(Or(Succeed(), MatchError("the server could not find the requested resource"))) // Some objects do not have a status
+		ExpectWithOffset(1, c.Status().Update(ctx, statuscopy)).To(Or(Succeed(), MatchError("the server could not find the requested resource"))) // Some objects do not have a status
 		// Delete if timestamp set
 		if deletecopy.GetDeletionTimestamp() != nil {
-			Expect(c.Delete(ctx, deletecopy)).To(Succeed())
+			ExpectWithOffset(1, c.Delete(ctx, deletecopy)).To(Succeed())
 		}
 	}
 }


### PR DESCRIPTION

**Description**

Removes a check for un-initialized nodes that would block all
consolidation if a node fails to start and re-uses the nominated
node check from the emptiness controller to accomplish
a similar task.  Upon node deletion, wait for the node to be
deleted to pause consolidation which ensures we don't overshoot
consolidation due to a PDB throttling the deletion of a node.

**How was this change tested?**

* Unit testing & deployed to EKS.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
