### PR TITLE
fix: Add an observer reconcile event on node nomination eviction

### DIFF
--- a/pkg/cloudprovider/aws/fake/atomic.go
+++ b/pkg/cloudprovider/aws/fake/atomic.go
@@ -19,8 +19,6 @@ import (
 	"encoding/json"
 	"log"
 	"sync"
-
-	set "github.com/deckarep/golang-set"
 )
 
 // AtomicPtr is intended for use in mocks to easily expose variables for use in testing.  It makes setting and retrieving
@@ -130,47 +128,4 @@ func (a *AtomicPtrSlice[T]) Pop() *T {
 	last := a.values[len(a.values)-1]
 	a.values = a.values[0 : len(a.values)-1]
 	return last
-}
-
-// AtomicSlice exposes a slice of a type in a race-free manner.
-type AtomicSlice[T any] struct {
-	mu     sync.Mutex
-	values []T
-}
-
-func (a *AtomicSlice[T]) Reset() {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.values = nil
-}
-
-func (a *AtomicSlice[T]) Add(input T) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.values = append(a.values, input)
-
-	b := set.NewSet()
-	b.Cardinality()
-}
-
-func (a *AtomicSlice[T]) Range(f func(pool T) bool) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	for _, v := range a.values {
-		if !f(v) {
-			return
-		}
-	}
-}
-
-func (a *AtomicSlice[T]) Set(values []T) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.values = values
-}
-
-func (a *AtomicSlice[T]) Len() int {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return len(a.values)
 }

--- a/pkg/cloudprovider/aws/fake/ec2api.go
+++ b/pkg/cloudprovider/aws/fake/ec2api.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/cloudprovider/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/test"
+	"github.com/aws/karpenter/pkg/utils/atomic"
 )
 
 type CapacityPool struct {
@@ -57,7 +58,7 @@ type EC2Behavior struct {
 	CalledWithDescribeImagesInput       AtomicPtrSlice[ec2.DescribeImagesInput]
 	Instances                           sync.Map
 	LaunchTemplates                     sync.Map
-	InsufficientCapacityPools           AtomicSlice[CapacityPool]
+	InsufficientCapacityPools           atomic.Slice[CapacityPool]
 	NextError                           AtomicError
 }
 

--- a/pkg/utils/atomic/slice.go
+++ b/pkg/utils/atomic/slice.go
@@ -1,0 +1,59 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"sync"
+)
+
+// Slice exposes a slice of a type in a race-free manner.
+type Slice[T any] struct {
+	mu     sync.RWMutex
+	values []T
+}
+
+func (a *Slice[T]) Reset() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.values = nil
+}
+
+func (a *Slice[T]) Add(input T) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.values = append(a.values, input)
+}
+
+func (a *Slice[T]) Range(f func(pool T) bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, v := range a.values {
+		if !f(v) {
+			return
+		}
+	}
+}
+
+func (a *Slice[T]) Set(values []T) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.values = values
+}
+
+func (a *Slice[T]) Len() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.values)
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Adds an observer reconcile event when node nomination eviction occurs
- This fixes a bug where a node that has a scale down while being nominated will not have `ttlSecondsAfterEmpty` triggered

**How was this change tested?**

* `TEST_FILTER=Integration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
