### PR TITLE
test: Always print test logs, even if cleanup fails

### DIFF
--- a/test/pkg/environment/aws/setup.go
+++ b/test/pkg/environment/aws/setup.go
@@ -34,22 +34,25 @@ var (
 )
 
 func (env *Environment) BeforeEach(opts ...common.Option) {
-	options := common.ResolveOptions(opts)
-	if options.EnableDebug {
-		fmt.Println("------- START AWS BEFORE -------")
-		defer fmt.Println("------- END AWS BEFORE -------")
-	}
 	env.ExpectSettingsCreatedOrUpdated(settings.Registration.DefaultData, awssettings.Registration.DefaultData)
 	env.Environment.BeforeEach(opts...)
 }
 
-func (env *Environment) AfterEach(opts ...common.Option) {
+func (env *Environment) Cleanup(opts ...common.Option) {
 	options := common.ResolveOptions(opts)
-	if options.EnableDebug {
-		fmt.Println("------- START AWS AFTER -------")
-		defer fmt.Println("------- END AWS AFTER -------")
+	if !options.DisableDebug {
+		fmt.Println("------- START AWS CLEANUP -------")
+		defer fmt.Println("------- END AWS CLEANUP -------")
 	}
 	env.ExpectSettingsDeleted()
 	env.Environment.CleanupObjects(CleanableObjects, options)
+	env.Environment.Cleanup(opts...)
+}
+
+func (env *Environment) ForceCleanup(opts ...common.Option) {
+	env.Environment.ForceCleanup(opts...)
+}
+
+func (env *Environment) AfterEach(opts ...common.Option) {
 	env.Environment.AfterEach(opts...)
 }

--- a/test/pkg/environment/common/options.go
+++ b/test/pkg/environment/common/options.go
@@ -14,25 +14,15 @@ limitations under the License.
 
 package common
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
-
 type Option func(Options) Options
 
 type Options struct {
-	EnableDebug      bool
-	IgnoreCleanupFor []client.Object
+	DisableDebug bool
 }
 
-func EnableDebug(o Options) Options {
-	o.EnableDebug = true
+func DisableDebug(o Options) Options {
+	o.DisableDebug = true
 	return o
-}
-
-func IgnoreCleanupFor(objs ...client.Object) func(Options) Options {
-	return func(o Options) Options {
-		o.IgnoreCleanupFor = append(o.IgnoreCleanupFor, objs...)
-		return o
-	}
 }
 
 func ResolveOptions(opts []Option) Options {

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -49,13 +49,10 @@ func TestConsolidation(t *testing.T) {
 	RunSpecs(t, "Consolidation")
 }
 
-var _ = BeforeEach(func() {
-	env.BeforeEach(common.EnableDebug)
-})
-
-var _ = AfterEach(func() {
-	env.AfterEach(common.EnableDebug)
-})
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.ForceCleanup() })
+var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("Consolidation", func() {
 	It("should consolidate nodes (delete)", Label(common.NoWatch), Label(common.NoEvents), func() {

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/karpenter/test/pkg/environment/aws"
-	"github.com/aws/karpenter/test/pkg/environment/common"
 )
 
 var env *aws.Environment
@@ -36,5 +35,7 @@ func TestIntegration(t *testing.T) {
 	RunSpecs(t, "Integration")
 }
 
-var _ = BeforeEach(func() { env.BeforeEach(common.EnableDebug) })
-var _ = AfterEach(func() { env.AfterEach(common.EnableDebug) })
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.ForceCleanup() })
+var _ = AfterEach(func() { env.AfterEach() })

--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -43,6 +43,8 @@ func TestIPv6(t *testing.T) {
 }
 
 var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.ForceCleanup() })
 var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("IPv6", func() {

--- a/test/suites/utilization/suite_test.go
+++ b/test/suites/utilization/suite_test.go
@@ -44,8 +44,10 @@ func TestUtilization(t *testing.T) {
 	RunSpecs(t, "Utilization")
 }
 
-var _ = BeforeEach(func() { env.BeforeEach(common.EnableDebug) })
-var _ = AfterEach(func() { env.AfterEach(common.EnableDebug) })
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.ForceCleanup() })
+var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("Utilization", Label(common.NoWatch), Label(common.NoEvents), func() {
 	It("should provision one pod per node", func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Always prints test logs now since log dump is in a separate `AfterEach` block
- Always do ForceCleanup to avoid test pollution

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
