### PR TITLE
fix: Fix cloudformation and sqs queue backoff

### DIFF
--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -148,7 +149,8 @@ var _ = Describe("AWSNodeTemplate", func() {
 				sqsapi.GetQueueURLBehavior.Error.Set(awsErrWithCode(sqs.ErrCodeQueueDoesNotExist), awsfake.MaxCalls(0)) // This mocks the queue not existing
 				sqsapi.CreateQueueBehavior.Error.Set(awsErrWithCode(sqs.ErrCodeQueueDeletedRecently), awsfake.MaxCalls(0))
 
-				ExpectReconcileFailed(ctx, controller, client.ObjectKeyFromObject(provider))
+				result := ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(provider))
+				Expect(result.RequeueAfter).To(Equal(time.Minute))
 				Expect(sqsapi.CreateQueueBehavior.FailedCalls()).To(Equal(1))
 			})
 		})

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -50,6 +50,9 @@ var (
 		AccessDeniedCode,
 		AccessDeniedExceptionCode,
 	)
+	recentlyDeletedErrorCodes = sets.NewString(
+		sqs.ErrCodeQueueDeletedRecently,
+	)
 )
 
 type InstanceTerminatedError struct {
@@ -83,7 +86,7 @@ func IsNotFound(err error) bool {
 }
 
 // IsAccessDenied returns true if the error is an AWS error (even if it's
-// wrapped) and is a known to mean "access denied" (as opposed to a more
+// wrapped) and is known to mean "access denied" (as opposed to a more
 // serious or unexpected error)
 func IsAccessDenied(err error) bool {
 	if err == nil {
@@ -92,6 +95,19 @@ func IsAccessDenied(err error) bool {
 	var awsError awserr.Error
 	if errors.As(err, &awsError) {
 		return accessDeniedErrorCodes.Has(awsError.Code())
+	}
+	return false
+}
+
+// IsRecentlyDeleted returns true if the error is an AWS error (even if it's
+// wrapped) and is known to mean "recently deleted"
+func IsRecentlyDeleted(err error) bool {
+	if err == nil {
+		return false
+	}
+	var awsError awserr.Error
+	if errors.As(err, &awsError) {
+		return recentlyDeletedErrorCodes.Has(awsError.Code())
 	}
 	return false
 }

--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -107,7 +107,8 @@ var _ = Describe("Interruption", Label("AWS"), func() {
 		instanceID := parseProviderID(node.Spec.ProviderID)
 
 		By("Interrupting the spot instance")
-		_, events, _ := env.InterruptionAPI.Interrupt(env.Context, []string{instanceID}, 0, true)
+		_, events, err := env.InterruptionAPI.Interrupt(env.Context, []string{instanceID}, 0, true)
+		Expect(err).ToNot(HaveOccurred())
 
 		// Monitor the events channel
 		done := make(chan struct{})

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
@@ -94,7 +94,11 @@ Resources:
               - events:DeleteRule
               - events:RemoveTargets
               - events:ListTagsForResource
+            Condition:
+              StringEquals:
+                aws:ResourceTag/karpenter.sh/discovery: !Sub "${ClusterName}"
           - Effect: Allow
             Resource: "*"
             Action:
+              # Read Operations
               - events:ListRules


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Fixes cloudformation template to use tags
- Fixes backoff when queue was recently deleted

**How was this change tested?**

* 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
