### PR TITLE
fix: swap action order to get a clean git commit message

### DIFF
--- a/.github/workflows/stable-release.yaml
+++ b/.github/workflows/stable-release.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   stable-release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'aws/karpenter' }}
+    if: github.event.workflow_run.conclusion == 'success' && github.repository == 'aws/karpenter'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -49,22 +49,20 @@ jobs:
                archive_format: 'zip',
             });
             let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/tags.zip`, Buffer.from(download.data));
-      - run: unzip tags.zip
+            fs.writeFileSync(`/tmp/tags.zip`, Buffer.from(download.data));
+      - run: unzip /tmp/tags.zip -d /tmp
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::071440425669:role/Github
           aws-region: us-east-1
+      - run: SNAPSHOT_TAG=$(cat /tmp/tag.txt) make snapshot
       - run: make docgen
       - run: |
           git config user.name "StableRelease"
           git config user.email "StableRelease@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git config pull.rebase false
-      - run: SNAPSHOT_TAG=$(cat tag.txt) make snapshot
-      - run: SNAPSHOT_TAG=$(cat tag.txt) make stable-release-pr
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: SNAPSHOT_TAG=$(cat /tmp/tag.txt) make stable-release-pr
       - name: Create Pull Request
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
…files in the repo

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

**Description**
Changes the order of jobs such that at the time of releasing the binary there are no changes to the code base hence not showing "{commit-id}-dirty in the binary.


**How was this change tested?**

* My fork

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
