### PR TITLE
fix: correct removal of preferred topology spread constraint

### DIFF
--- a/pkg/controllers/provisioning/scheduling/preferences.go
+++ b/pkg/controllers/provisioning/scheduling/preferences.go
@@ -93,7 +93,7 @@ func (p *Preferences) removeTopologySpreadScheduleAnyway(pod *v1.Pod) *string {
 		if tsc.WhenUnsatisfiable == v1.ScheduleAnyway {
 			msg := fmt.Sprintf("removing: spec.topologySpreadConstraints = %s", pretty.Concise(tsc))
 			pod.Spec.TopologySpreadConstraints[i] = pod.Spec.TopologySpreadConstraints[len(pod.Spec.TopologySpreadConstraints)-1]
-			pod.Spec.TopologySpreadConstraints = pod.Spec.TopologySpreadConstraints[1:]
+			pod.Spec.TopologySpreadConstraints = pod.Spec.TopologySpreadConstraints[:len(pod.Spec.TopologySpreadConstraints)-1]
 			return ptr.String(msg)
 		}
 	}


### PR DESCRIPTION
Fixes #2545

**Description**

We would sometimes remove the incorrect topology spread constraint,  resulting in removing a non-preferred constraint which lead to an invalid scheduling decision.


**How was this change tested?**

* Unit testing & deployed to EKS.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
