### PR TITLE
docs: Spot consolidation wording change

### DIFF
--- a/website/content/en/preview/tasks/deprovisioning.md
+++ b/website/content/en/preview/tasks/deprovisioning.md
@@ -72,7 +72,7 @@ When there are multiple nodes that could be potentially deleted or replaced, Kar
 * nodes with lower priority pods
 
 {{% alert title="Note" color="primary" %}}
-Karpenter only uses the deletion consolidation mechanism for spot nodes.  It will not replace a spot node with a cheaper spot node.  Spot instance types are selected with the `capacity-optimized-prioritized` strategy and often the cheapest spot instance type is not launched due to the likelihood of interruption. Consolidation would then replace the spot instance with a cheaper instance negating the `capacity-optimized-prioritized` strategy entirely and increasing interruption rate.  
+For spot nodes, Karpenter only uses the deletion consolidation mechanism.  It will not replace a spot node with a cheaper spot node.  Spot instance types are selected with the `capacity-optimized-prioritized` strategy and often the cheapest spot instance type is not launched due to the likelihood of interruption. Consolidation would then replace the spot instance with a cheaper instance negating the `capacity-optimized-prioritized` strategy entirely and increasing interruption rate.  
 {{% /alert %}}
 
 ## What can cause deprovisioning to fail?


### PR DESCRIPTION
**Description**

Tiny change to the wording on spot node consolidation.

It wasn't clear if the deletion consolidation mechanism was only used when working with spot nodes (and not available for on-demand) or when managing spot nodes it only uses the deletion consolidation mechanism.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No
