### PR TITLE
test: Fix upgrade E2E test for upgrade CRDs

### DIFF
--- a/test/suites/common/upgrade-crds.yaml
+++ b/test/suites/common/upgrade-crds.yaml
@@ -18,5 +18,5 @@ spec:
     image: public.ecr.aws/karpenter-testing/tools:latest
     script: |
       aws eks update-kubeconfig --name $(params.cluster-name)
-      kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/$(params.git-ref)/charts/karpenter/crds/karpenter.sh_provisioners.yaml
-      kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/$(params.git-ref)/charts/karpenter/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+      kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/$(params.git-ref)/pkg/apis/crds/karpenter.sh_provisioners.yaml
+      kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/$(params.git-ref)/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Upgrade CRDs points to the wrong location in E2E tests with #2792 
- Settings injection can be simplified in `main.go`

**How was this change tested?**

* `make battletest`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
