### PR TITLE
fix: metrics docs generation

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -29,7 +29,7 @@ var (
 			Namespace: Namespace,
 			Subsystem: nodeSubsystem,
 			Name:      "created",
-			Help:      "Number of nodes created in total.",
+			Help:      "Number of nodes created in total by Karpenter. Labeled by reason the node was created.",
 		},
 		[]string{
 			"reason",
@@ -40,7 +40,7 @@ var (
 			Namespace: Namespace,
 			Subsystem: nodeSubsystem,
 			Name:      "terminated",
-			Help:      "Number of nodes terminated in total.",
+			Help:      "Number of nodes terminated in total by Karpenter. Labeled by reason the node was terminated.",
 		},
 		[]string{
 			"reason",

--- a/website/content/en/preview/tasks/metrics.md
+++ b/website/content/en/preview/tasks/metrics.md
@@ -32,17 +32,17 @@ The Provisioner Usage Percentage is the percentage of each resource used based o
 
 ## Nodes Metrics
 
-### `karpenter_nodes_created`
-Number of nodes created in total by Karpenter. Labeled by reason the node was created.
-
-### `karpenter_nodes_terminated`
-Number of nodes terminated in total by Karpenter. Labeled by reason the node was terminated.
-
 ### `karpenter_nodes_allocatable`
 Node allocatable are the resources allocatable by nodes.
 
+### `karpenter_nodes_created`
+Number of nodes created in total by Karpenter. Labeled by reason the node was created.
+
 ### `karpenter_nodes_system_overhead`
 Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
+
+### `karpenter_nodes_terminated`
+Number of nodes terminated in total by Karpenter. Labeled by reason the node was terminated.
 
 ### `karpenter_nodes_termination_time_seconds`
 The time taken between a node's deletion request and the removal of its finalizer


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change
-->

Fixes # <!-- issue number -->
N/A

**Description**
Fixes an issue with `make docgen` which was introduced in https://github.com/aws/karpenter/pull/2595.  Adds mapping for identifiers to values.
```
% make docgen
go run hack/docs/metrics_gen_docs.go pkg/ website/content/en/preview/tasks/metrics.md
2022/10/11 18:12:36 parsing code in pkg/
2022/10/11 18:12:36 unsupported value *ast.Ident Namespace
exit status 1
make: *** [docgen] Error 1
```

**How was this change tested?**
* Ran `make docgen` after fix.  
* Validated that the metrics documentation was created successfully.
```
% make docgen
go run hack/docs/metrics_gen_docs.go pkg/ website/content/en/preview/tasks/metrics.md
2022/10/11 18:13:12 parsing code in pkg/
2022/10/11 18:13:12 writing output to website/content/en/preview/tasks/metrics.md
go run hack/docs/instancetypes_gen_docs.go website/content/en/preview/AWS/instance-types.md
{"level":"info","ts":1665511994.9409213,"logger":"fallback.aws.pricing","caller":"aws/pricing.go:110","msg":"Assuming isolated VPC, pricing information will not be updated"}
2022/10/11 18:13:16 writing output to website/content/en/preview/AWS/instance-types.md
go run hack/docs/configuration_gen_docs.go website/content/en/preview/tasks/configuration.md
2022/10/11 18:13:16 writing output to website/content/en/preview/tasks/configuration.md
```


**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes metrics docs generation script
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
