### PR TITLE
docs: Fixes OCI Helm repository

### DIFF
--- a/website/content/en/v0.17.0/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.17.0/getting-started/getting-started-with-terraform/_index.md
@@ -289,7 +289,7 @@ resource "helm_release" "karpenter" {
   create_namespace = true
 
   name       = "karpenter"
-  repository = "oci://public.ecr.aws/karpenter/karpenter"
+  repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
   version    = "v0.17.0"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes #2633

**Description**
Fixes docs for Terraform + Helm instalation. The repository should be `repository = "oci://public.ecr.aws/karpenter"`, as the last `/karpenter` is the chart name that is defined in Line 293

**How was this change tested?**

I installed it using the guide. The 

**Does this change impact docs?**
- [x] Yes, PR includes docs updates

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes docs for Helm Terraform instalation 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
