### PR TITLE
chore: Migrate from `config.Config` to `settings.Settings` injection

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -47,9 +47,9 @@ func main() {
 	runtime.Must(manager.AddHealthzCheck("cloud-provider", awsCloudProvider.LivenessProbe))
 	cloudProvider := cloudprovidermetrics.Decorate(awsCloudProvider)
 
-	settingsStore := settingsstore.WatchSettings(ctx, ctx.ConfigMapWatcher, settings.Registration)
+	settingsStore := settingsstore.WatchSettingsOrDie(ctx, ctx.Clientset, ctx.ConfigMapWatcher, settings.Registration)
 	if err := ctx.ConfigMapWatcher.Start(ctx.Done()); err != nil {
-		panic(fmt.Errorf("starting ConfigMap watcher, %w", err))
+		panic(fmt.Sprintf("Starting ConfigMap watcher, %v", err))
 	}
 
 	// TODO: Remove settings injection once nominationPeriod no longer relies on it

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.114
-	github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06
+	github.com/aws/karpenter-core v0.0.2-0.20221024200040-c2d6e5014c66
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.21.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.114
-	github.com/aws/karpenter-core v0.0.2-0.20221021235942-051216a25fdc
+	github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.21.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.114 h1:plIkWc/RsHr3DXBj4MEw9sEW4CcL/e2ryokc+CKyq1I=
 github.com/aws/aws-sdk-go v1.44.114/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/karpenter-core v0.0.2-0.20221021235942-051216a25fdc h1:jYeeAYgQ4oc7gAsq71K0MiAB6fFfWae1Fg4nEbFkcAE=
-github.com/aws/karpenter-core v0.0.2-0.20221021235942-051216a25fdc/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
+github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06 h1:MpO8ok8j9KASKcfuM+aHbf0g77PK4GMKJl9NxoyQcIU=
+github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.114 h1:plIkWc/RsHr3DXBj4MEw9sEW4CcL/e2ryokc+CKyq1I=
 github.com/aws/aws-sdk-go v1.44.114/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06 h1:MpO8ok8j9KASKcfuM+aHbf0g77PK4GMKJl9NxoyQcIU=
-github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
+github.com/aws/karpenter-core v0.0.2-0.20221024200040-c2d6e5014c66 h1:P1yjt9+2Dgda0r5DJqFaRZEXNAzg1Vy9IA84ejc1Ql4=
+github.com/aws/karpenter-core v0.0.2-0.20221024200040-c2d6e5014c66/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cloudprovider/instancetypes_test.go
+++ b/pkg/cloudprovider/instancetypes_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Instance Types", func() {
 		// ensure the provisioner is shut down at the end of this test
 		defer cancelFunc()
 
-		prov := provisioning.NewProvisioner(cancelCtx, cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+		prov := provisioning.NewProvisioner(cancelCtx, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 		provisionContoller := provisioning.NewController(env.Client, prov, recorder)
 		ExpectApplied(ctx, env.Client, provisioner)
 		for _, pod := range ExpectProvisioned(cancelCtx, env.Client, provisionContoller,

--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -606,7 +606,7 @@ var _ = Describe("LaunchTemplates", func() {
 	Context("User Data", func() {
 		It("should not specify --use-max-pods=false when using ENI-based pod density", func() {
 			opts.AWSENILimitedPodDensity = true
-			prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+			prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 			controllerWithOpts := provisioning.NewController(env.Client, prov, recorder)
 			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
 			pod := ExpectProvisioned(ctx, env.Client, controllerWithOpts, test.UnschedulablePod())[0]
@@ -618,7 +618,7 @@ var _ = Describe("LaunchTemplates", func() {
 		})
 		It("should specify --use-max-pods=false when not using ENI-based pod density", func() {
 			opts.AWSENILimitedPodDensity = false
-			prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+			prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 			controllerWithOpts := provisioning.NewController(env.Client, prov, recorder)
 			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
 			pod := ExpectProvisioned(ctx, env.Client, controllerWithOpts, test.UnschedulablePod())[0]
@@ -888,7 +888,7 @@ var _ = Describe("LaunchTemplates", func() {
 		Context("Bottlerocket", func() {
 			It("should merge in custom user data", func() {
 				opts.AWSENILimitedPodDensity = false
-				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 				controllerWithOpts := provisioning.NewController(env.Client, prov, recorder)
 
 				provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
@@ -922,7 +922,7 @@ var _ = Describe("LaunchTemplates", func() {
 			})
 			It("should bootstrap when custom user data is empty", func() {
 				opts.AWSENILimitedPodDensity = false
-				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 				controllerWithOpts := provisioning.NewController(env.Client, prov, recorder)
 
 				provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
@@ -952,7 +952,7 @@ var _ = Describe("LaunchTemplates", func() {
 			})
 			It("should not bootstrap when provider ref points to a non-existent resource", func() {
 				opts.AWSENILimitedPodDensity = false
-				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 				controllerWithOpts := provisioning.NewController(env.Client, prov, recorder)
 
 				provider.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
@@ -1089,7 +1089,7 @@ var _ = Describe("LaunchTemplates", func() {
 		Context("AL2 Custom UserData", func() {
 			It("should merge in custom user data", func() {
 				opts.AWSENILimitedPodDensity = false
-				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 				controllerWithOpts := provisioning.NewController(env.Client, prov, recorder)
 
 				content, _ := os.ReadFile("testdata/al2_userdata_input.golden")
@@ -1111,7 +1111,7 @@ var _ = Describe("LaunchTemplates", func() {
 			})
 			It("should handle empty custom user data", func() {
 				opts.AWSENILimitedPodDensity = false
-				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), cfg, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster)
+				prov := provisioning.NewProvisioner(injection.WithOptions(ctx, opts), env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 				controllerWithOpts := provisioning.NewController(env.Client, prov, recorder)
 				nodeTemplate := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 					UserData: nil,

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -16,13 +16,13 @@ package controllers
 
 import (
 	"github.com/aws/karpenter-core/pkg/controllers/state"
-	"github.com/aws/karpenter-core/pkg/operator"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
 	awscontext "github.com/aws/karpenter/pkg/context"
 	"github.com/aws/karpenter/pkg/events"
 )
 
-func GetControllers(ctx awscontext.Context, cluster *state.Cluster) []operator.Controller {
+func GetControllers(ctx awscontext.Context, cluster *state.Cluster) []controller.Controller {
 	_ = events.NewRecorder(ctx.EventRecorder)
 
-	return []operator.Controller{}
+	return []controller.Controller{}
 }

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/aws/aws-sdk-go v1.44.114
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06
+	github.com/aws/karpenter-core v0.0.2-0.20221024200040-c2d6e5014c66
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.21.1
 	github.com/samber/lo v1.32.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/aws/aws-sdk-go v1.44.114
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.0.2-0.20221021235942-051216a25fdc
+	github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.21.1
 	github.com/samber/lo v1.32.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -64,8 +64,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.44.114 h1:plIkWc/RsHr3DXBj4MEw9sEW4CcL/e2ryokc+CKyq1I=
 github.com/aws/aws-sdk-go v1.44.114/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/karpenter-core v0.0.2-0.20221021235942-051216a25fdc h1:jYeeAYgQ4oc7gAsq71K0MiAB6fFfWae1Fg4nEbFkcAE=
-github.com/aws/karpenter-core v0.0.2-0.20221021235942-051216a25fdc/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
+github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06 h1:MpO8ok8j9KASKcfuM+aHbf0g77PK4GMKJl9NxoyQcIU=
+github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/test/go.sum
+++ b/test/go.sum
@@ -64,8 +64,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.44.114 h1:plIkWc/RsHr3DXBj4MEw9sEW4CcL/e2ryokc+CKyq1I=
 github.com/aws/aws-sdk-go v1.44.114/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06 h1:MpO8ok8j9KASKcfuM+aHbf0g77PK4GMKJl9NxoyQcIU=
-github.com/aws/karpenter-core v0.0.2-0.20221024163251-a47b6211ec06/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
+github.com/aws/karpenter-core v0.0.2-0.20221024200040-c2d6e5014c66 h1:P1yjt9+2Dgda0r5DJqFaRZEXNAzg1Vy9IA84ejc1Ql4=
+github.com/aws/karpenter-core v0.0.2-0.20221024200040-c2d6e5014c66/go.mod h1:inbUQ43WPgGrDn2YTlHLOvxYmH6Lv5Uhim63H5FeK58=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Adds a `settings.Controller` that watches the `karpenter-global-settings` ConfigMap
- Creates a wrapper around the configMap.Data called `settings.Settings`
- Injects this settings into `Reconcile` context using the `InjectSettings` decorator

__NOTE: This PR doesn't fix dynamically updating the `nominationPeriod`. That needs some more thought and should be done in a separate PR.__

The use-case of this is to be able to do the following:

```go
operatorsettings.FromContext(ctx).BatchMaxDuration
```

Or for cloudproviders, something like

```go
awssettings.FromContext(ctx).EnablePodENI
```

**How was this change tested?**

* `make battletest`
* `TEST_FILTER=Integration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
