### PR TITLE
chore: Add an implementation of `atomic.Lazy` which caches values internally

### DIFF
--- a/pkg/utils/atomic/cached_val.go
+++ b/pkg/utils/atomic/cached_val.go
@@ -1,0 +1,85 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/karpenter/pkg/utils/ptr"
+)
+
+type Option func(Options) Options
+
+type Options struct {
+	ignoreCache bool
+}
+
+func IgnoreCacheOption(o Options) Options {
+	o.ignoreCache = true
+	return o
+}
+
+// CachedVal persistently stores a value in memory
+type CachedVal[T any] struct {
+	value   *T
+	mu      sync.RWMutex
+	Resolve func(context.Context) (T, error)
+}
+
+// Set assigns the passed value
+func (c *CachedVal[T]) Set(v T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value = &v
+}
+
+// TryGet attempts to get a non-nil value from the internal value. If the internal value is nil, the Resolve function
+// will attempt to resolve the value, setting the value to be persistently stored if the resolve of Resolve is non-nil.
+func (c *CachedVal[T]) TryGet(ctx context.Context, opts ...Option) (T, error) {
+	o := resolveOptions(opts)
+	c.mu.RLock()
+	if c.value != nil && !o.ignoreCache {
+		ret := *c.value
+		c.mu.RUnlock()
+		return ret, nil
+	}
+	c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// We have to check if the field is set again here in case multiple threads make it past the read-locked section
+	if c.value != nil && !o.ignoreCache {
+		return *c.value, nil
+	}
+	if c.Resolve == nil {
+		return *new(T), nil
+	}
+	ret, err := c.Resolve(ctx)
+	if err != nil {
+		return *new(T), err
+	}
+	c.value = ptr.To(ret) // copies the value so we don't keep the reference
+	return ret, nil
+}
+
+func resolveOptions(opts []Option) Options {
+	o := Options{}
+	for _, opt := range opts {
+		if opt != nil {
+			o = opt(o)
+		}
+	}
+	return o
+}

--- a/pkg/utils/atomic/lazy.go
+++ b/pkg/utils/atomic/lazy.go
@@ -32,15 +32,16 @@ func IgnoreCacheOption(o Options) Options {
 	return o
 }
 
-// CachedVal persistently stores a value in memory
-type CachedVal[T any] struct {
+// Lazy persistently stores a value in memory by evaluating
+// the Resolve function when the value is accessed
+type Lazy[T any] struct {
 	value   *T
 	mu      sync.RWMutex
 	Resolve func(context.Context) (T, error)
 }
 
 // Set assigns the passed value
-func (c *CachedVal[T]) Set(v T) {
+func (c *Lazy[T]) Set(v T) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.value = &v
@@ -48,7 +49,7 @@ func (c *CachedVal[T]) Set(v T) {
 
 // TryGet attempts to get a non-nil value from the internal value. If the internal value is nil, the Resolve function
 // will attempt to resolve the value, setting the value to be persistently stored if the resolve of Resolve is non-nil.
-func (c *CachedVal[T]) TryGet(ctx context.Context, opts ...Option) (T, error) {
+func (c *Lazy[T]) TryGet(ctx context.Context, opts ...Option) (T, error) {
 	o := resolveOptions(opts)
 	c.mu.RLock()
 	if c.value != nil && !o.ignoreCache {

--- a/pkg/utils/atomic/suite_test.go
+++ b/pkg/utils/atomic/suite_test.go
@@ -1,0 +1,101 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/karpenter/pkg/utils/atomic"
+)
+
+func TestAtomic(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Atomic")
+}
+
+var _ = Describe("Atomic", func() {
+	It("should resolve a value when set", func() {
+		str := atomic.CachedVal[string]{}
+		str.Resolve = func(_ context.Context) (string, error) { return "", nil }
+		str.Set("value")
+		ret, err := str.TryGet(context.Background())
+		Expect(err).To(Succeed())
+		Expect(ret).To(Equal("value"))
+	})
+	It("should resolve a value and set a value when empty", func() {
+		str := atomic.CachedVal[string]{}
+		str.Resolve = func(_ context.Context) (string, error) { return "value", nil }
+		ret, err := str.TryGet(context.Background())
+		Expect(err).To(Succeed())
+		Expect(ret).To(Equal("value"))
+	})
+	It("should error out when the fallback function returns an err", func() {
+		str := atomic.CachedVal[string]{}
+		str.Resolve = func(_ context.Context) (string, error) { return "value", fmt.Errorf("failed") }
+		ret, err := str.TryGet(context.Background())
+		Expect(err).ToNot(Succeed())
+		Expect(ret).To(BeEmpty())
+	})
+	It("should ignore the cache when option set", func() {
+		str := atomic.CachedVal[string]{}
+		str.Resolve = func(_ context.Context) (string, error) { return "newvalue", nil }
+		str.Set("hasvalue")
+		ret, err := str.TryGet(context.Background(), atomic.IgnoreCacheOption)
+		Expect(err).To(Succeed())
+		Expect(ret).To(Equal("newvalue"))
+	})
+	It("shouldn't deadlock on multiple reads", func() {
+		calls := 0
+		str := atomic.CachedVal[string]{}
+		str.Resolve = func(_ context.Context) (string, error) { calls++; return "value", nil }
+		wg := &sync.WaitGroup{}
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
+				ret, err := str.TryGet(context.Background())
+				Expect(err).To(Succeed())
+				Expect(ret).To(Equal("value"))
+			}()
+		}
+		wg.Wait()
+		Expect(calls).To(Equal(1))
+	})
+	It("shouldn't deadlock on multiple writes", func() {
+		calls := 0
+		str := atomic.CachedVal[string]{}
+		str.Resolve = func(_ context.Context) (string, error) { calls++; return "value", nil }
+		wg := &sync.WaitGroup{}
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
+				ret, err := str.TryGet(context.Background(), atomic.IgnoreCacheOption)
+				Expect(err).To(Succeed())
+				Expect(ret).To(Equal("value"))
+			}()
+		}
+		wg.Wait()
+		Expect(calls).To(Equal(100))
+	})
+})

--- a/pkg/utils/atomic/suite_test.go
+++ b/pkg/utils/atomic/suite_test.go
@@ -33,7 +33,7 @@ func TestAtomic(t *testing.T) {
 
 var _ = Describe("Atomic", func() {
 	It("should resolve a value when set", func() {
-		str := atomic.CachedVal[string]{}
+		str := atomic.Lazy[string]{}
 		str.Resolve = func(_ context.Context) (string, error) { return "", nil }
 		str.Set("value")
 		ret, err := str.TryGet(context.Background())
@@ -41,21 +41,21 @@ var _ = Describe("Atomic", func() {
 		Expect(ret).To(Equal("value"))
 	})
 	It("should resolve a value and set a value when empty", func() {
-		str := atomic.CachedVal[string]{}
+		str := atomic.Lazy[string]{}
 		str.Resolve = func(_ context.Context) (string, error) { return "value", nil }
 		ret, err := str.TryGet(context.Background())
 		Expect(err).To(Succeed())
 		Expect(ret).To(Equal("value"))
 	})
 	It("should error out when the fallback function returns an err", func() {
-		str := atomic.CachedVal[string]{}
+		str := atomic.Lazy[string]{}
 		str.Resolve = func(_ context.Context) (string, error) { return "value", fmt.Errorf("failed") }
 		ret, err := str.TryGet(context.Background())
 		Expect(err).ToNot(Succeed())
 		Expect(ret).To(BeEmpty())
 	})
 	It("should ignore the cache when option set", func() {
-		str := atomic.CachedVal[string]{}
+		str := atomic.Lazy[string]{}
 		str.Resolve = func(_ context.Context) (string, error) { return "newvalue", nil }
 		str.Set("hasvalue")
 		ret, err := str.TryGet(context.Background(), atomic.IgnoreCacheOption)
@@ -64,7 +64,7 @@ var _ = Describe("Atomic", func() {
 	})
 	It("shouldn't deadlock on multiple reads", func() {
 		calls := 0
-		str := atomic.CachedVal[string]{}
+		str := atomic.Lazy[string]{}
 		str.Resolve = func(_ context.Context) (string, error) { calls++; return "value", nil }
 		wg := &sync.WaitGroup{}
 		for i := 0; i < 100; i++ {
@@ -82,7 +82,7 @@ var _ = Describe("Atomic", func() {
 	})
 	It("shouldn't deadlock on multiple writes", func() {
 		calls := 0
-		str := atomic.CachedVal[string]{}
+		str := atomic.Lazy[string]{}
 		str.Resolve = func(_ context.Context) (string, error) { calls++; return "value", nil }
 		wg := &sync.WaitGroup{}
 		for i := 0; i < 100; i++ {

--- a/pkg/utils/ptr/ptr.go
+++ b/pkg/utils/ptr/ptr.go
@@ -30,3 +30,11 @@ func Node(node v1.Node) *v1.Node {
 func Quantity(quantity resource.Quantity) *resource.Quantity {
 	return &quantity
 }
+
+func To[T any](v T) *T {
+	return &v
+}
+
+func From[T any](v *T) T {
+	return *v
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Adds an implementation of lazy evaluation which allows us to cache an api call persistently internally with lazy evaluation

```go
var queueURL atomic.Lazy[string]

queueURL.Resolve = func(ctx context.Context) (string, error) {
	ret, err := provider.client.GetQueueUrlWithContext(ctx, provider.getQueueURLInput)
	if err != nil {
		return "", fmt.Errorf("fetching queue url, %w", err)
	}
	return aws.StringValue(ret.QueueUrl), nil
}
queueURL.Set("new-url")
```

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
