### PR TITLE
fix: Remove comment after wait command

### DIFF
--- a/website/content/en/v0.16.0/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/v0.16.0/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh
@@ -5,4 +5,4 @@ helm upgrade --install --namespace karpenter --create-namespace \
   --set clusterName=${CLUSTER_NAME} \
   --set clusterEndpoint=${CLUSTER_ENDPOINT} \
   --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
-  --wait # for the defaulting webhook to install before creating a Provisioner
+  --wait


### PR DESCRIPTION
The comment after the wait command causes the `helm upgrade` command to fail with the following message:
> Error: "helm upgrade" requires 2 arguments

Removing the comment fixes this error.

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # NA

**Description**
This is a fix to the `helm upgrade` script in the getting started documentation. The documentation doesn't make it clear that users should remove this comment before running the command/script, otherwise it will fail.

**How was this change tested?**

* Removing the comment after the last command in the script resolved my issue.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
This is a change to the Getting Started document where developers could experience issues trying to install the Helm chart needed for Karpenter.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
