### PR TITLE
feat: Label provisioned nodes with AMI ID

### DIFF
--- a/pkg/cloudproviders/aws/apis/v1alpha1/register.go
+++ b/pkg/cloudproviders/aws/apis/v1alpha1/register.go
@@ -71,6 +71,7 @@ var (
 	LabelInstanceGPUManufacturer = LabelDomain + "/instance-gpu-manufacturer"
 	LabelInstanceGPUCount        = LabelDomain + "/instance-gpu-count"
 	LabelInstanceGPUMemory       = LabelDomain + "/instance-gpu-memory"
+	LabelInstanceAMIID           = LabelDomain + "/instance-ami-id"
 )
 
 var (

--- a/pkg/cloudproviders/aws/cloudprovider/instance.go
+++ b/pkg/cloudproviders/aws/cloudprovider/instance.go
@@ -339,6 +339,7 @@ func (p *InstanceProvider) instanceToNode(ctx context.Context, instance *ec2.Ins
 					labels[key] = req.Values()[0]
 				}
 			}
+			labels[v1alpha1.LabelInstanceAMIID] = aws.StringValue(instance.ImageId)
 			labels[v1.LabelTopologyZone] = aws.StringValue(instance.Placement.AvailabilityZone)
 			labels[v1alpha5.LabelCapacityType] = getCapacityType(instance)
 

--- a/pkg/cloudproviders/aws/fake/ec2api.go
+++ b/pkg/cloudproviders/aws/fake/ec2api.go
@@ -138,9 +138,16 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 			if skipInstance {
 				continue
 			}
+			amiID := aws.String("")
+			if e.CalledWithCreateLaunchTemplateInput.Len() > 0 {
+				lt := e.CalledWithCreateLaunchTemplateInput.Pop()
+				amiID = lt.LaunchTemplateData.ImageId
+				e.CalledWithCreateLaunchTemplateInput.Add(lt)
+			}
 			instanceState := ec2.InstanceStateNameRunning
 			for i := 0; i < int(*input.TargetCapacitySpecification.TotalTargetCapacity); i++ {
 				instance := &ec2.Instance{
+					ImageId:               aws.String(*amiID),
 					InstanceId:            aws.String(test.RandomName()),
 					Placement:             &ec2.Placement{AvailabilityZone: input.LaunchTemplateConfigs[0].Overrides[0].AvailabilityZone},
 					PrivateDnsName:        aws.String(randomdata.IpV4Address()),


### PR DESCRIPTION
**Description**
This adds AMI-ID as a label on provisioned nodes. 

**How was this change tested?**

* `make dev`
* `make apply` and saw a node provisioned with the AMI ID label.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
