### PR TITLE
fix: change desired nodegroup replicas to match default controller replicas

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step02-create-cluster.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step02-create-cluster.sh
@@ -12,7 +12,7 @@ managedNodeGroups:
   - instanceType: m5.large
     amiFamily: AmazonLinux2
     name: ${CLUSTER_NAME}-ng
-    desiredCapacity: 1
+    desiredCapacity: 2
     minSize: 1
     maxSize: 10
 iam:

--- a/website/content/en/v0.16.0/getting-started/getting-started-with-eksctl/scripts/step02-create-cluster.sh
+++ b/website/content/en/v0.16.0/getting-started/getting-started-with-eksctl/scripts/step02-create-cluster.sh
@@ -12,7 +12,7 @@ managedNodeGroups:
   - instanceType: m5.large
     amiFamily: AmazonLinux2
     name: ${CLUSTER_NAME}-ng
-    desiredCapacity: 1
+    desiredCapacity: 2
     minSize: 1
     maxSize: 10
 iam:


### PR DESCRIPTION
**Description**
Helm chart defaults to 2 replicas for Karpenter controller pod. On a fresh install, this could return these log lines:

```
karpenter-64df6c45c8-m97x2 controller 2022-08-26T21:09:05.443Z	ERROR	controller.provisioning	Could not schedule pod, incompatible with provisioner "default", incompatible requirements, key karpenter.sh/provisioner-name, karpenter.sh/provisioner-name DoesNotExist not in karpenter.sh/provisioner-name In [default]	{"commit": "639756a", "pod": "karpenter/karpenter-64df6c45c8-pttpz"}
```

Changing the default node group replicas to 2 so that this doesn't happen. 


**How was this change tested?**

* Incremented my desired capacity on my ASG and the pod scheduled and the errors no longer occurred. 

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
