### PR TITLE
fix: do not fail when discovering kube-dns cluster ip

### DIFF
--- a/pkg/cloudprovider/amifamily/al2.go
+++ b/pkg/cloudprovider/amifamily/al2.go
@@ -80,7 +80,7 @@ func (a AL2) containerRuntime(instanceTypes []cloudprovider.InstanceType) string
 }
 
 func (a AL2) defaultIPv6DNS(kubeletConfig *v1alpha5.KubeletConfiguration) *v1alpha5.KubeletConfiguration {
-	if a.KubeDNSIP.To4() != nil {
+	if a.KubeDNSIP == nil || a.KubeDNSIP.To4() != nil {
 		return kubeletConfig
 	}
 	if kubeletConfig != nil && len(kubeletConfig.ClusterDNS) != 0 {

--- a/pkg/cloudprovider/amifamily/resolver.go
+++ b/pkg/cloudprovider/amifamily/resolver.go
@@ -172,7 +172,7 @@ func GetAMIFamily(amiFamily *string, options *Options) AMIFamily {
 func (o Options) DefaultMetadataOptions() *v1alpha1.MetadataOptions {
 	return &v1alpha1.MetadataOptions{
 		HTTPEndpoint:            aws.String(ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled),
-		HTTPProtocolIPv6:        aws.String(lo.Ternary(o.KubeDNSIP.To4() == nil, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Disabled)),
+		HTTPProtocolIPv6:        aws.String(lo.Ternary(o.KubeDNSIP != nil && o.KubeDNSIP.To4() == nil, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Disabled)),
 		HTTPPutResponseHopLimit: aws.Int64(2),
 		HTTPTokens:              aws.String(ec2.LaunchTemplateHttpTokensStateRequired),
 	}

--- a/pkg/cloudprovider/amifamily/resolver.go
+++ b/pkg/cloudprovider/amifamily/resolver.go
@@ -172,7 +172,7 @@ func GetAMIFamily(amiFamily *string, options *Options) AMIFamily {
 func (o Options) DefaultMetadataOptions() *v1alpha1.MetadataOptions {
 	return &v1alpha1.MetadataOptions{
 		HTTPEndpoint:            aws.String(ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled),
-		HTTPProtocolIPv6:        aws.String(lo.Ternary(o.KubeDNSIP != nil && o.KubeDNSIP.To4() == nil, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Disabled)),
+		HTTPProtocolIPv6:        aws.String(lo.Ternary(o.KubeDNSIP == nil || o.KubeDNSIP.To4() != nil, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Disabled, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled)),
 		HTTPPutResponseHopLimit: aws.Int64(2),
 		HTTPTokens:              aws.String(ec2.LaunchTemplateHttpTokensStateRequired),
 	}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -71,9 +71,10 @@ type CloudProvider struct {
 func New(ctx awscontext.Context) *CloudProvider {
 	kubeDNSIP, err := kubeDNSIP(ctx, ctx.KubernetesInterface)
 	if err != nil {
-		logging.FromContext(ctx).Fatalf("Unable to detect the IP of the kube-dns service, %s", err)
+		logging.FromContext(ctx).Debugf("Unable to detect the IP of the kube-dns service, %s", err)
+	} else {
+		logging.FromContext(ctx).Debugf("Discovered DNS IP %s", kubeDNSIP)
 	}
-	logging.FromContext(ctx).Debugf("Discovered DNS IP %s", kubeDNSIP)
 	ec2api := ec2.New(ctx.Session)
 	if err := checkEC2Connectivity(ctx, ec2api); err != nil {
 		logging.FromContext(ctx).Fatalf("Checking EC2 API connectivity, %s", err)
@@ -174,6 +175,9 @@ func kubeDNSIP(ctx context.Context, kubernetesInterface kubernetes.Interface) (n
 		return nil, err
 	}
 	kubeDNSIP := net.ParseIP(dnsService.Spec.ClusterIP)
+	if kubeDNSIP == nil {
+		return nil, fmt.Errorf("parsing cluster IP")
+	}
 	return kubeDNSIP, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

https://github.com/aws/karpenter/issues/2787

**Description**
 - Do not fail on startup if kube-dns cannot be discovered. Some users have a custom dns setup and are not using kube-dns. Karpenter should still function if that is the case. 

**How was this change tested?**

* Removed rbac permissions and Karpenter started up successfully whereas before it would go into a CrashLoopBackoff.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
