### PR TITLE
fix: AMI Selection to use latest AMI

### DIFF
--- a/pkg/cloudprovider/aws/amifamily/ami.go
+++ b/pkg/cloudprovider/aws/amifamily/ami.go
@@ -204,7 +204,7 @@ func getMostRecentCompatibleAMI(compatibleAMIs map[string][]cloudprovider.Instan
 	for _, ami := range amis {
 		if _, exists := compatibleAMIs[*ami.ImageId]; exists {
 			mostRecent[*ami.ImageId] = compatibleAMIs[*ami.ImageId]
-			return mostRecent
+			break
 		}
 	}
 	return mostRecent

--- a/pkg/cloudprovider/aws/amifamily/ami.go
+++ b/pkg/cloudprovider/aws/amifamily/ami.go
@@ -77,7 +77,7 @@ func (p *AMIProvider) Get(ctx context.Context, provider *awsv1alpha1.AWS, nodeRe
 		if _, exists := amiSelector["aws-ids"]; exists {
 			return amiIDs, nil
 		} else {
-			return getMostRecentCompatibleAMI(amiIDs, amis), nil
+			return getMostRecentCompatibleAMI(ctx, amiIDs, amis), nil
 		}
 	} else {
 		for _, instanceType := range nodeRequest.InstanceTypeOptions {
@@ -199,11 +199,12 @@ func sortAMIsByCreationDate(amis []*ec2.Image) []*ec2.Image {
 	return amis
 }
 
-func getMostRecentCompatibleAMI(compatibleAMIs map[string][]cloudprovider.InstanceType, amis []*ec2.Image) map[string][]cloudprovider.InstanceType {
+func getMostRecentCompatibleAMI(ctx context.Context, compatibleAMIs map[string][]cloudprovider.InstanceType, amis []*ec2.Image) map[string][]cloudprovider.InstanceType {
 	mostRecent := map[string][]cloudprovider.InstanceType{}
 	for _, ami := range amis {
 		if _, exists := compatibleAMIs[*ami.ImageId]; exists {
 			mostRecent[*ami.ImageId] = compatibleAMIs[*ami.ImageId]
+			logging.FromContext(ctx).Debugf("Using most recent compatible AMI: %s", *ami.ImageId)
 			break
 		}
 	}

--- a/pkg/cloudprovider/aws/amifamily/ami.go
+++ b/pkg/cloudprovider/aws/amifamily/ami.go
@@ -55,7 +55,11 @@ type AMIProvider struct {
 // If AMI overrides are specified in the AWSNodeTemplate, then only those AMIs will be chosen.
 func (p *AMIProvider) Get(ctx context.Context, provider *awsv1alpha1.AWS, nodeRequest *cloudprovider.NodeRequest, options *Options, amiFamily AMIFamily) (map[string][]cloudprovider.InstanceType, error) {
 	amiIDs := map[string][]cloudprovider.InstanceType{}
-	amiRequirements, err := p.getAMIRequirements(ctx, nodeRequest.Template.ProviderRef)
+	amiSelector, err := p.getAMISelector(ctx, nodeRequest.Template.ProviderRef)
+	if err != nil {
+		return nil, err
+	}
+	amiRequirements, amis, err := p.getAMIRequirements(ctx, amiSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +73,11 @@ func (p *AMIProvider) Get(ctx context.Context, provider *awsv1alpha1.AWS, nodeRe
 		}
 		if len(amiIDs) == 0 {
 			return nil, fmt.Errorf("no instance types satisfy requirements of amis %v,", lo.Keys(amiRequirements))
+		}
+		if _, exists := amiSelector["aws-ids"]; exists {
+			return amiIDs, nil
+		} else {
+			return getMostRecentCompatibleAMI(amiIDs, amis), nil
 		}
 	} else {
 		for _, instanceType := range nodeRequest.InstanceTypeOptions {
@@ -98,42 +107,37 @@ func (p *AMIProvider) getDefaultAMIFromSSM(ctx context.Context, _ cloudprovider.
 	return ami, nil
 }
 
-func (p *AMIProvider) getAMIRequirements(ctx context.Context, providerRef *v1alpha5.ProviderRef) (map[string]scheduling.Requirements, error) {
-	amiRequirements := map[string]scheduling.Requirements{}
+func (p *AMIProvider) getAMISelector(ctx context.Context, providerRef *v1alpha5.ProviderRef) (map[string]string, error) {
+	amiSelector := map[string]string{}
 	if providerRef != nil {
 		var ant v1alpha1.AWSNodeTemplate
 		if err := p.kubeClient.Get(ctx, types.NamespacedName{Name: providerRef.Name}, &ant); err != nil {
-			return amiRequirements, fmt.Errorf("retrieving provider reference, %w", err)
+			return amiSelector, fmt.Errorf("retrieving provider reference, %w", err)
 		}
 		if len(ant.Spec.AMISelector) == 0 {
-			return amiRequirements, nil
+			return amiSelector, nil
 		}
-		return p.selectAMIs(ctx, ant.Spec.AMISelector)
+		return ant.Spec.AMISelector, nil
 	}
-	return amiRequirements, nil
+	return amiSelector, nil
 }
 
-func (p *AMIProvider) selectAMIs(ctx context.Context, amiSelector map[string]string) (map[string]scheduling.Requirements, error) {
-	var amis []*ec2.Image
-	ec2AMIs, err := p.fetchAMIsFromEC2(ctx, amiSelector)
-	if err != nil {
-		return nil, err
+func (p *AMIProvider) getAMIRequirements(ctx context.Context, amiSelector map[string]string) (map[string]scheduling.Requirements, []*ec2.Image, error) {
+	if len(amiSelector) > 0 {
+		ec2AMIs, err := p.fetchAMIsFromEC2(ctx, amiSelector)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(ec2AMIs) == 0 {
+			return nil, nil, fmt.Errorf("no amis exist given constraints")
+		}
+		var amiIDs = map[string]scheduling.Requirements{}
+		for _, ec2AMI := range ec2AMIs {
+			amiIDs[*ec2AMI.ImageId] = p.getRequirementsFromImage(ec2AMI)
+		}
+		return amiIDs, ec2AMIs, nil
 	}
-	if len(ec2AMIs) == 0 {
-		return nil, fmt.Errorf("no amis exist given constraints")
-	}
-	if _, exists := amiSelector["aws-ids"]; exists {
-		amis = ec2AMIs
-	} else {
-		mostRecentAMI := getMostRecentAMI(ec2AMIs)
-		amis = append(amis, mostRecentAMI)
-		logging.FromContext(ctx).Debugf("Using most recent image: %s", *mostRecentAMI.ImageId)
-	}
-	var amiIDs = map[string]scheduling.Requirements{}
-	for _, ami := range amis {
-		amiIDs[*ami.ImageId] = p.getRequirementsFromImage(ami)
-	}
-	return amiIDs, nil
+	return nil, nil, nil
 }
 
 func (p *AMIProvider) fetchAMIsFromEC2(ctx context.Context, amiSelector map[string]string) ([]*ec2.Image, error) {
@@ -150,12 +154,14 @@ func (p *AMIProvider) fetchAMIsFromEC2(ctx context.Context, amiSelector map[stri
 	if err != nil {
 		return nil, fmt.Errorf("describing images %+v, %w", filters, err)
 	}
-	p.ec2Cache.SetDefault(fmt.Sprint(hash), output.Images)
-	amiIDs := lo.Map(output.Images, func(ami *ec2.Image, _ int) string { return *ami.ImageId })
+
+	images := sortAMIsByCreationDate(output.Images)
+	p.ec2Cache.SetDefault(fmt.Sprint(hash), images)
+	amiIDs := lo.Map(images, func(ami *ec2.Image, _ int) string { return *ami.ImageId })
 	if p.cm.HasChanged("amiIDs", amiIDs) {
 		logging.FromContext(ctx).Debugf("Discovered images: %s", amiIDs)
 	}
-	return output.Images, nil
+	return images, nil
 }
 
 func getFilters(amiSelector map[string]string) []*ec2.Filter {
@@ -182,7 +188,7 @@ func getFilters(amiSelector map[string]string) []*ec2.Filter {
 	return filters
 }
 
-func getMostRecentAMI(amis []*ec2.Image) *ec2.Image {
+func sortAMIsByCreationDate(amis []*ec2.Image) []*ec2.Image {
 	if len(amis) > 1 {
 		sort.Slice(amis, func(i, j int) bool {
 			itime, _ := time.Parse(time.RFC3339, aws.StringValue(amis[i].CreationDate))
@@ -190,7 +196,18 @@ func getMostRecentAMI(amis []*ec2.Image) *ec2.Image {
 			return itime.Unix() > jtime.Unix()
 		})
 	}
-	return amis[0]
+	return amis
+}
+
+func getMostRecentCompatibleAMI(compatibleAMIs map[string][]cloudprovider.InstanceType, amis []*ec2.Image) map[string][]cloudprovider.InstanceType {
+	mostRecent := map[string][]cloudprovider.InstanceType{}
+	for _, ami := range amis {
+		if _, exists := compatibleAMIs[*ami.ImageId]; exists {
+			mostRecent[*ami.ImageId] = compatibleAMIs[*ami.ImageId]
+			return mostRecent
+		}
+	}
+	return mostRecent
 }
 
 func (p *AMIProvider) getRequirementsFromImage(ec2Image *ec2.Image) scheduling.Requirements {

--- a/pkg/cloudprovider/aws/launchtemplate_test.go
+++ b/pkg/cloudprovider/aws/launchtemplate_test.go
@@ -1184,7 +1184,7 @@ var _ = Describe("LaunchTemplates", func() {
 				)
 				Expect(expectedImageIds.Equal(actualImageIds)).To(BeTrue())
 			})
-			It("should create a launch template with the most recent AMI when multiple amis are discovered via tags", func() {
+			It("should create a launch template with the most recent compatible AMI when multiple amis are discovered via tags", func() {
 				opts.AWSENILimitedPodDensity = false
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 					{
@@ -1199,7 +1199,7 @@ var _ = Describe("LaunchTemplates", func() {
 					},
 					{
 						ImageId:      aws.String("ami-789"),
-						Architecture: aws.String("x86_64"),
+						Architecture: aws.String("arm64"),
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 				}})
@@ -1209,15 +1209,24 @@ var _ = Describe("LaunchTemplates", func() {
 					AWS:         *provider,
 				})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
-				newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
+				newProvisioner := test.Provisioner(test.ProvisionerOptions{
+					ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name},
+					Requirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelArchStable,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{v1alpha5.ArchitectureAmd64},
+						},
+					},
+				})
 				ExpectApplied(ctx, env.Client, newProvisioner)
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect("ami-789").To(Equal(*input.LaunchTemplateData.ImageId))
+				Expect("ami-456").To(Equal(*input.LaunchTemplateData.ImageId))
 			})
-			It("should create a launch template with the most recent AMI when multiple amis are discovered via name", func() {
+			It("should create a launch template with the most recent compatible AMI when multiple amis are discovered via name", func() {
 				opts.AWSENILimitedPodDensity = false
 				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
@@ -1233,7 +1242,7 @@ var _ = Describe("LaunchTemplates", func() {
 					},
 					{
 						ImageId:      aws.String("ami-789"),
-						Architecture: aws.String("x86_64"),
+						Architecture: aws.String("arm64"),
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 				}})
@@ -1243,7 +1252,16 @@ var _ = Describe("LaunchTemplates", func() {
 					AWS:         *provider,
 				})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
-				newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
+				newProvisioner := test.Provisioner(test.ProvisionerOptions{
+					ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name},
+					Requirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelArchStable,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{v1alpha5.ArchitectureAmd64},
+						},
+					},
+				})
 				ExpectApplied(ctx, env.Client, newProvisioner)
 				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
 				ExpectScheduled(ctx, env.Client, pod)
@@ -1257,7 +1275,7 @@ var _ = Describe("LaunchTemplates", func() {
 				}
 				Expect(actualFilter).To(Equal(expectedFilter))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect("ami-789").To(Equal(*input.LaunchTemplateData.ImageId))
+				Expect("ami-456").To(Equal(*input.LaunchTemplateData.ImageId))
 			})
 			It("should fail if no amis match selector.", func() {
 				opts.AWSENILimitedPodDensity = false

--- a/pkg/cloudprovider/aws/launchtemplate_test.go
+++ b/pkg/cloudprovider/aws/launchtemplate_test.go
@@ -1110,7 +1110,10 @@ var _ = Describe("LaunchTemplates", func() {
 					AWS:         *provider,
 				})
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
-					{ImageId: aws.String("ami-123"), Architecture: aws.String("x86_64")},
+					{
+						ImageId:      aws.String("ami-123"),
+						Architecture: aws.String("x86_64"),
+						CreationDate: aws.String("2022-08-15T12:00:00Z")},
 				}})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
@@ -1130,7 +1133,10 @@ var _ = Describe("LaunchTemplates", func() {
 					AWS:         *provider,
 				})
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
-					{ImageId: aws.String("ami-123"), Architecture: aws.String("x86_64")},
+					{
+						ImageId:      aws.String("ami-123"),
+						Architecture: aws.String("x86_64"),
+						CreationDate: aws.String("2022-08-15T12:00:00Z")},
 				}})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
@@ -1142,7 +1148,7 @@ var _ = Describe("LaunchTemplates", func() {
 				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
 				Expect("special user data").To(Equal(string(userData)))
 			})
-			It("should create multiple launch templates when multiple aws-ids specified in AWSNodeTemplate", func() {
+			It("should correctly use ami selector with specific IDs in AWSNodeTemplate", func() {
 				opts.AWSENILimitedPodDensity = false
 				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 					UserData:    nil,
@@ -1154,13 +1160,13 @@ var _ = Describe("LaunchTemplates", func() {
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
 						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("t3.large")}},
-						CreationDate: aws.String("2022-08-05T12:00:00Z"),
+						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 					{
 						ImageId:      aws.String("ami-456"),
 						Architecture: aws.String("x86_64"),
 						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
-						CreationDate: aws.String("2022-08-10T12:00:00Z"),
+						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 				}})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
@@ -1177,6 +1183,34 @@ var _ = Describe("LaunchTemplates", func() {
 					},
 				}
 				Expect(actualFilter).To(Equal(expectedFilter))
+			})
+			It("should create multiple launch templates when multiple amis are discovered with non-equivalent requirements", func() {
+				opts.AWSENILimitedPodDensity = false
+				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
+					{
+						ImageId:      aws.String("ami-123"),
+						Architecture: aws.String("x86_64"),
+						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("t3.large")}},
+						CreationDate: aws.String("2022-08-15T12:00:00Z"),
+					},
+					{
+						ImageId:      aws.String("ami-456"),
+						Architecture: aws.String("x86_64"),
+						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
+						CreationDate: aws.String("2022-08-10T12:00:00Z"),
+					},
+				}})
+				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					UserData:    nil,
+					AMISelector: map[string]string{"karpenter.sh/discovery": "my-cluster"},
+					AWS:         *provider,
+				})
+				ExpectApplied(ctx, env.Client, nodeTemplate)
+				newProvisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
+				ExpectApplied(ctx, env.Client, newProvisioner)
+				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
+				ExpectScheduled(ctx, env.Client, pod)
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(2))
 				expectedImageIds := sets.NewString("ami-123", "ami-456")
 				actualImageIds := sets.NewString(
 					*fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
@@ -1184,23 +1218,24 @@ var _ = Describe("LaunchTemplates", func() {
 				)
 				Expect(expectedImageIds.Equal(actualImageIds)).To(BeTrue())
 			})
-			It("should create a launch template with the most recent compatible AMI when multiple amis are discovered via tags", func() {
+			It("should create a launch template with the newest compatible AMI when multiple amis are discovered", func() {
 				opts.AWSENILimitedPodDensity = false
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 					{
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
-						CreationDate: aws.String("2022-08-05T12:00:00Z"),
+						CreationDate: aws.String("2020-01-01T12:00:00Z"),
 					},
 					{
 						ImageId:      aws.String("ami-456"),
 						Architecture: aws.String("x86_64"),
-						CreationDate: aws.String("2022-08-10T12:00:00Z"),
+						CreationDate: aws.String("2021-01-01T12:00:00Z"),
 					},
 					{
+						// Incompatible because required ARM64
 						ImageId:      aws.String("ami-789"),
 						Architecture: aws.String("arm64"),
-						CreationDate: aws.String("2022-08-15T12:00:00Z"),
+						CreationDate: aws.String("2022-01-01T12:00:00Z"),
 					},
 				}})
 				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
@@ -1226,57 +1261,7 @@ var _ = Describe("LaunchTemplates", func() {
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
 				Expect("ami-456").To(Equal(*input.LaunchTemplateData.ImageId))
 			})
-			It("should create a launch template with the most recent compatible AMI when multiple amis are discovered via name", func() {
-				opts.AWSENILimitedPodDensity = false
-				provider, _ := awsv1alpha1.Deserialize(provisioner.Spec.Provider)
-				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
-					{
-						ImageId:      aws.String("ami-123"),
-						Architecture: aws.String("x86_64"),
-						CreationDate: aws.String("2022-08-05T12:00:00Z"),
-					},
-					{
-						ImageId:      aws.String("ami-456"),
-						Architecture: aws.String("x86_64"),
-						CreationDate: aws.String("2022-08-10T12:00:00Z"),
-					},
-					{
-						ImageId:      aws.String("ami-789"),
-						Architecture: aws.String("arm64"),
-						CreationDate: aws.String("2022-08-15T12:00:00Z"),
-					},
-				}})
-				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
-					UserData:    nil,
-					AMISelector: map[string]string{"name": "eks*"},
-					AWS:         *provider,
-				})
-				ExpectApplied(ctx, env.Client, nodeTemplate)
-				newProvisioner := test.Provisioner(test.ProvisionerOptions{
-					ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name},
-					Requirements: []v1.NodeSelectorRequirement{
-						{
-							Key:      v1.LabelArchStable,
-							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{v1alpha5.ArchitectureAmd64},
-						},
-					},
-				})
-				ExpectApplied(ctx, env.Client, newProvisioner)
-				pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]
-				ExpectScheduled(ctx, env.Client, pod)
-				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
-				actualFilter := fakeEC2API.CalledWithDescribeImagesInput.Pop().Filters
-				expectedFilter := []*ec2.Filter{
-					{
-						Name:   aws.String("name"),
-						Values: aws.StringSlice([]string{"eks*"}),
-					},
-				}
-				Expect(actualFilter).To(Equal(expectedFilter))
-				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				Expect("ami-456").To(Equal(*input.LaunchTemplateData.ImageId))
-			})
+
 			It("should fail if no amis match selector.", func() {
 				opts.AWSENILimitedPodDensity = false
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{}})
@@ -1295,7 +1280,7 @@ var _ = Describe("LaunchTemplates", func() {
 			It("should fail if no instanceType matches ami requirements.", func() {
 				opts.AWSENILimitedPodDensity = false
 				fakeEC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
-					{ImageId: aws.String("ami-123"), Architecture: aws.String("newnew")},
+					{ImageId: aws.String("ami-123"), Architecture: aws.String("newnew"), CreationDate: aws.String("2022-01-01T12:00:00Z")},
 				}})
 				nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 					UserData:    nil,


### PR DESCRIPTION
**Description**
From https://github.com/aws/karpenter/pull/2330

**How was this change tested?**

* ran `make dev`
* applied changes to my local cluster and found the nodes with new AMIs created.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
