### PR TITLE
test: Add ephemeral storage requests and pipelinerun cleanup cron

### DIFF
--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-cleanup-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-cleanup-cron.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karpenter-tests-cleanup
+  namespace: karpenter-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: karpenter-tests-cleanup-role
+  namespace: karpenter-tests
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns"]
+    verbs: ["delete", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: karpenter-tests-cleanup-role-binding
+  namespace: karpenter-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karpenter-tests-cleanup-role
+subjects:
+  - kind: ServiceAccount
+    name: karpenter-tests-cleanup
+    namespace: karpenter-tests
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipelines-cleanup
+  namespace: karpenter-tests
+data:
+  pipelines-cleanup.sh: |+
+    #!/usr/bin/env bash
+    set -euo pipefail
+    kubectl get pipelineruns -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 <= "'$(date -d 'now-7 days' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | xargs --no-run-if-empty kubectl delete pipelinerun
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pipelines-cleanup
+  namespace: karpenter-tests
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: pipelines-cleanup
+              configMap:
+                name: pipelines-cleanup
+                defaultMode: 0777
+          containers:
+            - command:
+                - /bin/sh
+                - -c
+                - /bin/pipelines-cleanup.sh
+              image: public.ecr.aws/bitnami/kubectl:1.22
+              imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: pipelines-cleanup
+                  mountPath: /bin/pipelines-cleanup.sh
+                  subPath: pipelines-cleanup.sh
+              name: pipelines-cleanup
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 256Mi
+                limits:
+                  memory: 256Mi
+          restartPolicy: OnFailure
+          serviceAccountName: karpenter-tests-cleanup
+      ttlSecondsAfterFinished: 300
+  # every day on the 12th hour
+  schedule: '* 12 * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/test-suites.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/test-suites.yaml
@@ -8,9 +8,11 @@ spec:
   - defaultRequest:  # The default requests
       cpu: 250m
       memory: 256Mi
+      ephemeral-storage: 2Gi
     min:  # The minimum requests
       cpu: 250m
       memory: 256Mi
+      ephemeral-storage: 2Gi
     type: Container
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

- Adds a cleanup cronjob which will delete any pipelineruns that are beyond 7 days from when the job runs. This task will run daily.
- Adds `ephmeral-storage` requests for the PipelineRun so that the containers generated by the pipeline run account for the resource usage of the ephemeral volume

**How was this change tested?**

* Deployment of `CronJob` to local cluster, testing with shorter timeframes

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
