### PR TITLE
fix: ensure the cloud provider sets it's defaulting/validate webhooks

### DIFF
--- a/pkg/cloudprovider/aws/cloudprovider.go
+++ b/pkg/cloudprovider/aws/cloudprovider.go
@@ -82,7 +82,10 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *Cloud
 	// if performing validation only, then only the Validate()/Default() methods will be called which
 	// don't require any other setup
 	if options.WebhookOnly {
-		return &CloudProvider{}
+		cp := &CloudProvider{}
+		v1alpha5.ValidateHook = cp.Validate
+		v1alpha5.DefaultHook = cp.Default
+		return cp
 	}
 
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named("aws"))
@@ -215,6 +218,7 @@ func (*CloudProvider) Default(ctx context.Context, provisioner *v1alpha5.Provisi
 }
 
 func defaultLabels(provisioner *v1alpha5.Provisioner) {
+	logging.FromContext(context.Background()).Infof("set default labels on %s", provisioner.Name)
 	for key, value := range map[string]string{
 		v1alpha5.LabelCapacityType: ec2.DefaultTargetCapacityTypeOnDemand,
 		v1.LabelArchStable:         v1alpha5.ArchitectureAmd64,

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -198,6 +198,22 @@ var _ = Describe("Allocation", func() {
 				Values:   []string{v1alpha5.ArchitectureAmd64},
 			}))
 		})
+		It("should default requirements hooks in webhook mode", func() {
+			// clear our hook to ensure that creating the cloud provider in webhook mode sets it
+			v1alpha5.DefaultHook = func(ctx context.Context, provisoner *v1alpha5.Provisioner) {}
+			NewCloudProvider(ctx, cloudprovider.Options{WebhookOnly: true})
+			v1alpha5.DefaultHook(ctx, provisioner)
+			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
+				Key:      v1alpha5.LabelCapacityType,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{awsv1alpha1.CapacityTypeOnDemand},
+			}))
+			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
+				Key:      v1.LabelArchStable,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{v1alpha5.ArchitectureAmd64},
+			}))
+		})
 	})
 	Context("Validation", func() {
 		It("should validate", func() {


### PR DESCRIPTION
Fixes #2407

**Description**
ensure the cloud provider sets it's defaulting/validate webhooks
**How was this change tested?**

* Unit testing & deployed to EKS

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
