### PR TITLE
test: fix ipv6 tests by removing custom test ami

### DIFF
--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -48,7 +48,6 @@ var _ = AfterEach(func() { env.AfterEach() })
 var _ = Describe("IPv6", func() {
 	It("should provision an IPv6 node by discovering kube-dns IPv6", func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
-			AMISelector: map[string]string{"aws-ids": "ami-0f17a47520a746bec"},
 			AWS: v1alpha1.AWS{
 				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
@@ -79,7 +78,6 @@ var _ = Describe("IPv6", func() {
 	It("should provision an IPv6 node by discovering kubeletConfig kube-dns IP", func() {
 		clusterDNSAddr := env.ExpectIPv6ClusterDNS()
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
-			AMISelector: map[string]string{"aws-ids": "ami-0f17a47520a746bec"},
 			AWS: v1alpha1.AWS{
 				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 				SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Fixes the IPv6 e2e tests. I was using a custom built AMI to test the tests before the ipv6 bootstrap changes were released in the EKS Optimized AMI and forgot to remove :\  

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
