### PR TITLE
chore: Create a struct object for ICE cache

### DIFF
--- a/pkg/cloudproviders/aws/cloudprovider/cloudprovider.go
+++ b/pkg/cloudproviders/aws/cloudprovider/cloudprovider.go
@@ -114,7 +114,7 @@ func NewCloudProvider(ctx context.Context, options cloudprovider.Options) *Cloud
 		logging.FromContext(ctx).Fatalf("Checking EC2 API connectivity, %s", err)
 	}
 	subnetProvider := NewSubnetProvider(ec2api)
-	instanceTypeProvider := NewInstanceTypeProvider(ctx, sess, options, ec2api, subnetProvider)
+	instanceTypeProvider := NewInstanceTypeProvider(ctx, sess, options, ec2api, subnetProvider, NewUnavailableOfferingsCache())
 	cloudprovider := &CloudProvider{
 		instanceTypeProvider: instanceTypeProvider,
 		instanceProvider: NewInstanceProvider(ctx, ec2api, instanceTypeProvider, subnetProvider,

--- a/pkg/cloudproviders/aws/cloudprovider/instance.go
+++ b/pkg/cloudproviders/aws/cloudprovider/instance.go
@@ -359,7 +359,7 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 func (p *InstanceProvider) updateUnavailableOfferingsCache(ctx context.Context, errors []*ec2.CreateFleetError, capacityType string) {
 	for _, err := range errors {
 		if isUnfulfillableCapacity(err) {
-			p.instanceTypeProvider.CacheUnavailable(ctx, err, capacityType)
+			p.instanceTypeProvider.unavailableOfferings.MarkUnavailableForFleetErr(ctx, err, capacityType)
 		}
 	}
 }

--- a/pkg/cloudproviders/aws/cloudprovider/instancetypes.go
+++ b/pkg/cloudproviders/aws/cloudprovider/instancetypes.go
@@ -57,13 +57,13 @@ type InstanceTypeProvider struct {
 	// Has one cache entry for all the instance types (key: InstanceTypesCacheKey)
 	// Has one cache entry for all the zones for each subnet selector (key: InstanceTypesZonesCacheKeyPrefix:<hash_of_selector>)
 	// Values cached *before* considering insufficient capacity errors from the unavailableOfferings cache.
-	cache *cache.Cache
-	// key: <capacityType>:<instanceType>:<zone>, value: struct{}{}
-	unavailableOfferings *cache.Cache
+	cache                *cache.Cache
+	unavailableOfferings *UnavailableOfferingsCache
 	cm                   *pretty.ChangeMonitor
 }
 
-func NewInstanceTypeProvider(ctx context.Context, sess *session.Session, options cloudprovider.Options, ec2api ec2iface.EC2API, subnetProvider *SubnetProvider) *InstanceTypeProvider {
+func NewInstanceTypeProvider(ctx context.Context, sess *session.Session, options cloudprovider.Options,
+	ec2api ec2iface.EC2API, subnetProvider *SubnetProvider, unavailableOfferings *UnavailableOfferingsCache) *InstanceTypeProvider {
 	return &InstanceTypeProvider{
 		ec2api:         ec2api,
 		region:         *sess.Config.Region,
@@ -74,7 +74,7 @@ func NewInstanceTypeProvider(ctx context.Context, sess *session.Session, options
 			*sess.Config.Region,
 			injection.GetOptions(ctx).AWSIsolatedVPC, options.StartAsync),
 		cache:                cache.New(InstanceTypesAndZonesCacheTTL, CacheCleanupInterval),
-		unavailableOfferings: cache.New(UnfulfillableCapacityErrorCacheTTL, CacheCleanupInterval),
+		unavailableOfferings: unavailableOfferings,
 		cm:                   pretty.NewChangeMonitor(),
 	}
 }
@@ -122,7 +122,7 @@ func (p *InstanceTypeProvider) createOfferings(ctx context.Context, instanceType
 		// while usage classes should be a distinct set, there's no guarantee of that
 		for capacityType := range sets.NewString(aws.StringValueSlice(instanceType.SupportedUsageClasses)...) {
 			// exclude any offerings that have recently seen an insufficient capacity error from EC2
-			_, isUnavailable := p.unavailableOfferings.Get(UnavailableOfferingsCacheKey(*instanceType.InstanceType, zone, capacityType))
+			isUnavailable := p.unavailableOfferings.IsUnavailable(*instanceType.InstanceType, zone, capacityType)
 			var price float64
 			var ok bool
 			switch capacityType {
@@ -235,23 +235,4 @@ func (p *InstanceTypeProvider) filter(instanceType *ec2.InstanceTypeInfo) bool {
 		return false
 	}
 	return true
-}
-
-// CacheUnavailable allows the InstanceProvider to communicate recently observed temporary capacity shortages in
-// the provided offerings
-func (p *InstanceTypeProvider) CacheUnavailable(ctx context.Context, fleetErr *ec2.CreateFleetError, capacityType string) {
-	instanceType := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.InstanceType)
-	zone := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.AvailabilityZone)
-	logging.FromContext(ctx).Debugf("%s for offering { instanceType: %s, zone: %s, capacityType: %s }, avoiding for %s",
-		aws.StringValue(fleetErr.ErrorCode),
-		instanceType,
-		zone,
-		capacityType,
-		UnfulfillableCapacityErrorCacheTTL)
-	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
-	p.unavailableOfferings.SetDefault(UnavailableOfferingsCacheKey(instanceType, zone, capacityType), struct{}{})
-}
-
-func UnavailableOfferingsCacheKey(instanceType string, zone string, capacityType string) string {
-	return fmt.Sprintf("%s:%s:%s", capacityType, instanceType, zone)
 }

--- a/pkg/cloudproviders/aws/cloudprovider/instancetypes_test.go
+++ b/pkg/cloudproviders/aws/cloudprovider/instancetypes_test.go
@@ -16,6 +16,7 @@ package cloudprovider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -706,7 +707,7 @@ var _ = Describe("Instance Types", func() {
 			ExpectNotScheduled(ctx, env.Client, pod)
 			// capacity shortage is over - expire the item from the cache and try again
 			fakeEC2API.InsufficientCapacityPools.Set([]fake.CapacityPool{})
-			unavailableOfferingsCache.Delete(UnavailableOfferingsCacheKey("inf1.6xlarge", "test-zone-1a", awsv1alpha1.CapacityTypeOnDemand))
+			unavailableOfferingsCache.cache.Delete(fmt.Sprintf("%s:%s:%s", awsv1alpha1.CapacityTypeOnDemand, "inf1.6xlarge", "test-zone-1a"))
 			pod = ExpectProvisioned(ctx, env.Client, controller, pod)[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, "inf1.6xlarge"))

--- a/pkg/cloudproviders/aws/cloudprovider/suite_test.go
+++ b/pkg/cloudproviders/aws/cloudprovider/suite_test.go
@@ -61,7 +61,7 @@ var securityGroupCache *cache.Cache
 var subnetCache *cache.Cache
 var ssmCache *cache.Cache
 var ec2Cache *cache.Cache
-var unavailableOfferingsCache *cache.Cache
+var unavailableOfferingsCache *UnavailableOfferingsCache
 var instanceTypeCache *cache.Cache
 var instanceTypeProvider *InstanceTypeProvider
 var fakeEC2API *fake.EC2API
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func() {
 		ctx = injection.WithOptions(ctx, opts)
 		ctx, stop = context.WithCancel(ctx)
 		launchTemplateCache = cache.New(CacheTTL, CacheCleanupInterval)
-		unavailableOfferingsCache = cache.New(UnfulfillableCapacityErrorCacheTTL, CacheCleanupInterval)
+		unavailableOfferingsCache = NewUnavailableOfferingsCache()
 		securityGroupCache = cache.New(CacheTTL, CacheCleanupInterval)
 		subnetCache = cache.New(CacheTTL, CacheCleanupInterval)
 		ssmCache = cache.New(CacheTTL, CacheCleanupInterval)
@@ -171,7 +171,7 @@ var _ = BeforeEach(func() {
 	launchTemplateCache.Flush()
 	securityGroupCache.Flush()
 	subnetCache.Flush()
-	unavailableOfferingsCache.Flush()
+	unavailableOfferingsCache.cache.Flush()
 	ssmCache.Flush()
 	ec2Cache.Flush()
 	instanceTypeCache.Flush()

--- a/pkg/cloudproviders/aws/cloudprovider/unavailableofferingscache.go
+++ b/pkg/cloudproviders/aws/cloudprovider/unavailableofferingscache.go
@@ -1,0 +1,68 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/patrickmn/go-cache"
+	"knative.dev/pkg/logging"
+)
+
+// UnavailableOfferingsCache stores any offerings that return ICE (insufficient capacity errors) when
+// attempting to launch the capacity. These offerings are ignored as long as they are in the cache on
+// GetInstanceTypes responses
+type UnavailableOfferingsCache struct {
+	// key: <capacityType>:<instanceType>:<zone>, value: struct{}{}
+	cache *cache.Cache
+}
+
+func NewUnavailableOfferingsCache() *UnavailableOfferingsCache {
+	return &UnavailableOfferingsCache{
+		cache: cache.New(UnfulfillableCapacityErrorCacheTTL, CacheCleanupInterval),
+	}
+}
+
+// IsUnavailable returns true if the offering appears in the cache
+func (u *UnavailableOfferingsCache) IsUnavailable(instanceType, zone, capacityType string) bool {
+	_, found := u.cache.Get(u.key(instanceType, zone, capacityType))
+	return found
+}
+
+// MarkUnavailable communicates recently observed temporary capacity shortages in the provided offerings
+func (u *UnavailableOfferingsCache) MarkUnavailable(ctx context.Context, unavailableReason, instanceType, zone, capacityType string) {
+	// even if the key is already in the cache, we still need to call Set to extend the cached entry's TTL
+	logging.FromContext(ctx).Debugf("%s for offering { instanceType: %s, zone: %s, capacityType: %s }, avoiding for %s",
+		unavailableReason,
+		instanceType,
+		zone,
+		capacityType,
+		UnfulfillableCapacityErrorCacheTTL)
+	u.cache.SetDefault(u.key(instanceType, zone, capacityType), struct{}{})
+}
+
+func (u *UnavailableOfferingsCache) MarkUnavailableForFleetErr(ctx context.Context, fleetErr *ec2.CreateFleetError, capacityType string) {
+	instanceType := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.InstanceType)
+	zone := aws.StringValue(fleetErr.LaunchTemplateAndOverrides.Overrides.AvailabilityZone)
+	u.MarkUnavailable(ctx, aws.StringValue(fleetErr.ErrorCode), instanceType, zone, capacityType)
+}
+
+// key returns the cache key for all offerings in the cache
+func (u *UnavailableOfferingsCache) key(instanceType string, zone string, capacityType string) string {
+	return fmt.Sprintf("%s:%s:%s", capacityType, instanceType, zone)
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- `UnavailableOfferingsCache` becomes an encapsulated concept and is injected into the `InstanceTypeProvder`
- This preps initializing `UnavailableOfferingsCache` at the top-level and injecting it into the `notification_controller` with the spot interruption PR

**How was this change tested?**

* `make test`
* `make battletest`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
