### PR TITLE
feat: Support CNI Custom Networking

### DIFF
--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -391,7 +391,7 @@ func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2
 				},
 				NetworkInfo: &ec2.NetworkInfo{
 					MaximumNetworkInterfaces:  aws.Int64(3),
-					Ipv4AddressesPerInterface: aws.Int64(30),
+					Ipv4AddressesPerInterface: aws.Int64(10),
 				},
 			},
 			{

--- a/pkg/cloudprovider/aws/suite_test.go
+++ b/pkg/cloudprovider/aws/suite_test.go
@@ -90,6 +90,7 @@ var _ = BeforeSuite(func() {
 			AWSENILimitedPodDensity:   true,
 			AWSEnablePodENI:           true,
 			AWSDefaultInstanceProfile: "test-instance-profile",
+			AWSCniCustomNetworking:    false,
 		}
 		Expect(opts.Validate()).To(Succeed(), "Failed to validate options")
 		ctx = injection.WithOptions(ctx, opts)

--- a/pkg/utils/options/options.go
+++ b/pkg/utils/options/options.go
@@ -53,6 +53,7 @@ type Options struct {
 	AWSDefaultInstanceProfile string
 	AWSEnablePodENI           bool
 	AWSIsolatedVPC            bool
+	AWSCniCustomNetworking    bool
 }
 
 // New creates an Options struct and registers CLI flags and environment variables to fill-in the Options struct fields
@@ -79,6 +80,7 @@ func New() *Options {
 	f.StringVar(&opts.AWSDefaultInstanceProfile, "aws-default-instance-profile", env.WithDefaultString("AWS_DEFAULT_INSTANCE_PROFILE", ""), "The default instance profile to use when provisioning nodes in AWS")
 	f.BoolVar(&opts.AWSEnablePodENI, "aws-enable-pod-eni", env.WithDefaultBool("AWS_ENABLE_POD_ENI", false), "If true then instances that support pod ENI will report a vpc.amazonaws.com/pod-eni resource")
 	f.BoolVar(&opts.AWSIsolatedVPC, "aws-isolated-vpc", env.WithDefaultBool("AWS_ISOLATED_VPC", false), "If true then assume we can't reach AWS services which don't have a VPC endpoint")
+	f.BoolVar(&opts.AWSCniCustomNetworking, "aws-cni-custom-networking", env.WithDefaultBool("AWS_CNI_CUSTOM_NETWORKING", false), "If true then assume an ENI is used for the worker subnet and may not be used for pods when calculating ENI pod limits")
 	return opts
 }
 

--- a/website/content/en/preview/tasks/configuration.md
+++ b/website/content/en/preview/tasks/configuration.md
@@ -14,6 +14,7 @@ There are two main configuration mechanisms that can be used to configure Karpen
 
 | Environment Variable | CLI Flag | Description |
 |--|--|--|
+| AWS_CNI_CUSTOM_NETWORKING | \-\-aws-cni-custom-networking | If true then assume an ENI is used for the worker subnet and may not be used for pods when calculating ENI pod limits (default = false)|
 | AWS_DEFAULT_INSTANCE_PROFILE | \-\-aws-default-instance-profile | The default instance profile to use when provisioning nodes in AWS|
 | AWS_ENABLE_POD_ENI | \-\-aws-enable-pod-eni | If true then instances that support pod ENI will report a vpc.amazonaws.com/pod-eni resource (default = false)|
 | AWS_ENI_LIMITED_POD_DENSITY | \-\-aws-eni-limited-pod-density | Indicates whether new nodes should use ENI-based pod density. DEPRECATED: Use `.spec.kubeletConfiguration.maxPods` to set pod density on a per-provisioner basis (default = true)|
@@ -25,6 +26,8 @@ There are two main configuration mechanisms that can be used to configure Karpen
 | HEALTH_PROBE_PORT | \-\-health-probe-port | The port the health probe endpoint binds to for reporting controller health (default = 8081)|
 | KUBE_CLIENT_BURST | \-\-kube-client-burst | The maximum allowed burst of queries to the kube-apiserver (default = 300)|
 | KUBE_CLIENT_QPS | \-\-kube-client-qps | The smoothed rate of qps to kube-apiserver (default = 200)|
+| LEADER_ELECT | \-\-leader-elect | Start leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. (default = true)|
+| MEMORY_LIMIT | \-\-memory-limit | Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value. (default = -1)|
 | METRICS_PORT | \-\-metrics-port | The port the metric endpoint binds to for operating metrics about the controller itself (default = 8080)|
 | VM_MEMORY_OVERHEAD | \-\-vm-memory-overhead | The VM memory overhead as a percent that will be subtracted from the total memory for all instance types (default = 0.075)|
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

Fixes #2273

**Description**

Adds a config option to accommodate CNI Custom Networking, wherein one ENI on a node is reserved for a dedicated worker subnet, and additional ENIs are created in a dedicated pod subnet.

**How was this change tested?**

* make test

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

```
Add option to support CNI Custom Networking
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
