### PR TITLE
chore: Use log.Fatalf instead of log.Printf and os.Exit

### DIFF
--- a/hack/code/prices_gen.go
+++ b/hack/code/prices_gen.go
@@ -37,8 +37,7 @@ import (
 func main() {
 	flag.Parse()
 	if flag.NArg() != 1 {
-		log.Printf("Usage: %s pkg/cloudprovider/aws/zz_generated.pricing.go", os.Args[0])
-		os.Exit(1)
+		log.Fatalf("Usage: %s pkg/cloudprovider/aws/zz_generated.pricing.go", os.Args[0])
 	}
 
 	f, err := os.Create("pricing.heapprofile")

--- a/hack/docs/configuration_gen_docs.go
+++ b/hack/docs/configuration_gen_docs.go
@@ -26,8 +26,7 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		log.Printf("Usage: %s path/to/markdown.md", os.Args[0])
-		os.Exit(1)
+		log.Fatalf("Usage: %s path/to/markdown.md", os.Args[0])
 	}
 	outputFileName := os.Args[1]
 	mdFile, err := os.ReadFile(outputFileName)

--- a/hack/docs/instancetypes_gen_docs.go
+++ b/hack/docs/instancetypes_gen_docs.go
@@ -41,8 +41,7 @@ import (
 func main() {
 	flag.Parse()
 	if flag.NArg() != 1 {
-		log.Printf("Usage: %s path/to/markdown.md", os.Args[0])
-		os.Exit(1)
+		log.Fatalf("Usage: %s path/to/markdown.md", os.Args[0])
 	}
 
 	os.Setenv("AWS_SDK_LOAD_CONFIG", "true")

--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -45,8 +45,7 @@ func (i metricInfo) qualifiedName() string {
 func main() {
 	flag.Parse()
 	if flag.NArg() != 2 {
-		log.Printf("Usage: %s path/to/metrics/controller path/to/markdown.md", os.Args[0])
-		os.Exit(1)
+		log.Fatalf("Usage: %s path/to/metrics/controller path/to/markdown.md", os.Args[0])
 	}
 	fset := token.NewFileSet()
 	var packages []*ast.Package


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Use log.Fatalf

**How was this change tested?**

* make test

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
