### PR TITLE
BREAKING CHANGE: Move instance type filtering from implicit to explicit at defaulting time

### DIFF
--- a/pkg/apis/v1alpha5/provisioner.go
+++ b/pkg/apis/v1alpha5/provisioner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 )
 
@@ -42,23 +43,30 @@ func (p *Provisioner) Validate(ctx context.Context) (errs *apis.FieldError) {
 }
 
 func (p *Provisioner) SetDefaults(ctx context.Context) {
-	for key, value := range map[string]string{
-		v1alpha5.LabelCapacityType: ec2.DefaultTargetCapacityTypeOnDemand,
-		v1.LabelArchStable:         v1alpha5.ArchitectureAmd64,
-	} {
-		hasLabel := false
-		if _, ok := p.Spec.Labels[key]; ok {
-			hasLabel = true
-		}
-		for _, requirement := range p.Spec.Requirements {
-			if requirement.Key == key {
-				hasLabel = true
-			}
-		}
-		if !hasLabel {
-			p.Spec.Requirements = append(p.Spec.Requirements, v1.NodeSelectorRequirement{
-				Key: key, Operator: v1.NodeSelectorOpIn, Values: []string{value},
-			})
-		}
+	requirements := scheduling.NewNodeSelectorRequirements(p.Spec.Requirements...)
+
+	// default to amd64
+	if !requirements.Has(v1.LabelArchStable) {
+		p.Spec.Requirements = append(p.Spec.Requirements, v1.NodeSelectorRequirement{
+			Key: v1.LabelArchStable, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.ArchitectureAmd64},
+		})
+	}
+
+	// default to on-demand
+	if !requirements.Has(v1alpha5.LabelCapacityType) {
+		p.Spec.Requirements = append(p.Spec.Requirements, v1.NodeSelectorRequirement{
+			Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{ec2.DefaultTargetCapacityTypeOnDemand},
+		})
+	}
+
+	// default to C, M, R categories if no instance type constraints are specified
+	if !requirements.Has(v1.LabelInstanceTypeStable) &&
+		!requirements.Has(v1alpha1.LabelInstanceFamily) &&
+		!requirements.Has(v1alpha1.LabelInstanceCategory) &&
+		!requirements.Has(v1alpha1.LabelInstanceGeneration) {
+		p.Spec.Requirements = append(p.Spec.Requirements, []v1.NodeSelectorRequirement{
+			{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpIn, Values: []string{"c", "m", "r"}},
+			{Key: v1alpha1.LabelInstanceGeneration, Operator: v1.NodeSelectorOpGt, Values: []string{"2"}},
+		}...)
 	}
 }

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -26,16 +26,17 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	apisv1alpha5 "github.com/aws/karpenter/pkg/apis/v1alpha5"
 )
 
-var provisioner *v1alpha5.Provisioner
 var ctx context.Context
 
 func TestIntegration(t *testing.T) {
@@ -44,284 +45,350 @@ func TestIntegration(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 }
 
-var _ = Describe("Validate", func() {
+var _ = Describe("Provisioner", func() {
+	var provisioner *v1alpha5.Provisioner
+
 	BeforeEach(func() {
 		provisioner = test.Provisioner(test.ProvisionerOptions{Provider: &v1alpha1.AWS{
-			AMIFamily:             aws.String(v1alpha1.AMIFamilyAL2),
 			SubnetSelector:        map[string]string{"*": "*"},
 			SecurityGroupSelector: map[string]string{"*": "*"},
 		}})
 	})
-	It("should validate", func() {
-		Expect(provisioner.Validate(ctx)).To(Succeed())
-	})
-	It("should succeed if provider undefined", func() {
-		provisioner.Spec.Provider = nil
-		Expect(provisioner.Validate(ctx)).To(Succeed())
+
+	Context("SetDefaults", func() {
+		It("should default architecture to amd64", func() {
+			SetDefaults(ctx, provisioner)
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1.LabelArchStable)).
+				To(Equal(scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64)))
+		})
+		It("should not default architecture if set", func() {
+			provisioner.Spec.Requirements = append(provisioner.Spec.Requirements,
+				v1.NodeSelectorRequirement{Key: v1.LabelArchStable, Operator: v1.NodeSelectorOpDoesNotExist})
+			SetDefaults(ctx, provisioner)
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1.LabelArchStable)).
+				To(Equal(scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpDoesNotExist)))
+		})
+		It("should default capacity-type to on-demand", func() {
+			SetDefaults(ctx, provisioner)
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha5.LabelCapacityType)).
+				To(Equal(scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, v1alpha1.CapacityTypeOnDemand)))
+		})
+		It("should not default capacity-type if set", func() {
+			provisioner.Spec.Requirements = append(provisioner.Spec.Requirements,
+				v1.NodeSelectorRequirement{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpDoesNotExist})
+			SetDefaults(ctx, provisioner)
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha5.LabelCapacityType)).
+				To(Equal(scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpDoesNotExist)))
+		})
+		It("should default instance-category, generation to c m r, gen>1", func() {
+			SetDefaults(ctx, provisioner)
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha1.LabelInstanceCategory)).
+				To(Equal(scheduling.NewRequirement(v1alpha1.LabelInstanceCategory, v1.NodeSelectorOpIn, "c", "m", "r")))
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha1.LabelInstanceGeneration)).
+				To(Equal(scheduling.NewRequirement(v1alpha1.LabelInstanceGeneration, v1.NodeSelectorOpGt, "2")))
+		})
+		It("should not default instance-category, generation if set", func() {
+			provisioner.Spec.Requirements = append(provisioner.Spec.Requirements,
+				v1.NodeSelectorRequirement{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists})
+			SetDefaults(ctx, provisioner)
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha1.LabelInstanceCategory)).
+				To(Equal(scheduling.NewRequirement(v1alpha1.LabelInstanceCategory, v1.NodeSelectorOpExists)))
+			Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha1.LabelInstanceGeneration)).
+				To(Equal(scheduling.NewRequirement(v1alpha1.LabelInstanceGeneration, v1.NodeSelectorOpExists)))
+		})
+		It("should not default instance-category if any instance label is set", func() {
+			for _, label := range []string{v1.LabelInstanceTypeStable, v1alpha1.LabelInstanceFamily} {
+				provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{{Key: label, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}}}
+				SetDefaults(ctx, provisioner)
+				Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(label)).
+					To(Equal(scheduling.NewRequirement(label, v1.NodeSelectorOpIn, "test")))
+				Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha1.LabelInstanceCategory)).
+					To(Equal(scheduling.NewRequirement(v1alpha1.LabelInstanceCategory, v1.NodeSelectorOpExists)))
+				Expect(scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...).Get(v1alpha1.LabelInstanceGeneration)).
+					To(Equal(scheduling.NewRequirement(v1alpha1.LabelInstanceGeneration, v1.NodeSelectorOpExists)))
+			}
+		})
 	})
 
-	Context("SubnetSelector", func() {
-		It("should not allow empty string keys or values", func() {
-			provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-			Expect(err).ToNot(HaveOccurred())
-			for key, value := range map[string]string{
-				"":    "value",
-				"key": "",
-			} {
-				provider.SubnetSelector = map[string]string{key: value}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-			}
-		})
-	})
-	Context("SecurityGroupSelector", func() {
-		It("should not allow with a custom launch template", func() {
-			provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-			Expect(err).ToNot(HaveOccurred())
-			provider.LaunchTemplateName = aws.String("my-lt")
-			provider.SecurityGroupSelector = map[string]string{"key": "value"}
-			ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-		})
-		It("should not allow empty string keys or values", func() {
-			provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-			Expect(err).ToNot(HaveOccurred())
-			for key, value := range map[string]string{
-				"":    "value",
-				"key": "",
-			} {
-				provider.SecurityGroupSelector = map[string]string{key: value}
-				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-			}
-		})
-	})
+	Context("Validate", func() {
 
-	Context("Labels", func() {
-		It("should not allow unrecognized labels with the aws label prefix", func() {
-			provisioner.Spec.Labels = map[string]string{v1alpha1.LabelDomain + "/" + randomdata.SillyName(): randomdata.SillyName()}
-			ExpectNotValid(ctx, provisioner)
-		})
-		It("should support well known labels", func() {
-			for _, label := range []string{
-				v1alpha1.LabelInstanceHypervisor,
-				v1alpha1.LabelInstanceFamily,
-				v1alpha1.LabelInstanceSize,
-				v1alpha1.LabelInstanceCPU,
-				v1alpha1.LabelInstanceMemory,
-				v1alpha1.LabelInstanceGPUName,
-				v1alpha1.LabelInstanceGPUManufacturer,
-				v1alpha1.LabelInstanceGPUCount,
-				v1alpha1.LabelInstanceGPUMemory,
-			} {
-				provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
-				Expect(provisioner.Validate(ctx)).To(Succeed())
-			}
-		})
-	})
-	Context("MetadataOptions", func() {
-		It("should not allow with a custom launch template", func() {
-			provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-			Expect(err).ToNot(HaveOccurred())
-			provider.LaunchTemplateName = aws.String("my-lt")
-			provider.MetadataOptions = &v1alpha1.MetadataOptions{}
-			provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-			ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-		})
-		It("should allow missing values", func() {
-			provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-			Expect(err).ToNot(HaveOccurred())
-			provider.MetadataOptions = &v1alpha1.MetadataOptions{}
-			provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+		It("should validate", func() {
 			Expect(provisioner.Validate(ctx)).To(Succeed())
 		})
-		Context("HTTPEndpoint", func() {
-			It("should allow enum values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				for i := range ec2.LaunchTemplateInstanceMetadataEndpointState_Values() {
-					value := ec2.LaunchTemplateInstanceMetadataEndpointState_Values()[i]
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{
-						HTTPEndpoint: &value,
-					}
-					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-					Expect(provisioner.Validate(ctx)).To(Succeed())
-				}
-			})
-			It("should not allow non-enum values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{
-					HTTPEndpoint: aws.String(randomdata.SillyName()),
-				}
-				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-			})
+		It("should succeed if provider undefined", func() {
+			provisioner.Spec.Provider = nil
+			Expect(provisioner.Validate(ctx)).To(Succeed())
 		})
-		Context("HTTPProtocolIpv6", func() {
-			It("should allow enum values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				for i := range ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values() {
-					value := ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values()[i]
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{
-						HTTPProtocolIPv6: &value,
-					}
-					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-					Expect(provisioner.Validate(ctx)).To(Succeed())
-				}
-			})
-			It("should not allow non-enum values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{
-					HTTPProtocolIPv6: aws.String(randomdata.SillyName()),
-				}
-				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-			})
-		})
-		Context("HTTPPutResponseHopLimit", func() {
-			It("should validate inside accepted range", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{
-					HTTPPutResponseHopLimit: aws.Int64(int64(randomdata.Number(1, 65))),
-				}
-				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-				Expect(provisioner.Validate(ctx)).To(Succeed())
-			})
-			It("should not validate outside accepted range", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{}
-				// We expect to be able to invalidate any hop limit between
-				// [math.MinInt64, 1). But, to avoid a panic here, we can't
-				// exceed math.MaxInt for the difference between bounds of
-				// the random number range. So we divide the range
-				// approximately in half and test on both halves.
-				provider.MetadataOptions.HTTPPutResponseHopLimit = aws.Int64(int64(randomdata.Number(math.MinInt64, math.MinInt64/2)))
-				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-				provider.MetadataOptions.HTTPPutResponseHopLimit = aws.Int64(int64(randomdata.Number(math.MinInt64/2, 1)))
-				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
 
-				provider.MetadataOptions.HTTPPutResponseHopLimit = aws.Int64(int64(randomdata.Number(65, math.MaxInt64)))
-				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
-			})
-		})
-		Context("HTTPTokens", func() {
-			It("should allow enum values", func() {
+		Context("SubnetSelector", func() {
+			It("should not allow empty string keys or values", func() {
 				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
-				for _, value := range ec2.LaunchTemplateHttpTokensState_Values() {
-					provider.MetadataOptions = &v1alpha1.MetadataOptions{
-						HTTPTokens: aws.String(value),
-					}
-					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
-					Expect(provisioner.Validate(ctx)).To(Succeed())
+				for key, value := range map[string]string{
+					"":    "value",
+					"key": "",
+				} {
+					provider.SubnetSelector = map[string]string{key: value}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				}
-			})
-			It("should not allow non-enum values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.MetadataOptions = &v1alpha1.MetadataOptions{
-					HTTPTokens: aws.String(randomdata.SillyName()),
-				}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
 			})
 		})
-		Context("BlockDeviceMappings", func() {
+		Context("SecurityGroupSelector", func() {
 			It("should not allow with a custom launch template", func() {
 				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
 				provider.LaunchTemplateName = aws.String("my-lt")
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					DeviceName: aws.String("/dev/xvda"),
-					EBS: &v1alpha1.BlockDevice{
-						VolumeSize: resource.NewScaledQuantity(1, resource.Giga),
-					},
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+				provider.SecurityGroupSelector = map[string]string{"key": "value"}
+				Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 			})
-			It("should validate minimal device mapping", func() {
+			It("should not allow empty string keys or values", func() {
 				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					DeviceName: aws.String("/dev/xvda"),
-					EBS: &v1alpha1.BlockDevice{
-						VolumeSize: resource.NewScaledQuantity(1, resource.Giga),
-					},
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+				for key, value := range map[string]string{
+					"":    "value",
+					"key": "",
+				} {
+					provider.SecurityGroupSelector = map[string]string{key: value}
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				}
 			})
-			It("should validate ebs device mapping with snapshotID only", func() {
+		})
+
+		Context("Labels", func() {
+			It("should not allow unrecognized labels with the aws label prefix", func() {
+				provisioner.Spec.Labels = map[string]string{v1alpha1.LabelDomain + "/" + randomdata.SillyName(): randomdata.SillyName()}
+				Expect(Validate(ctx, provisioner)).ToNot(Succeed())
+			})
+			It("should support well known labels", func() {
+				for _, label := range []string{
+					v1alpha1.LabelInstanceHypervisor,
+					v1alpha1.LabelInstanceFamily,
+					v1alpha1.LabelInstanceSize,
+					v1alpha1.LabelInstanceCPU,
+					v1alpha1.LabelInstanceMemory,
+					v1alpha1.LabelInstanceGPUName,
+					v1alpha1.LabelInstanceGPUManufacturer,
+					v1alpha1.LabelInstanceGPUCount,
+					v1alpha1.LabelInstanceGPUMemory,
+				} {
+					provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
+					Expect(provisioner.Validate(ctx)).To(Succeed())
+				}
+			})
+		})
+		Context("MetadataOptions", func() {
+			It("should not allow with a custom launch template", func() {
 				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					DeviceName: aws.String("/dev/xvda"),
-					EBS: &v1alpha1.BlockDevice{
-						SnapshotID: aws.String("snap-0123456789"),
-					},
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+				provider.LaunchTemplateName = aws.String("my-lt")
+				provider.MetadataOptions = &v1alpha1.MetadataOptions{}
+				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+				Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 			})
-			It("should not allow volume size below minimum", func() {
+			It("should allow missing values", func() {
 				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
 				Expect(err).ToNot(HaveOccurred())
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					DeviceName: aws.String("/dev/xvda"),
-					EBS: &v1alpha1.BlockDevice{
-						VolumeSize: resource.NewScaledQuantity(100, resource.Mega),
-					},
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+				provider.MetadataOptions = &v1alpha1.MetadataOptions{}
+				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+				Expect(provisioner.Validate(ctx)).To(Succeed())
 			})
-			It("should not allow volume size above max", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					DeviceName: aws.String("/dev/xvda"),
-					EBS: &v1alpha1.BlockDevice{
-						VolumeSize: resource.NewScaledQuantity(65, resource.Tera),
-					},
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+			Context("HTTPEndpoint", func() {
+				It("should allow enum values", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					for i := range ec2.LaunchTemplateInstanceMetadataEndpointState_Values() {
+						value := ec2.LaunchTemplateInstanceMetadataEndpointState_Values()[i]
+						provider.MetadataOptions = &v1alpha1.MetadataOptions{
+							HTTPEndpoint: &value,
+						}
+						provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+						Expect(provisioner.Validate(ctx)).To(Succeed())
+					}
+				})
+				It("should not allow non-enum values", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						HTTPEndpoint: aws.String(randomdata.SillyName()),
+					}
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
 			})
-			It("should not allow nil device name", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					EBS: &v1alpha1.BlockDevice{
-						VolumeSize: resource.NewScaledQuantity(65, resource.Tera),
-					},
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+			Context("HTTPProtocolIpv6", func() {
+				It("should allow enum values", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					for i := range ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values() {
+						value := ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values()[i]
+						provider.MetadataOptions = &v1alpha1.MetadataOptions{
+							HTTPProtocolIPv6: &value,
+						}
+						provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+						Expect(provisioner.Validate(ctx)).To(Succeed())
+					}
+				})
+				It("should not allow non-enum values", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						HTTPProtocolIPv6: aws.String(randomdata.SillyName()),
+					}
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
 			})
-			It("should not allow nil volume size", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					DeviceName: aws.String("/dev/xvda"),
-					EBS:        &v1alpha1.BlockDevice{},
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+			Context("HTTPPutResponseHopLimit", func() {
+				It("should validate inside accepted range", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						HTTPPutResponseHopLimit: aws.Int64(int64(randomdata.Number(1, 65))),
+					}
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(provisioner.Validate(ctx)).To(Succeed())
+				})
+				It("should not validate outside accepted range", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.MetadataOptions = &v1alpha1.MetadataOptions{}
+					// We expect to be able to invalidate any hop limit between
+					// [math.MinInt64, 1). But, to avoid a panic here, we can't
+					// exceed math.MaxInt for the difference between bounds of
+					// the random number range. So we divide the range
+					// approximately in half and test on both halves.
+					provider.MetadataOptions.HTTPPutResponseHopLimit = aws.Int64(int64(randomdata.Number(math.MinInt64, math.MinInt64/2)))
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+					provider.MetadataOptions.HTTPPutResponseHopLimit = aws.Int64(int64(randomdata.Number(math.MinInt64/2, 1)))
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+
+					provider.MetadataOptions.HTTPPutResponseHopLimit = aws.Int64(int64(randomdata.Number(65, math.MaxInt64)))
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
 			})
-			It("should not allow empty ebs block", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
-				Expect(err).ToNot(HaveOccurred())
-				provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
-					DeviceName: aws.String("/dev/xvda"),
-				}}
-				ExpectNotValid(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))
+			Context("HTTPTokens", func() {
+				It("should allow enum values", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					for _, value := range ec2.LaunchTemplateHttpTokensState_Values() {
+						provider.MetadataOptions = &v1alpha1.MetadataOptions{
+							HTTPTokens: aws.String(value),
+						}
+						provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+						Expect(provisioner.Validate(ctx)).To(Succeed())
+					}
+				})
+				It("should not allow non-enum values", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						HTTPTokens: aws.String(randomdata.SillyName()),
+					}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+			})
+			Context("BlockDeviceMappings", func() {
+				It("should not allow with a custom launch template", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.LaunchTemplateName = aws.String("my-lt")
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+						EBS: &v1alpha1.BlockDevice{
+							VolumeSize: resource.NewScaledQuantity(1, resource.Giga),
+						},
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+				It("should validate minimal device mapping", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+						EBS: &v1alpha1.BlockDevice{
+							VolumeSize: resource.NewScaledQuantity(1, resource.Giga),
+						},
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+				It("should validate ebs device mapping with snapshotID only", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+						EBS: &v1alpha1.BlockDevice{
+							SnapshotID: aws.String("snap-0123456789"),
+						},
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+				It("should not allow volume size below minimum", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+						EBS: &v1alpha1.BlockDevice{
+							VolumeSize: resource.NewScaledQuantity(100, resource.Mega),
+						},
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+				It("should not allow volume size above max", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+						EBS: &v1alpha1.BlockDevice{
+							VolumeSize: resource.NewScaledQuantity(65, resource.Tera),
+						},
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+				It("should not allow nil device name", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						EBS: &v1alpha1.BlockDevice{
+							VolumeSize: resource.NewScaledQuantity(65, resource.Tera),
+						},
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+				It("should not allow nil volume size", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+						EBS:        &v1alpha1.BlockDevice{},
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+				It("should not allow empty ebs block", func() {
+					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					Expect(err).ToNot(HaveOccurred())
+					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
+						DeviceName: aws.String("/dev/xvda"),
+					}}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
 			})
 		})
 	})
 })
 
-func ExpectNotValid(ctx context.Context, provisioner *v1alpha5.Provisioner) {
-	Expect(multierr.Combine(
+func SetDefaults(ctx context.Context, provisioner *v1alpha5.Provisioner) {
+	prov := apisv1alpha5.Provisioner(*provisioner)
+	prov.SetDefaults(ctx)
+	*provisioner = v1alpha5.Provisioner(prov)
+}
+
+func Validate(ctx context.Context, provisioner *v1alpha5.Provisioner) error {
+	return multierr.Combine(
 		lo.ToPtr(apisv1alpha5.Provisioner(*provisioner)).Validate(ctx),
 		provisioner.Validate(ctx),
-	)).ToNot(Succeed())
+	)
 }

--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -915,7 +915,10 @@ var _ = Describe("LaunchTemplates", func() {
 			Expect(string(userData)).To(ContainSubstring("--container-runtime dockerd"))
 		})
 		It("should specify --container-runtime docker when using Neuron GPUs", func() {
-			ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
+			ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{
+				Provider:     provider,
+				Requirements: []v1.NodeSelectorRequirement{{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists}},
+			}))
 			pod := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, coretest.UnschedulablePod(coretest.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: map[v1.ResourceName]resource.Quantity{
@@ -934,7 +937,10 @@ var _ = Describe("LaunchTemplates", func() {
 			Expect(string(userData)).To(ContainSubstring("--container-runtime docker"))
 		})
 		It("should specify --container-runtime containerd when using Nvidia GPUs", func() {
-			ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
+			ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{
+				Provider:     provider,
+				Requirements: []v1.NodeSelectorRequirement{{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists}},
+			}))
 			pod := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, coretest.UnschedulablePod(coretest.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: map[v1.ResourceName]resource.Quantity{
@@ -1285,13 +1291,13 @@ var _ = Describe("LaunchTemplates", func() {
 					{
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
-						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("t3.large")}},
+						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 					{
 						ImageId:      aws.String("ami-456"),
 						Architecture: aws.String("x86_64"),
-						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
+						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.xlarge")}},
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 				}})
@@ -1316,13 +1322,13 @@ var _ = Describe("LaunchTemplates", func() {
 					{
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
-						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("t3.large")}},
+						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 					{
 						ImageId:      aws.String("ami-456"),
 						Architecture: aws.String("x86_64"),
-						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.large")}},
+						Tags:         []*ec2.Tag{{Key: aws.String(v1.LabelInstanceTypeStable), Value: aws.String("m5.xlarge")}},
 						CreationDate: aws.String("2022-08-10T12:00:00Z"),
 					},
 				}})

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -182,7 +182,13 @@ var _ = BeforeEach(func() {
 		SecurityGroupSelector: map[string]string{"*": "*"},
 	}
 
-	provisioner = test.Provisioner(coretest.ProvisionerOptions{Provider: provider})
+	provisioner = test.Provisioner(coretest.ProvisionerOptions{
+		Provider: provider,
+		Requirements: []v1.NodeSelectorRequirement{{
+			Key:      v1alpha1.LabelInstanceCategory,
+			Operator: v1.NodeSelectorOpExists,
+		}},
+	})
 
 	fakeEC2API.Reset()
 	fakePricingAPI.Reset()

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -39,7 +39,10 @@ var _ = Describe("Scheduling", func() {
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
 		}})
-		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef:  &v1alpha5.ProviderRef{Name: provider.Name},
+			Requirements: []v1.NodeSelectorRequirement{{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists}},
+		})
 		nodeSelector := map[string]string{
 			// Well Known
 			v1alpha5.ProvisionerNameLabelKey: provisioner.Name,

--- a/test/suites/integration/webhook_test.go
+++ b/test/suites/integration/webhook_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Webhooks", func() {
 				env.ExpectCreated(provisioner)
 				env.ExpectFound(provisioner)
 
-				Expect(len(provisioner.Spec.Requirements)).To(Equal(2))
+				Expect(len(provisioner.Spec.Requirements)).To(Equal(4))
 				Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 					Key:      v1alpha5.LabelCapacityType,
 					Operator: v1.NodeSelectorOpIn,
@@ -47,6 +47,16 @@ var _ = Describe("Webhooks", func() {
 					Key:      v1.LabelArchStable,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{v1alpha5.ArchitectureAmd64},
+				}))
+				Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
+					Key:      v1alpha1.LabelInstanceCategory,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"c", "m", "r"},
+				}))
+				Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
+					Key:      v1alpha1.LabelInstanceGeneration,
+					Operator: v1.NodeSelectorOpGt,
+					Values:   []string{"2"},
 				}))
 			})
 		})

--- a/website/content/en/preview/upgrade-guide/_index.md
+++ b/website/content/en/preview/upgrade-guide/_index.md
@@ -98,7 +98,8 @@ By adopting this practice we allow our users who are early adopters to test out 
 # Released Upgrade Notes
 
 ## Upgrading to v0.19.0+
-* v0.19.0 combines the karpenter webhook and controller containers into a single binary, which requires changes to the helm chart. If your Karpenter installation (helm or otherwise) currently customizes the karpenter webhook, your deployment tooling may require minor changes.
+* The karpenter webhook and controller containers are combined into a single binary, which requires changes to the helm chart. If your Karpenter installation (helm or otherwise) currently customizes the karpenter webhook, your deployment tooling may require minor changes.
+* Instance category defaults are now explicitly persisted in the Provisioner, rather than handled implicitly in memory. By default, Provisioners will limit instance category to c,m,r. If any instance type constraints are applied, it will override this default. If you have created Provisioners in the past with unconstrained instance type, family, or category, Karpenter will now more flexibly use instance types than before. If you would like to apply these constraints, they must be included in the Provisioner CRD.
 
 ## Upgrading to v0.18.0+
 * v0.18.0 removes the `karpenter_consolidation_nodes_created` and `karpenter_consolidation_nodes_terminated` prometheus metrics in favor of the more generic `karpenter_nodes_created` and `karpenter_nodes_terminated` metrics. You can still see nodes created and terminated by consolidation by checking the `reason` label on the metrics. Check out all the metrics published by Karpenter [here](../tasks/metrics/).


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
This change will force a minor version bump as specified in https://karpenter.sh/docs/upgrade-guide/

Instance category defaults are now explicitly persisted in the Provisioner, rather than handled implicitly in memory. By default, Provisioners will limit instance category to c,m,r. If any instance type constraints are applied, it will override this default. If you have created Provisioners in the past with unconstrained instance type, family, or category, Karpenter will now more flexibly use instance types than before. If you would like to apply these constraints, they must be included in the Provisioner CRD.

This also helps to decouple instance type from provisioner, enabling upcoming work.

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Instance category defaults are now explicitly persisted in the Provisioner, rather than handled implicitly in memory. By default, Provisioners will limit instance category to c,m,r. If any instance type constraints are applied, it will override this default. If you have created Provisioners in the past with unconstrained instance type, family, or category, Karpenter will now more flexibly use instance types than before. If you would like to apply these constraints, they must be included in the Provisioner CRD.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
