### PR TITLE
docs: Add docs on additional kubeletConfiguration for `kubeReserved`, `evictionHard`, and `podsPerCore`

### DIFF
--- a/website/content/en/preview/tasks/pod-density.md
+++ b/website/content/en/preview/tasks/pod-density.md
@@ -8,11 +8,7 @@ description: >
 
 Pod density is the number of pods per node. 
 
-Kubernetes has a default limit of 110 pods per node. If you are using the EKS Optimized AMI on AWS, the [number of pods is limited by instance type](https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt) in the default configuration. 
-
-## Max Pods
-
-Do not use the `max-pods` argument to kubelet. Karpenter is not aware of this value. For example, Karpenter may provision an instance expecting it to accommodate more pods than this static limit. 
+Kubernetes has a default limit of 110 pods per node. If you are using the EKS Optimized AMI on AWS, the [number of pods is limited by instance type](https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt) in the default configuration.
 
 ## Increase Pod Density
 
@@ -30,9 +26,17 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 
 ### Provisioner-Specific Pod Density
 
-Pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
+#### Static Pod Density
 
-See [Provisioner API Kubelet Configuration](../../provisioner/#maximum-pods) for more details.
+Static pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
+
+See [Provisioner API Kubelet Configuration](../../provisioner/#max-pods) for more details.
+
+#### Dynamic Pod Density
+
+Dynamic pod density (density that scales with the instance size) can be configured at the provisioner level by specifying `podsPerCore` within the `.spec.kubeletConfiguration`. Karpenter will calculate the expected pod density for each instance based on the instance's number of logical cores (vCPUs) and will account for this during scheduling.
+
+See [Provisioner API Kubelet Configuration](../../provisioner/#pods-per-core) for more details.
 
 ### Controller-Wide Pod Density
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Adds docs for the implementation of #2444 

**How was this change tested?**

* Manual view of Netlify docs

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
