### PR TITLE
fix: nightlies do not try to tag webhook as it's now removed

### DIFF
--- a/hack/release/add-snapshot-tag.sh
+++ b/hack/release/add-snapshot-tag.sh
@@ -15,7 +15,6 @@ source "${SCRIPT_DIR}/common.sh"
 
 tagAllRepositories(){
     tagRelease controller "${SNAPSHOT_TAG}"
-    tagRelease webhook "${SNAPSHOT_TAG}"
     tagRelease karpenter "v0-${SNAPSHOT_TAG}"
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
Nightlies were broken by https://github.com/aws/karpenter/pull/2728

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ x ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
