### PR TITLE
fix: Fixed API Code Gen

### DIFF
--- a/hack/api-code-gen.sh
+++ b/hack/api-code-gen.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 pricing() {
-  GENERATED_FILE="pkg/cloudproviders/aws/cloudprovider/zz_generated.pricing.go"
-  NO_UPDATE=$' pkg/cloudproviders/aws/cloudprovider/zz_generated.pricing.go | 4 ++--\n 1 file changed, 2 insertions(+), 2 deletions(-)'
+  GENERATED_FILE="pkg/cloudprovider/zz_generated.pricing.go"
+  NO_UPDATE=$' pkg/cloudprovider/zz_generated.pricing.go | 4 ++--\n 1 file changed, 2 insertions(+), 2 deletions(-)'
   SUBJECT="Pricing"
 
   go run hack/code/prices_gen.go -- "${GENERATED_FILE}"
@@ -13,7 +13,7 @@ pricing() {
 }
 
 vpcLimits() {
-  GENERATED_FILE="pkg/cloudproviders/aws/cloudprovider/zz_generated.vpclimits.go"
+  GENERATED_FILE="pkg/cloudprovider/zz_generated.vpclimits.go"
   NO_UPDATE=''
   SUBJECT="VPC Limits"
 

--- a/hack/code/prices_gen.go
+++ b/hack/code/prices_gen.go
@@ -38,7 +38,7 @@ import (
 func main() {
 	flag.Parse()
 	if flag.NArg() != 1 {
-		log.Fatalf("Usage: %s pkg/cloudproviders/aws/cloudprovider/zz_generated.pricing.go", os.Args[0])
+		log.Fatalf("Usage: %s pkg/cloudprovider/zz_generated.pricing.go", os.Args[0])
 	}
 
 	f, err := os.Create("pricing.heapprofile")

--- a/hack/code/vpc_limits_gen.go
+++ b/hack/code/vpc_limits_gen.go
@@ -35,7 +35,7 @@ func main() {
 	opts := options{}
 	flag.StringVar(&opts.urlInput, "url", "https://raw.githubusercontent.com/aws/amazon-vpc-resource-controller-k8s/master/pkg/aws/vpc/limits.go",
 		"url of the raw vpc/limits.go file in the github.com/aws/amazon-vpc-resource-controller-k8s repo")
-	flag.StringVar(&opts.sourceOutput, "output", "pkg/cloudproviders/aws/cloudprovider/zz_generated.vpclimits.go", "output location for the generated go source file")
+	flag.StringVar(&opts.sourceOutput, "output", "pkg/cloudprovider/zz_generated.vpclimits.go", "output location for the generated go source file")
 	flag.Parse()
 
 	limitsURL, err := url.Parse(opts.urlInput)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
```
❯ make api-code-gen
GOFLAGS="-ldflags=-X=github.com/aws/karpenter/pkg/utils/project.Version=v0.18.0-49-g6f4e5e12" ./hack/api-code-gen.sh
M	hack/api-code-gen.sh
M	hack/code/prices_gen.go
M	hack/code/vpc_limits_gen.go
Already on 'api-code-gen'
2022/10/24 11:30:09 waiting on pricing update...
2022/10/24 11:30:10 waiting on pricing update...
{"level":"info","ts":1666636210.25562,"logger":"fallback.pricing","caller":"cloudprovider/pricing.go:416","msg":"updated spot pricing with 560 instance types and 2631 offerings"}
2022/10/24 11:30:11 waiting on pricing update...
2022/10/24 11:30:12 waiting on pricing update...
{"level":"info","ts":1666636212.653006,"logger":"fallback.pricing","caller":"cloudprovider/pricing.go:267","msg":"updated on-demand pricing with 560 instance types"}
Checking git diff for updates.  pkg/cloudprovider/zz_generated.pricing.go | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-),  pkg/cloudprovider/zz_generated.pricing.go | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
No updates from AWS API for Pricing beside timestamps since last update
Updated 1 path from the index
Downloaded vpc/limits.go from "https://raw.githubusercontent.com/aws/amazon-vpc-resource-controller-k8s/master/pkg/aws/vpc/limits.go" to file "pkg/cloudprovider/zz_generated.vpclimits.go"
Checking git diff for updates. ,
No updates from AWS API for VPC Limits
Updated 0 paths from the index
```

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
