### PR TITLE
fix: Disable leader election for webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,14 +86,14 @@ build: ## Build the Karpenter controller and webhook images using ko build
 	$(eval WEBHOOK_IMG=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/webhook))
 
 apply: build ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
-	helm upgrade --install karpenter charts/karpenter --namespace karpenter \
+	helm upgrade --install karpenter charts/karpenter --namespace ${SYSTEM_NAMESPACE} \
 		$(HELM_OPTS) \
 		--set controller.image=$(CONTROLLER_IMG) \
 		--set webhook.image=$(WEBHOOK_IMG)
 
 install:  ## Deploy the latest released version into your ~/.kube/config cluster
 	@echo Upgrading to $(shell grep version charts/karpenter/Chart.yaml)
-	helm upgrade --install karpenter charts/karpenter --namespace karpenter \
+	helm upgrade --install karpenter charts/karpenter --namespace ${SYSTEM_NAMESPACE} \
 		$(HELM_OPTS)
 
 delete: ## Delete the controller from your ~/.kube/config cluster

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -60,6 +60,9 @@ func Initialize(injectCloudProvider func(context.Context, cloudprovider.Options)
 		ServiceName: opts.KarpenterService,
 		SecretName:  fmt.Sprintf("%s-cert", opts.KarpenterService),
 	})
+	// TODO: This can be removed if we eventually decide that we need leader election. Having leader election has resulted in the webhook
+	// having issues described in https://github.com/aws/karpenter/issues/2562 so these issues need to be resolved if this line is removed
+	ctx = sharedmain.WithHADisabled(ctx) // Disable leader election for webhook
 
 	// Register the cloud provider to attach vendor specific validation logic.
 	// TODO(https://github.com/aws/karpenter/issues/2052)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2562 

**Description**

- Revert leader-election for webhooks with Karpenter in HA mode

**How was this change tested?**

* Manual install of Karpenter

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
