### PR TITLE
fix: Mark nodes that are pending deletion in cluster state for scheduling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ battletest: ## Run randomized, racing, code coveraged, tests
 
 e2etests: ## Run the e2e suite against your local cluster
 	go clean -testcache
-	go test -p 1 -timeout 180m -v ./test/suites/... -run=${TEST_FILTER}
+	CLUSTER_NAME=${CLUSTER_NAME} go test -p 1 -timeout 180m -v ./test/suites/... -run=${TEST_FILTER}
 
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -134,6 +134,12 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, provisioner *v1alpha
 				v1.ResourcePods: resource.MustParse("1"),
 			},
 		}),
+		NewInstanceType(InstanceTypeOptions{
+			Name: "ten-pod-instance-type",
+			Resources: map[v1.ResourceName]resource.Quantity{
+				v1.ResourcePods: resource.MustParse("10"),
+			},
+		}),
 	}, nil
 }
 

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -134,12 +134,6 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, provisioner *v1alpha
 				v1.ResourcePods: resource.MustParse("1"),
 			},
 		}),
-		NewInstanceType(InstanceTypeOptions{
-			Name: "ten-pod-instance-type",
-			Resources: map[v1.ResourceName]resource.Quantity{
-				v1.ResourcePods: resource.MustParse("10"),
-			},
-		}),
 	}, nil
 }
 

--- a/pkg/controllers/consolidation/types.go
+++ b/pkg/controllers/consolidation/types.go
@@ -41,6 +41,7 @@ const (
 	consolidateResultDelete
 	consolidateResultDeleteEmpty
 	consolidateResultReplace
+	consolidateResultNoAction
 )
 
 func (r consolidateResult) String() string {
@@ -55,6 +56,8 @@ func (r consolidateResult) String() string {
 		return "Delete (empty node)"
 	case consolidateResultReplace:
 		return "Replace"
+	case consolidateResultNoAction:
+		return "NoAction"
 	default:
 		return fmt.Sprintf("Unknown (%d)", r)
 	}

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -47,6 +47,9 @@ func (r *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 	expirationTime := node.CreationTimestamp.Add(expirationTTL)
 	if r.clock.Now().After(expirationTime) {
 		logging.FromContext(ctx).Infof("Triggering termination for expired node after %s (+%s)", expirationTTL, time.Since(expirationTime))
+
+		// The delete operation implicitly marks the node for deletion for handling with scheduling
+		// This also implicitly triggers provisioning of the new node since at least one pod should go pending
 		if err := r.kubeClient.Delete(ctx, node); err != nil {
 			return reconcile.Result{}, fmt.Errorf("deleting node, %w", err)
 		}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -144,6 +144,9 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	var stateNodes []*state.Node
 	var markedForDeletionNodes []*state.Node
 	p.cluster.ForEachNode(func(node *state.Node) bool {
+		// We don't consider the nodes that are MarkedForDeletion since this capacity shouldn't be considered
+		// as persistent capacity for the cluster (since it will soon be removed). Additionally, we are scheduling for
+		// the pods that are on these nodes so the MarkedForDeletion node capacity can't be considered.
 		if !node.MarkedForDeletion {
 			stateNodes = append(stateNodes, node.DeepCopy())
 		} else {

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	cloudProvider = &fake.CloudProvider{}
+	recorder.Reset()
 	cluster = state.NewCluster(fakeClock, cfg, env.Client, cloudProvider)
 })
 
@@ -206,13 +206,11 @@ var _ = Describe("Provisioning", func() {
 		ExpectApplied(ctx, env.Client, node, provisioner)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
-		var scheduledPods []*v1.Pod
-		// Schedule 10 pods to the node that currently exists
-		for i := 0; i < 5; i++ {
+		// Schedule 3 pods to the node that currently exists
+		for i := 0; i < 3; i++ {
 			pod := test.UnschedulablePod()
 			ExpectApplied(ctx, env.Client, pod)
 			ExpectManualBinding(ctx, env.Client, pod, node)
-			scheduledPods = append(scheduledPods, pod)
 		}
 
 		// Node shouldn't fully delete since it has a finalizer
@@ -221,7 +219,7 @@ var _ = Describe("Provisioning", func() {
 
 		// Provision without a binding since some pods will already be bound
 		// Should all schedule to the new node, ignoring the old node
-		ExpectProvisionedNoBinding(ctx, env.Client, controller, test.UnschedulablePod(), test.UnschedulablePod(), test.UnschedulablePod())
+		ExpectProvisionedNoBinding(ctx, env.Client, controller, test.UnschedulablePod(), test.UnschedulablePod())
 		nodes := &v1.NodeList{}
 		Expect(env.Client.List(ctx, nodes)).To(Succeed())
 		Expect(len(nodes.Items)).To(Equal(2))

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -47,6 +47,9 @@ import (
 
 var ctx context.Context
 var fakeClock *clock.FakeClock
+var cluster *state.Cluster
+var nodeController *state.NodeController
+var cloudProvider cloudprovider.CloudProvider
 var controller *provisioning.Controller
 var env *test.Environment
 var recorder *test.EventRecorder
@@ -61,12 +64,12 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(ctx, func(e *test.Environment) {
-		cloudProvider := &fake.CloudProvider{}
-		recorder = test.NewEventRecorder()
+		cloudProvider = &fake.CloudProvider{}
 		cfg = test.NewConfig()
 		recorder = test.NewEventRecorder()
 		fakeClock = clock.NewFakeClock(time.Now())
-		cluster := state.NewCluster(fakeClock, cfg, e.Client, cloudProvider)
+		cluster = state.NewCluster(fakeClock, cfg, e.Client, cloudProvider)
+		nodeController = state.NewNodeController(e.Client, cluster)
 		prov := provisioning.NewProvisioner(ctx, cfg, e.Client, corev1.NewForConfigOrDie(e.Config), recorder, cloudProvider, cluster)
 		controller = provisioning.NewController(e.Client, prov, recorder)
 		instanceTypes, _ := cloudProvider.GetInstanceTypes(context.Background(), nil)
@@ -76,6 +79,11 @@ var _ = BeforeSuite(func() {
 		}
 	})
 	Expect(env.Start()).To(Succeed(), "Failed to start environment")
+})
+
+var _ = BeforeEach(func() {
+	cloudProvider = &fake.CloudProvider{}
+	cluster = state.NewCluster(fakeClock, cfg, env.Client, cloudProvider)
 })
 
 var _ = AfterSuite(func() {
@@ -181,6 +189,47 @@ var _ = Describe("Provisioning", func() {
 		for _, pod := range pods {
 			ExpectScheduled(ctx, env.Client, pod)
 		}
+	})
+	It("should schedule all pods on one node when node is in deleting state", func() {
+		provisioner := test.Provisioner()
+		its, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+		Expect(err).To(BeNil())
+		node := test.Node(test.NodeOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					v1.LabelInstanceTypeStable:       its[0].Name(),
+				},
+				Finalizers: []string{v1alpha5.TerminationFinalizer},
+			}},
+		)
+		ExpectApplied(ctx, env.Client, node, provisioner)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+
+		var scheduledPods []*v1.Pod
+		// Schedule 10 pods to the node that currently exists
+		for i := 0; i < 5; i++ {
+			pod := test.UnschedulablePod()
+			ExpectApplied(ctx, env.Client, pod)
+			ExpectManualBinding(ctx, env.Client, pod, node)
+			scheduledPods = append(scheduledPods, pod)
+		}
+
+		// Node shouldn't fully delete since it has a finalizer
+		Expect(env.Client.Delete(ctx, node)).To(Succeed())
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+
+		// Provision without a binding since some pods will already be bound
+		// Should all schedule to the new node, ignoring the old node
+		ExpectProvisionedNoBinding(ctx, env.Client, controller, test.UnschedulablePod(), test.UnschedulablePod(), test.UnschedulablePod())
+		nodes := &v1.NodeList{}
+		Expect(env.Client.List(ctx, nodes)).To(Succeed())
+		Expect(len(nodes.Items)).To(Equal(2))
+
+		// Scheduler should attempt to schedule all the pods to the new node
+		recorder.ForEachBinding(func(p *v1.Pod, n *v1.Node) {
+			Expect(n.Name).ToNot(Equal(node.Name))
+		})
 	})
 	Context("Resource Limits", func() {
 		It("should not schedule when limits are exceeded", func() {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -180,6 +180,15 @@ func (c *Cluster) NominateNodeForPod(nodeName string) {
 	c.nominatedNodes.SetDefault(nodeName, nil)
 }
 
+// UnmarkForDeletion removes the marking on the node as a node the controller intends to delete
+func (c *Cluster) UnmarkForDeletion(nodeName string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.nodes[nodeName]; ok {
+		c.nodes[nodeName].MarkedForDeletion = false
+	}
+}
+
 // MarkForDeletion marks the node as pending deletion in the internal cluster state
 func (c *Cluster) MarkForDeletion(nodeName string) {
 	c.mu.Lock()

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -345,9 +345,10 @@ func (c *Cluster) updateNode(ctx context.Context, node *v1.Node) error {
 		if oldNode.Node.Labels[v1alpha5.LabelNodeInitialized] != n.Node.Labels[v1alpha5.LabelNodeInitialized] {
 			c.recordConsolidationChange()
 		}
-		if oldNode.MarkedForDeletion {
-			n.MarkedForDeletion = true
-		}
+		// We mark the node for deletion either:
+		// 1. If the DeletionTimestamp is set (the node is explicitly being deleted)
+		// 2. If the last state of the node has the node MarkedForDeletion
+		n.MarkedForDeletion = n.MarkedForDeletion || oldNode.MarkedForDeletion
 	}
 	c.nodes[node.Name] = n
 

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -508,7 +508,7 @@ var _ = Describe("Node Resource Level", func() {
 		ExpectNodeResourceRequest(node, v1.ResourceCPU, "2.5")
 		ExpectNodeResourceRequest(node, v1.ResourceMemory, "2Gi")
 	})
-	FIt("should mark node for deletion when node is deleted", func() {
+	It("should mark node for deletion when node is deleted", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -1,0 +1,30 @@
+package node
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter/pkg/utils/pod"
+)
+
+// GetNodePods gets the list of schedulable pods from a node based on nodeName
+func GetNodePods(ctx context.Context, kubeClient client.Client, nodeName string) ([]*v1.Pod, error) {
+	var podList v1.PodList
+	if err := kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
+		return nil, fmt.Errorf("listing pods, %w", err)
+	}
+	var pods []*v1.Pod
+	for i := range podList.Items {
+		// these pods don't need to be rescheduled
+		if pod.IsOwnedByNode(&podList.Items[i]) ||
+			pod.IsOwnedByDaemonSet(&podList.Items[i]) ||
+			pod.IsTerminal(&podList.Items[i]) {
+			continue
+		}
+		pods = append(pods, &podList.Items[i])
+	}
+	return pods, nil
+}

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -1,3 +1,17 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package node
 
 import (

--- a/test/pkg/environment/expectations.go
+++ b/test/pkg/environment/expectations.go
@@ -218,6 +218,13 @@ func (env *Environment) ExpectCreatedNodeCount(comparator string, nodeCount int)
 		fmt.Sprintf("expected %d created nodes, had %d", nodeCount, env.Monitor.CreatedNodes()))
 }
 
+func (env *Environment) EventuallyExpectCreatedNodeCount(comparator string, nodeCount int) {
+	Eventually(func(g Gomega) {
+		g.Expect(env.Monitor.CreatedNodes()).To(BeNumerically(comparator, nodeCount),
+			fmt.Sprintf("expected %d created nodes, had %d", nodeCount, env.Monitor.CreatedNodes()))
+	}).Should(Succeed())
+}
+
 func (env *Environment) GetNode(nodeName string) v1.Node {
 	var node v1.Node
 	Expect(env.Client.Get(env.Context, types.NamespacedName{Name: nodeName}, &node)).To(Succeed())

--- a/test/suites/integration/expiration_test.go
+++ b/test/suites/integration/expiration_test.go
@@ -1,0 +1,111 @@
+package integration_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/ptr"
+
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+)
+
+var _ = Describe("Expiration", func() {
+	It("should expire the node after the TTLSecondsUntilExpired is reached", func() {
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef:            &v1alpha5.ProviderRef{Name: provider.Name},
+			TTLSecondsUntilExpired: ptr.Int64(30),
+		})
+		var numPods int32 = 3
+
+		dep := test.Deployment(test.DeploymentOptions{
+			Replicas: numPods,
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "large-app"},
+				},
+			},
+		})
+
+		env.ExpectCreatedNodeCount("==", 0)
+		env.ExpectCreated(provisioner, provider, dep)
+
+		// We don't care if the pod goes healthy, just if the node is expired
+		env.EventuallyExpectCreatedNodeCount("==", 1)
+		node := env.Monitor.GetCreatedNodes()[0]
+
+		// Eventually expect the node to be gone
+		env.EventuallyExpectNotFound(&node)
+	})
+	It("should replace expired node with a single node and schedule all pods", func() {
+		provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+		})
+		var numPods int32 = 5
+
+		// We should setup a PDB that will only allow a minimum of 1 pod to be pending at a time
+		minAvailable := intstr.FromInt(int(numPods) - 1)
+		pdb := test.PodDisruptionBudget(test.PDBOptions{
+			Labels: map[string]string{
+				"app": "large-app",
+			},
+			MinAvailable: &minAvailable,
+		})
+		dep := test.Deployment(test.DeploymentOptions{
+			Replicas: numPods,
+			PodOptions: test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "large-app"},
+				},
+			},
+		})
+
+		selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+		env.ExpectCreatedNodeCount("==", 0)
+		env.ExpectCreated(provisioner, provider, pdb, dep)
+
+		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+		env.ExpectCreatedNodeCount("==", 1)
+
+		node := env.Monitor.GetCreatedNodes()[0]
+
+		// Reset the monitor so that we can expect a single node to be spun up after expiration
+		env.Monitor.Reset()
+
+		// Set the TTLSecondsUntilExpired to get the node deleted
+		provisioner.Spec.TTLSecondsUntilExpired = ptr.Int64(60)
+		env.ExpectUpdate(provisioner)
+
+		// Eventually the node deletion timestamp will be set
+		Eventually(func(g Gomega) {
+			n := &v1.Node{}
+			g.Expect(env.Client.Get(env.Context, types.NamespacedName{Name: node.Name}, n)).Should(Succeed())
+			g.Expect(n.DeletionTimestamp.IsZero()).Should(BeFalse())
+		}).Should(Succeed())
+
+		// Remove the TTLSecondsUntilExpired to make sure new node isn't deleted
+		provisioner.Spec.TTLSecondsUntilExpired = nil
+		env.ExpectUpdate(provisioner)
+
+		// After the deletion timestamp is set and all pods are drained
+		// the node should be gone
+		env.EventuallyExpectNotFound(&node)
+
+		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+		env.ExpectCreatedNodeCount("==", 1)
+	})
+})

--- a/test/suites/integration/expiration_test.go
+++ b/test/suites/integration/expiration_test.go
@@ -1,3 +1,17 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package integration_test
 
 import (


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Enables pods that are under Expiry with PDBs to schedule a node that will fit all the pods that are on a node marked for deletion rather than slowly trickling the pending pods onto a large number of small nodes

**How was this change tested?**

* `make test`
* Latency testing with large scale-ups
* `TEST_FILTER=Integration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
