### PR TITLE
docs: Add troubleshooting guidance for CRD upgrades

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -59,6 +59,7 @@ See [Kubernetes cluster autoscaler]({{< ref "./concepts/#kubernetes-cluster-auto
 See [Scheduling]({{< ref "./concepts/#scheduling" >}}) for details on how Karpenter interacts with the Kubernetes scheduler.
 
 ## Provisioning
+
 ### What features does the Karpenter provisioner support?
 See [Provisioner API]({{< ref "./provisioner" >}}) for provisioner examples and descriptions of features.
 

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -6,6 +6,18 @@ description: >
   Troubleshoot Karpenter problems
 ---
 
+## Unknown field in Provisioner spec
+
+If you are upgrading from an older version of Karpenter, there may have been changes in the CRD between versions. Attempting to utilize newer functionality which is surfaced in newer versions of the CRD may result in the following error message:
+
+```
+error: error validating "STDIN": error validating data: ValidationError(Provisioner.spec): unknown field "<fieldName>" in sh.karpenter.v1alpha5.Provisioner.spec; if you choose to ignore these errors, turn validation off with --validate=false
+```
+
+If you see this error, you can solve the problem by following the [Custom Resource Definition Upgrade Guidance](../upgrade-guide/#custom-resource-definition-crd-upgrades).
+
+Info on whether there has been a change to the CRD between versions of Karpenter can be found in the [Release Notes](../upgrade-guide/#released-upgrade-notes)
+
 ## Unable to schedule pod due to insufficient node group instances
 
 v0.16.0 changed the default replicas from 1 to 2. 
@@ -19,6 +31,7 @@ To solve this you can either reduce the replicas back from 2 to 1, or ensure the
 To do so on AWS increase the `minimum` and `desired` parameters on the node group autoscaling group to launch at lease 2 instances.
 
 ## Node not created
+
 In some circumstances, Karpenter controller can fail to start up a node.
 For example, providing the wrong block storage device name in a custom launch template can result in a failure to start the node and an error similar to:
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Adds an additional place in the troubleshooting docs to point users to upgrade their CRDs

**How was this change tested?**

* Manual view of Preview Docs

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
