### PR TITLE
test: Add policy-binding for interruption E2E

### DIFF
--- a/pkg/controllers/nodetemplate/infrastructure.go
+++ b/pkg/controllers/nodetemplate/infrastructure.go
@@ -122,7 +122,7 @@ func (i *InfrastructureReconciler) ensureQueue(ctx context.Context) error {
 	if !queueExists {
 		logging.FromContext(ctx).Debugf("Queue not found, creating the SQS interruption queue")
 		if err := i.sqsProvider.CreateQueue(ctx); err != nil {
-			return fmt.Errorf("creating the SQSS interruption queue with policy, %w", err)
+			return fmt.Errorf("creating the SQS interruption queue with policy, %w", err)
 		}
 	}
 	// Always attempt to set the queue attributes, even after creation to help set the queue policy

--- a/test/suites/common/setup.yaml
+++ b/test/suites/common/setup.yaml
@@ -104,6 +104,7 @@ spec:
         --cluster "$(params.cluster-name)" --name karpenter --namespace karpenter \
         --role-name "$(params.cluster-name)-karpenter" \
         --attach-policy-arn "arn:aws:iam::$(cat $(results.account-id.path)):policy/KarpenterControllerPolicy-$(params.cluster-name)" \
+        --attach-policy-arn "arn:aws:iam::$(cat $(results.account-id.path)):policy/KarpenterEventPolicy-$(params.cluster-name)" \
         --role-only \
         --approve
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Adds policy binding for new `KarpenterEventPolicy-${CLUSTER_NAME}` policy to service account

**How was this change tested?**

* Tested in Tekton pipelines

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
