### PR TITLE
fix: Fix metrics docgen with manual subsystem

### DIFF
--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -250,7 +250,11 @@ func getIdentMapping(identName string) (string, error) {
 	identMapping := map[string]string{
 		"metrics.Namespace": metrics.Namespace,
 		"Namespace":         metrics.Namespace,
-		"nodeSubsystem":     "nodes",
+
+		"nodeSubsystem":           "nodes",
+		"interruptionSubsystem":   "interruption",
+		"nodeTemplateSubsystem":   "nodetemplate",
+		"deprovisioningSubsystem": "deprovisioning",
 	}
 	if v, ok := identMapping[identName]; ok {
 		return v, nil

--- a/pkg/controllers/interruption/metrics.go
+++ b/pkg/controllers/interruption/metrics.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	subsystem              = "aws_interruption_controller"
+	interruptionSubsystem  = "interruption"
 	messageTypeLabel       = "message_type"
 	actionTypeLabel        = "action_type"
 	terminationReasonLabel = "interruption"
@@ -32,7 +32,7 @@ var (
 	receivedMessages = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
+			Subsystem: interruptionSubsystem,
 			Name:      "received_messages",
 			Help:      "Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.",
 		},
@@ -41,7 +41,7 @@ var (
 	deletedMessages = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
+			Subsystem: interruptionSubsystem,
 			Name:      "deleted_messages",
 			Help:      "Count of messages deleted from the SQS queue.",
 		},
@@ -49,7 +49,7 @@ var (
 	messageLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
+			Subsystem: interruptionSubsystem,
 			Name:      "message_latency_time_seconds",
 			Help:      "Length of time between message creation in queue and an action taken on the message by the controller.",
 			Buckets:   metrics.DurationBuckets(),
@@ -58,7 +58,7 @@ var (
 	actionsPerformed = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
+			Subsystem: interruptionSubsystem,
 			Name:      "actions_performed",
 			Help:      "Number of notification actions performed. Labeled by action",
 		},

--- a/pkg/controllers/nodetemplate/metrics.go
+++ b/pkg/controllers/nodetemplate/metrics.go
@@ -21,14 +21,14 @@ import (
 	"github.com/aws/karpenter-core/pkg/metrics"
 )
 
-const subSystem = "nodetemplate_infrastructure"
+const interruptionSubsystem = "interruption"
 
 var (
 	infrastructureCreateDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: subSystem,
-			Name:      "create_time_seconds",
+			Subsystem: interruptionSubsystem,
+			Name:      "infrastructure_create_time_seconds",
 			Help:      "Length of time to create infrastructure.",
 			Buckets:   metrics.DurationBuckets(),
 		},
@@ -36,8 +36,8 @@ var (
 	infrastructureDeleteDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: subSystem,
-			Name:      "delete_time_seconds",
+			Subsystem: interruptionSubsystem,
+			Name:      "infrastructure_delete_time_seconds",
 			Help:      "Length of time to delete infrastructure.",
 			Buckets:   metrics.DurationBuckets(),
 		},

--- a/website/content/en/preview/tasks/metrics.md
+++ b/website/content/en/preview/tasks/metrics.md
@@ -8,16 +8,36 @@ description: >
 ---
 <!-- this document is generated from hack/docs/metrics_gen_docs.go -->
 Karpenter makes several metrics available in Prometheus format to allow monitoring cluster provisioning status. These metrics are available by default at `karpenter.karpenter.svc.cluster.local:8080/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../configuration)
-## Consolidation Metrics
+## Deprovisioning Metrics
 
-### `karpenter_consolidation_actions_performed`
-Number of consolidation actions performed. Labeled by action.
+### `karpenter_deprovisioning_actions_performed`
+Number of deprovisioning actions performed. Labeled by action.
 
-### `karpenter_consolidation_evaluation_duration_seconds`
-Duration of the consolidation evaluation process in seconds.
+### `karpenter_deprovisioning_evaluation_duration_seconds`
+Duration of the deprovisioning evaluation process in seconds.
 
-### `karpenter_consolidation_replacement_node_initialized_seconds`
+### `karpenter_deprovisioning_replacement_node_initialized_seconds`
 Amount of time required for a replacement node to become initialized.
+
+## Interruption Metrics
+
+### `karpenter_interruption_actions_performed`
+Number of notification actions performed. Labeled by action
+
+### `karpenter_interruption_deleted_messages`
+Count of messages deleted from the SQS queue.
+
+### `karpenter_interruption_infrastructure_create_time_seconds`
+Length of time to create infrastructure.
+
+### `karpenter_interruption_infrastructure_delete_time_seconds`
+Length of time to delete infrastructure.
+
+### `karpenter_interruption_message_latency_time_seconds`
+Length of time between message creation in queue and an action taken on the message by the controller.
+
+### `karpenter_interruption_received_messages`
+Count of messages received from the SQS queue. Broken down by message type and whether the message was actionable.
 
 ## Provisioner Metrics
 
@@ -48,10 +68,10 @@ Number of nodes terminated in total by Karpenter. Labeled by reason the node was
 The time taken between a node's deletion request and the removal of its finalizer
 
 ### `karpenter_nodes_total_daemon_limits`
-Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
+Node total daemon limits are the resources specified by DaemonSet pod limits.
 
 ### `karpenter_nodes_total_daemon_requests`
-Node total daemon limits are the resources specified by DaemonSet pod limits.
+Node total daemon requests are the resource requested by DaemonSet pods bound to nodes.
 
 ### `karpenter_nodes_total_pod_limits`
 Node total pod limits are the resources specified by non-DaemonSet pod limits.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Fixes metrics docgen by manually mapping identifiers

**How was this change tested?**

* `make docgen`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
