### PR TITLE
docs: Update terraform example and troubleshoot guide for new v.0.16…

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
@@ -160,9 +160,10 @@ module "eks" {
       # Not required nor used - avoid tagging two security groups with same tag as well
       create_security_group = false
 
-      min_size     = 1
-      max_size     = 1
-      desired_size = 1
+      # Ensure enough capacity to run 2 Karpenter pods
+      min_size     = 2
+      max_size     = 2
+      desired_size = 2
 
       iam_role_additional_policies = [
         # Required by Karpenter

--- a/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-terraform/_index.md
@@ -162,7 +162,7 @@ module "eks" {
 
       # Ensure enough capacity to run 2 Karpenter pods
       min_size     = 2
-      max_size     = 2
+      max_size     = 3
       desired_size = 2
 
       iam_role_additional_policies = [

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -6,6 +6,18 @@ description: >
   Troubleshoot Karpenter problems
 ---
 
+## Unable to schedule pod due to insufficient node group instances
+
+v0.16 changed the default replicas from 1 to 2. 
+
+Karpenter won't launch capacity to run itself (log related to the `karpenter.sh/provisioner-name DoesNotExist requirement`) 
+so it can't provision for the second Karpenter pod. 
+
+To solve this you can either reduce the replicas back from 2 to 1, or ensure there is enough capacity that isn't being managed by Karpenter 
+(these are instances with the name `karpenter.sh/provisioner-name/<PROVIDER_NAME>`) to run both pods.
+
+To do so on AWS increase the `minimum` and `desired` parameters on the node group autoscaling group to launch at lease 2 instances.
+
 ## Node not created
 In some circumstances, Karpenter controller can fail to start up a node.
 For example, providing the wrong block storage device name in a custom launch template can result in a failure to start the node and an error similar to:

--- a/website/content/en/v0.16.0/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.16.0/getting-started/getting-started-with-terraform/_index.md
@@ -160,9 +160,10 @@ module "eks" {
       # Not required nor used - avoid tagging two security groups with same tag as well
       create_security_group = false
 
-      min_size     = 1
-      max_size     = 1
-      desired_size = 1
+      # Ensure enough capacity to run 2 Karpenter pods
+      min_size     = 2
+      max_size     = 2
+      desired_size = 2
 
       iam_role_additional_policies = [
         # Required by Karpenter

--- a/website/content/en/v0.16.0/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.16.0/getting-started/getting-started-with-terraform/_index.md
@@ -162,7 +162,7 @@ module "eks" {
 
       # Ensure enough capacity to run 2 Karpenter pods
       min_size     = 2
-      max_size     = 2
+      max_size     = 3
       desired_size = 2
 
       iam_role_additional_policies = [

--- a/website/content/en/v0.16.0/troubleshooting.md
+++ b/website/content/en/v0.16.0/troubleshooting.md
@@ -6,6 +6,18 @@ description: >
   Troubleshoot Karpenter problems
 ---
 
+## Unable to schedule pod due to insufficient node group instances
+
+v0.16 changed the default replicas from 1 to 2.
+
+Karpenter won't launch capacity to run itself (log related to the `karpenter.sh/provisioner-name DoesNotExist requirement`)
+so it can't provision for the second Karpenter pod.
+
+To solve this you can either reduce the replicas back from 2 to 1, or ensure there is enough capacity that isn't being managed by Karpenter
+(these are instances with the name `karpenter.sh/provisioner-name/<PROVIDER_NAME>`) to run both pods.
+
+To do so on AWS increase the `minimum` and `desired` parameters on the node group autoscaling group to launch at lease 2 instances.
+
 ## Node not created
 In some circumstances, Karpenter controller can fail to start up a node.
 For example, providing the wrong block storage device name in a custom launch template can result in a failure to start the node and an error similar to:


### PR DESCRIPTION
… replicateset change


**Description**

**How was this change tested?**
No code changes!



Update troubleshoot guide and Terraform examples to reflect 0.16 changes regarding the replicaSet (desired pods = 2).
Linked to this issue https://github.com/aws/karpenter/issues/2383

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
