### PR TITLE
chore: change website examples to recommended providerRef

### DIFF
--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -59,8 +59,7 @@ or on the controller, node provisioning will fail. The KarpenterControllerPolicy
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -73,8 +72,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -146,9 +144,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -180,14 +177,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -200,12 +196,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -219,8 +214,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -233,18 +227,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF

--- a/website/content/en/v0.13.0/AWS/provisioning.md
+++ b/website/content/en/v0.13.0/AWS/provisioning.md
@@ -58,8 +58,7 @@ or on the controller, node provisioning will fail.
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -72,8 +71,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -145,9 +143,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -179,14 +176,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -199,12 +195,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -218,8 +213,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -232,18 +226,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData

--- a/website/content/en/v0.13.0/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh
+++ b/website/content/en/v0.13.0/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF

--- a/website/content/en/v0.13.1/AWS/provisioning.md
+++ b/website/content/en/v0.13.1/AWS/provisioning.md
@@ -58,8 +58,7 @@ or on the controller, node provisioning will fail.
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -72,8 +71,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -145,9 +143,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -179,14 +176,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -199,12 +195,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -218,8 +213,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -232,18 +226,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData

--- a/website/content/en/v0.13.1/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh
+++ b/website/content/en/v0.13.1/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF

--- a/website/content/en/v0.13.2/AWS/provisioning.md
+++ b/website/content/en/v0.13.2/AWS/provisioning.md
@@ -58,8 +58,7 @@ or on the controller, node provisioning will fail.
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -72,8 +71,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -145,9 +143,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -179,14 +176,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -199,12 +195,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -218,8 +213,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -232,18 +226,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData

--- a/website/content/en/v0.13.2/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh
+++ b/website/content/en/v0.13.2/getting-started/getting-started-with-eksctl/scripts/step12-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF

--- a/website/content/en/v0.14.0-rc.0/AWS/provisioning.md
+++ b/website/content/en/v0.14.0-rc.0/AWS/provisioning.md
@@ -59,8 +59,7 @@ or on the controller, node provisioning will fail. The KarpenterControllerPolicy
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -73,8 +72,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -146,9 +144,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -180,14 +177,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -200,12 +196,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -219,8 +214,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -233,18 +227,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData
@@ -329,4 +322,3 @@ Refer to general [Kubernetes GPU](https://kubernetes.io/docs/tasks/manage-gpus/s
 * `amd.com/gpu`: [AMD GPU device plugin for Kubernetes](https://github.com/RadeonOpenCompute/k8s-device-plugin)
 * `aws.amazon.com/neuron`: [Kubernetes enviroment setup for Neuron](https://github.com/aws/aws-neuron-sdk/blob/master/neuron-deploy/tutorials/tutorial-k8s.rst)
 {{% /alert %}}
-

--- a/website/content/en/v0.14.0-rc.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
+++ b/website/content/en/v0.14.0-rc.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF

--- a/website/content/en/v0.14.0/AWS/provisioning.md
+++ b/website/content/en/v0.14.0/AWS/provisioning.md
@@ -59,8 +59,7 @@ or on the controller, node provisioning will fail. The KarpenterControllerPolicy
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -73,8 +72,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -146,9 +144,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -180,14 +177,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -200,12 +196,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -219,8 +214,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -233,18 +227,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData
@@ -329,4 +322,3 @@ Refer to general [Kubernetes GPU](https://kubernetes.io/docs/tasks/manage-gpus/s
 * `amd.com/gpu`: [AMD GPU device plugin for Kubernetes](https://github.com/RadeonOpenCompute/k8s-device-plugin)
 * `aws.amazon.com/neuron`: [Kubernetes enviroment setup for Neuron](https://github.com/aws/aws-neuron-sdk/blob/master/neuron-deploy/tutorials/tutorial-k8s.rst)
 {{% /alert %}}
-

--- a/website/content/en/v0.14.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
+++ b/website/content/en/v0.14.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF

--- a/website/content/en/v0.15.0/AWS/provisioning.md
+++ b/website/content/en/v0.15.0/AWS/provisioning.md
@@ -59,8 +59,7 @@ or on the controller, node provisioning will fail. The KarpenterControllerPolicy
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -73,8 +72,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -146,9 +144,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -180,14 +177,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -200,12 +196,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -219,8 +214,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -233,18 +227,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData
@@ -329,4 +322,3 @@ Refer to general [Kubernetes GPU](https://kubernetes.io/docs/tasks/manage-gpus/s
 * `amd.com/gpu`: [AMD GPU device plugin for Kubernetes](https://github.com/RadeonOpenCompute/k8s-device-plugin)
 * `aws.amazon.com/neuron`: [Kubernetes enviroment setup for Neuron](https://github.com/aws/aws-neuron-sdk/blob/master/neuron-deploy/tutorials/tutorial-k8s.rst)
 {{% /alert %}}
-

--- a/website/content/en/v0.15.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
+++ b/website/content/en/v0.15.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF

--- a/website/content/en/v0.16.0/AWS/provisioning.md
+++ b/website/content/en/v0.16.0/AWS/provisioning.md
@@ -59,8 +59,7 @@ or on the controller, node provisioning will fail. The KarpenterControllerPolicy
 
 ```
 spec:
-  provider:
-    instanceProfile: MyInstanceProfile
+  instanceProfile: MyInstanceProfile
 ```
 
 ### LaunchTemplate
@@ -73,8 +72,7 @@ Review the [Launch Template documentation](../launch-templates/) to learn how to
 
 ```
 spec:
-  provider:
-    launchTemplate: MyLaunchTemplate
+  launchTemplate: MyLaunchTemplate
 ```
 
 ### SubnetSelector (required)
@@ -146,9 +144,8 @@ If multiple securityGroups are printed, you will need a more targeted securityGr
 Select all security groups with a specified tag:
 ```
 spec:
-  provider:
-    securityGroupSelector:
-      karpenter.sh/discovery/MyClusterName: '*'
+  securityGroupSelector:
+    karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
@@ -180,14 +177,13 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the provider tags section which are merged with and can override the default tag values.
+Additional tags can be added in the providerRef tags section which are merged with and can override the default tag values.
 ```
 spec:
-  provider:
-    tags:
-      InternalAccountingTag: 1234
-      dev.corp.net/app: Calculator
-      dev.corp.net/team: MyTeam
+  tags:
+    InternalAccountingTag: 1234
+    dev.corp.net/app: Calculator
+    dev.corp.net/team: MyTeam
 ```
 
 ### Metadata Options
@@ -200,12 +196,11 @@ If metadataOptions are omitted from this provisioner, the following default sett
 
 ```
 spec:
-  provider:
-    metadataOptions:
-      httpEndpoint: enabled
-      httpProtocolIPv6: disabled
-      httpPutResponseHopLimit: 2
-      httpTokens: required
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2
+    httpTokens: required
 ```
 
 ### Amazon Machine Image (AMI) Family
@@ -219,8 +214,7 @@ Note: If a custom launch template is specified, then the AMI value in the launch
 
 ```
 spec:
-  provider:
-    amiFamily: Bottlerocket
+  amiFamily: Bottlerocket
 ```
 
 ### Block Device Mappings
@@ -233,18 +227,17 @@ Note: If a custom launch template is specified, then the `BlockDeviceMappings` f
 
 ```
 spec:
-  provider:
-    blockDeviceMappings:
-      - deviceName: /dev/xvda
-        ebs:
-          volumeSize: 100Gi
-          volumeType: gp3
-          iops: 10000
-          encrypted: true
-          kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
-          deleteOnTermination: true
-          throughput: 125
-          snapshotID: snap-0123456789
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        iops: 10000
+        encrypted: true
+        kmsKeyID: "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        deleteOnTermination: true
+        throughput: 125
+        snapshotID: snap-0123456789
 ```
 
 ### UserData
@@ -329,4 +322,3 @@ Refer to general [Kubernetes GPU](https://kubernetes.io/docs/tasks/manage-gpus/s
 * `amd.com/gpu`: [AMD GPU device plugin for Kubernetes](https://github.com/RadeonOpenCompute/k8s-device-plugin)
 * `aws.amazon.com/neuron`: [Kubernetes enviroment setup for Neuron](https://github.com/aws/aws-neuron-sdk/blob/master/neuron-deploy/tutorials/tutorial-k8s.rst)
 {{% /alert %}}
-

--- a/website/content/en/v0.16.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
+++ b/website/content/en/v0.16.0/getting-started/getting-started-with-eksctl/scripts/step13-add-provisioner.sh
@@ -11,10 +11,17 @@ spec:
   limits:
     resources:
       cpu: 1000
-  provider:
-    subnetSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${CLUSTER_NAME}
+  providerRef:
+    name: default
   ttlSecondsAfterEmpty: 30
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
+  securityGroupSelector:
+    karpenter.sh/discovery: ${CLUSTER_NAME}
 EOF


### PR DESCRIPTION
**Description**
`providerRef` was introduced in v0.13.0 with `AWSNodeTemplate` where `provider` became deprecated. Changing the `getting-started-with-eksctl` and `AWS/provisioning.MD` folders to reflect this. 
**How was this change tested?**

*

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
