### PR TITLE
test: Fix integration test monitor flakiness

### DIFF
--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -25,6 +25,8 @@ import (
 )
 
 // GetNodePods gets the list of schedulable pods from a variadic list of nodes
+// It ignores pods that are owned by the node, a daemonset or are in a terminal
+// or terminating state
 func GetNodePods(ctx context.Context, kubeClient client.Client, nodes ...*v1.Node) ([]*v1.Pod, error) {
 	var pods []*v1.Pod
 	for _, node := range nodes {
@@ -36,7 +38,8 @@ func GetNodePods(ctx context.Context, kubeClient client.Client, nodes ...*v1.Nod
 			// these pods don't need to be rescheduled
 			if pod.IsOwnedByNode(&podList.Items[i]) ||
 				pod.IsOwnedByDaemonSet(&podList.Items[i]) ||
-				pod.IsTerminal(&podList.Items[i]) {
+				pod.IsTerminal(&podList.Items[i]) ||
+				pod.IsTerminating(&podList.Items[i]) {
 				continue
 			}
 			pods = append(pods, &podList.Items[i])

--- a/test/pkg/environment/environment.go
+++ b/test/pkg/environment/environment.go
@@ -42,14 +42,15 @@ import (
 
 type Environment struct {
 	context.Context
-	ClusterName string
-	Region      string
-	Client      client.Client
-	KubeClient  kubernetes.Interface
-	EC2API      ec2.EC2
-	SSMAPI      ssm.SSM
-	IAMAPI      iam.IAM
-	Monitor     *Monitor
+	ClusterName       string
+	Region            string
+	Client            client.Client
+	KubeClient        kubernetes.Interface
+	EC2API            ec2.EC2
+	SSMAPI            ssm.SSM
+	IAMAPI            iam.IAM
+	Monitor           *Monitor
+	StartingNodeCount int
 }
 
 func NewEnvironment(t *testing.T) (*Environment, error) {

--- a/test/pkg/environment/monitor.go
+++ b/test/pkg/environment/monitor.go
@@ -103,7 +103,7 @@ func (m *Monitor) NodeCount() int {
 
 // NodeCountAtReset returns the number of nodes that were running when the monitor was last reset, typically at the
 // beginning of a test
-func (m *Monitor) NodeCountAtReset() interface{} {
+func (m *Monitor) NodeCountAtReset() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.numberNodesAtReset


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Fixes failures due to calling `env.Monitor.Reset()` within a test
- Ignores pods that are `Terminating` for scheduling

**How was this change tested?**

* `TEST_FILTER=Integration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
