### PR TITLE
feat: increase instance type flexibility on each fleet call

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -51,7 +51,7 @@ import (
 
 const (
 	// MaxInstanceTypes defines the number of instance type options to pass to CreateFleet
-	MaxInstanceTypes = 20
+	MaxInstanceTypes = 60
 )
 
 func init() {

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -112,10 +112,10 @@ Yes, Karpenter supports provisioning metal instance types when a Provisioner's `
 
 Karpenter batches pending pods and then binpacks them based on CPU, memory, and GPUs required, taking into account node overhead, VPC CNI resources required, and daemon sets that will be packed when bringing up a new node.
 By default Karpenter uses all available instance types, but it can be constrained in the provisioner spec with the [instance-type](https://kubernetes.io/docs/reference/labels-annotations-taints/#nodekubernetesioinstance-type) well-known label in the requirements section.
-After the pods are binpacked on the most efficient instance type (i.e. the smallest instance type that can fit the pod batch), Karpenter takes 19 other instance types that are larger than the most efficient packing, and passes all 20 instance type options to an API called Amazon EC2 Fleet.
+After the pods are binpacked on the most efficient instance type (i.e. the smallest instance type that can fit the pod batch), Karpenter takes 59 other instance types that are larger than the most efficient packing, and passes all 60 instance type options to an API called Amazon EC2 Fleet.
 The EC2 fleet API attempts to provision the instance type based on a user-defined allocation strategy.
 If you are using the on-demand capacity type, then Karpenter uses the `lowest-price` allocation strategy.
-So fleet will provision the lowest price instance type it can get from the 20 Karpenter passed it.
+So fleet will provision the lowest price instance type it can get from the 60 Karpenter passed it.
 If the instance type is unavailable for some reason, then fleet will move on to the next cheapest instance type.
 If you are using the spot capacity type, Karpenter uses the capacity-optimized-prioritized allocation strategy which tells fleet to find the instance type that EC2 has the most capacity of which will decrease the probability of a spot interruption happening in the near term.
 See [Choose the appropriate allocation strategy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html#ec2-fleet-allocation-use-cases) for information on fleet optimization.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->
https://github.com/aws/karpenter/issues/2721

**Description**
 - Increase the flexibility of instance type options passed to each EC2 Fleet call. 

**How was this change tested?**
* scaled out a flexible pod and checked cloudtrail for the fleet request. It successfully added 180 instance types (60*3 AZs)

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
