### PR TITLE
docs: Migrate from `provider` to `providerRef`

### DIFF
--- a/website/content/en/preview/provisioner.md
+++ b/website/content/en/preview/provisioner.md
@@ -85,8 +85,9 @@ spec:
       cpu: "1000"
       memory: 1000Gi
 
-  # These fields vary per cloud provider, see your cloud provider specific documentation
-  provider: {}
+  # References cloud provider-specific custom resource, see your cloud provider specific documentation
+  providerRef:
+    name: default
 ```
 
 ## Node deprovisioning
@@ -251,8 +252,8 @@ Karpenter limits instance types when scheduling to those that will not exceed th
 
 Review the [resource limit task](../tasks/set-resource-limits) for more information.
 
-## spec.provider
+## spec.providerRef
 
-This section is cloud provider specific. Reference the appropriate documentation:
+This field points to the cloud provider-specific custom resource. Reference the appropriate documentation:
 
 - [AWS](../aws/provisioning/)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Another migration of `provider` to `providerRef` in Provisioner API docs

**How was this change tested?**

* Manual view of Preview docs

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
