### PR TITLE
fix: updating prom scrape target

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/prometheus-values.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/prometheus-values.yaml
@@ -9,6 +9,12 @@ server:
 
 extraScrapeConfigs: |
     - job_name: karpenter
-      static_configs:
-      - targets:
-        - karpenter.karpenter:8080
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - karpenter
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_endpoint_port_name]
+        regex: http-metrics
+        action: keep


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->
#2480

**Description**
Prior to this change, static scrape targets were configured for the Karpenter service in the Prometheus scrape config.  When only a single Karpenter pod exists, this was fine given Prom would always scrape the one existing Karpenter pod.  When more than one replica exists, Prometheus will potential hit one or the other pod at each scrape interval which can skew metrics.  This change uses the Endpoint discovery mechanism to discover the service endpoints and then scrape them each directly.

**How was this change tested?**
* Manually validated that queries used by Grafana are aggregating metrics.  
* I also manually validated that Grafana dashboards still are returning what looks like accurate data.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update Karpenter scrape target in prometheus to support multiple replicas
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
