### PR TITLE
fix: Fix adding CMW before call to start informer

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -15,10 +15,7 @@ limitations under the License.
 package controllers
 
 import (
-	"knative.dev/pkg/logging"
-
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
-	"github.com/aws/karpenter/pkg/config"
 	"github.com/aws/karpenter/pkg/controllers/consolidation"
 	"github.com/aws/karpenter/pkg/controllers/counter"
 	metricspod "github.com/aws/karpenter/pkg/controllers/metrics/pod"
@@ -37,13 +34,8 @@ func init() {
 }
 
 func GetControllers(opts operator.Options, cloudProvider cloudprovider.CloudProvider) []operator.Controller {
-	cfg, err := config.New(opts.Ctx, opts.Clientset, opts.Cmw)
-	if err != nil {
-		// this does not happen if the config map is missing or invalid, only if some other error occurs
-		logging.FromContext(opts.Ctx).Fatalf("unable to load config, %s", err)
-	}
-	cluster := state.NewCluster(opts.Clock, cfg, opts.KubeClient, cloudProvider)
-	provisioner := provisioning.NewProvisioner(opts.Ctx, cfg, opts.KubeClient, opts.Clientset.CoreV1(), opts.Recorder, cloudProvider, cluster)
+	cluster := state.NewCluster(opts.Clock, opts.Config, opts.KubeClient, cloudProvider)
+	provisioner := provisioning.NewProvisioner(opts.Ctx, opts.Config, opts.KubeClient, opts.Clientset.CoreV1(), opts.Recorder, cloudProvider, cluster)
 
 	metricsstate.StartMetricScraper(opts.Ctx, cluster)
 

--- a/pkg/operator/options.go
+++ b/pkg/operator/options.go
@@ -22,7 +22,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/configmap/informer"
@@ -33,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/aws/karpenter/pkg/apis"
+	"github.com/aws/karpenter/pkg/config"
 	"github.com/aws/karpenter/pkg/events"
 	"github.com/aws/karpenter/pkg/utils/injection"
 	"github.com/aws/karpenter/pkg/utils/options"
@@ -57,12 +57,11 @@ func init() {
 type Options struct {
 	Ctx        context.Context
 	Recorder   events.Recorder
-	Config     *rest.Config
+	Config     config.Config
 	KubeClient client.Client
 	Clientset  *kubernetes.Clientset
 	Clock      clock.Clock
 	Options    *options.Options
-	Cmw        *informer.InformedWatcher
 	StartAsync <-chan struct{}
 }
 
@@ -87,6 +86,12 @@ func NewOptionsWithManagerOrDie() (Options, manager.Manager) {
 		logging.FromContext(ctx).Infof("Setting GC memory limit to %d, container limit = %d", newLimit, opts.MemoryLimit)
 		debug.SetMemoryLimit(newLimit)
 	}
+
+	cfg, err := config.New(ctx, clientSet, cmw)
+	if err != nil {
+		// this does not happen if the config map is missing or invalid, only if some other error occurs
+		logging.FromContext(ctx).Fatalf("unable to load config, %s", err)
+	}
 	if err := cmw.Start(ctx.Done()); err != nil {
 		logging.FromContext(ctx).Errorf("watching configmaps, config changes won't be applied immediately, %s", err)
 	}
@@ -99,12 +104,11 @@ func NewOptionsWithManagerOrDie() (Options, manager.Manager) {
 	return Options{
 		Ctx:        ctx,
 		Recorder:   recorder,
-		Config:     controllerRuntimeConfig,
+		Config:     cfg,
 		Clientset:  clientSet,
 		KubeClient: manager.GetClient(),
 		Clock:      clock.RealClock{},
 		Options:    opts,
-		Cmw:        cmw,
 		StartAsync: manager.Elected(),
 	}, manager
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Fixes not having `karpenter-global-settings` added to the configMapWatcher informer

**How was this change tested?**

* `TEST_FILTER=Integration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
