### PR TITLE
test: Fix flaky expiration test

### DIFF
--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -229,13 +229,13 @@ func (env *Environment) ForceCleanup(opts ...Option) {
 
 	// Delete all the nodes if they weren't deleted by the provisioner propagation
 	Expect(env.Client.DeleteAllOf(env, &v1.Node{},
-		client.HasLabels([]string{test.DiscoveryLabel}),
+		client.HasLabels([]string{v1alpha5.ProvisionerNameLabelKey}),
 		client.PropagationPolicy(metav1.DeletePropagationForeground),
 	)).To(Succeed())
 	Eventually(func(g Gomega) {
 		stored := &v1.NodeList{}
 		g.Expect(env.Client.List(env, stored,
-			client.HasLabels([]string{test.DiscoveryLabel}))).To(Succeed())
+			client.HasLabels([]string{v1alpha5.ProvisionerNameLabelKey}))).To(Succeed())
 		g.Expect(len(stored.Items)).To(BeZero())
 	}).Should(Succeed())
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Expiration tests are flaking because a previous test is provisioning a node in the middle of two tests. This causes an extra node to exist on the cluster when the test starts

**How was this change tested?**

* `FOCUS=Expiration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
