### PR TITLE
fix: query for both forms of Linux/Unix OS on spot

### DIFF
--- a/pkg/cloudproviders/aws/cloudprovider/pricing.go
+++ b/pkg/cloudproviders/aws/cloudprovider/pricing.go
@@ -368,7 +368,7 @@ func (p *PricingProvider) updateSpotPricing(ctx context.Context) error {
 
 	prices := map[string]map[string]float64{}
 	if err := p.ec2.DescribeSpotPriceHistoryPagesWithContext(ctx, &ec2.DescribeSpotPriceHistoryInput{
-		ProductDescriptions: []*string{aws.String("Linux/UNIX")},
+		ProductDescriptions: []*string{aws.String("Linux/UNIX"), aws.String("Linux/UNIX (Amazon VPC)")},
 		// get the latest spot price for each instance type
 		StartTime: aws.Time(time.Now()),
 	}, func(output *ec2.DescribeSpotPriceHistoryOutput, b bool) bool {

--- a/pkg/cloudproviders/aws/cloudprovider/pricing_test.go
+++ b/pkg/cloudproviders/aws/cloudprovider/pricing_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/pricing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 
 	"github.com/aws/karpenter/pkg/cloudproviders/aws/fake"
 )
@@ -174,5 +175,29 @@ var _ = Describe("Pricing", func() {
 
 		_, ok := p.SpotPrice("c99.large", "test-zone-1b")
 		Expect(ok).To(BeFalse())
+	})
+	It("should query for  `Linux/UNIX` and `Linux/UNIX (Amazon VPC)`", func() {
+		updateStart := time.Now()
+		fakeEC2API.DescribeSpotPriceHistoryOutput.Set(&ec2.DescribeSpotPriceHistoryOutput{
+			SpotPriceHistory: []*ec2.SpotPrice{
+				{
+					AvailabilityZone: aws.String("test-zone-1a"),
+					InstanceType:     aws.String("c99.large"),
+					SpotPrice:        aws.String("1.23"),
+					Timestamp:        &updateStart,
+				},
+			},
+		})
+		fakePricingAPI.GetProductsOutput.Set(&pricing.GetProductsOutput{
+			PriceList: []aws.JSONValue{
+				fake.NewOnDemandPrice("c98.large", 1.20),
+				fake.NewOnDemandPrice("c99.large", 1.23),
+			},
+		})
+		p := NewPricingProvider(ctx, fakePricingAPI, fakeEC2API, "", false, make(chan struct{}))
+		Eventually(func() bool { return p.OnDemandLastUpdated().After(updateStart) }, 5*time.Second).Should(BeTrue())
+		inp := fakeEC2API.DescribeSpotPriceHistoryInput.Clone()
+		Expect(lo.Map(inp.ProductDescriptions, func(x *string, _ int) string { return *x })).
+			To(ContainElements("Linux/UNIX", "Linux/UNIX (Amazon VPC)"))
 	})
 })

--- a/pkg/cloudproviders/aws/cloudprovider/pricing_test.go
+++ b/pkg/cloudproviders/aws/cloudprovider/pricing_test.go
@@ -176,7 +176,11 @@ var _ = Describe("Pricing", func() {
 		_, ok := p.SpotPrice("c99.large", "test-zone-1b")
 		Expect(ok).To(BeFalse())
 	})
-	It("should query for  `Linux/UNIX` and `Linux/UNIX (Amazon VPC)`", func() {
+	It("should query for both `Linux/UNIX` and `Linux/UNIX (Amazon VPC)`", func() {
+		// If an account supports EC2 classic, then the non-classic instance types have a product
+		// description of Linux/UNIX (Amazon VPC)
+		// If it doesn't, they have a product description of Linux/UNIX. To work in both cases, we
+		// need to search for both values.
 		updateStart := time.Now()
 		fakeEC2API.DescribeSpotPriceHistoryOutput.Set(&ec2.DescribeSpotPriceHistoryOutput{
 			SpotPriceHistory: []*ec2.SpotPrice{

--- a/pkg/cloudproviders/aws/fake/ec2api.go
+++ b/pkg/cloudproviders/aws/fake/ec2api.go
@@ -52,6 +52,7 @@ type EC2Behavior struct {
 	DescribeInstanceTypesOutput         AtomicPtr[ec2.DescribeInstanceTypesOutput]
 	DescribeInstanceTypeOfferingsOutput AtomicPtr[ec2.DescribeInstanceTypeOfferingsOutput]
 	DescribeAvailabilityZonesOutput     AtomicPtr[ec2.DescribeAvailabilityZonesOutput]
+	DescribeSpotPriceHistoryInput       AtomicPtr[ec2.DescribeSpotPriceHistoryInput]
 	DescribeSpotPriceHistoryOutput      AtomicPtr[ec2.DescribeSpotPriceHistoryOutput]
 	CalledWithCreateFleetInput          AtomicPtrSlice[ec2.CreateFleetInput]
 	CalledWithCreateLaunchTemplateInput AtomicPtrSlice[ec2.CreateLaunchTemplateInput]
@@ -86,6 +87,7 @@ func (e *EC2API) Reset() {
 	e.CalledWithCreateFleetInput.Reset()
 	e.CalledWithCreateLaunchTemplateInput.Reset()
 	e.CalledWithDescribeImagesInput.Reset()
+	e.DescribeSpotPriceHistoryInput.Reset()
 	e.DescribeSpotPriceHistoryOutput.Reset()
 	e.Instances.Range(func(k, v any) bool {
 		e.Instances.Delete(k)
@@ -694,7 +696,8 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 	return nil
 }
 
-func (e *EC2API) DescribeSpotPriceHistoryPagesWithContext(_ aws.Context, _ *ec2.DescribeSpotPriceHistoryInput, fn func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool, opts ...request.Option) error {
+func (e *EC2API) DescribeSpotPriceHistoryPagesWithContext(_ aws.Context, in *ec2.DescribeSpotPriceHistoryInput, fn func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool, opts ...request.Option) error {
+	e.DescribeSpotPriceHistoryInput.Set(in)
 	if !e.NextError.IsNil() {
 		defer e.NextError.Reset()
 		return e.NextError.Get()


### PR DESCRIPTION

Fixes #2568 

**Description**

Depending on account settings, instances may be listed under one of two product descriptions.  We should query for them both to ensure we don't fail to launch spot instances.

**How was this change tested?**

- Unit testing
- Deployed to EKS and verified that my spot instance prices were still fetched.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
