### PR TITLE
feat: consolidation enhancements

### DIFF
--- a/charts/karpenter/templates/clusterrole.yaml
+++ b/charts/karpenter/templates/clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
     resources: ["storageclasses", "csinodes"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["apps"]
-    resources: ["daemonsets", "replicasets", "statefulsets"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
     verbs: ["list", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]

--- a/pkg/cloudprovider/aws/amifamily/ami.go
+++ b/pkg/cloudprovider/aws/amifamily/ami.go
@@ -90,7 +90,7 @@ func (p *AMIProvider) getDefaultAMIFromSSM(ctx context.Context, _ cloudprovider.
 	}
 	ami := aws.StringValue(output.Parameter.Value)
 	p.ssmCache.SetDefault(ssmQuery, ami)
-	if p.cm.HasChanged("ssmquery", ami+ssmQuery) {
+	if p.cm.HasChanged("ssmquery-"+ssmQuery, ami) {
 		logging.FromContext(ctx).Debugf("Discovered %s for query %q", ami, ssmQuery)
 	}
 	return ami, nil

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -160,7 +160,7 @@ func (p *LaunchTemplateProvider) ensureLaunchTemplate(ctx context.Context, optio
 	} else if len(output.LaunchTemplates) != 1 {
 		return nil, fmt.Errorf("expected to find one launch template, but found %d", len(output.LaunchTemplates))
 	} else {
-		if p.cm.HasChanged("launchtemplate"+name, name) {
+		if p.cm.HasChanged("launchtemplate-"+name, name) {
 			logging.FromContext(ctx).Debugf("Discovered launch template %s", name)
 		}
 		launchTemplate = output.LaunchTemplates[0]

--- a/pkg/cloudprovider/aws/launchtemplate.go
+++ b/pkg/cloudprovider/aws/launchtemplate.go
@@ -160,7 +160,9 @@ func (p *LaunchTemplateProvider) ensureLaunchTemplate(ctx context.Context, optio
 	} else if len(output.LaunchTemplates) != 1 {
 		return nil, fmt.Errorf("expected to find one launch template, but found %d", len(output.LaunchTemplates))
 	} else {
-		logging.FromContext(ctx).Debugf("Discovered launch template %s", name)
+		if p.cm.HasChanged("launchtemplate"+name, name) {
+			logging.FromContext(ctx).Debugf("Discovered launch template %s", name)
+		}
 		launchTemplate = output.LaunchTemplates[0]
 	}
 	p.cache.SetDefault(name, launchTemplate)

--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -17,7 +17,6 @@ package consolidation
 import (
 	"context"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"sort"
 	"sync"
 	"time"
@@ -26,9 +25,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
@@ -639,7 +638,7 @@ func (c *Controller) statefulSetsReady(ctx context.Context) bool {
 	var sslist appsv1.StatefulSetList
 	if err := c.kubeClient.List(ctx, &sslist); err != nil {
 		// failed to list, assume there must be one non-ready as it's harmless and just ensures we wait longer
-		return true
+		return false
 	}
 	for _, rs := range sslist.Items {
 		desired := ptr.Int32Value(rs.Spec.Replicas)

--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -109,12 +109,13 @@ func (c *Controller) run(ctx context.Context) {
 				continue
 			}
 
-			// don't consolidate as we recently scaled down too soon
+			// don't consolidate as we recently scaled up/down too soon
 			stabilizationTime := c.clock.Now().Add(-c.stabilizationWindow(ctx))
 			// capture the state before we process so if something changes during consolidation we'll re-look
 			// immediately
 			clusterState := c.cluster.ClusterConsolidationState()
-			if c.cluster.LastNodeDeletionTime().Before(stabilizationTime) {
+			if c.cluster.LastNodeDeletionTime().Before(stabilizationTime) &&
+				c.cluster.LastNodeCreationTime().Before(stabilizationTime) {
 				result, err := c.ProcessCluster(ctx)
 				if err != nil {
 					logging.FromContext(ctx).Errorf("consolidating cluster, %s", err)

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -190,3 +190,9 @@ error: error validating "provisioner.yaml": error validating data: ValidationErr
 ```
 
 The `startupTaints` parameter was added in v0.10.0.  Helm upgrades do not upgrade the CRD describing the provisioner, so it must be done manually. For specific details, see the [Upgrade Guide]({{< ref "./upgrade-guide/#upgrading-to-v0100" >}})
+
+## Consolidation
+
+### Why do I sometimes see an extra node get launched when updating a deployment that then remains empty and is removed?
+
+Consolidation packs pods tightly onto nodes which can leave little free allocatable CPU/memory on your nodes.  If a deployment uses a deployment strategy with a non-zero `maxSurge`, such as the default 25%, those surge pods may not have anywhere to run. In this case Karpenter will launch a new node so that the surge pods can run and then remove it soon after if it's not needed.

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -193,6 +193,6 @@ The `startupTaints` parameter was added in v0.10.0.  Helm upgrades do not upgrad
 
 ## Consolidation
 
-### Why do I sometimes see an extra node get launched when updating a deployment that then remains empty and is removed?
+### Why do I sometimes see an extra node get launched when updating a deployment that remains empty and is later removed?
 
-Consolidation packs pods tightly onto nodes which can leave little free allocatable CPU/memory on your nodes.  If a deployment uses a deployment strategy with a non-zero `maxSurge`, such as the default 25%, those surge pods may not have anywhere to run. In this case Karpenter will launch a new node so that the surge pods can run and then remove it soon after if it's not needed.
+Consolidation packs pods tightly onto nodes which can leave little free allocatable CPU/memory on your nodes.  If a deployment uses a deployment strategy with a non-zero `maxSurge`, such as the default 25%, those surge pods may not have anywhere to run. In this case, Karpenter will launch a new node so that the surge pods can run and then remove it soon after if it's not needed.


### PR DESCRIPTION
**Description**
- Monitor for deployment/stateful set updates when reducing the stabilitization window
- Consider the last node creation time as part of the stabilization window
- Reduce some more log spam
- Add a FAQ entry explaining why sometimes an extra node appears when updating a deployment image

**How was this change tested?**

* Unit tested and deployed to EKS.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
