### PR TITLE
chore: Propagate errors correctly in make tidy and make download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ coverage:
 	go tool cover -html coverage.out -o coverage.html
 
 verify: tidy download codegen ## Verify code. Includes dependencies, linting, formatting, etc
-	golangci-lint run
+	$(foreach dir,$(MOD_DIRS),cd $(dir) && golangci-lint run $(newline))
 	@git diff --quiet ||\
 		{ echo "New file modification detected in the Git working tree. Please check in before commit.";\
 		if [ $(MAKECMDGOALS) = 'ci' ]; then\
@@ -143,11 +143,14 @@ website: ## Serve the docs website locally
 	cd website && npm install && git submodule update --init --recursive && hugo server
 
 tidy: ## Recursively "go mod tidy" on all directories where go.mod exists
-	@echo go mod tidy
-	$(foreach dir,$(MOD_DIRS),$(shell cd $(dir) && go mod tidy))
+	$(foreach dir,$(MOD_DIRS),cd $(dir) && go mod tidy $(newline))
 
 download: ## Recursively "go mod download" on all directories where go.mod exists
-	@echo go mod download
-	$(foreach dir,$(MOD_DIRS),$(shell cd $(dir) && go mod download))
+	$(foreach dir,$(MOD_DIRS),cd $(dir) && go mod download $(newline))
 
 .PHONY: help dev ci release test battletest e2etests verify tidy download codegen docgen apply delete toolchain licenses issues website nightly snapshot
+
+define newline
+
+
+endef


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**

Correctly propagate error codes coming from `make tidy` and `make download`

**How was this change tested?**

* `make tidy` with error in `go.mod` resolution

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
