### PR TITLE
chore: Decouple cache from implementation through interface

### DIFF
--- a/pkg/cloudproviders/aws/cache.go
+++ b/pkg/cloudproviders/aws/cache.go
@@ -1,0 +1,33 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+var _ Cache = (*cache.Cache)(nil)
+
+// Cache decouples the implementation of the cache from the callers
+type Cache interface {
+	Get(string) (interface{}, bool)
+	GetWithExpiration(string) (interface{}, time.Time, bool)
+	SetDefault(string, interface{})
+	ItemCount() int
+	OnEvicted(func(string, interface{}))
+	Delete(string)
+}

--- a/pkg/cloudproviders/aws/cloudprovider/subnets.go
+++ b/pkg/cloudproviders/aws/cloudprovider/subnets.go
@@ -20,13 +20,14 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
+	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/patrickmn/go-cache"
 	"knative.dev/pkg/logging"
 
+	"github.com/aws/karpenter/pkg/cloudproviders/aws"
 	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/utils/functional"
 	"github.com/aws/karpenter/pkg/utils/pretty"
@@ -35,7 +36,7 @@ import (
 type SubnetProvider struct {
 	sync.Mutex
 	ec2api ec2iface.EC2API
-	cache  *cache.Cache
+	cache  aws.Cache
 	cm     *pretty.ChangeMonitor
 }
 
@@ -87,18 +88,18 @@ func getFilters(provider *v1alpha1.AWS) []*ec2.Filter {
 		if key == "aws-ids" {
 			filterValues := functional.SplitCommaSeparatedString(value)
 			filters = append(filters, &ec2.Filter{
-				Name:   aws.String("subnet-id"),
-				Values: aws.StringSlice(filterValues),
+				Name:   awssdk.String("subnet-id"),
+				Values: awssdk.StringSlice(filterValues),
 			})
 		} else if value == "*" {
 			filters = append(filters, &ec2.Filter{
-				Name:   aws.String("tag-key"),
-				Values: []*string{aws.String(key)},
+				Name:   awssdk.String("tag-key"),
+				Values: []*string{awssdk.String(key)},
 			})
 		} else {
 			filters = append(filters, &ec2.Filter{
-				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
-				Values: []*string{aws.String(value)},
+				Name:   awssdk.String(fmt.Sprintf("tag:%s", key)),
+				Values: []*string{awssdk.String(value)},
 			})
 		}
 	}
@@ -108,7 +109,7 @@ func getFilters(provider *v1alpha1.AWS) []*ec2.Filter {
 func prettySubnets(subnets []*ec2.Subnet) []string {
 	names := []string{}
 	for _, subnet := range subnets {
-		names = append(names, fmt.Sprintf("%s (%s)", aws.StringValue(subnet.SubnetId), aws.StringValue(subnet.AvailabilityZone)))
+		names = append(names, fmt.Sprintf("%s (%s)", awssdk.StringValue(subnet.SubnetId), awssdk.StringValue(subnet.AvailabilityZone)))
 	}
 	return names
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Decouples the underlying implementation of the cache from the callers
- This change is being made so that the cache can be injected into providers, this also eases the test burden since the tests can inject their own implementation of the cache into some providers
- Also, in general relying on an interface is good practice so we can change the underlying implementation more seamlessly later by creating a wrapper around whatever we are relying on.

**How was this change tested?**

* `make test`
* `make battletest`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
