### PR TITLE
fix: reduce pod nomination event counts

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -137,7 +137,10 @@ func Initialize(injectCloudProvider func(context.Context, cloudprovider.Options)
 	}
 
 	realClock := clock.RealClock{}
-	recorder := events.NewDedupeRecorder(events.NewRecorder(manager.GetEventRecorderFor(appName)))
+	recorder := events.NewRecorder(manager.GetEventRecorderFor(appName))
+	recorder = events.NewLoadSheddingRecorder(recorder)
+	recorder = events.NewDedupeRecorder(recorder)
+
 	cluster := state.NewCluster(realClock, cfg, manager.GetClient(), cloudProvider)
 	provisioner := provisioning.NewProvisioner(ctx, cfg, manager.GetClient(), clientSet.CoreV1(), recorder, cloudProvider, cluster)
 	consolidation.NewController(ctx, realClock, manager.GetClient(), provisioner, cloudProvider, recorder, cluster, manager.Elected())

--- a/pkg/events/loadshedding.go
+++ b/pkg/events/loadshedding.go
@@ -1,0 +1,71 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+func NewLoadSheddingRecorder(r Recorder) Recorder {
+	return &loadshedding{
+		rec:              r,
+		nominationBucket: flowcontrol.NewTokenBucketRateLimiter(5, 10),
+	}
+}
+
+type loadshedding struct {
+	rec              Recorder
+	nominationBucket flowcontrol.RateLimiter
+}
+
+func (l *loadshedding) NominatePod(pod *v1.Pod, node *v1.Node) {
+	// Pod nominations occur very often, especially in large scale-ups.  They normally aren't particularly useful
+	// during a scaleup, but are useful when at a steady state where we have a bug and think a pod will schedule
+	// that actually won't.  This prevents us from hammering the API server with events that likely aren't useful
+	// which can slow down node creation or result in events being dropped anyway by the K8s client.
+	if !l.nominationBucket.TryAccept() {
+		return
+	}
+	l.rec.NominatePod(pod, node)
+}
+
+func (l *loadshedding) EvictPod(pod *v1.Pod) {
+	l.rec.EvictPod(pod)
+}
+
+func (l *loadshedding) PodFailedToSchedule(pod *v1.Pod, err error) {
+	l.rec.PodFailedToSchedule(pod, err)
+}
+
+func (l *loadshedding) NodeFailedToDrain(node *v1.Node, err error) {
+	l.rec.NodeFailedToDrain(node, err)
+}
+
+func (l *loadshedding) TerminatingNodeForConsolidation(node *v1.Node, reason string) {
+	l.rec.TerminatingNodeForConsolidation(node, reason)
+}
+
+func (l *loadshedding) LaunchingNodeForConsolidation(node *v1.Node, reason string) {
+	l.rec.LaunchingNodeForConsolidation(node, reason)
+}
+
+func (l *loadshedding) WaitingOnReadinessForConsolidation(node *v1.Node) {
+	l.rec.WaitingOnReadinessForConsolidation(node)
+}
+
+func (l *loadshedding) WaitingOnDeletionForConsolidation(node *v1.Node) {
+	l.rec.WaitingOnDeletionForConsolidation(node)
+}


### PR DESCRIPTION
**Description**
These aren't useful during large scale-ups, so drop them instead
of loading the API server.  The case where these are useful is
if we believe a pod will schedule, but kube-scheduler won't.  In
this case, the pod nominations will be repeated indefinitely and
will be available on the pod.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
