### PR TITLE
chore: Initialize cloudprovider-specific controllers

### DIFF
--- a/pkg/cloudproviders/aws/cloudprovider/instance.go
+++ b/pkg/cloudproviders/aws/cloudprovider/instance.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 	awserrors "github.com/aws/karpenter/pkg/cloudproviders/aws/errors"
+	"github.com/aws/karpenter/pkg/cloudproviders/aws/utils"
 	"github.com/aws/karpenter/pkg/operator/injection"
 	"github.com/aws/karpenter/pkg/operator/options"
 
@@ -111,7 +112,7 @@ func (p *InstanceProvider) Create(ctx context.Context, provider *v1alpha1.AWS, n
 }
 
 func (p *InstanceProvider) Terminate(ctx context.Context, node *v1.Node) error {
-	id, err := getInstanceID(node)
+	id, err := utils.ParseInstanceID(node)
 	if err != nil {
 		return fmt.Errorf("getting instance ID for node %s, %w", node.Name, err)
 	}
@@ -412,14 +413,6 @@ func (p *InstanceProvider) prioritizeInstanceTypes(instanceTypes []cloudprovider
 		return genericInstanceTypes
 	}
 	return instanceTypes
-}
-
-func getInstanceID(node *v1.Node) (*string, error) {
-	id := strings.Split(node.Spec.ProviderID, "/")
-	if len(id) < 5 {
-		return nil, fmt.Errorf("parsing instance id %s", node.Spec.ProviderID)
-	}
-	return aws.String(id[4]), nil
 }
 
 func combineFleetErrors(errors []*ec2.CreateFleetError) (errs error) {

--- a/pkg/cloudproviders/aws/controllers/controllers.go
+++ b/pkg/cloudproviders/aws/controllers/controllers.go
@@ -1,0 +1,28 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	awscontext "github.com/aws/karpenter/pkg/cloudproviders/aws/context"
+	"github.com/aws/karpenter/pkg/cloudproviders/aws/events"
+	"github.com/aws/karpenter/pkg/controllers/state"
+	"github.com/aws/karpenter/pkg/operator"
+)
+
+func GetControllers(ctx awscontext.Context, cluster *state.Cluster) []operator.Controller {
+	_ = events.NewRecorder(ctx.EventRecorder)
+
+	return []operator.Controller{}
+}

--- a/pkg/cloudproviders/aws/utils/utils.go
+++ b/pkg/cloudproviders/aws/utils/utils.go
@@ -1,0 +1,52 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/ptr"
+
+	"github.com/aws/karpenter/pkg/operator/injection"
+)
+
+// ParseInstanceID parses the provider ID stored on the node to get the instance ID
+// associated with a node
+func ParseInstanceID(node *v1.Node) (*string, error) {
+	r := regexp.MustCompile(`aws:///(?P<AZ>.*)/(?P<InstanceID>.*)`)
+	matches := r.FindStringSubmatch(node.Spec.ProviderID)
+	if matches == nil {
+		return nil, fmt.Errorf("parsing instance id %s", node.Spec.ProviderID)
+	}
+	for i, name := range r.SubexpNames() {
+		if name == "InstanceID" {
+			return ptr.String(matches[i]), nil
+		}
+	}
+	return nil, fmt.Errorf("parsing instance id %s", node.Spec.ProviderID)
+}
+
+// GetClusterNameHash gets the SHA256 hex-encoded checksum of the cluster name, truncated at the passed truncatedAt
+func GetClusterNameHash(ctx context.Context, truncateAt int) string {
+	h := sha256.New()
+	h.Write([]byte(injection.GetOptions(ctx).ClusterName))
+	checkSum := h.Sum([]byte{})
+	return hex.EncodeToString(checkSum)[:truncateAt]
+}

--- a/pkg/cloudproviders/common/cloudprovider/types.go
+++ b/pkg/cloudproviders/common/cloudprovider/types.go
@@ -21,6 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
@@ -34,6 +35,7 @@ type Context struct {
 	ClientSet     *kubernetes.Clientset
 	KubeClient    client.Client
 	EventRecorder record.EventRecorder
+	Clock         clock.Clock
 	// StartAsync is a channel that is closed when leader election has been won.  This is a signal to start any  async
 	// processing that should only occur while the cloud provider is the leader.
 	StartAsync <-chan struct{}

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -33,8 +33,7 @@ func init() {
 	metrics.MustRegister() // Registers cross-controller metrics
 }
 
-func GetControllers(ctx operator.Context, cloudProvider cloudprovider.CloudProvider) []operator.Controller {
-	cluster := state.NewCluster(ctx.Clock, ctx.Config, ctx.KubeClient, cloudProvider)
+func GetControllers(ctx operator.Context, cluster *state.Cluster, cloudProvider cloudprovider.CloudProvider) []operator.Controller {
 	provisioner := provisioning.NewProvisioner(ctx, ctx.Config, ctx.KubeClient, ctx.Clientset.CoreV1(), ctx.EventRecorder, cloudProvider, cluster)
 
 	metricsstate.StartMetricScraper(ctx, cluster)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Adds AWS-specific controllers to `cloudproviders/aws/controllers`
- Adds a `GetControllers()` function that does provider instantiation

**How was this change tested?**

* `make test`
* Manual deployment to EKS cluster

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
