### PR TITLE
fix: kube-dns: allow setting ip for clusters without kube-dns

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -166,6 +167,11 @@ func getCABundle(ctx context.Context, restConfig *rest.Config) (*string, error) 
 }
 
 func kubeDNSIP(ctx context.Context, kubernetesInterface kubernetes.Interface) (net.IP, error) {
+	envIp := os.Getenv("KARPENTER_KUBERNETES_DNS_IP")
+	if envIp != "" {
+		return net.ParseIP(envIp), nil
+	}
+
 	if kubernetesInterface == nil {
 		return nil, fmt.Errorf("no K8s client provided")
 	}


### PR DESCRIPTION
Fixes https://github.com/aws/karpenter/issues/2787

**How was this change tested?**

* deployed to cluster with hardcoded coredns ip

**Does this change impact docs?**
- [X] No

**Release Note**

```release-note
- allow setting dns ip via KARPENTER_KUBERNETES_DNS_IP for clusters without kube-dns
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
