### PR TITLE
docs: fix bottlerocket node template for GPU volume size

### DIFF
--- a/examples/provisioner/bottlerocket.yaml
+++ b/examples/provisioner/bottlerocket.yaml
@@ -23,7 +23,7 @@ spec:
     - deviceName: /dev/xvda
       ebs:
         volumeType: gp3
-        volumeSize: 2G # if using GPU, replace with 3G since the GPU bottlerocket AMI requires at least 3G
+        volumeSize: 2G # if using GPU, replace with 4G since the GPU bottlerocket AMI requires at least 4G
         deleteOnTermination: true
     - deviceName: /dev/xvdb
       ebs:

--- a/examples/provisioner/bottlerocket.yaml
+++ b/examples/provisioner/bottlerocket.yaml
@@ -23,7 +23,7 @@ spec:
     - deviceName: /dev/xvda
       ebs:
         volumeType: gp3
-        volumeSize: 2Gi
+        volumeSize: 2G # if using GPU, replace with 3G since the GPU bottlerocket AMI requires at least 3G
         deleteOnTermination: true
     - deviceName: /dev/xvdb
       ebs:

--- a/examples/provisioner/bottlerocket.yaml
+++ b/examples/provisioner/bottlerocket.yaml
@@ -23,10 +23,10 @@ spec:
     - deviceName: /dev/xvda
       ebs:
         volumeType: gp3
-        volumeSize: 2G # if using GPU, replace with 4G since the GPU bottlerocket AMI requires at least 4G
+        volumeSize: 4Gi
         deleteOnTermination: true
     - deviceName: /dev/xvdb
       ebs:
         volumeType: gp3
-        volumeSize: 20G # replace with your required disk size
+        volumeSize: 20Gi # replace with your required disk size
         deleteOnTermination: true


### PR DESCRIPTION
**Description**

the GPU bottlerocket AMI requires at least 3GB. otherwise you run into:

> 2022-08-30T13:27:52.897Z        ERROR   controller.provisioning Provisioning failed, launching node, creating cloud provider instance, with fleet error(s), InvalidBlockDeviceMapping: Volume of size 3GB is smaller than  snapshot 'snap-0c5c999fe56c48b6f', expect size >= 4GB        {"commit": "639756a"}

The normal bottlerocket AMI size is still 2GB, just GPU is a bit bigger.

There was also a typo with the volume size value.

**How was this change tested?**

* N/A

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
