### PR TITLE
chore: rely on neutral capacity type and break dependency on gpu vendor strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help: ## Display help
 
 dev: verify test ## Run all steps in the developer loop
 
-ci: toolchain verify licenses battletest coverage ## Run all steps used by continuous integration
+ci: toolchain verify licenses vulncheck battletest coverage ## Run all steps used by continuous integration
 
 run: ## Run Karpenter controller binary against your local cluster
 	SYSTEM_NAMESPACE=${SYSTEM_NAMESPACE} go run ./cmd/controller/main.go \
@@ -76,6 +76,8 @@ verify: tidy download codegen ## Verify code. Includes dependencies, linting, fo
 		fi;}
 	@echo "Validating codegen/docgen build scripts..."
 	@find hack/code hack/docs -name "*.go" -type f -exec go build -o /dev/null {} \;
+
+vulncheck: ## Verify code vulnerabilities
 	@govulncheck ./pkg/...
 
 licenses: download ## Verifies dependency licenses
@@ -144,7 +146,7 @@ tidy: ## Recursively "go mod tidy" on all directories where go.mod exists
 download: ## Recursively "go mod download" on all directories where go.mod exists
 	$(foreach dir,$(MOD_DIRS),cd $(dir) && go mod download $(newline))
 
-.PHONY: help dev ci release test battletest e2etests verify tidy download codegen docgen apply delete toolchain licenses issues website nightly snapshot
+.PHONY: help dev ci release test battletest e2etests verify tidy download codegen docgen apply delete toolchain licenses vulncheck issues website nightly snapshot
 
 define newline
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.114
-	github.com/aws/karpenter-core v0.0.2-0.20221017165612-70c16abe656e
+	github.com/aws/karpenter-core v0.0.2-0.20221018173200-be50f859aa81
 	github.com/deckarep/golang-set v1.8.0
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.114 h1:plIkWc/RsHr3DXBj4MEw9sEW4CcL/e2ryokc+CKyq1I=
 github.com/aws/aws-sdk-go v1.44.114/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/karpenter-core v0.0.2-0.20221017165612-70c16abe656e h1:X1zyJUeKttAjzNmdd3FkcrH0Vlq+fEznC7izXJcdE4w=
-github.com/aws/karpenter-core v0.0.2-0.20221017165612-70c16abe656e/go.mod h1:vQko57qiP/cxqWDgLTTvdR9A6AUXriWd8eg0dDTJJpY=
+github.com/aws/karpenter-core v0.0.2-0.20221018173200-be50f859aa81 h1:VIsG0kj1/ZyFtcQhkONV+yyLN96u9tl7p7ku5uGAwAM=
+github.com/aws/karpenter-core v0.0.2-0.20221018173200-be50f859aa81/go.mod h1:vQko57qiP/cxqWDgLTTvdR9A6AUXriWd8eg0dDTJJpY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cloudproviders/aws/cloudprovider/instance.go
+++ b/pkg/cloudproviders/aws/cloudprovider/instance.go
@@ -160,7 +160,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, provider *v1alpha
 			{ResourceType: aws.String(ec2.ResourceTypeFleet), Tags: tags},
 		},
 	}
-	if capacityType == v1alpha1.CapacityTypeSpot {
+	if capacityType == v1alpha5.CapacityTypeSpot {
 		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{AllocationStrategy: aws.String(ec2.SpotAllocationStrategyCapacityOptimizedPrioritized)}
 	} else {
 		createFleetInput.OnDemandOptions = &ec2.OnDemandOptionsRequest{AllocationStrategy: aws.String(ec2.FleetOnDemandAllocationStrategyLowestPrice)}
@@ -189,7 +189,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, provider *v1alpha
 
 func (p *InstanceProvider) checkODFallback(nodeRequest *cloudprovider.NodeRequest, launchTemplateConfigs []*ec2.FleetLaunchTemplateConfigRequest) error {
 	// only evaluate for on-demand fallback if the capacity type for the request is OD and both OD and spot are allowed in requirements
-	if p.getCapacityType(nodeRequest) != v1alpha1.CapacityTypeOnDemand || !nodeRequest.Template.Requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha1.CapacityTypeSpot) {
+	if p.getCapacityType(nodeRequest) != v1alpha5.CapacityTypeOnDemand || !nodeRequest.Template.Requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha5.CapacityTypeSpot) {
 		return nil
 	}
 
@@ -294,7 +294,7 @@ func (p *InstanceProvider) getOverrides(instanceTypeOptions []cloudprovider.Inst
 		// Add a priority for spot requests since we are using the capacity-optimized-prioritized spot allocation strategy
 		// to reduce the likelihood of getting an excessively large instance type.
 		// instanceTypeOptions are sorted by vcpus and memory so this prioritizes smaller instance types.
-		if capacityType == v1alpha1.CapacityTypeSpot {
+		if capacityType == v1alpha5.CapacityTypeSpot {
 			override.Priority = aws.Float64(float64(i))
 		}
 		overrides = append(overrides, override)
@@ -370,16 +370,16 @@ func (p *InstanceProvider) updateUnavailableOfferingsCache(ctx context.Context, 
 // available offering. The AWS Cloud Provider defaults to [ on-demand ], so spot
 // must be explicitly included in capacity type requirements.
 func (p *InstanceProvider) getCapacityType(nodeRequest *cloudprovider.NodeRequest) string {
-	if nodeRequest.Template.Requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha1.CapacityTypeSpot) {
+	if nodeRequest.Template.Requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha5.CapacityTypeSpot) {
 		for _, instanceType := range nodeRequest.InstanceTypeOptions {
 			for _, offering := range cloudprovider.AvailableOfferings(instanceType) {
-				if nodeRequest.Template.Requirements.Get(v1.LabelTopologyZone).Has(offering.Zone) && offering.CapacityType == v1alpha1.CapacityTypeSpot {
-					return v1alpha1.CapacityTypeSpot
+				if nodeRequest.Template.Requirements.Get(v1.LabelTopologyZone).Has(offering.Zone) && offering.CapacityType == v1alpha5.CapacityTypeSpot {
+					return v1alpha5.CapacityTypeSpot
 				}
 			}
 		}
 	}
-	return v1alpha1.CapacityTypeOnDemand
+	return v1alpha5.CapacityTypeOnDemand
 }
 
 // prioritizeInstanceTypes is used to eliminate less desirable instance types (like GPUs) from the list of possible instance types when
@@ -435,7 +435,7 @@ func combineFleetErrors(errors []*ec2.CreateFleetError) (errs error) {
 
 func getCapacityType(instance *ec2.Instance) string {
 	if instance.SpotInstanceRequestId != nil {
-		return v1alpha1.CapacityTypeSpot
+		return v1alpha5.CapacityTypeSpot
 	}
-	return v1alpha1.CapacityTypeOnDemand
+	return v1alpha5.CapacityTypeOnDemand
 }

--- a/pkg/cloudproviders/aws/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudproviders/aws/cloudprovider/launchtemplate_test.go
@@ -78,7 +78,7 @@ var _ = Describe("LaunchTemplates", func() {
 			{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{awsv1alpha1.CapacityTypeSpot},
+				Values:   []string{v1alpha5.CapacityTypeSpot},
 			},
 		}}))
 		pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())[0]

--- a/pkg/cloudproviders/aws/cloudprovider/suite_test.go
+++ b/pkg/cloudproviders/aws/cloudprovider/suite_test.go
@@ -199,7 +199,7 @@ var _ = Describe("Allocation", func() {
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{awsv1alpha1.CapacityTypeOnDemand},
+				Values:   []string{v1alpha5.CapacityTypeOnDemand},
 			}))
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1.LabelArchStable,
@@ -215,7 +215,7 @@ var _ = Describe("Allocation", func() {
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{awsv1alpha1.CapacityTypeOnDemand},
+				Values:   []string{v1alpha5.CapacityTypeOnDemand},
 			}))
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1.LabelArchStable,

--- a/pkg/cloudproviders/aws/fake/ec2api.go
+++ b/pkg/cloudproviders/aws/fake/ec2api.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/test"
 	"github.com/aws/karpenter/pkg/utils/atomic"
 )
@@ -120,7 +119,7 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 	var skippedPools []CapacityPool
 	var spotInstanceRequestID *string
 
-	if aws.StringValue(input.TargetCapacitySpecification.DefaultTargetCapacityType) == v1alpha1.CapacityTypeSpot {
+	if aws.StringValue(input.TargetCapacitySpecification.DefaultTargetCapacityType) == v1alpha5.CapacityTypeSpot {
 		spotInstanceRequestID = aws.String(test.RandomName())
 	}
 

--- a/pkg/cloudproviders/common/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudproviders/common/cloudprovider/fake/cloudprovider.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
 	"github.com/aws/karpenter-core/pkg/scheduling"
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
 	"github.com/aws/karpenter/pkg/test"
 
@@ -91,12 +90,6 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, provisioner *v1alpha
 			Name: "default-instance-type",
 		}),
 		NewInstanceType(InstanceTypeOptions{
-			Name: "pod-eni-instance-type",
-			Resources: map[v1.ResourceName]resource.Quantity{
-				v1alpha1.ResourceAWSPodENI: resource.MustParse("1"),
-			},
-		}),
-		NewInstanceType(InstanceTypeOptions{
 			Name: "small-instance-type",
 			Resources: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:    resource.MustParse("2"),
@@ -104,20 +97,14 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, provisioner *v1alpha
 			},
 		}),
 		NewInstanceType(InstanceTypeOptions{
-			Name: "nvidia-gpu-instance-type",
+			Name: "gpu-vendor-instance-type",
 			Resources: map[v1.ResourceName]resource.Quantity{
-				v1alpha1.ResourceNVIDIAGPU: resource.MustParse("2"),
+				ResourceGPUVendorA: resource.MustParse("2"),
 			}}),
 		NewInstanceType(InstanceTypeOptions{
-			Name: "amd-gpu-instance-type",
+			Name: "gpu-vendor-b-instance-type",
 			Resources: map[v1.ResourceName]resource.Quantity{
-				v1alpha1.ResourceAMDGPU: resource.MustParse("2"),
-			},
-		}),
-		NewInstanceType(InstanceTypeOptions{
-			Name: "aws-neuron-instance-type",
-			Resources: map[v1.ResourceName]resource.Quantity{
-				v1alpha1.ResourceAWSNeuron: resource.MustParse("2"),
+				ResourceGPUVendorB: resource.MustParse("2"),
 			},
 		}),
 		NewInstanceType(InstanceTypeOptions{

--- a/pkg/cloudproviders/common/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudproviders/common/cloudprovider/fake/instancetype.go
@@ -25,17 +25,17 @@ import (
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
 
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
-	LabelInstanceSize       = "size"
-	ExoticInstanceLabelKey  = "special"
-	IntegerInstanceLabelKey = "integer"
+	LabelInstanceSize                       = "size"
+	ExoticInstanceLabelKey                  = "special"
+	IntegerInstanceLabelKey                 = "integer"
+	ResourceGPUVendorA      v1.ResourceName = "fake.com/vendor-a"
+	ResourceGPUVendorB      v1.ResourceName = "fake.com/vendor-b"
 )
 
 func init() {
@@ -99,7 +99,7 @@ func InstanceTypesAssorted() []cloudprovider.InstanceType {
 	for _, cpu := range []int{1, 2, 4, 8, 16, 32, 64} {
 		for _, mem := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
 			for _, zone := range []string{"test-zone-1", "test-zone-2", "test-zone-3"} {
-				for _, ct := range []string{v1alpha1.CapacityTypeSpot, v1alpha1.CapacityTypeOnDemand} {
+				for _, ct := range []string{v1alpha5.CapacityTypeSpot, v1alpha5.CapacityTypeOnDemand} {
 					for _, os := range []utilsets.String{utilsets.NewString("linux"), utilsets.NewString("windows")} {
 						for _, arch := range []string{v1alpha5.ArchitectureAmd64, v1alpha5.ArchitectureArm64} {
 							opts := InstanceTypeOptions{
@@ -176,7 +176,7 @@ func priceFromResources(resources v1.ResourceList) float64 {
 			price += 0.1 * v.AsApproximateFloat64()
 		case v1.ResourceMemory:
 			price += 0.1 * v.AsApproximateFloat64() / (1e9)
-		case v1alpha1.ResourceNVIDIAGPU, v1alpha1.ResourceAMDGPU:
+		case ResourceGPUVendorA, ResourceGPUVendorB:
 			price += 1.0
 		}
 	}

--- a/pkg/controllers/consolidation/controller.go
+++ b/pkg/controllers/consolidation/controller.go
@@ -39,7 +39,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
 	"github.com/aws/karpenter/pkg/controllers/provisioning"
 	pscheduling "github.com/aws/karpenter/pkg/controllers/provisioning/scheduling"
@@ -564,8 +563,8 @@ func (c *Controller) computeNodeConsolidationOption(ctx context.Context, node ca
 	// If the existing node is spot and the replacement is spot, we don't consolidate.  We don't have a reliable
 	// mechanism to determine if this replacement makes sense given instance type availability (e.g. we may replace
 	// a spot node with one that is less available and more likely to be reclaimed).
-	if node.capacityType == v1alpha1.CapacityTypeSpot &&
-		newNodes[0].Requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha1.CapacityTypeSpot) {
+	if node.capacityType == v1alpha5.CapacityTypeSpot &&
+		newNodes[0].Requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha5.CapacityTypeSpot) {
 		return lifecycleCommand{action: deprovisionActionNotPossible}, nil
 	}
 
@@ -574,8 +573,8 @@ func (c *Controller) computeNodeConsolidationOption(ctx context.Context, node ca
 	// spot capacity is insufficient we don't replace the node with a more expensive on-demand node.  Instead the launch
 	// should fail and we'll just leave the node alone.
 	ctReq := newNodes[0].Requirements.Get(v1alpha5.LabelCapacityType)
-	if ctReq.Has(v1alpha1.CapacityTypeSpot) && ctReq.Has(v1alpha1.CapacityTypeOnDemand) {
-		newNodes[0].Requirements.Add(scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, v1alpha1.CapacityTypeSpot))
+	if ctReq.Has(v1alpha5.CapacityTypeSpot) && ctReq.Has(v1alpha5.CapacityTypeOnDemand) {
+		newNodes[0].Requirements.Add(scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, v1alpha5.CapacityTypeSpot))
 	}
 
 	return lifecycleCommand{

--- a/pkg/controllers/consolidation/helpers.go
+++ b/pkg/controllers/consolidation/helpers.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
 	"github.com/aws/karpenter-core/pkg/scheduling"
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
 
 	v1 "k8s.io/api/core/v1"
@@ -80,9 +79,9 @@ func disruptionCost(ctx context.Context, pods []*v1.Pod) float64 {
 // to get the launch price; else, it uses the on-demand launch price
 func worstLaunchPrice(ofs []cloudprovider.Offering, reqs scheduling.Requirements) float64 {
 	// We prefer to launch spot offerings, so we will get the worst price based on the node requirements
-	if reqs.Get(v1alpha5.LabelCapacityType).Has(v1alpha1.CapacityTypeSpot) {
+	if reqs.Get(v1alpha5.LabelCapacityType).Has(v1alpha5.CapacityTypeSpot) {
 		spotOfferings := lo.Filter(ofs, func(of cloudprovider.Offering, _ int) bool {
-			return of.CapacityType == v1alpha1.CapacityTypeSpot && reqs.Get(v1.LabelTopologyZone).Has(of.Zone)
+			return of.CapacityType == v1alpha5.CapacityTypeSpot && reqs.Get(v1.LabelTopologyZone).Has(of.Zone)
 		})
 		if len(spotOfferings) > 0 {
 			return lo.MaxBy(spotOfferings, func(of1, of2 cloudprovider.Offering) bool {
@@ -90,9 +89,9 @@ func worstLaunchPrice(ofs []cloudprovider.Offering, reqs scheduling.Requirements
 			}).Price
 		}
 	}
-	if reqs.Get(v1alpha5.LabelCapacityType).Has(v1alpha1.CapacityTypeOnDemand) {
+	if reqs.Get(v1alpha5.LabelCapacityType).Has(v1alpha5.CapacityTypeOnDemand) {
 		onDemandOfferings := lo.Filter(ofs, func(of cloudprovider.Offering, _ int) bool {
-			return of.CapacityType == v1alpha1.CapacityTypeOnDemand && reqs.Get(v1.LabelTopologyZone).Has(of.Zone)
+			return of.CapacityType == v1alpha5.CapacityTypeOnDemand && reqs.Get(v1.LabelTopologyZone).Has(of.Zone)
 		})
 		if len(onDemandOfferings) > 0 {
 			return lo.MaxBy(onDemandOfferings, func(of1, of2 cloudprovider.Offering) bool {

--- a/pkg/controllers/consolidation/suite_test.go
+++ b/pkg/controllers/consolidation/suite_test.go
@@ -40,7 +40,6 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider/fake"
 	"github.com/aws/karpenter/pkg/controllers/consolidation"
@@ -108,7 +107,7 @@ var _ = BeforeEach(func() {
 	cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
 	onDemandInstances = lo.Filter(cloudProvider.InstanceTypes, func(i cloudprovider.InstanceType, _ int) bool {
 		for _, o := range cloudprovider.AvailableOfferings(i) {
-			if o.CapacityType == v1alpha1.CapacityTypeOnDemand {
+			if o.CapacityType == v1alpha5.CapacityTypeOnDemand {
 				return true
 			}
 		}
@@ -410,7 +409,7 @@ var _ = Describe("Replace Nodes", func() {
 			Name: "current-on-demand",
 			Offerings: []cloudprovider.Offering{
 				{
-					CapacityType: v1alpha1.CapacityTypeOnDemand,
+					CapacityType: v1alpha5.CapacityTypeOnDemand,
 					Zone:         "test-zone-1a",
 					Price:        0.5,
 					Available:    false,
@@ -421,19 +420,19 @@ var _ = Describe("Replace Nodes", func() {
 			Name: "potential-spot-replacement",
 			Offerings: []cloudprovider.Offering{
 				{
-					CapacityType: v1alpha1.CapacityTypeSpot,
+					CapacityType: v1alpha5.CapacityTypeSpot,
 					Zone:         "test-zone-1a",
 					Price:        1.0,
 					Available:    true,
 				},
 				{
-					CapacityType: v1alpha1.CapacityTypeSpot,
+					CapacityType: v1alpha5.CapacityTypeSpot,
 					Zone:         "test-zone-1b",
 					Price:        0.2,
 					Available:    true,
 				},
 				{
-					CapacityType: v1alpha1.CapacityTypeSpot,
+					CapacityType: v1alpha5.CapacityTypeSpot,
 					Zone:         "test-zone-1c",
 					Price:        0.4,
 					Available:    true,
@@ -498,7 +497,7 @@ var _ = Describe("Replace Nodes", func() {
 			Name: "current-on-demand",
 			Offerings: []cloudprovider.Offering{
 				{
-					CapacityType: v1alpha1.CapacityTypeOnDemand,
+					CapacityType: v1alpha5.CapacityTypeOnDemand,
 					Zone:         "test-zone-1a",
 					Price:        0.5,
 					Available:    false,
@@ -509,25 +508,25 @@ var _ = Describe("Replace Nodes", func() {
 			Name: "on-demand-replacement",
 			Offerings: []cloudprovider.Offering{
 				{
-					CapacityType: v1alpha1.CapacityTypeOnDemand,
+					CapacityType: v1alpha5.CapacityTypeOnDemand,
 					Zone:         "test-zone-1a",
 					Price:        0.6,
 					Available:    true,
 				},
 				{
-					CapacityType: v1alpha1.CapacityTypeOnDemand,
+					CapacityType: v1alpha5.CapacityTypeOnDemand,
 					Zone:         "test-zone-1b",
 					Price:        0.6,
 					Available:    true,
 				},
 				{
-					CapacityType: v1alpha1.CapacityTypeSpot,
+					CapacityType: v1alpha5.CapacityTypeSpot,
 					Zone:         "test-zone-1b",
 					Price:        0.2,
 					Available:    true,
 				},
 				{
-					CapacityType: v1alpha1.CapacityTypeSpot,
+					CapacityType: v1alpha5.CapacityTypeSpot,
 					Zone:         "test-zone-1c",
 					Price:        0.3,
 					Available:    true,
@@ -569,7 +568,7 @@ var _ = Describe("Replace Nodes", func() {
 				{
 					Key:      v1alpha5.LabelCapacityType,
 					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{v1alpha1.CapacityTypeOnDemand},
+					Values:   []string{v1alpha5.CapacityTypeOnDemand},
 				},
 			},
 		})

--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider"
 	"github.com/aws/karpenter/pkg/cloudproviders/common/cloudprovider/fake"
 	"github.com/aws/karpenter/pkg/test"
@@ -224,14 +223,14 @@ var _ = Describe("Instance Type Selection", func() {
 			{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1alpha1.CapacityTypeSpot},
+				Values:   []string{v1alpha5.CapacityTypeSpot},
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
 		pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.LabelCapacityType, v1alpha1.CapacityTypeSpot)
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.LabelCapacityType, v1alpha5.CapacityTypeSpot)
 	})
 	It("should schedule on one of the cheapest instances (pod ct = spot)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -239,18 +238,18 @@ var _ = Describe("Instance Type Selection", func() {
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1alpha1.CapacityTypeSpot},
+				Values:   []string{v1alpha5.CapacityTypeSpot},
 			}}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.LabelCapacityType, v1alpha1.CapacityTypeSpot)
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.LabelCapacityType, v1alpha5.CapacityTypeSpot)
 	})
 	It("should schedule on one of the cheapest instances (prov ct = ondemand, prov zone = test-zone-1)", func() {
 		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 			{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1alpha1.CapacityTypeOnDemand},
+				Values:   []string{v1alpha5.CapacityTypeOnDemand},
 			},
 			{
 				Key:      v1.LabelTopologyZone,
@@ -262,7 +261,7 @@ var _ = Describe("Instance Type Selection", func() {
 		pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha1.CapacityTypeOnDemand, "test-zone-1")
+		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeOnDemand, "test-zone-1")
 	})
 	It("should schedule on one of the cheapest instances (pod ct = spot, pod zone = test-zone-1)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -270,7 +269,7 @@ var _ = Describe("Instance Type Selection", func() {
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1alpha1.CapacityTypeSpot},
+				Values:   []string{v1alpha5.CapacityTypeSpot},
 			},
 				{
 					Key:      v1.LabelTopologyZone,
@@ -280,14 +279,14 @@ var _ = Describe("Instance Type Selection", func() {
 			}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha1.CapacityTypeSpot, "test-zone-1")
+		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeSpot, "test-zone-1")
 	})
 	It("should schedule on one of the cheapest instances (prov ct = spot, pod zone = test-zone-2)", func() {
 		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 			{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1alpha1.CapacityTypeSpot},
+				Values:   []string{v1alpha5.CapacityTypeSpot},
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -299,7 +298,7 @@ var _ = Describe("Instance Type Selection", func() {
 			}}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha1.CapacityTypeSpot, "test-zone-2")
+		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeSpot, "test-zone-2")
 	})
 	It("should schedule on one of the cheapest instances (prov ct = ondemand/test-zone-1/arm64/windows)", func() {
 		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
@@ -316,7 +315,7 @@ var _ = Describe("Instance Type Selection", func() {
 			{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1alpha1.CapacityTypeOnDemand},
+				Values:   []string{v1alpha5.CapacityTypeOnDemand},
 			},
 			{
 				Key:      v1.LabelTopologyZone,
@@ -328,7 +327,7 @@ var _ = Describe("Instance Type Selection", func() {
 		pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha1.CapacityTypeOnDemand, "test-zone-1")
+		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeOnDemand, "test-zone-1")
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "windows")
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, "arm64")
 	})
@@ -351,7 +350,7 @@ var _ = Describe("Instance Type Selection", func() {
 				{
 					Key:      v1alpha5.LabelCapacityType,
 					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{v1alpha1.CapacityTypeSpot},
+					Values:   []string{v1alpha5.CapacityTypeSpot},
 				},
 				{
 					Key:      v1.LabelTopologyZone,
@@ -361,7 +360,7 @@ var _ = Describe("Instance Type Selection", func() {
 			}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha1.CapacityTypeSpot, "test-zone-2")
+		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeSpot, "test-zone-2")
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "linux")
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, "amd64")
 	})
@@ -382,7 +381,7 @@ var _ = Describe("Instance Type Selection", func() {
 				{
 					Key:      v1alpha5.LabelCapacityType,
 					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{v1alpha1.CapacityTypeSpot},
+					Values:   []string{v1alpha5.CapacityTypeSpot},
 				},
 				{
 					Key:      v1.LabelTopologyZone,
@@ -392,7 +391,7 @@ var _ = Describe("Instance Type Selection", func() {
 			}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha1.CapacityTypeSpot, "test-zone-2")
+		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeSpot, "test-zone-2")
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "linux")
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, "amd64")
 	})
@@ -536,8 +535,8 @@ var _ = Describe("Instance Type Selection", func() {
 					v1.ResourceMemory: resource.MustParse("1Gi"),
 				},
 				Offerings: []cloudprovider.Offering{
-					{CapacityType: v1alpha1.CapacityTypeOnDemand, Zone: "test-zone-1a", Price: 1.0, Available: true},
-					{CapacityType: v1alpha1.CapacityTypeSpot, Zone: "test-zone-1a", Price: 0.2, Available: true},
+					{CapacityType: v1alpha5.CapacityTypeOnDemand, Zone: "test-zone-1a", Price: 1.0, Available: true},
+					{CapacityType: v1alpha5.CapacityTypeSpot, Zone: "test-zone-1a", Price: 0.2, Available: true},
 				},
 			}),
 			fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -549,8 +548,8 @@ var _ = Describe("Instance Type Selection", func() {
 					v1.ResourceMemory: resource.MustParse("1Gi"),
 				},
 				Offerings: []cloudprovider.Offering{
-					{CapacityType: v1alpha1.CapacityTypeOnDemand, Zone: "test-zone-1a", Price: 1.3, Available: true},
-					{CapacityType: v1alpha1.CapacityTypeSpot, Zone: "test-zone-1a", Price: 0.1, Available: true},
+					{CapacityType: v1alpha5.CapacityTypeOnDemand, Zone: "test-zone-1a", Price: 1.3, Available: true},
+					{CapacityType: v1alpha5.CapacityTypeSpot, Zone: "test-zone-1a", Price: 0.1, Available: true},
 				},
 			}),
 		}

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/controllers/provisioning"
 	"github.com/aws/karpenter/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter/pkg/test"
@@ -96,7 +95,7 @@ var _ = BeforeEach(func() {
 	provisioner = test.Provisioner(test.ProvisionerOptions{Requirements: []v1.NodeSelectorRequirement{{
 		Key:      v1alpha5.LabelCapacityType,
 		Operator: v1.NodeSelectorOpIn,
-		Values:   []string{v1alpha1.CapacityTypeSpot, v1alpha1.CapacityTypeOnDemand},
+		Values:   []string{v1alpha5.CapacityTypeSpot, v1alpha5.CapacityTypeOnDemand},
 	}}})
 	// reset instance types
 	newCP := fake.CloudProvider{}
@@ -1150,7 +1149,7 @@ var _ = Describe("Topology", func() {
 		})
 		It("should respect provisioner capacity type constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot, v1alpha1.CapacityTypeOnDemand}}}
+				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeSpot, v1alpha5.CapacityTypeOnDemand}}}
 			topology := []v1.TopologySpreadConstraint{{
 				TopologyKey:       v1alpha5.LabelCapacityType,
 				WhenUnsatisfiable: v1.DoNotSchedule,
@@ -1182,7 +1181,7 @@ var _ = Describe("Topology", func() {
 			}
 			// force this pod onto spot
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot}}}
+				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeSpot}}}
 			ExpectApplied(ctx, env.Client, provisioner)
 			ExpectProvisioned(ctx, env.Client, controller,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
@@ -1191,7 +1190,7 @@ var _ = Describe("Topology", func() {
 
 			// now only allow scheduling pods on on-demand
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeOnDemand}}}
+				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeOnDemand}}}
 			ExpectApplied(ctx, env.Client, provisioner)
 			ExpectProvisioned(ctx, env.Client, controller,
 				MakePods(5, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
@@ -1214,7 +1213,7 @@ var _ = Describe("Topology", func() {
 				},
 			}
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot}}}
+				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeSpot}}}
 			ExpectApplied(ctx, env.Client, provisioner)
 			ExpectProvisioned(ctx, env.Client, controller,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
@@ -1222,7 +1221,7 @@ var _ = Describe("Topology", func() {
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
 
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeOnDemand}}}
+				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeOnDemand}}}
 			ExpectApplied(ctx, env.Client, provisioner)
 			ExpectProvisioned(ctx, env.Client, controller,
 				MakePods(5, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
@@ -1234,8 +1233,8 @@ var _ = Describe("Topology", func() {
 		})
 		It("should only count running/scheduled pods with matching labels scheduled to nodes with a corresponding domain", func() {
 			wrongNamespace := test.RandomName()
-			firstNode := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1alpha5.LabelCapacityType: v1alpha1.CapacityTypeSpot}}})
-			secondNode := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1alpha5.LabelCapacityType: v1alpha1.CapacityTypeOnDemand}}})
+			firstNode := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1alpha5.LabelCapacityType: v1alpha5.CapacityTypeSpot}}})
+			secondNode := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{v1alpha5.LabelCapacityType: v1alpha5.CapacityTypeOnDemand}}})
 			thirdNode := test.Node(test.NodeOptions{}) // missing topology capacity type
 			topology := []v1.TopologySpreadConstraint{{
 				TopologyKey:       v1alpha5.LabelCapacityType,
@@ -1774,12 +1773,12 @@ var _ = Describe("Topology", func() {
 					MakePods(5, test.PodOptions{
 						ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 						TopologySpreadConstraints: topology,
-						NodeSelector:              map[string]string{v1alpha5.LabelCapacityType: v1alpha1.CapacityTypeSpot},
+						NodeSelector:              map[string]string{v1alpha5.LabelCapacityType: v1alpha5.CapacityTypeSpot},
 					}),
 					MakePods(5, test.PodOptions{
 						ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 						TopologySpreadConstraints: topology,
-						NodeSelector:              map[string]string{v1alpha5.LabelCapacityType: v1alpha1.CapacityTypeOnDemand},
+						NodeSelector:              map[string]string{v1alpha5.LabelCapacityType: v1alpha5.CapacityTypeOnDemand},
 					})...,
 				)...,
 			)
@@ -1800,7 +1799,7 @@ var _ = Describe("Topology", func() {
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					TopologySpreadConstraints: topology,
 					NodeRequirements: []v1.NodeSelectorRequirement{
-						{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeSpot}},
+						{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeSpot}},
 					},
 				})...)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3))
@@ -1811,7 +1810,7 @@ var _ = Describe("Topology", func() {
 				ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 				TopologySpreadConstraints: topology,
 				NodeRequirements: []v1.NodeSelectorRequirement{
-					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha1.CapacityTypeOnDemand, v1alpha1.CapacityTypeSpot}},
+					{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeOnDemand, v1alpha5.CapacityTypeSpot}},
 				},
 			})...)
 
@@ -3487,7 +3486,7 @@ var _ = Describe("Binpacking", func() {
 				},
 				Offerings: []cloudprovider.Offering{
 					{
-						CapacityType: v1alpha1.CapacityTypeOnDemand,
+						CapacityType: v1alpha5.CapacityTypeOnDemand,
 						Zone:         "test-zone-1a",
 						Price:        3.00,
 						Available:    true,
@@ -3502,7 +3501,7 @@ var _ = Describe("Binpacking", func() {
 				},
 				Offerings: []cloudprovider.Offering{
 					{
-						CapacityType: v1alpha1.CapacityTypeOnDemand,
+						CapacityType: v1alpha5.CapacityTypeOnDemand,
 						Zone:         "test-zone-1a",
 						Price:        2.00,
 						Available:    true,
@@ -3517,7 +3516,7 @@ var _ = Describe("Binpacking", func() {
 				},
 				Offerings: []cloudprovider.Offering{
 					{
-						CapacityType: v1alpha1.CapacityTypeOnDemand,
+						CapacityType: v1alpha5.CapacityTypeOnDemand,
 						Zone:         "test-zone-1a",
 						Price:        1.00,
 						Available:    true,
@@ -4121,8 +4120,8 @@ var _ = Describe("No Pre-Binding", func() {
 		// Issue #1459
 		opts := test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
-				v1.ResourceCPU:             resource.MustParse("10m"),
-				v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
+				v1.ResourceCPU:          resource.MustParse("10m"),
+				fake.ResourceGPUVendorA: resource.MustParse("1"),
 			},
 		}}
 
@@ -4142,10 +4141,10 @@ var _ = Describe("No Pre-Binding", func() {
 
 		// simulate kubelet zeroing out the extended resources on the node at startup
 		node1.Status.Capacity = map[v1.ResourceName]resource.Quantity{
-			v1alpha1.ResourceNVIDIAGPU: resource.MustParse("0"),
+			fake.ResourceGPUVendorA: resource.MustParse("0"),
 		}
 		node1.Status.Allocatable = map[v1.ResourceName]resource.Quantity{
-			v1alpha1.ResourceNVIDIAGPU: resource.MustParse("0"),
+			fake.ResourceGPUVendorB: resource.MustParse("0"),
 		}
 
 		ExpectApplied(ctx, env.Client, node1)

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/controllers/provisioning"
 	"github.com/aws/karpenter/pkg/test"
 
@@ -158,13 +157,10 @@ var _ = Describe("Provisioning", func() {
 		ExpectApplied(ctx, env.Client, test.Provisioner())
 		for _, pod := range ExpectProvisioned(ctx, env.Client, controller,
 			test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{Limits: v1.ResourceList{v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1")}},
+				ResourceRequirements: v1.ResourceRequirements{Limits: v1.ResourceList{fake.ResourceGPUVendorA: resource.MustParse("1")}},
 			}),
 			test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{Limits: v1.ResourceList{v1alpha1.ResourceAMDGPU: resource.MustParse("1")}},
-			}),
-			test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{Limits: v1.ResourceList{v1alpha1.ResourceAWSNeuron: resource.MustParse("1")}},
+				ResourceRequirements: v1.ResourceRequirements{Limits: v1.ResourceList{fake.ResourceGPUVendorB: resource.MustParse("1")}},
 			}),
 		) {
 			ExpectScheduled(ctx, env.Client, pod)
@@ -321,7 +317,7 @@ var _ = Describe("Provisioning", func() {
 			pod := ExpectProvisioned(ctx, env.Client, controller, test.UnschedulablePod(
 				test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						v1alpha1.ResourceNVIDIAGPU: resource.MustParse("1"),
+						fake.ResourceGPUVendorA: resource.MustParse("1"),
 					},
 				}}))[0]
 			// only available instance type has 2 GPUs which would exceed the limit

--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
-
-	"github.com/aws/karpenter/pkg/cloudproviders/aws/apis/v1alpha1"
 )
 
 // ProvisionerOptions customizes a Provisioner.
@@ -71,7 +69,7 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 		options.Requirements = append(options.Requirements, v1.NodeSelectorRequirement{
 			Key:      v1alpha5.LabelCapacityType,
 			Operator: v1.NodeSelectorOpIn,
-			Values:   []string{v1alpha1.CapacityTypeOnDemand},
+			Values:   []string{v1alpha5.CapacityTypeOnDemand},
 		})
 	}
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/aws/aws-sdk-go v1.44.114
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.0.2-0.20221017165612-70c16abe656e
+	github.com/aws/karpenter-core v0.0.2-0.20221018173200-be50f859aa81
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.21.1
 	github.com/samber/lo v1.32.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -64,8 +64,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.44.114 h1:plIkWc/RsHr3DXBj4MEw9sEW4CcL/e2ryokc+CKyq1I=
 github.com/aws/aws-sdk-go v1.44.114/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/karpenter-core v0.0.2-0.20221017165612-70c16abe656e h1:X1zyJUeKttAjzNmdd3FkcrH0Vlq+fEznC7izXJcdE4w=
-github.com/aws/karpenter-core v0.0.2-0.20221017165612-70c16abe656e/go.mod h1:vQko57qiP/cxqWDgLTTvdR9A6AUXriWd8eg0dDTJJpY=
+github.com/aws/karpenter-core v0.0.2-0.20221018173200-be50f859aa81 h1:VIsG0kj1/ZyFtcQhkONV+yyLN96u9tl7p7ku5uGAwAM=
+github.com/aws/karpenter-core v0.0.2-0.20221018173200-be50f859aa81/go.mod h1:vQko57qiP/cxqWDgLTTvdR9A6AUXriWd8eg0dDTJJpY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -326,7 +326,7 @@ var _ = Describe("Consolidation", func() {
 				if n.Labels[v1alpha5.ProvisionerNameLabelKey] != provisioner.Name {
 					continue
 				}
-				if n.Labels[v1alpha5.LabelCapacityType] == awsv1alpha1.CapacityTypeSpot {
+				if n.Labels[v1alpha5.LabelCapacityType] == v1alpha5.CapacityTypeSpot {
 					numSpotNodes++
 				} else {
 					numOtherNodes++

--- a/test/suites/integration/webhook_test.go
+++ b/test/suites/integration/webhook_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Webhooks", func() {
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{awsv1alpha1.CapacityTypeOnDemand},
+				Values:   []string{v1alpha5.CapacityTypeOnDemand},
 			}))
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1.LabelArchStable,
@@ -140,7 +140,7 @@ var _ = Describe("Webhooks", func() {
 					{
 						Key:      v1alpha5.LabelCapacityType,
 						Operator: "within",
-						Values:   []string{awsv1alpha1.CapacityTypeSpot},
+						Values:   []string{v1alpha5.CapacityTypeSpot},
 					},
 				},
 			})


### PR DESCRIPTION


<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
