### PR TITLE
feat: add a node TTL for consolidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test: ## Run tests
 	go test -run=${TEST_FILTER} ./pkg/...
 
 battletest: ## Run randomized, racing, code coveraged, tests
-	go test -run=${TEST_FILTER} ./pkg/... \
+	go test -v -run=${TEST_FILTER} ./pkg/... \
 		-race \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./pkg/... \
 		-ginkgo.randomizeAllSpecs \

--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -16,6 +16,7 @@ package consolidation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -25,9 +26,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
@@ -36,11 +37,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/scheduling"
 
 	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
 	"github.com/aws/karpenter/pkg/controllers/provisioning"
-	"github.com/aws/karpenter/pkg/controllers/provisioning/scheduling"
+	pscheduling "github.com/aws/karpenter/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter/pkg/controllers/state"
 	"github.com/aws/karpenter/pkg/events"
 	"github.com/aws/karpenter/pkg/metrics"
@@ -62,6 +64,8 @@ type Controller struct {
 
 // pollingPeriod that we inspect cluster to look for opportunities to consolidate
 const pollingPeriod = 10 * time.Second
+
+var errCandidateNodeDeleting = fmt.Errorf("candidate node is deleting")
 
 // waitRetryOptions are the retry options used when waiting on a node to become ready or to be deleted
 // readiness can take some time as the node needs to come up, have any daemonset extended resoruce plugins register, etc.
@@ -97,7 +101,7 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 				case <-ctx.Done():
 					logging.FromContext(ctx).Infof("Shutting down")
 					return
-				case <-time.After(pollingPeriod):
+				case <-c.clock.After(pollingPeriod):
 					_, _ = c.Reconcile(ctx, reconcile.Request{})
 				}
 			}
@@ -113,20 +117,14 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return reconcile.Result{}, nil
 	}
 
-	// don't consolidate as we recently scaled up/down too soon
-	stabilizationTime := c.clock.Now().Add(-c.stabilizationWindow(ctx))
-	// capture the state before we process so if something changes during consolidation we'll re-look
-	// immediately
 	clusterState := c.cluster.ClusterConsolidationState()
-	if c.cluster.LastNodeDeletionTime().Before(stabilizationTime) &&
-		c.cluster.LastNodeCreationTime().Before(stabilizationTime) {
-		result, err := c.ProcessCluster(ctx)
-		if err != nil {
-			logging.FromContext(ctx).Errorf("consolidating cluster, %s", err)
-		} else if result == ProcessResultNothingToDo {
-			c.lastConsolidationState = clusterState
-		}
+	result, err := c.ProcessCluster(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Errorf("consolidating cluster, %s", err)
+	} else if result == DeprovisioningResultNothingToDo {
+		c.lastConsolidationState = clusterState
 	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -143,32 +141,45 @@ type candidateNode struct {
 }
 
 // ProcessCluster is exposed for unit testing purposes
-func (c *Controller) ProcessCluster(ctx context.Context) (ProcessResult, error) {
-	candidates, err := c.candidateNodes(ctx)
-	if err != nil {
-		return ProcessResultFailed, fmt.Errorf("determining candidate nodes, %w", err)
-	}
-	if len(candidates) == 0 {
-		return ProcessResultNothingToDo, nil
-	}
+func (c *Controller) ProcessCluster(ctx context.Context) (DeprovisioningResult, error) {
 
-	emptyNodes := lo.Filter(candidates, func(n candidateNode, _ int) bool { return len(n.pods) == 0 })
-	// first see if there are empty nodes that we can delete immediately, and if so delete them all at once
-	if len(emptyNodes) > 0 {
-		c.performConsolidation(ctx, consolidationAction{
-			oldNodes: lo.Map(emptyNodes, func(n candidateNode, _ int) *v1.Node { return n.Node }),
-			result:   consolidateResultDeleteEmpty,
-		})
-		return ProcessResultConsolidated, nil
-	}
+	// range over the different lifecycle methods. We'll only let one method perform an action
+	for _, fn := range []func(ctx context.Context, candidates []candidateNode) (DeprovisioningResult, error){
+		c.deleteEmptyNodes,
+		c.consolidateNodes,
+	} {
+		// capture new cluster state before each attempt
+		candidates, err := c.candidateNodes(ctx)
+		if err != nil {
+			return DeprovisioningResultFailed, fmt.Errorf("determining candidate nodes, %w", err)
+		}
+		if len(candidates) == 0 {
+			return DeprovisioningResultNothingToDo, nil
+		}
 
+		result, err := fn(ctx, candidates)
+		if err != nil {
+			return DeprovisioningResultFailed, err
+		}
+		// only go on to the next lifecycle action if the previous did nothing
+		if result == DeprovisioningResultNothingToDo {
+			continue
+		}
+		return result, nil
+	}
+	return DeprovisioningResultNothingToDo, nil
+}
+
+// consolidateNodes looks at the non-empty nodes and executes the first viable consolidation action
+func (c *Controller) consolidateNodes(ctx context.Context, candidates []candidateNode) (DeprovisioningResult, error) {
 	pdbs, err := NewPDBLimits(ctx, c.kubeClient)
 	if err != nil {
-		return ProcessResultFailed, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
+		return DeprovisioningResultFailed, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
 	}
 
 	// the remaining nodes are all non-empty, so we just consolidate the first one that we can
 	sort.Slice(candidates, byNodeDisruptionCost(candidates))
+	validationFailed := false
 	for _, node := range candidates {
 		// is this a node that we can terminate?  This check is meant to be fast so we can save the expense of simulated
 		// scheduling unless its really needed
@@ -176,23 +187,62 @@ func (c *Controller) ProcessCluster(ctx context.Context) (ProcessResult, error) 
 			continue
 		}
 
-		action, err := c.nodeConsolidationOptionReplaceOrDelete(ctx, node)
+		cmd, err := c.computeNodeConsolidationOption(ctx, node)
 		if err != nil {
 			logging.FromContext(ctx).Errorf("calculating consolidation option, %s", err)
 			continue
 		}
-		if action.result == consolidateResultDelete || action.result == consolidateResultReplace {
+		if cmd.action == lifecycleActionDelete || cmd.action == lifecycleActionReplace {
+			isValid, err := c.validateCommand(ctx, cmd)
+			if err != nil {
+				logging.FromContext(ctx).Errorf("validating command, %s", err)
+				continue
+			}
+			if !isValid {
+				validationFailed = true
+				logging.FromContext(ctx).Debugf("skipping consolidation %s due to failing validation", cmd)
+				continue
+			}
 			// perform the first consolidation we can since we are looking at nodes in ascending order of disruption cost
-			c.performConsolidation(ctx, action)
-			return ProcessResultConsolidated, nil
+			c.executeCommand(ctx, cmd)
+			return DeprovisioningResultSuccess, nil
 		}
 	}
-	return ProcessResultNothingToDo, nil
+	// if any validation failed the cluster state is in flux so we want to retry instead of waiting on the cluster
+	// state to change again.
+	if validationFailed {
+		return DeprovisioningResultRetry, nil
+	}
+	return DeprovisioningResultNothingToDo, nil
+}
+
+// deleteEmptyNodes identifies any empty nodes and if possible, deletes them.
+func (c *Controller) deleteEmptyNodes(ctx context.Context, candidates []candidateNode) (DeprovisioningResult, error) {
+	emptyNodes := lo.Filter(candidates, func(n candidateNode, _ int) bool { return len(n.pods) == 0 })
+	// first see if there are empty nodes that we can delete immediately, and if so delete them all at once
+	if len(emptyNodes) == 0 {
+		return DeprovisioningResultNothingToDo, nil
+	}
+
+	cmd := lifecycleCommand{
+		nodesToRemove: lo.Map(emptyNodes, func(n candidateNode, _ int) *v1.Node { return n.Node }),
+		action:        lifecycleActionDeleteEmpty,
+		created:       c.clock.Now(),
+	}
+	isValid, err := c.validateCommand(ctx, cmd)
+	if err != nil {
+		return DeprovisioningResultFailed, fmt.Errorf("validating command, %w", err)
+	}
+	if !isValid {
+		return DeprovisioningResultRetry, nil
+	}
+
+	c.executeCommand(ctx, cmd)
+	return DeprovisioningResultSuccess, nil
 }
 
 // candidateNodes returns nodes that appear to be currently consolidatable based off of their provisioner
-//
-//gocyclo:ignore
+// nolint:gocyclo
 func (c *Controller) candidateNodes(ctx context.Context) ([]candidateNode, error) {
 	provisioners, instanceTypesByProvisioner, err := c.buildProvisionerMap(ctx)
 	if err != nil {
@@ -237,17 +287,13 @@ func (c *Controller) candidateNodes(ctx context.Context) ([]candidateNode, error
 			return true
 		}
 
+		// Skip the node if it is nominated by a recent provisioning pass to be the target of a pending pod.
 		if c.cluster.IsNodeNominated(n.Node.Name) {
 			return true
 		}
 
 		// skip nodes that are annotated as do-not-consolidate
 		if n.Node.Annotations[v1alpha5.DoNotConsolidateNodeAnnotationKey] == "true" {
-			return true
-		}
-
-		// skip nodes that the scheduler thinks will soon have pending pods bound to them
-		if c.cluster.IsNodeNominated(n.Node.Name) {
 			return true
 		}
 
@@ -303,20 +349,20 @@ func (c *Controller) buildProvisionerMap(ctx context.Context) (map[string]*v1alp
 	return provisioners, instanceTypesByProvisioner, nil
 }
 
-func (c *Controller) performConsolidation(ctx context.Context, action consolidationAction) {
-	if action.result != consolidateResultDelete &&
-		action.result != consolidateResultReplace &&
-		action.result != consolidateResultDeleteEmpty {
-		logging.FromContext(ctx).Errorf("Invalid disruption action calculated: %s", action.result)
+func (c *Controller) executeCommand(ctx context.Context, action lifecycleCommand) {
+	if action.action != lifecycleActionDelete &&
+		action.action != lifecycleActionReplace &&
+		action.action != lifecycleActionDeleteEmpty {
+		logging.FromContext(ctx).Errorf("Invalid disruption action calculated: %s", action.action)
 		return
 	}
 
-	consolidationActionsPerformedCounter.With(prometheus.Labels{"action": action.result.String()}).Add(1)
+	consolidationActionsPerformedCounter.With(prometheus.Labels{"action": action.action.String()}).Add(1)
 
 	// action's stringer
 	logging.FromContext(ctx).Infof("Consolidating via %s", action.String())
 
-	if action.result == consolidateResultReplace {
+	if action.action == lifecycleActionReplace {
 		if err := c.launchReplacementNode(ctx, action); err != nil {
 			// If we failed to launch the replacement, don't consolidate.  If this is some permanent failure,
 			// we don't want to disrupt workloads with no way to provision new nodes for them.
@@ -325,7 +371,7 @@ func (c *Controller) performConsolidation(ctx context.Context, action consolidat
 		}
 	}
 
-	for _, oldNode := range action.oldNodes {
+	for _, oldNode := range action.nodesToRemove {
 		c.recorder.TerminatingNodeForConsolidation(oldNode, action.String())
 		if err := c.kubeClient.Delete(ctx, oldNode); err != nil {
 			logging.FromContext(ctx).Errorf("Deleting node, %s", err)
@@ -336,7 +382,7 @@ func (c *Controller) performConsolidation(ctx context.Context, action consolidat
 
 	// We wait for nodes to delete to ensure we don't start another round of consolidation until this node is fully
 	// deleted.
-	for _, oldnode := range action.oldNodes {
+	for _, oldnode := range action.nodesToRemove {
 		c.waitForDeletion(ctx, oldnode)
 	}
 }
@@ -349,7 +395,7 @@ func (c *Controller) waitForDeletion(ctx context.Context, node *v1.Node) {
 		var n v1.Node
 		nerr := c.kubeClient.Get(ctx, client.ObjectKey{Name: node.Name}, &n)
 		// We expect the not node found error, at which point we know the node is deleted.
-		if errors.IsNotFound(nerr) {
+		if apierrors.IsNotFound(nerr) {
 			return nil
 		}
 		// make the user aware of why consolidation is paused
@@ -376,15 +422,15 @@ func byNodeDisruptionCost(nodes []candidateNode) func(i int, j int) bool {
 }
 
 // launchReplacementNode launches a replacement node and blocks until it is ready
-func (c *Controller) launchReplacementNode(ctx context.Context, action consolidationAction) error {
+func (c *Controller) launchReplacementNode(ctx context.Context, action lifecycleCommand) error {
 	defer metrics.Measure(consolidationReplacementNodeInitializedHistogram)()
-	if len(action.oldNodes) != 1 {
-		return fmt.Errorf("expected a single node to replace, found %d", len(action.oldNodes))
+	if len(action.nodesToRemove) != 1 {
+		return fmt.Errorf("expected a single node to replace, found %d", len(action.nodesToRemove))
 	}
-	oldNode := action.oldNodes[0]
+	oldNode := action.nodesToRemove[0]
 
 	// cordon the node before we launch the replacement to prevent new pods from scheduling to the node
-	if err := c.setNodeUnschedulable(ctx, action.oldNodes[0].Name, true); err != nil {
+	if err := c.setNodeUnschedulable(ctx, action.nodesToRemove[0].Name, true); err != nil {
 		return fmt.Errorf("cordoning node %s, %w", oldNode.Name, err)
 	}
 
@@ -472,83 +518,47 @@ func (c *Controller) calculateLifetimeRemaining(node candidateNode) float64 {
 	return remaining
 }
 
-// nolint:gocyclo
-func (c *Controller) nodeConsolidationOptionReplaceOrDelete(ctx context.Context, node candidateNode) (consolidationAction, error) {
+//nolint:gocyclo
+func (c *Controller) computeNodeConsolidationOption(ctx context.Context, node candidateNode) (lifecycleCommand, error) {
 	defer metrics.Measure(consolidationDurationHistogram.WithLabelValues("Replace/Delete"))()
-
-	var stateNodes []*state.Node
-	var markedForDeletionNodes []*state.Node
-	candidateNodeIsDeleting := false
-
-	c.cluster.ForEachNode(func(n *state.Node) bool {
-		if node.Name == n.Node.Name && n.MarkedForDeletion {
-			candidateNodeIsDeleting = true
+	newNodes, allPodsScheduled, err := c.simulateScheduling(ctx, node)
+	if err != nil {
+		// if a candidate node is now deleting, just retry
+		if errors.Is(err, errCandidateNodeDeleting) {
+			return lifecycleCommand{action: lifecycleActionDoNothing}, nil
 		}
-		if n.Node.Name != node.Name {
-			if !n.MarkedForDeletion {
-				stateNodes = append(stateNodes, n.DeepCopy())
-			} else {
-				markedForDeletionNodes = append(markedForDeletionNodes, n.DeepCopy())
-			}
-		}
-		return true
-	})
-	// We do one final check to ensure that the node that we are attempting to consolidate isn't
-	// already handled for deletion by some other controller. This could happen if the node was markedForDeletion
-	// between returning the candidateNodes and getting the stateNodes above
-	if candidateNodeIsDeleting {
-		return consolidationAction{result: consolidateResultNoAction}, nil
+		return lifecycleCommand{}, err
 	}
 
-	// We get the pods that are on nodes that are deleting
-	deletingNodePods, err := nodeutils.GetNodePods(ctx, c.kubeClient, lo.Map(markedForDeletionNodes, func(n *state.Node, _ int) *v1.Node { return n.Node })...)
-	if err != nil {
-		return consolidationAction{result: consolidateResultUnknown}, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
-	}
-	pods := append(node.pods, deletingNodePods...)
-	scheduler, err := c.provisioner.NewScheduler(ctx, pods, stateNodes, scheduling.SchedulerOptions{
-		SimulationMode: true,
-	})
-
-	if err != nil {
-		return consolidationAction{result: consolidateResultUnknown}, fmt.Errorf("creating scheduler, %w", err)
-	}
-
-	newNodes, inflightNodes, err := scheduler.Solve(ctx, pods)
-	if err != nil {
-		return consolidationAction{result: consolidateResultUnknown}, fmt.Errorf("simulating scheduling, %w", err)
+	// if not all of the pods were scheduled, we can't do anything
+	if !allPodsScheduled {
+		return lifecycleCommand{action: lifecycleActionNonePossible}, nil
 	}
 
 	// were we able to schedule all the pods on the inflight nodes?
 	if len(newNodes) == 0 {
-		schedulableCount := 0
-		for _, inflight := range inflightNodes {
-			schedulableCount += len(inflight.Pods)
-		}
-		if len(node.pods) == schedulableCount {
-			return consolidationAction{
-				oldNodes:       []*v1.Node{node.Node},
-				disruptionCost: disruptionCost(ctx, node.pods),
-				result:         consolidateResultDelete,
-			}, nil
-		}
+		return lifecycleCommand{
+			nodesToRemove: []*v1.Node{node.Node},
+			action:        lifecycleActionDelete,
+			created:       c.clock.Now(),
+		}, nil
 	}
 
 	// we're not going to turn a single node into multiple nodes
 	if len(newNodes) != 1 {
-		return consolidationAction{result: consolidateResultNotPossible}, nil
+		return lifecycleCommand{action: lifecycleActionNonePossible}, nil
 	}
 
 	// get the current node price based on the offering
 	// fallback if we can't find the specific zonal pricing data
 	offering, ok := cloudprovider.GetOffering(node.instanceType, node.capacityType, node.zone)
 	if !ok {
-		return consolidationAction{result: consolidateResultUnknown}, fmt.Errorf("getting offering price from candidate node, %w", err)
+		return lifecycleCommand{action: lifecycleActionFailed}, fmt.Errorf("getting offering price from candidate node, %w", err)
 	}
 	newNodes[0].InstanceTypeOptions = filterByPrice(newNodes[0].InstanceTypeOptions, newNodes[0].Requirements, offering.Price)
 	if len(newNodes[0].InstanceTypeOptions) == 0 {
 		// no instance types remain after filtering by price
-		return consolidationAction{result: consolidateResultNotPossible}, nil
+		return lifecycleCommand{action: lifecycleActionNonePossible}, nil
 	}
 
 	// If the existing node is spot and the replacement is spot, we don't consolidate.  We don't have a reliable
@@ -556,114 +566,84 @@ func (c *Controller) nodeConsolidationOptionReplaceOrDelete(ctx context.Context,
 	// a spot node with one that is less available and more likely to be reclaimed).
 	if node.capacityType == v1alpha1.CapacityTypeSpot &&
 		newNodes[0].Requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha1.CapacityTypeSpot) {
-		return consolidationAction{result: consolidateResultNotPossible}, nil
+		return lifecycleCommand{action: lifecycleActionNonePossible}, nil
 	}
 
-	return consolidationAction{
-		oldNodes:        []*v1.Node{node.Node},
-		disruptionCost:  disruptionCost(ctx, node.pods),
-		result:          consolidateResultReplace,
+	// We are consolidating a node from OD -> [OD,Spot] but have filtered the instance types by cost based on the
+	// assumption, that the spot variant will launch. We also need to add a requirement to the node to ensure that if
+	// spot capacity is insufficient we don't replace the node with a more expensive on-demand node.  Instead the launch
+	// should fail and we'll just leave the node alone.
+	ctReq := newNodes[0].Requirements.Get(v1alpha5.LabelCapacityType)
+	if ctReq.Has(v1alpha1.CapacityTypeSpot) && ctReq.Has(v1alpha1.CapacityTypeOnDemand) {
+		newNodes[0].Requirements.Add(scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, v1alpha1.CapacityTypeSpot))
+	}
+
+	return lifecycleCommand{
+		nodesToRemove:   []*v1.Node{node.Node},
+		action:          lifecycleActionReplace,
 		replacementNode: newNodes[0],
+		created:         c.clock.Now(),
 	}, nil
 }
 
-func (c *Controller) hasPendingPods(ctx context.Context) bool {
-	var podList v1.PodList
-	if err := c.kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": ""}); err != nil {
-		// failed to list pods, assume there must be pending as it's harmless and just ensures we wait longer
+func (c *Controller) simulateScheduling(ctx context.Context, nodesToDelete ...candidateNode) (newNodes []*pscheduling.Node, allPodsScheduled bool, err error) {
+	var stateNodes []*state.Node
+	var markedForDeletionNodes []*state.Node
+	candidateNodeIsDeleting := false
+	candidateNodeNames := sets.NewString(lo.Map(nodesToDelete, func(t candidateNode, i int) string { return t.Name })...)
+	c.cluster.ForEachNode(func(n *state.Node) bool {
+		// not a candidate node
+		if _, ok := candidateNodeNames[n.Node.Name]; !ok {
+			if !n.MarkedForDeletion {
+				stateNodes = append(stateNodes, n.DeepCopy())
+			} else {
+				markedForDeletionNodes = append(markedForDeletionNodes, n.DeepCopy())
+			}
+		} else if n.MarkedForDeletion {
+			// candidate node and marked for deletion
+			candidateNodeIsDeleting = true
+		}
 		return true
+	})
+	// We do one final check to ensure that the node that we are attempting to consolidate isn't
+	// already handled for deletion by some other controller. This could happen if the node was markedForDeletion
+	// between returning the candidateNodes and getting the stateNodes above
+	if candidateNodeIsDeleting {
+		return nil, false, errCandidateNodeDeleting
 	}
-	for i := range podList.Items {
-		if pod.IsProvisionable(&podList.Items[i]) {
-			return true
-		}
-	}
-	return false
-}
 
-func (c *Controller) deploymentsReady(ctx context.Context) bool {
-	var depList appsv1.DeploymentList
-	if err := c.kubeClient.List(ctx, &depList); err != nil {
-		// failed to list, assume there must be one non-ready as it's harmless and just ensures we wait longer
-		return false
+	// We get the pods that are on nodes that are deleting
+	deletingNodePods, err := nodeutils.GetNodePods(ctx, c.kubeClient, lo.Map(markedForDeletionNodes, func(n *state.Node, _ int) *v1.Node { return n.Node })...)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
 	}
-	for _, ds := range depList.Items {
-		desired := ptr.Int32Value(ds.Spec.Replicas)
-		if ds.Spec.Replicas == nil {
-			// unspecified defaults to 1
-			desired = 1
-		}
-		if ds.Status.ReadyReplicas < desired || ds.Status.UpdatedReplicas < desired {
-			return false
-		}
+	var pods []*v1.Pod
+	for _, n := range nodesToDelete {
+		pods = append(pods, n.pods...)
 	}
-	return true
-}
+	pods = append(pods, deletingNodePods...)
+	scheduler, err := c.provisioner.NewScheduler(ctx, pods, stateNodes, pscheduling.SchedulerOptions{
+		SimulationMode: true,
+	})
 
-func (c *Controller) replicaSetsReady(ctx context.Context) bool {
-	var rsList appsv1.ReplicaSetList
-	if err := c.kubeClient.List(ctx, &rsList); err != nil {
-		// failed to list, assume there must be one non-ready as it's harmless and just ensures we wait longer
-		return false
+	if err != nil {
+		return nil, false, fmt.Errorf("creating scheduler, %w", err)
 	}
-	for _, rs := range rsList.Items {
-		desired := ptr.Int32Value(rs.Spec.Replicas)
-		if rs.Spec.Replicas == nil {
-			// unspecified defaults to 1
-			desired = 1
-		}
-		if rs.Status.ReadyReplicas < desired {
-			return false
-		}
-	}
-	return true
-}
 
-func (c *Controller) replicationControllersReady(ctx context.Context) bool {
-	var rsList v1.ReplicationControllerList
-	if err := c.kubeClient.List(ctx, &rsList); err != nil {
-		// failed to list, assume there must be one non-ready as it's harmless and just ensures we wait longer
-		return false
+	newNodes, ifn, err := scheduler.Solve(ctx, pods)
+	if err != nil {
+		return nil, false, fmt.Errorf("simulating scheduling, %w", err)
 	}
-	for _, rs := range rsList.Items {
-		desired := ptr.Int32Value(rs.Spec.Replicas)
-		if rs.Spec.Replicas == nil {
-			// unspecified defaults to 1
-			desired = 1
-		}
-		if rs.Status.ReadyReplicas < desired {
-			return false
-		}
-	}
-	return true
-}
 
-func (c *Controller) statefulSetsReady(ctx context.Context) bool {
-	var sslist appsv1.StatefulSetList
-	if err := c.kubeClient.List(ctx, &sslist); err != nil {
-		// failed to list, assume there must be one non-ready as it's harmless and just ensures we wait longer
-		return false
+	podsScheduled := 0
+	for _, n := range newNodes {
+		podsScheduled += len(n.Pods)
 	}
-	for _, rs := range sslist.Items {
-		desired := ptr.Int32Value(rs.Spec.Replicas)
-		if rs.Spec.Replicas == nil {
-			// unspecified defaults to 1
-			desired = 1
-		}
-		if rs.Status.ReadyReplicas < desired || rs.Status.UpdatedReplicas < desired {
-			return false
-		}
+	for _, n := range ifn {
+		podsScheduled += len(n.Pods)
 	}
-	return true
-}
 
-func (c *Controller) stabilizationWindow(ctx context.Context) time.Duration {
-	// no pending pods, and all replica sets/replication controllers are reporting ready so quickly consider another consolidation
-	if !c.hasPendingPods(ctx) && c.deploymentsReady(ctx) && c.replicaSetsReady(ctx) &&
-		c.replicationControllersReady(ctx) && c.statefulSetsReady(ctx) {
-		return 0
-	}
-	return 5 * time.Minute
+	return newNodes, podsScheduled == len(pods), nil
 }
 
 func (c *Controller) setNodeUnschedulable(ctx context.Context, nodeName string, isUnschedulable bool) error {
@@ -688,4 +668,134 @@ func (c *Controller) setNodeUnschedulable(ctx context.Context, nodeName string, 
 		return fmt.Errorf("patching node %s, %w", node.Name, err)
 	}
 	return nil
+}
+
+// validateCommand is used to validate that a lifecycleCommand is still able to be performed by re-inspecting nodes and
+// re-simulating scheduling
+func (c *Controller) validateCommand(ctx context.Context, cmd lifecycleCommand) (bool, error) {
+	// verifyDelay is how long we wait before re-validating our lifecycle command
+	verifyDelay := 15 * time.Second
+	// figure out how long we need to delay for verification based on when the command was constructed
+	remainingDelay := verifyDelay - c.clock.Since(cmd.created)
+	if remainingDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return false, fmt.Errorf("context canceled")
+		case <-c.clock.After(remainingDelay):
+		}
+	}
+
+	// we've waited and now need to get the new cluster state
+	nodes, err := c.mapNodes(ctx, cmd.nodesToRemove)
+	if err != nil {
+		return false, err
+	}
+
+	switch cmd.action {
+	case lifecycleActionDeleteEmpty:
+		// delete empty isn't quite a special case of replace as we only want to perform the action if the nodes are
+		// empty, not if they just won't create a new node if deleted
+		return c.validateDeleteEmpty(nodes)
+	case lifecycleActionDelete, lifecycleActionReplace:
+		// deletion is just a special case of replace where we don't launch a replacement node
+		return c.validateReplace(ctx, nodes, cmd.replacementNode)
+	default:
+		return false, fmt.Errorf("unsupported action %s", cmd.action)
+	}
+}
+
+// mapNodes maps from a list of *v1.Node to candidateNode
+func (c *Controller) mapNodes(ctx context.Context, nodes []*v1.Node) ([]candidateNode, error) {
+	verifyNodeNames := sets.NewString(lo.Map(nodes, func(t *v1.Node, i int) string { return t.Name })...)
+	candidateNodes, err := c.candidateNodes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("determining candidate node, %w", err)
+	}
+	var ret []candidateNode
+	for _, c := range candidateNodes {
+		if verifyNodeNames.Has(c.Name) {
+			ret = append(ret, c)
+		}
+	}
+	return ret, nil
+}
+
+// validateDeleteEmpty validates that the given nodes are still empty
+func (c *Controller) validateDeleteEmpty(nodesToDelete []candidateNode) (bool, error) {
+	// the deletion of empty nodes is easy to validate, we just ensure that all the nodesToDelete are still empty and that
+	// the node isn't a target of a recent scheduling simulation
+	for _, n := range nodesToDelete {
+		if len(n.pods) != 0 && !c.cluster.IsNodeNominated(n.Name) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// validateReplace validates that given the nodes to delete and the replacement node, the replacement is still valid
+func (c *Controller) validateReplace(ctx context.Context, nodesToDelete []candidateNode, replacementNode *pscheduling.Node) (bool, error) {
+	newNodes, allPodsScheduled, err := c.simulateScheduling(ctx, nodesToDelete...)
+	if err != nil {
+		return false, fmt.Errorf("simluating scheduling, %w", err)
+	}
+	if !allPodsScheduled {
+		return false, nil
+	}
+
+	// We want to ensure that the re-simulated scheduling using the current cluster state produces the same result.
+	// There are three possible options for the number of new nodesToDelete that we need to handle:
+	// len(newNodes) == 0, as long as we weren't expecting a new node, this is valid
+	// len(newNodes) > 1, something in the cluster changed so that the nodesToDelete we were going to delete can no longer
+	//                    be deleted without producing more than one node
+	// len(newNodes) == 1, as long as the node looks like what we were expecting, this is valid
+	if len(newNodes) == 0 {
+		if replacementNode == nil {
+			// scheduling produced zero new nodes and we weren't expecting any, so this is valid.
+			return true, nil
+		}
+		// if it produced no new nodes, but we were expecting one we should re-simulate as there is likely a better
+		// consolidation option now
+		return false, nil
+	}
+
+	// we need more than one replacement node which is never valid currently (all of our node replacement is m->1, never m->n)
+	if len(newNodes) > 1 {
+		return false, nil
+	}
+
+	// we now know that scheduling simulation wants to create one new node
+	if replacementNode == nil {
+		// but we weren't expecting any new nodes, so this is invalid
+		return false, nil
+	}
+
+	// We know that the scheduling simulation wants to create a new node and that the command we are verifying wants
+	// to create a new node. The scheduling simulation doesn't apply any filtering to instance types, so it may include
+	// instance types that we don't want to launch which were filtered out when the lifecycleCommand was created.  To
+	// check if our lifecycleCommand is valid, we just want to ensure that the list of instance types we are considering
+	// creating are a subset of what scheduling says we should create.
+	//
+	// This is necessary since consolidation only wants cheaper nodes.  Suppose consolidation determined we should delete
+	// a 4xlarge and replace it with a 2xlarge. If things have changed and the scheduling simulation we just performed
+	// now says that we need to launch a 4xlarge. It's still launching the correct number of nodes, but it's just
+	// as expensive or possibly more so we shouldn't validate.
+	if !instanceTypesAreSubset(replacementNode.InstanceTypeOptions, newNodes[0].InstanceTypeOptions) {
+		return false, nil
+	}
+
+	// Now we know:
+	// - current scheduling simulation says to create a new node with types T = {T_0, T_1, ..., T_n}
+	// - our lifecycle command says to create a node with types {U_0, U_1, ..., U_n} where U is a subset of T
+	return true, nil
+}
+
+// instanceTypesAreSubset returns true if the lhs slice of instance types are a subset of the rhs.
+func instanceTypesAreSubset(lhs []cloudprovider.InstanceType, rhs []cloudprovider.InstanceType) bool {
+	rhsNames := sets.NewString(lo.Map(rhs, func(t cloudprovider.InstanceType, i int) string { return t.Name() })...)
+	for _, l := range lhs {
+		if _, ok := rhsNames[l.Name()]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/controllers/consolidation/suite_test.go
+++ b/pkg/controllers/consolidation/suite_test.go
@@ -93,6 +93,16 @@ var _ = AfterSuite(func() {
 	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
 })
 
+func triggerVerifyAction() {
+	for i := 0; i < 10; i++ {
+		time.Sleep(250 * time.Millisecond)
+		if fakeClock.HasWaiters() {
+			break
+		}
+	}
+	fakeClock.Step(45 * time.Second)
+}
+
 var _ = BeforeEach(func() {
 	cloudProvider.CreateCalls = nil
 	cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
@@ -209,7 +219,10 @@ var _ = Describe("Replace Nodes", func() {
 					},
 				}}})
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -230,6 +243,7 @@ var _ = Describe("Replace Nodes", func() {
 		// consolidation won't delete the old node until the new node is ready
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, node)
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
@@ -274,7 +288,10 @@ var _ = Describe("Replace Nodes", func() {
 			},
 		})
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node1 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -333,7 +350,9 @@ var _ = Describe("Replace Nodes", func() {
 					},
 				}}})
 
-		prov := test.Provisioner(test.ProvisionerOptions{TTLSecondsUntilExpired: aws.Int64(30), Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+		})
 		regularNode := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -378,6 +397,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(regularNode))
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(annotatedNode))
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -446,7 +466,10 @@ var _ = Describe("Replace Nodes", func() {
 					},
 				}}})
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -540,7 +563,8 @@ var _ = Describe("Replace Nodes", func() {
 
 		// provisioner should require on-demand instance for this test case
 		prov := test.Provisioner(test.ProvisionerOptions{
-			Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
 			Requirements: []v1.NodeSelectorRequirement{
 				{
 					Key:      v1alpha5.LabelCapacityType,
@@ -594,7 +618,10 @@ var _ = Describe("Replace Nodes", func() {
 					},
 				}}})
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Finalizers: []string{"unit-test.com/block-deletion"},
@@ -618,6 +645,7 @@ var _ = Describe("Replace Nodes", func() {
 		fakeClock.Step(10 * time.Minute)
 
 		var consolidationFinished atomic.Bool
+		go triggerVerifyAction()
 		go func() {
 			_, err := controller.ProcessCluster(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -668,7 +696,10 @@ var _ = Describe("Delete Node", func() {
 					},
 				}}})
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node1 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -709,6 +740,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -756,7 +788,10 @@ var _ = Describe("Delete Node", func() {
 			},
 		})
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node1 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -798,6 +833,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -831,7 +867,10 @@ var _ = Describe("Delete Node", func() {
 			v1alpha5.DoNotEvictPodAnnotationKey: "true",
 		}
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node1 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -873,6 +912,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -903,7 +943,10 @@ var _ = Describe("Delete Node", func() {
 		// pod[2] is a stand-alone (non ReplicaSet) pod
 		pods[2].OwnerReferences = nil
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		node1 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -945,6 +988,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -979,7 +1023,11 @@ var _ = Describe("Node Lifetime Consideration", func() {
 					},
 				}}})
 
-		prov := test.Provisioner(test.ProvisionerOptions{TTLSecondsUntilExpired: aws.Int64(3), Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:          &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty:   aws.Int64(0),
+			TTLSecondsUntilExpired: aws.Int64(3),
+		})
 		node1 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -1024,6 +1072,7 @@ var _ = Describe("Node Lifetime Consideration", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.SetTime(time.Now())
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1071,7 +1120,10 @@ var _ = Describe("Topology Consideration", func() {
 		testZone2Instance := mostExpensiveInstanceWithZone("test-zone-2")
 		testZone3Instance := leastExpensiveInstanceWithZone("test-zone-3")
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		zone1Node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -1119,6 +1171,7 @@ var _ = Describe("Topology Consideration", func() {
 		// consolidation won't delete the old node until the new node is ready
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, zone1Node, zone2Node, zone3Node)
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
@@ -1173,7 +1226,10 @@ var _ = Describe("Topology Consideration", func() {
 		testZone2Instance := leastExpensiveInstanceWithZone("test-zone-2")
 		testZone3Instance := leastExpensiveInstanceWithZone("test-zone-3")
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		zone1Node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -1218,6 +1274,7 @@ var _ = Describe("Topology Consideration", func() {
 
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, zone1Node, zone2Node, zone3Node)
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
@@ -1256,6 +1313,7 @@ var _ = Describe("Empty Nodes", func() {
 		// inform cluster state about the nodes
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1299,6 +1357,7 @@ var _ = Describe("Empty Nodes", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
+		go triggerVerifyAction()
 		_, err := controller.ProcessCluster(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -1310,6 +1369,117 @@ var _ = Describe("Empty Nodes", func() {
 	})
 })
 
+var _ = Describe("Consolidation TTL", func() {
+	It("should wait for the node TTL before consolidating", func() {
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+		})
+
+		node1 := test.Node(test.NodeOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1alpha5.LabelNodeInitialized:    "true",
+				},
+			},
+			Allocatable: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:  resource.MustParse("32"),
+				v1.ResourcePods: resource.MustParse("100"),
+			}})
+
+		ExpectApplied(ctx, env.Client, node1, prov)
+
+		// inform cluster state about the nodes
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
+		var wg sync.WaitGroup
+		wg.Add(1)
+		finished := atomic.Bool{}
+		go func() {
+			defer wg.Done()
+			defer finished.Store(true)
+			_, err := controller.ProcessCluster(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// wait for the controller to block on the validation timeout
+		Eventually(fakeClock.HasWaiters).Should(BeTrue())
+		// controller should be blocking during the timeout
+		Expect(finished.Load()).To(BeFalse())
+		// and the node should not be deleted yet
+		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(node1), node1)).To(Succeed())
+
+		// advance the clock so that the timeout expires
+		fakeClock.Step(31 * time.Second)
+		// controller should finish
+		Eventually(finished.Load, 10*time.Second).Should(BeTrue())
+		wg.Wait()
+
+		// we don't need any new nodes
+		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
+		// and should delete the empty one
+		ExpectNotFound(ctx, env.Client, node1)
+	})
+	It("should not consolidate if the action becomes invalid during the node TTL wait", func() {
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+		})
+
+		node1 := test.Node(test.NodeOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1alpha5.LabelNodeInitialized:    "true",
+				},
+			},
+			Allocatable: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:  resource.MustParse("32"),
+				v1.ResourcePods: resource.MustParse("100"),
+			}})
+
+		pod := test.Pod()
+		ExpectApplied(ctx, env.Client, node1, prov, pod)
+
+		// inform cluster state about the nodes
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
+		var wg sync.WaitGroup
+		wg.Add(1)
+		finished := atomic.Bool{}
+		go func() {
+			defer wg.Done()
+			defer finished.Store(true)
+			_, err := controller.ProcessCluster(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		// wait for the controller to block on the validation timeout
+		Eventually(fakeClock.HasWaiters).Should(BeTrue())
+		// controller should be blocking during the timeout
+		Expect(finished.Load()).To(BeFalse())
+		// and the node should not be deleted yet
+		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(node1), node1)).To(Succeed())
+
+		// make the node non-empty
+		ExpectManualBinding(ctx, env.Client, pod, node1)
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
+
+		// advance the clock so that the timeout expires
+		fakeClock.Step(31 * time.Second)
+		// controller should finish
+		Eventually(finished.Load, 10*time.Second).Should(BeTrue())
+		wg.Wait()
+
+		// we don't need any new nodes
+		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
+		// and the empty one is now not empty, so we should keep it
+		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(node1), node1)).To(Succeed())
+	})
+})
 var _ = Describe("Parallelization", func() {
 	It("should schedule an additional node when receiving pending pods while consolidating", func() {
 		labels := map[string]string{
@@ -1333,7 +1503,10 @@ var _ = Describe("Parallelization", func() {
 					},
 				}}})
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 
 		// Add a finalizer to the node so that it sticks around for the scheduling loop
 		node := test.Node(test.NodeOptions{
@@ -1358,6 +1531,7 @@ var _ = Describe("Parallelization", func() {
 		fakeClock.Step(10 * time.Minute)
 
 		// Run the processing loop in parallel in the background with environment context
+		go triggerVerifyAction()
 		go func() {
 			_, err := controller.ProcessCluster(env.Ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -1386,7 +1560,10 @@ var _ = Describe("Parallelization", func() {
 		ExpectApplied(ctx, env.Client, rs)
 		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
 
-		prov := test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: aws.Bool(true)}})
+		prov := test.Provisioner(test.ProvisionerOptions{
+			Consolidation:        &v1alpha5.Consolidation{Enabled: aws.Bool(true)},
+			TTLSecondsAfterEmpty: aws.Int64(0),
+		})
 		podOpts := test.PodOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,
@@ -1458,7 +1635,7 @@ var _ = Describe("Parallelization", func() {
 		fakeClock.Step(10 * time.Minute)
 		result, err := controller.ProcessCluster(env.Ctx)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(consolidation.ProcessResultNothingToDo))
+		Expect(result).To(Equal(consolidation.DeprovisioningResultNothingToDo))
 	})
 })
 

--- a/pkg/controllers/consolidation/types.go
+++ b/pkg/controllers/consolidation/types.go
@@ -17,63 +17,85 @@ package consolidation
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
 	"github.com/aws/karpenter/pkg/controllers/provisioning/scheduling"
 )
 
-// ProcessResult is used to indicate the result of consolidating so we can optimize by not trying to consolidate if
+// DeprovisioningResult is used to indicate the action of consolidating so we can optimize by not trying to consolidate if
 // we were unable to consolidate the cluster and it hasn't changed state with respect to pods/nodes.
-type ProcessResult byte
+type DeprovisioningResult byte
 
 const (
-	ProcessResultNothingToDo ProcessResult = iota
-	ProcessResultFailed
-	ProcessResultConsolidated
+	DeprovisioningResultNothingToDo DeprovisioningResult = iota // there are no actions that can be performed given the current cluster state
+	DeprovisioningResultRetry                                   // we attempted an action, but its validation failed so retry soon
+	DeprovisioningResultFailed                                  // the action failed entirely
+	DeprovisioningResultSuccess                                 // the action was successful
 )
 
-type consolidateResult byte
-
-const (
-	consolidateResultUnknown consolidateResult = iota
-	consolidateResultNotPossible
-	consolidateResultDelete
-	consolidateResultDeleteEmpty
-	consolidateResultReplace
-	consolidateResultNoAction
-)
-
-func (r consolidateResult) String() string {
+func (r DeprovisioningResult) String() string {
 	switch r {
-	case consolidateResultUnknown:
-		return "Unknown"
-	case consolidateResultNotPossible:
-		return "Not Possible"
-	case consolidateResultDelete:
-		return "Delete"
-	case consolidateResultDeleteEmpty:
-		return "Delete (empty node)"
-	case consolidateResultReplace:
-		return "Replace"
-	case consolidateResultNoAction:
-		return "NoAction"
+	case DeprovisioningResultNothingToDo:
+		return "Nothing to do"
+	case DeprovisioningResultRetry:
+		return "Retry"
+	case DeprovisioningResultFailed:
+		return "Failed"
+	case DeprovisioningResultSuccess:
+		return "Success"
 	default:
 		return fmt.Sprintf("Unknown (%d)", r)
 	}
 }
 
-type consolidationAction struct {
-	oldNodes        []*v1.Node
-	disruptionCost  float64
-	result          consolidateResult
-	replacementNode *scheduling.Node
+type lifecyleAction byte
+
+const (
+	lifeCycleActionUnknown lifecyleAction = iota
+	lifecycleActionNonePossible
+	lifecycleActionDelete
+	lifecycleActionDeleteEmpty
+	lifecycleActionReplace
+	lifecycleActionDoNothing
+	lifecycleActionFailed
+)
+
+func (a lifecyleAction) String() string {
+	switch a {
+	case lifeCycleActionUnknown:
+		return "Unknown"
+	case lifecycleActionNonePossible:
+		return "Not Possible"
+	case lifecycleActionDelete:
+		return "Delete"
+	case lifecycleActionDeleteEmpty:
+		return "Delete (empty node)"
+	case lifecycleActionReplace:
+		return "Replace"
+	case lifecycleActionDoNothing:
+		return "NoAction"
+	case lifecycleActionFailed:
+		return "Failed"
+	default:
+		return fmt.Sprintf("Unknown (%d)", a)
+	}
 }
 
-func (o consolidationAction) String() string {
+type lifecycleCommand struct {
+	nodesToRemove   []*v1.Node
+	action          lifecyleAction
+	replacementNode *scheduling.Node
+	created         time.Time
+}
+
+func (o lifecycleCommand) String() string {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%s, terminating %d nodes ", o.result, len(o.oldNodes))
-	for i, old := range o.oldNodes {
+	fmt.Fprintf(&buf, "%s, terminating %d nodes ", o.action, len(o.nodesToRemove))
+	for i, old := range o.nodesToRemove {
 		if i != 0 {
 			fmt.Fprint(&buf, ", ")
 		}
@@ -81,9 +103,22 @@ func (o consolidationAction) String() string {
 		if instanceType, ok := old.Labels[v1.LabelInstanceTypeStable]; ok {
 			fmt.Fprintf(&buf, "/%s", instanceType)
 		}
+		if capacityType, ok := old.Labels[v1alpha5.LabelCapacityType]; ok {
+			fmt.Fprintf(&buf, "/%s", capacityType)
+		}
 	}
 	if o.replacementNode != nil {
-		fmt.Fprintf(&buf, " and replacing with a node from types %s",
+		ct := o.replacementNode.Requirements.Get(v1alpha5.LabelCapacityType)
+		nodeDesc := "node"
+		// if there is a single capacity type value, we know what will launch. This makes it more clear
+		// in logs why we replaced a node with one that at first glance appears more expensive when doing an OD->spot
+		// replacement
+		if ct.Len() == 1 {
+			nodeDesc = fmt.Sprintf("%s node", ct.Any())
+		}
+
+		fmt.Fprintf(&buf, " and replacing with %s from types %s",
+			nodeDesc,
 			scheduling.InstanceTypeList(o.replacementNode.InstanceTypeOptions))
 	}
 	return buf.String()

--- a/pkg/controllers/consolidation/types.go
+++ b/pkg/controllers/consolidation/types.go
@@ -52,33 +52,33 @@ func (r DeprovisioningResult) String() string {
 	}
 }
 
-type lifecyleAction byte
+type deprovisionAction byte
 
 const (
-	lifeCycleActionUnknown lifecyleAction = iota
-	lifecycleActionNonePossible
-	lifecycleActionDelete
-	lifecycleActionDeleteEmpty
-	lifecycleActionReplace
-	lifecycleActionDoNothing
-	lifecycleActionFailed
+	deprovisionActionUnknown deprovisionAction = iota
+	deprovisionActionNotPossible
+	deprovisionActionDelete
+	deprovisionActionDeleteEmpty
+	deprovisionActionReplace
+	deprovisionActionDoNothing
+	deprovisionActionFailed
 )
 
-func (a lifecyleAction) String() string {
+func (a deprovisionAction) String() string {
 	switch a {
-	case lifeCycleActionUnknown:
+	case deprovisionActionUnknown:
 		return "Unknown"
-	case lifecycleActionNonePossible:
+	case deprovisionActionNotPossible:
 		return "Not Possible"
-	case lifecycleActionDelete:
+	case deprovisionActionDelete:
 		return "Delete"
-	case lifecycleActionDeleteEmpty:
+	case deprovisionActionDeleteEmpty:
 		return "Delete (empty node)"
-	case lifecycleActionReplace:
+	case deprovisionActionReplace:
 		return "Replace"
-	case lifecycleActionDoNothing:
+	case deprovisionActionDoNothing:
 		return "NoAction"
-	case lifecycleActionFailed:
+	case deprovisionActionFailed:
 		return "Failed"
 	default:
 		return fmt.Sprintf("Unknown (%d)", a)
@@ -87,7 +87,7 @@ func (a lifecyleAction) String() string {
 
 type lifecycleCommand struct {
 	nodesToRemove   []*v1.Node
-	action          lifecyleAction
+	action          deprovisionAction
 	replacementNode *scheduling.Node
 	created         time.Time
 }


### PR DESCRIPTION
Fixes #2370

**Description**

- Use a consolidation TTL of 15 seconds which allows removing the stabilization window

**How was this change tested?**

* Unit testing, E2E tests and deployed to EKS.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
