### PR TITLE
test: increase delete-cluster timeout and log more during E2E tests

### DIFF
--- a/test/suites/common/cleanup.yaml
+++ b/test/suites/common/cleanup.yaml
@@ -17,7 +17,7 @@ spec:
   - name: delete-cluster
     image: public.ecr.aws/karpenter-testing/tools:latest
     script: |
-      eksctl delete cluster --name $(params.cluster-name) --wait || true
+      eksctl delete cluster --name $(params.cluster-name) --timeout 60m --wait || true
 
   - name: delete-iam-policies
     image: public.ecr.aws/karpenter-testing/tools:latest


### PR DESCRIPTION
**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
