### PR TITLE
BREAKING CHANGE: Migrate termination and creation metrics to shared metrics

### DIFF
--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -326,7 +326,6 @@ func (c *Controller) performConsolidation(ctx context.Context, action consolidat
 		if err := c.kubeClient.Delete(ctx, oldNode); err != nil {
 			logging.FromContext(ctx).Errorf("Deleting node, %s", err)
 		} else {
-			consolidationNodesTerminatedCounter.Inc()
 			metrics.NodesTerminatedCounter.WithLabelValues(metrics.ConsolidationReason).Inc()
 		}
 	}
@@ -396,7 +395,6 @@ func (c *Controller) launchReplacementNode(ctx context.Context, action consolida
 		return fmt.Errorf("expected a single node name, got %d", len(nodeNames))
 	}
 
-	consolidationNodesCreatedCounter.Inc()
 	metrics.NodesCreatedCounter.WithLabelValues(metrics.ConsolidationReason).Inc()
 
 	// We have the new node created at the API server so mark the old node for deletion

--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -326,7 +326,8 @@ func (c *Controller) performConsolidation(ctx context.Context, action consolidat
 		if err := c.kubeClient.Delete(ctx, oldNode); err != nil {
 			logging.FromContext(ctx).Errorf("Deleting node, %s", err)
 		} else {
-			consolidationNodesTerminatedCounter.Add(1)
+			consolidationNodesTerminatedCounter.Inc()
+			metrics.NodesTerminatedCounter.WithLabelValues(metrics.ConsolidationReason).Inc()
 		}
 	}
 
@@ -395,7 +396,8 @@ func (c *Controller) launchReplacementNode(ctx context.Context, action consolida
 		return fmt.Errorf("expected a single node name, got %d", len(nodeNames))
 	}
 
-	consolidationNodesCreatedCounter.Add(1)
+	consolidationNodesCreatedCounter.Inc()
+	metrics.NodesCreatedCounter.WithLabelValues(metrics.ConsolidationReason).Inc()
 
 	// We have the new node created at the API server so mark the old node for deletion
 	c.cluster.MarkForDeletion(oldNode.Name)

--- a/pkg/controllers/consolidation/metrics.go
+++ b/pkg/controllers/consolidation/metrics.go
@@ -24,8 +24,6 @@ import (
 func init() {
 	crmetrics.Registry.MustRegister(consolidationDurationHistogram)
 	crmetrics.Registry.MustRegister(consolidationReplacementNodeInitializedHistogram)
-	crmetrics.Registry.MustRegister(consolidationNodesCreatedCounter)
-	crmetrics.Registry.MustRegister(consolidationNodesTerminatedCounter)
 	crmetrics.Registry.MustRegister(consolidationActionsPerformedCounter)
 }
 
@@ -39,6 +37,7 @@ var consolidationDurationHistogram = prometheus.NewHistogramVec(
 	},
 	[]string{"method"},
 )
+
 var consolidationReplacementNodeInitializedHistogram = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
@@ -47,6 +46,7 @@ var consolidationReplacementNodeInitializedHistogram = prometheus.NewHistogram(
 		Help:      "Amount of time required for a replacement node to become initialized.",
 		Buckets:   metrics.DurationBuckets(),
 	})
+
 var consolidationActionsPerformedCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
@@ -55,26 +55,4 @@ var consolidationActionsPerformedCounter = prometheus.NewCounterVec(
 		Help:      "Number of consolidation actions performed. Labeled by action.",
 	},
 	[]string{"action"},
-)
-
-// DEPRECATED: Use shared metric nodes_created instead of this metric to get number of nodes created by Karpenter
-// and the reason that nodes were created
-var consolidationNodesCreatedCounter = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "consolidation",
-		Name:      "nodes_created",
-		Help:      "Number of nodes created in total by consolidation.",
-	},
-)
-
-// DEPRECATED: Use shared metric nodes_terminated instead of this metric to get number of nodes terminated by Karpenter
-// and the reason that nodes were terminated
-var consolidationNodesTerminatedCounter = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "consolidation",
-		Name:      "nodes_terminated",
-		Help:      "Number of nodes terminated in total by consolidation.",
-	},
 )

--- a/pkg/controllers/consolidation/metrics.go
+++ b/pkg/controllers/consolidation/metrics.go
@@ -39,7 +39,6 @@ var consolidationDurationHistogram = prometheus.NewHistogramVec(
 	},
 	[]string{"method"},
 )
-
 var consolidationReplacementNodeInitializedHistogram = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
@@ -48,23 +47,6 @@ var consolidationReplacementNodeInitializedHistogram = prometheus.NewHistogram(
 		Help:      "Amount of time required for a replacement node to become initialized.",
 		Buckets:   metrics.DurationBuckets(),
 	})
-
-var consolidationNodesCreatedCounter = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "consolidation",
-		Name:      "nodes_created",
-		Help:      "Number of nodes created in total by consolidation.",
-	},
-)
-var consolidationNodesTerminatedCounter = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "consolidation",
-		Name:      "nodes_terminated",
-		Help:      "Number of nodes terminated in total by consolidation.",
-	},
-)
 var consolidationActionsPerformedCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
@@ -73,4 +55,26 @@ var consolidationActionsPerformedCounter = prometheus.NewCounterVec(
 		Help:      "Number of consolidation actions performed. Labeled by action.",
 	},
 	[]string{"action"},
+)
+
+// DEPRECATED: Use shared metric nodes_created instead of this metric to get number of nodes created by Karpenter
+// and the reason that nodes were created
+var consolidationNodesCreatedCounter = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: "consolidation",
+		Name:      "nodes_created",
+		Help:      "Number of nodes created in total by consolidation.",
+	},
+)
+
+// DEPRECATED: Use shared metric nodes_terminated instead of this metric to get number of nodes terminated by Karpenter
+// and the reason that nodes were terminated
+var consolidationNodesTerminatedCounter = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: "consolidation",
+		Name:      "nodes_terminated",
+		Help:      "Number of nodes terminated in total by consolidation.",
+	},
 )

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -56,6 +56,7 @@ import (
 	"github.com/aws/karpenter/pkg/controllers/state"
 	"github.com/aws/karpenter/pkg/controllers/termination"
 	"github.com/aws/karpenter/pkg/events"
+	"github.com/aws/karpenter/pkg/metrics"
 	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/options"
 	"github.com/aws/karpenter/pkg/utils/project"
@@ -70,6 +71,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(apis.AddToScheme(scheme))
+	metrics.MustRegister() // Registers cross-controller metrics
 }
 
 // Controller is an interface implemented by Karpenter custom resources.

--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter/pkg/controllers/state"
+	"github.com/aws/karpenter/pkg/metrics"
 	"github.com/aws/karpenter/pkg/utils/pod"
 )
 
@@ -90,6 +91,7 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisi
 		if err := r.kubeClient.Delete(ctx, n); err != nil {
 			return reconcile.Result{}, fmt.Errorf("deleting node, %w", err)
 		}
+		metrics.NodesTerminatedCounter.WithLabelValues(metrics.EmptinessReason).Inc()
 	}
 	return reconcile.Result{RequeueAfter: emptinessTime.Add(ttl).Sub(r.clock.Now())}, nil
 }

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter/pkg/metrics"
 )
 
 // Expiration is a subreconciler that terminates nodes after a period of time.
@@ -53,6 +54,7 @@ func (r *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 		if err := r.kubeClient.Delete(ctx, node); err != nil {
 			return reconcile.Result{}, fmt.Errorf("deleting node, %w", err)
 		}
+		metrics.NodesTerminatedCounter.WithLabelValues(metrics.ExpirationReason).Inc()
 	}
 	// 3. Backoff until expired
 	return reconcile.Result{RequeueAfter: time.Until(expirationTime)}, nil

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -186,7 +186,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 	// Any successfully created node is going to have the nodeName value filled in the slice
 	successfullyCreatedNodeCount := lo.CountBy(nodeNames, func(name string) bool { return name != "" })
-	metrics.NodesCreatedCounter.WithLabelValues(metrics.SchedulingReason).Add(float64(successfullyCreatedNodeCount))
+	metrics.NodesCreatedCounter.WithLabelValues(metrics.ProvisioningReason).Add(float64(successfullyCreatedNodeCount))
 
 	return err
 }

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -182,7 +182,12 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		return nil
 	}
 
-	_, err = p.LaunchNodes(ctx, LaunchOptions{RecordPodNomination: true}, nodes...)
+	nodeNames, err := p.LaunchNodes(ctx, LaunchOptions{RecordPodNomination: true}, nodes...)
+
+	// Any successfully created node is going to have the nodeName value filled in the slice
+	successfullyCreatedNodeCount := lo.CountBy(nodeNames, func(name string) bool { return name != "" })
+	metrics.NodesCreatedCounter.WithLabelValues(metrics.SchedulingReason).Add(float64(successfullyCreatedNodeCount))
+
 	return err
 }
 
@@ -191,6 +196,8 @@ type LaunchOptions struct {
 	RecordPodNomination bool
 }
 
+// LaunchNodes launches nodes passed into the function in parallel. It returns a slice of the successfully created node
+// names as well as a multierr of any errors that occurred while launching nodes
 func (p *Provisioner) LaunchNodes(ctx context.Context, opts LaunchOptions, nodes ...*scheduler.Node) ([]string, error) {
 	// Launch capacity and bind pods
 	errs := make([]error, len(nodes))

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -29,7 +29,7 @@ const (
 
 	// Reasons for CREATE/DELETE shared metrics
 	ConsolidationReason = "consolidation"
-	SchedulingReason    = "scheduling"
+	ProvisioningReason  = "provisioning"
 	ExpirationReason    = "expiration"
 	EmptinessReason     = "emptiness"
 )

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -26,6 +26,12 @@ const (
 
 	ErrorLabel       = "error"
 	ProvisionerLabel = "provisioner"
+
+	// Reasons for CREATE/DELETE shared metrics
+	ConsolidationReason = "consolidation"
+	SchedulingReason    = "scheduling"
+	ExpirationReason    = "expiration"
+	EmptinessReason     = "emptiness"
 )
 
 // DurationBuckets returns a []float64 of default threshold values for duration histograms.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,53 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	nodeSubsystem = "nodes"
+)
+
+var (
+	NodesCreatedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: nodeSubsystem,
+			Name:      "created",
+			Help:      "Number of nodes created in total.",
+		},
+		[]string{
+			"reason",
+		},
+	)
+	NodesTerminatedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: nodeSubsystem,
+			Name:      "terminated",
+			Help:      "Number of nodes terminated in total.",
+		},
+		[]string{
+			"reason",
+		},
+	)
+)
+
+func MustRegister() {
+	crmetrics.Registry.MustRegister(NodesCreatedCounter, NodesTerminatedCounter)
+}

--- a/website/content/en/preview/tasks/metrics.md
+++ b/website/content/en/preview/tasks/metrics.md
@@ -16,20 +16,6 @@ Number of consolidation actions performed. Labeled by action.
 ### `karpenter_consolidation_evaluation_duration_seconds`
 Duration of the consolidation evaluation process in seconds.
 
-### `karpenter_consolidation_nodes_created`
-Number of nodes created in total by consolidation.
-
-{{% alert title="Deprecation Warning" color="warning" %}}
-`karpenter_consolidation_nodes_created` is deprecated in favor of the `karpenter_nodes_created` with `reason=consolidation`
-{{% /alert %}}
-
-### `karpenter_consolidation_nodes_terminated`
-Number of nodes terminated in total by consolidation.
-
-{{% alert title="Deprecation Warning" color="warning" %}}
-`karpenter_consolidation_nodes_terminated` is deprecated in favor of the `karpenter_nodes_terminated` with `reason=consolidation`
-{{% /alert %}}
-
 ### `karpenter_consolidation_replacement_node_initialized_seconds`
 Amount of time required for a replacement node to become initialized.
 

--- a/website/content/en/preview/tasks/metrics.md
+++ b/website/content/en/preview/tasks/metrics.md
@@ -19,8 +19,16 @@ Duration of the consolidation evaluation process in seconds.
 ### `karpenter_consolidation_nodes_created`
 Number of nodes created in total by consolidation.
 
+{{% alert title="Deprecation Warning" color="warning" %}}
+`karpenter_consolidation_nodes_created` is deprecated in favor of the `karpenter_nodes_created` with `reason=consolidation`
+{{% /alert %}}
+
 ### `karpenter_consolidation_nodes_terminated`
 Number of nodes terminated in total by consolidation.
+
+{{% alert title="Deprecation Warning" color="warning" %}}
+`karpenter_consolidation_nodes_terminated` is deprecated in favor of the `karpenter_nodes_terminated` with `reason=consolidation`
+{{% /alert %}}
 
 ### `karpenter_consolidation_replacement_node_initialized_seconds`
 Amount of time required for a replacement node to become initialized.
@@ -37,6 +45,12 @@ The Provisioner Usage is the amount of resources that have been provisioned by a
 The Provisioner Usage Percentage is the percentage of each resource used based on the resources provisioned and the limits that have been configured in the range [0,100].  Labeled by provisioner name and resource type.
 
 ## Nodes Metrics
+
+### `karpenter_nodes_created`
+Number of nodes created in total by Karpenter. Labeled by reason the node was created.
+
+### `karpenter_nodes_terminated`
+Number of nodes terminated in total by Karpenter. Labeled by reason the node was terminated.
 
 ### `karpenter_nodes_allocatable`
 Node allocatable are the resources allocatable by nodes.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2443 

__!! BREAKING CHANGE !!__ 

- Removes `karpenter_consolidation_nodes_created` in favor of `karpenter_nodes_created` with `reason=consolidation`
- Removes `karpenter_consolidation_nodes_terminated` in favor of `karpenter_nodes_terminated` with `reason=consolidation`

**Description**

- Adds a global metric that counts the number of nodes that Karpenter has terminated and created
- Serves as a pre-req for changes that will come like `notification_controller` that will add its own reason to the set of termination metrics.
NOTE: This doesn't remove consolidation-based create/delete metrics, only deprecates them to be removed sometime in the future

**How was this change tested?**

* Deployed to EKS cluster and validated metrics through Prometheus Operator stack

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
