### PR TITLE
docs: update grafana metrics and add upgrade entry

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
@@ -208,14 +208,14 @@
                         "uid": "${datasource}"
                     },
                     "editorMode": "builder",
-                    "expr": "sum by(cluster) (karpenter_consolidation_nodes_created)",
+                    "expr": "sum by(cluster) (karpenter_nodes_created)",
                     "format": "time_series",
                     "legendFormat": "{{cluster}}",
                     "range": true,
                     "refId": "A"
                 }
             ],
-            "title": "Consolidation: Nodes Created",
+            "title": "Nodes Created",
             "type": "timeseries"
         },
         {
@@ -303,14 +303,14 @@
                         "uid": "${datasource}"
                     },
                     "editorMode": "builder",
-                    "expr": "sum by(cluster) (karpenter_consolidation_nodes_terminated)",
+                    "expr": "sum by(cluster) (karpenter_nodes_terminated)",
                     "format": "time_series",
                     "legendFormat": "{{cluster}}",
                     "range": true,
                     "refId": "A"
                 }
             ],
-            "title": "Consolidation: Nodes Terminated",
+            "title": "Nodes Terminated",
             "type": "timeseries"
         },
         {

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -97,6 +97,9 @@ By adopting this practice we allow our users who are early adopters to test out 
 
 # Released Upgrade Notes
 
+## Upgrading to v0.18.0+
+* v0.18.0 removes the `karpenter_consolidation_nodes_created` and `karpenter_consolidation_nodes_terminated` prometheus metrics in favor of the more generic `karpenter_nodes_created` and `karpenter_nodes_terminated` metrics. You can still see nodes created and terminated by consolidation by checking the `reason` label on the metrics. Check out all the metrics published by Karpenter [here](../tasks/metrics/).
+
 ## Upgrading to v0.17.0+
 Karpenter's Helm chart package is now stored in [Karpenter's OCI (Open Container Initiative) registry](https://gallery.ecr.aws/karpenter/karpenter). The Helm CLI supports the new format since [v3.8.0+](https://helm.sh/docs/topics/registries/).
 With this change [charts.karpenter.sh](https://charts.karpenter.sh/) is no longer updated but preserved to allow using older Karpenter versions. For examples on working with the Karpenter helm charts look at [Install Karpenter Helm Chart]({{< ref "../getting-started/getting-started-with-eksctl/#install-karpenter-helm-chart" >}}).


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->

https://github.com/aws/karpenter/pull/2595

**Description**
https://github.com/aws/karpenter/pull/2595 moved the consolidation metrics around which was a breaking change. This backfills the upgrade guide entry and updates the grafana dashboard. 


**How was this change tested?**

* `make website`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
