### PR TITLE
test: Add E2E validation for defaulting/validating webhooks

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -90,7 +90,7 @@ func IsRestrictedLabel(key string) error {
 		return nil
 	}
 	if IsRestrictedNodeLabel(key) {
-		return fmt.Errorf("label %s is restricted; specify a well known label: %v, or a custom label that does use a restricted domain: %v", key, WellKnownLabels.List(), RestrictedLabelDomains.List())
+		return fmt.Errorf("label %s is restricted; specify a well known label: %v, or a custom label that does not use a restricted domain: %v", key, WellKnownLabels.List(), RestrictedLabelDomains.List())
 	}
 	return nil
 }

--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/imdario/mergo"
+	. "github.com/onsi/gomega" //nolint:revive,stylecheck
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -73,6 +74,9 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 		})
 	}
 
+	raw := &runtime.RawExtension{}
+	ExpectWithOffset(1, raw.UnmarshalJSON(lo.Must(json.Marshal(options.Provider)))).To(Succeed())
+
 	provisioner := &v1alpha5.Provisioner{
 		ObjectMeta: ObjectMeta(options.ObjectMeta),
 		Spec: v1alpha5.ProvisionerSpec{
@@ -87,6 +91,7 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 			TTLSecondsUntilExpired: options.TTLSecondsUntilExpired,
 			Weight:                 options.Weight,
 			Consolidation:          options.Consolidation,
+			Provider:               raw,
 		},
 		Status: options.Status,
 	}

--- a/test/pkg/environment/expectations.go
+++ b/test/pkg/environment/expectations.go
@@ -306,6 +306,10 @@ func (env *Environment) ExpectUpdate(objects ...client.Object) {
 	}
 }
 
+func (env *Environment) ExpectFound(obj client.Object) {
+	ExpectWithOffset(1, env.Client.Get(env, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+}
+
 func (env *Environment) EventuallyExpectHealthy(pods ...*v1.Pod) {
 	for _, pod := range pods {
 		EventuallyWithOffset(1, func(g Gomega) {

--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -31,10 +31,6 @@ import (
 )
 
 var _ = Describe("Subnets", func() {
-	BeforeEach(func() {
-
-	})
-
 	It("should use the security-group-id selector", func() {
 		securityGroups := getSecurityGroups(map[string]string{"karpenter.sh/discovery": env.ClusterName})
 		Expect(len(securityGroups)).ToNot(Equal(0))

--- a/test/suites/integration/webhook_test.go
+++ b/test/suites/integration/webhook_test.go
@@ -1,0 +1,197 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/karpenter/pkg/apis/awsnodetemplate/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	awsv1alpha1 "github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/test"
+)
+
+var _ = Describe("Webhooks", func() {
+	Context("Defaulting Webhook", func() {
+		It("should set the default requirements when none are specified", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+			})
+			env.ExpectCreated(provisioner)
+			env.ExpectFound(provisioner)
+
+			Expect(len(provisioner.Spec.Requirements)).To(Equal(2))
+			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
+				Key:      v1alpha5.LabelCapacityType,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{awsv1alpha1.CapacityTypeOnDemand},
+			}))
+			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
+				Key:      v1.LabelArchStable,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{"amd64"},
+			}))
+		})
+	})
+	Context("Validating Webhook", func() {
+		It("should deny the request when provider and providerRef are combined", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				Provider: awsv1alpha1.AWS{
+					SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+					SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				},
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when a restricted label is used in labels (karpenter.sh/provisioner-name)", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: "my-custom-provisioner",
+				},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when a restricted label is used in labels (kubernetes.io/custom-label)", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Labels: map[string]string{
+					"kubernetes.io/custom-label": "custom-value",
+				},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when a requirement references a restricted label (karpenter.sh/provisioner-name)", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha5.ProvisionerNameLabelKey,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"default"},
+					},
+				},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when a requirement uses In but has no values", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1.LabelInstanceTypeStable,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{},
+					},
+				},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when a requirement uses an unknown operator", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha5.LabelCapacityType,
+						Operator: "within",
+						Values:   []string{awsv1alpha1.CapacityTypeSpot},
+					},
+				},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when Gt is used with multiple integer values", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      awsv1alpha1.LabelInstanceMemory,
+						Operator: v1.NodeSelectorOpGt,
+						Values:   []string{"1000000", "2000000"},
+					},
+				},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when Lt is used with multiple integer values", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      awsv1alpha1.LabelInstanceMemory,
+						Operator: v1.NodeSelectorOpLt,
+						Values:   []string{"1000000", "2000000"},
+					},
+				},
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+		It("should deny the request when consolidation and ttlSecondAfterEmpty are combined", func() {
+			provider := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: awsv1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Consolidation: &v1alpha5.Consolidation{
+					Enabled: ptr.Bool(true),
+				},
+				TTLSecondsAfterEmpty: ptr.Int64(60),
+			})
+			Expect(env.Client.Create(env, provisioner)).ToNot(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

E2E validation for defaulting/validating webhooks

**How was this change tested?**

* `TEST_FILTER=Integration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
