### PR TITLE
feat: Add `evictionSoft` support to `kubeletConfiguration`

### DIFF
--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -83,8 +83,8 @@ spec:
                   evictionSoftGracePeriod:
                     additionalProperties:
                       type: string
-                    description: EvictionGracePeriod is the map of signal names to
-                      quantities that define grace periods for each eviction signal
+                    description: EvictionSoftGracePeriod is the map of signal names
+                      to quantities that define grace periods for each eviction signal
                     type: object
                   kubeReserved:
                     additionalProperties:

--- a/charts/karpenter/crds/karpenter.sh_provisioners.yaml
+++ b/charts/karpenter/crds/karpenter.sh_provisioners.yaml
@@ -68,6 +68,24 @@ spec:
                     description: EvictionHard is the map of signal names to quantities
                       that define hard eviction thresholds
                     type: object
+                  evictionMaxPodGracePeriod:
+                    description: EvictionMaxPodGracePeriod is the maximum allowed
+                      grace period (in seconds) to use when terminating pods in response
+                      to soft eviction thresholds being met.
+                    format: int32
+                    type: integer
+                  evictionSoft:
+                    additionalProperties:
+                      type: string
+                    description: EvictionSoft is the map of signal names to quantities
+                      that define soft eviction thresholds
+                    type: object
+                  evictionSoftGracePeriod:
+                    additionalProperties:
+                      type: string
+                    description: EvictionGracePeriod is the map of signal names to
+                      quantities that define grace periods for each eviction signal
+                    type: object
                   kubeReserved:
                     additionalProperties:
                       anyOf:

--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -141,7 +141,7 @@ type KubeletConfiguration struct {
 	// EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
 	// +optional
 	EvictionSoft map[string]string `json:"evictionSoft,omitempty"`
-	// EvictionGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+	// EvictionSoftGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
 	// +optional
 	EvictionSoftGracePeriod map[string]metav1.Duration `json:"evictionSoftGracePeriod,omitempty"`
 	// EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in

--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -138,6 +138,16 @@ type KubeletConfiguration struct {
 	// EvictionHard is the map of signal names to quantities that define hard eviction thresholds
 	// +optional
 	EvictionHard map[string]string `json:"evictionHard,omitempty"`
+	// EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
+	// +optional
+	EvictionSoft map[string]string `json:"evictionSoft,omitempty"`
+	// EvictionGracePeriod is the map of signal names to quantities that define grace periods for each eviction signal
+	// +optional
+	EvictionSoftGracePeriod map[string]metav1.Duration `json:"evictionSoftGracePeriod,omitempty"`
+	// EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+	// response to soft eviction thresholds being met.
+	// +optional
+	EvictionMaxPodGracePeriod *int32 `json:"evictionMaxPodGracePeriod,omitempty"`
 }
 
 // Provisioner is the Schema for the Provisioners API

--- a/pkg/apis/provisioning/v1alpha5/suite_test.go
+++ b/pkg/apis/provisioning/v1alpha5/suite_test.go
@@ -396,7 +396,7 @@ var _ = Describe("Validation", func() {
 				}
 				Expect(provisioner.Validate(ctx)).To(Succeed())
 			})
-			It("should fail on evictionSoftGracePeriodf with invalid keys", func() {
+			It("should fail on evictionSoftGracePeriod with invalid keys", func() {
 				provisioner.Spec.KubeletConfiguration = &KubeletConfiguration{
 					EvictionSoftGracePeriod: map[string]metav1.Duration{
 						"memory": {Duration: time.Minute},

--- a/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
+++ b/pkg/apis/provisioning/v1alpha5/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ package v1alpha5
 
 import (
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 )
@@ -88,6 +89,25 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.EvictionSoft != nil {
+		in, out := &in.EvictionSoft, &out.EvictionSoft
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.EvictionSoftGracePeriod != nil {
+		in, out := &in.EvictionSoftGracePeriod, &out.EvictionSoftGracePeriod
+		*out = make(map[string]metav1.Duration, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.EvictionMaxPodGracePeriod != nil {
+		in, out := &in.EvictionMaxPodGracePeriod, &out.EvictionMaxPodGracePeriod
+		*out = new(int32)
+		**out = **in
 	}
 }
 

--- a/pkg/cloudprovider/aws/amifamily/al2.go
+++ b/pkg/cloudprovider/aws/amifamily/al2.go
@@ -96,3 +96,7 @@ func (a AL2) ENILimitedMemoryOverhead() bool {
 func (a AL2) PodsPerCoreEnabled() bool {
 	return true
 }
+
+func (a AL2) EvictionSoftEnabled() bool {
+	return true
+}

--- a/pkg/cloudprovider/aws/amifamily/al2.go
+++ b/pkg/cloudprovider/aws/amifamily/al2.go
@@ -28,6 +28,7 @@ import (
 )
 
 type AL2 struct {
+	DefaultFamily
 	*Options
 }
 
@@ -87,16 +88,4 @@ func (a AL2) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
 
 func (a AL2) EphemeralBlockDevice() *string {
 	return aws.String("/dev/xvda")
-}
-
-func (a AL2) ENILimitedMemoryOverhead() bool {
-	return true
-}
-
-func (a AL2) PodsPerCoreEnabled() bool {
-	return true
-}
-
-func (a AL2) EvictionSoftEnabled() bool {
-	return true
 }

--- a/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/aws/amifamily/bootstrap/eksbootstrap.go
@@ -131,7 +131,7 @@ func (e EKS) nodeLabelArg() string {
 	return fmt.Sprintf("%s%s", nodeLabelArg, strings.Join(labelStrings, ","))
 }
 
-// joinParameterArgs joins a map of keys and values by their separator. The separate will sit between the
+// joinParameterArgs joins a map of keys and values by their separator. The separator will sit between the
 // arguments in a comma-separated list i.e. arg1<sep>val1,arg2<sep>val2
 func joinParameterArgs[K comparable, V any](name string, m map[K]V, separator string) string {
 	var args []string

--- a/pkg/cloudprovider/aws/amifamily/bottlerocket.go
+++ b/pkg/cloudprovider/aws/amifamily/bottlerocket.go
@@ -30,6 +30,7 @@ import (
 )
 
 type Bottlerocket struct {
+	DefaultFamily
 	*Options
 }
 
@@ -82,23 +83,22 @@ func (b Bottlerocket) EphemeralBlockDevice() *string {
 	return aws.String("/dev/xvdb")
 }
 
-func (b Bottlerocket) ENILimitedMemoryOverhead() bool {
-	return false
-}
-
 // PodsPerCoreEnabled is currently disabled for Bottlerocket AMIFamily because it does
 // not currently support the podsPerCore parameter passed through the kubernetes settings TOML userData
 // If a Provisioner sets the podsPerCore value when using the Bottlerocket AMIFamily in the provider,
 // podsPerCore will be ignored
 // https://github.com/bottlerocket-os/bottlerocket/issues/1721
-func (b Bottlerocket) PodsPerCoreEnabled() bool {
-	return false
-}
 
 // EvictionSoftEnabled is currently disabled for Bottlerocket AMIFamily because it does
 // not currently support the evictionSoft parameter passed through the kubernetes settings TOML userData
 // If a Provisioner sets the evictionSoft value when using the Bottlerocket AMIFamily in the provider,
 // evictionSoft will be ignored
-func (b Bottlerocket) EvictionSoftEnabled() bool {
-	return false
+// https://github.com/bottlerocket-os/bottlerocket/issues/1445
+
+func (b Bottlerocket) FeatureFlags() FeatureFlags {
+	return FeatureFlags{
+		UsesENILimitedMemoryOverhead: false,
+		PodsPerCoreEnabled:           false,
+		EvictionSoftEnabled:          false,
+	}
 }

--- a/pkg/cloudprovider/aws/amifamily/bottlerocket.go
+++ b/pkg/cloudprovider/aws/amifamily/bottlerocket.go
@@ -94,3 +94,11 @@ func (b Bottlerocket) ENILimitedMemoryOverhead() bool {
 func (b Bottlerocket) PodsPerCoreEnabled() bool {
 	return false
 }
+
+// EvictionSoftEnabled is currently disabled for Bottlerocket AMIFamily because it does
+// not currently support the evictionSoft parameter passed through the kubernetes settings TOML userData
+// If a Provisioner sets the evictionSoft value when using the Bottlerocket AMIFamily in the provider,
+// evictionSoft will be ignored
+func (b Bottlerocket) EvictionSoftEnabled() bool {
+	return false
+}

--- a/pkg/cloudprovider/aws/amifamily/custom.go
+++ b/pkg/cloudprovider/aws/amifamily/custom.go
@@ -59,3 +59,7 @@ func (c Custom) ENILimitedMemoryOverhead() bool {
 func (c Custom) PodsPerCoreEnabled() bool {
 	return true
 }
+
+func (c Custom) EvictionSoftEnabled() bool {
+	return true
+}

--- a/pkg/cloudprovider/aws/amifamily/custom.go
+++ b/pkg/cloudprovider/aws/amifamily/custom.go
@@ -24,6 +24,7 @@ import (
 )
 
 type Custom struct {
+	DefaultFamily
 	*Options
 }
 
@@ -50,16 +51,4 @@ func (c Custom) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
 // to us.
 func (c Custom) EphemeralBlockDevice() *string {
 	return nil
-}
-
-func (c Custom) ENILimitedMemoryOverhead() bool {
-	return true
-}
-
-func (c Custom) PodsPerCoreEnabled() bool {
-	return true
-}
-
-func (c Custom) EvictionSoftEnabled() bool {
-	return true
 }

--- a/pkg/cloudprovider/aws/amifamily/resolver.go
+++ b/pkg/cloudprovider/aws/amifamily/resolver.go
@@ -78,6 +78,7 @@ type AMIFamily interface {
 	EphemeralBlockDevice() *string
 	ENILimitedMemoryOverhead() bool
 	PodsPerCoreEnabled() bool
+	EvictionSoftEnabled() bool
 }
 
 // New constructs a new launch template Resolver

--- a/pkg/cloudprovider/aws/amifamily/resolver.go
+++ b/pkg/cloudprovider/aws/amifamily/resolver.go
@@ -76,9 +76,25 @@ type AMIFamily interface {
 	DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping
 	DefaultMetadataOptions() *v1alpha1.MetadataOptions
 	EphemeralBlockDevice() *string
-	ENILimitedMemoryOverhead() bool
-	PodsPerCoreEnabled() bool
-	EvictionSoftEnabled() bool
+	FeatureFlags() FeatureFlags
+}
+
+// FeatureFlags describes whether the features below are enabled for a given AMIFamily
+type FeatureFlags struct {
+	UsesENILimitedMemoryOverhead bool
+	PodsPerCoreEnabled           bool
+	EvictionSoftEnabled          bool
+}
+
+// DefaultFamily provides default values for AMIFamilies that compose it
+type DefaultFamily struct{}
+
+func (d DefaultFamily) FeatureFlags() FeatureFlags {
+	return FeatureFlags{
+		UsesENILimitedMemoryOverhead: true,
+		PodsPerCoreEnabled:           true,
+		EvictionSoftEnabled:          true,
+	}
 }
 
 // New constructs a new launch template Resolver

--- a/pkg/cloudprovider/aws/amifamily/ubuntu.go
+++ b/pkg/cloudprovider/aws/amifamily/ubuntu.go
@@ -27,6 +27,7 @@ import (
 )
 
 type Ubuntu struct {
+	DefaultFamily
 	*Options
 }
 
@@ -61,16 +62,4 @@ func (u Ubuntu) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
 
 func (u Ubuntu) EphemeralBlockDevice() *string {
 	return aws.String("/dev/sda1")
-}
-
-func (u Ubuntu) ENILimitedMemoryOverhead() bool {
-	return true
-}
-
-func (u Ubuntu) PodsPerCoreEnabled() bool {
-	return true
-}
-
-func (u Ubuntu) EvictionSoftEnabled() bool {
-	return true
 }

--- a/pkg/cloudprovider/aws/amifamily/ubuntu.go
+++ b/pkg/cloudprovider/aws/amifamily/ubuntu.go
@@ -70,3 +70,7 @@ func (u Ubuntu) ENILimitedMemoryOverhead() bool {
 func (u Ubuntu) PodsPerCoreEnabled() bool {
 	return true
 }
+
+func (u Ubuntu) EvictionSoftEnabled() bool {
+	return true
+}

--- a/pkg/cloudprovider/aws/amifamily/userData.go
+++ b/pkg/cloudprovider/aws/amifamily/userData.go
@@ -30,7 +30,7 @@ type UserDataProvider struct {
 	kubeClient client.Client
 }
 
-// New constructs a new UserData provider
+// NewUserDataProvider constructs a new UserData provider
 func NewUserDataProvider(kubeClient client.Client) *UserDataProvider {
 	return &UserDataProvider{
 		kubeClient: kubeClient,

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -322,13 +322,16 @@ func (i *InstanceType) evictionThreshold(kc *v1alpha5.KubeletConfiguration, vmMe
 	overhead := v1.ResourceList{
 		v1.ResourceMemory: resource.MustParse("100Mi"),
 	}
-	if kc == nil || (kc.EvictionHard == nil && (kc.EvictionSoft == nil || !i.amiFamily().FeatureFlags().EvictionSoftEnabled)) {
+	if kc == nil {
 		return overhead
 	}
 
 	override := v1.ResourceList{}
-	evictionSignals := []map[string]string{kc.EvictionHard}
-	if i.amiFamily().FeatureFlags().EvictionSoftEnabled {
+	var evictionSignals []map[string]string
+	if kc.EvictionHard != nil {
+		evictionSignals = append(evictionSignals, kc.EvictionHard)
+	}
+	if kc.EvictionSoft != nil && i.amiFamily().FeatureFlags().EvictionSoftEnabled {
 		evictionSignals = append(evictionSignals, kc.EvictionSoft)
 	}
 

--- a/pkg/cloudprovider/aws/instancetype.go
+++ b/pkg/cloudprovider/aws/instancetype.go
@@ -322,31 +322,35 @@ func (i *InstanceType) evictionThreshold(kc *v1alpha5.KubeletConfiguration, vmMe
 	overhead := v1.ResourceList{
 		v1.ResourceMemory: resource.MustParse("100Mi"),
 	}
-	if kc == nil || kc.EvictionHard == nil {
+	if kc == nil || (kc.EvictionHard == nil && (kc.EvictionSoft == nil || !i.amiFamily().EvictionSoftEnabled())) {
 		return overhead
 	}
 
-	if v, ok := kc.EvictionHard[memoryAvailable]; ok {
-		if strings.HasSuffix(v, "%") {
-			p, err := strconv.ParseFloat(strings.Trim(v, "%"), 64)
-			if err != nil {
-				panic(fmt.Sprintf("expected percentage value to be a float but got %s, %v", v, err))
-			}
-			// Setting percentage value to 100% is considered disabling the threshold according to
-			// https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
-			if p == 100 {
-				p = 0
-			}
-			// Calculation is node.capacity * evictionHard[memory.available] if percentage
-			// From https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals
-			totalAllocatable := i.resources.Memory().DeepCopy()
-			totalAllocatable.Sub(vmMemoryOverhead)
-			overhead[v1.ResourceMemory] = resource.MustParse(fmt.Sprint(math.Ceil(float64(totalAllocatable.Value()) / 100 * p)))
-		} else {
-			overhead[v1.ResourceMemory] = resource.MustParse(v)
-		}
+	override := v1.ResourceList{}
+	evictionSignals := []map[string]string{kc.EvictionHard}
+	if i.amiFamily().EvictionSoftEnabled() {
+		evictionSignals = append(evictionSignals, kc.EvictionSoft)
 	}
-	return overhead
+
+	for _, m := range evictionSignals {
+		temp := v1.ResourceList{}
+		if v, ok := m[memoryAvailable]; ok {
+			if strings.HasSuffix(v, "%") {
+				p := parsePercentage(v)
+
+				// Calculation is node.capacity * evictionHard[memory.available] if percentage
+				// From https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals
+				totalAllocatable := i.resources.Memory().DeepCopy()
+				totalAllocatable.Sub(vmMemoryOverhead)
+				temp[v1.ResourceMemory] = resource.MustParse(fmt.Sprint(math.Ceil(float64(totalAllocatable.Value()) / 100 * p)))
+			} else {
+				temp[v1.ResourceMemory] = resource.MustParse(v)
+			}
+		}
+		override = resources.MaxResources(override, temp)
+	}
+	// Assign merges maps from left to right so overrides will always be taken last
+	return lo.Assign(overhead, override)
 }
 
 func (i *InstanceType) miscResources(overheadPercentage float64) v1.ResourceList {
@@ -357,7 +361,6 @@ func (i *InstanceType) miscResources(overheadPercentage float64) v1.ResourceList
 }
 
 func (i *InstanceType) computeMaxPods(ctx context.Context, kc *v1alpha5.KubeletConfiguration) *int64 {
-	amiFamily := amifamily.GetAMIFamily(i.provider.AMIFamily, &amifamily.Options{})
 	var mp *int64
 
 	switch {
@@ -369,12 +372,29 @@ func (i *InstanceType) computeMaxPods(ctx context.Context, kc *v1alpha5.KubeletC
 		mp = ptr.Int64(i.eniLimitedPods())
 	}
 
-	if kc != nil && ptr.Int32Value(kc.PodsPerCore) > 0 && amiFamily.PodsPerCoreEnabled() {
+	if kc != nil && ptr.Int32Value(kc.PodsPerCore) > 0 && i.amiFamily().PodsPerCoreEnabled() {
 		mp = ptr.Int64(lo.Min([]int64{int64(ptr.Int32Value(kc.PodsPerCore)) * ptr.Int64Value(i.VCpuInfo.DefaultVCpus), ptr.Int64Value(mp)}))
 	}
 	return mp
 }
 
+func (i *InstanceType) amiFamily() amifamily.AMIFamily {
+	return amifamily.GetAMIFamily(i.provider.AMIFamily, &amifamily.Options{})
+}
+
 func lowerKabobCase(s string) string {
 	return strings.ToLower(strings.ReplaceAll(s, " ", "-"))
+}
+
+func parsePercentage(v string) float64 {
+	p, err := strconv.ParseFloat(strings.Trim(v, "%"), 64)
+	if err != nil {
+		panic(fmt.Sprintf("expected percentage value to be a float but got %s, %v", v, err))
+	}
+	// Setting percentage value to 100% is considered disabling the threshold according to
+	// https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+	if p == 100 {
+		p = 0
+	}
+	return p
 }

--- a/pkg/cloudprovider/aws/instancetypes_test.go
+++ b/pkg/cloudprovider/aws/instancetypes_test.go
@@ -244,116 +244,273 @@ var _ = Describe("Instance Types", func() {
 	})
 
 	Context("KubeletConfiguration Overrides", func() {
-		It("should override system reserved cpus when specified", func() {
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			provisioner = test.Provisioner(test.ProvisionerOptions{
-				Kubelet: &v1alpha5.KubeletConfiguration{
-					SystemReserved: v1.ResourceList{
-						v1.ResourceCPU: resource.MustParse("2"),
+		Context("Reserved Resources", func() {
+			It("should override system reserved cpus when specified", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("2"),
+						},
 					},
-				},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Cpu().String()).To(Equal("2080m"))
 			})
-			it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
-			overhead := it.Overhead()
-			Expect(overhead.Cpu().String()).To(Equal("2080m"))
+			It("should override system reserved memory when specified", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+					},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("21473Mi"))
+			})
+			It("should override kube reserved when specified", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceCPU:              resource.MustParse("1"),
+							v1.ResourceMemory:           resource.MustParse("20Gi"),
+							v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceCPU:              resource.MustParse("2"),
+							v1.ResourceMemory:           resource.MustParse("10Gi"),
+							v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+						},
+					},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("30820Mi"))
+				Expect(overhead.Cpu().String()).To(Equal("3"))
+				Expect(overhead.StorageEphemeral().String()).To(Equal("3Gi"))
+			})
 		})
-		It("should override system reserved memory when specified", func() {
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			provisioner = test.Provisioner(test.ProvisionerOptions{
-				Kubelet: &v1alpha5.KubeletConfiguration{
-					SystemReserved: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("20Gi"),
+		Context("Eviction Thresholds", func() {
+			It("should override eviction threshold (hard) when specified as a quantity", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionHard: map[string]string{
+							memoryAvailable: "500Mi",
+						},
 					},
-				},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("31220Mi"))
 			})
-			it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
-			overhead := it.Overhead()
-			Expect(overhead.Memory().String()).To(Equal("21473Mi"))
-		})
-		It("should override kube reserved when specified", func() {
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			provisioner = test.Provisioner(test.ProvisionerOptions{
-				Kubelet: &v1alpha5.KubeletConfiguration{
-					SystemReserved: v1.ResourceList{
-						v1.ResourceCPU:              resource.MustParse("1"),
-						v1.ResourceMemory:           resource.MustParse("20Gi"),
-						v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+			It("should override eviction threshold (hard) when specified as a percentage value", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionHard: map[string]string{
+							memoryAvailable: "10%",
+						},
 					},
-					KubeReserved: v1.ResourceList{
-						v1.ResourceCPU:              resource.MustParse("2"),
-						v1.ResourceMemory:           resource.MustParse("10Gi"),
-						v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-				},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("33930241639"))
 			})
-			it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
-			overhead := it.Overhead()
-			Expect(overhead.Memory().String()).To(Equal("30820Mi"))
-			Expect(overhead.Cpu().String()).To(Equal("3"))
-			Expect(overhead.StorageEphemeral().String()).To(Equal("3Gi"))
-		})
-		It("should override eviction threshold (hard) when specified as a quantity", func() {
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			provisioner = test.Provisioner(test.ProvisionerOptions{
-				Kubelet: &v1alpha5.KubeletConfiguration{
-					SystemReserved: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("20Gi"),
+			It("should consider the eviction threshold (hard) disabled when specified as 100%", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionHard: map[string]string{
+							memoryAvailable: "100%",
+						},
 					},
-					KubeReserved: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("10Gi"),
-					},
-					EvictionHard: map[string]string{
-						memoryAvailable: "500Mi",
-					},
-				},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("30Gi"))
 			})
-			it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
-			overhead := it.Overhead()
-			Expect(overhead.Memory().String()).To(Equal("31220Mi"))
-		})
-		It("should override eviction threshold (hard) when specified as a percentage value", func() {
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			provisioner = test.Provisioner(test.ProvisionerOptions{
-				Kubelet: &v1alpha5.KubeletConfiguration{
-					SystemReserved: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("20Gi"),
+			It("should override eviction threshold (soft) when specified as a quantity", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionSoft: map[string]string{
+							memoryAvailable: "500Mi",
+						},
 					},
-					KubeReserved: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("10Gi"),
-					},
-					EvictionHard: map[string]string{
-						memoryAvailable: "10%",
-					},
-				},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("31220Mi"))
 			})
-			it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
-			overhead := it.Overhead()
-			Expect(overhead.Memory().String()).To(Equal("33930241639"))
-		})
-		It("should consider the eviction threshold (hard) disabled when specified as 100%", func() {
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			provisioner = test.Provisioner(test.ProvisionerOptions{
-				Kubelet: &v1alpha5.KubeletConfiguration{
-					SystemReserved: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("20Gi"),
+			It("should override eviction threshold (soft) when specified as a percentage value", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionSoft: map[string]string{
+							memoryAvailable: "10%",
+						},
 					},
-					KubeReserved: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("10Gi"),
-					},
-					EvictionHard: map[string]string{
-						memoryAvailable: "100%",
-					},
-				},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("33930241639"))
 			})
-			it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
-			overhead := it.Overhead()
-			Expect(overhead.Memory().String()).To(Equal("30Gi"))
+			It("should consider the eviction threshold (soft) disabled when specified as 100%", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionSoft: map[string]string{
+							memoryAvailable: "100%",
+						},
+					},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("30Gi"))
+			})
+			It("should ignore eviction threshold (soft) when using Bottlerocket AMI", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provider.AMIFamily = &awsv1alpha1.AMIFamilyBottlerocket
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionHard: map[string]string{
+							memoryAvailable: "1Gi",
+						},
+						EvictionSoft: map[string]string{
+							memoryAvailable: "10Gi",
+						},
+					},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("31Gi"))
+			})
+			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionSoft: map[string]string{
+							memoryAvailable: "3Gi",
+						},
+						EvictionHard: map[string]string{
+							memoryAvailable: "1Gi",
+						},
+					},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("33Gi"))
+			})
+			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionSoft: map[string]string{
+							memoryAvailable: "2%",
+						},
+						EvictionHard: map[string]string{
+							memoryAvailable: "5%",
+						},
+					},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("33071248180"))
+			})
+			It("should take the greater of evictionHard and evictionSoft for overhead with mixed percentage/value", func() {
+				instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+				Expect(err).To(BeNil())
+				provisioner = test.Provisioner(test.ProvisionerOptions{
+					Kubelet: &v1alpha5.KubeletConfiguration{
+						SystemReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						KubeReserved: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("10Gi"),
+						},
+						EvictionSoft: map[string]string{
+							memoryAvailable: "10%",
+						},
+						EvictionHard: map[string]string{
+							memoryAvailable: "1Gi",
+						},
+					},
+				})
+				it := NewInstanceType(injection.WithOptions(ctx, opts), instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", provider, nil)
+				overhead := it.Overhead()
+				Expect(overhead.Memory().String()).To(Equal("33930241639"))
+			})
 		})
 		It("should set max-pods to user-defined value if specified", func() {
 			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Adds `evictionSoft` support into `kubeletConfiguration`
- This adds the fields `evictionSoft`, `evictionSoftGracePeriod` and `evictionMaxPodGracePeriod`

```yaml
apiVersion: karpenter.sh/v1alpha5
kind: Provisioner
metadata:
  name: default
spec:
  ...
  kubeletConfiguration:
    evictionSoft:
      memory.available: "50%"
    evictionSoftGracePeriod:
      memory.available: 180s
    evictionMaxPodGracePeriod: 120
```

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add `evictionSoft` support into `kubeletConfiguration`
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
