### PR TITLE
While using Custome AMI, Controller Role cannot describe images

### DIFF
--- a/website/content/en/v0.16.1/getting-started/migrating-from-cas/scripts/step05-controller-iam.sh
+++ b/website/content/en/v0.16.1/getting-started/migrating-from-cas/scripts/step05-controller-iam.sh
@@ -26,6 +26,7 @@ echo '{
             "Action": [
                 "ssm:GetParameter",
                 "iam:PassRole",
+                "ec2:DescribeImages",
                 "ec2:RunInstances",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeSecurityGroups",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
While using Launch Template with Custom AMI the controller role cannot describe the AMI image ID and create Instance out of it.

**How was this change tested?**
I include ec2:DescribeImages to KarpenterControllerPolicy and Karpenter created the Instance with custom AMI.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
