### PR TITLE
test: Chaos testing for Runaway Scale-up Issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ apply: build ## Deploy the controller from the current state of your git reposit
 		--set controller.image=$(CONTROLLER_IMG)
 
 install:  ## Deploy the latest released version into your ~/.kube/config cluster
-	@echo Upgrading to $(shell grep version charts/karpenter/Chart.yaml)
-	helm upgrade --install karpenter charts/karpenter --namespace ${SYSTEM_NAMESPACE} \
+	@echo Upgrading to ${KARPENTER_VERSION}
+	helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace ${SYSTEM_NAMESPACE} \
 		$(HELM_OPTS)
 
 delete: ## Delete the controller from your ~/.kube/config cluster

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -37,7 +37,7 @@ data:
   pipelines-trigger.sh: |+
     #!/usr/bin/env bash
     set -euo pipefail
-    for suite in "Integration" "Consolidation" "Utilization" "Interruption"; do
+    for suite in "Integration" "Consolidation" "Utilization" "Interruption" "Chaos"; do
        cat <<EOF | kubectl create -f -
      apiVersion: tekton.dev/v1beta1
      kind: PipelineRun

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -45,6 +45,7 @@ type Environment struct {
 	context.Context
 
 	Client            client.Client
+	Config            *rest.Config
 	KubeClient        kubernetes.Interface
 	Monitor           *Monitor
 	SettingsStore     settingsstore.Store
@@ -69,6 +70,7 @@ func NewEnvironment(t *testing.T) *Environment {
 	gomega.SetDefaultEventuallyPollingInterval(1 * time.Second)
 	return &Environment{
 		Context:       ctx,
+		Config:        config,
 		Client:        client,
 		KubeClient:    kubernetes.NewForConfigOrDie(config),
 		SettingsStore: settingsStore,

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -192,8 +192,8 @@ func (env *Environment) startPodMonitor(stop <-chan struct{}) {
 func (env *Environment) startNodeMonitor(stop <-chan struct{}) {
 	factory := informers.NewSharedInformerFactoryWithOptions(env.KubeClient, time.Second*30,
 		informers.WithTweakListOptions(func(l *metav1.ListOptions) { l.LabelSelector = v1alpha5.ProvisionerNameLabelKey }))
-	podInformer := factory.Core().V1().Nodes().Informer()
-	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nodeInformer := factory.Core().V1().Nodes().Informer()
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node := obj.(*v1.Node)
 			if _, ok := node.Labels[test.DiscoveryLabel]; ok {

--- a/test/suites/chaos/suite_test.go
+++ b/test/suites/chaos/suite_test.go
@@ -1,25 +1,60 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package chaos
 
 import (
+	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	environmentaws "github.com/aws/karpenter/test/pkg/environment/aws"
+	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/test"
+	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
+	"github.com/aws/karpenter/pkg/apis/config/settings"
+	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	awstest "github.com/aws/karpenter/pkg/test"
+	"github.com/aws/karpenter/test/pkg/environment/common"
 )
 
-var env *environmentaws.Environment
+var env *common.Environment
 
-func TestConsolidation(t *testing.T) {
+func TestChaos(t *testing.T) {
 	RegisterFailHandler(Fail)
 	BeforeSuite(func() {
-		env = environmentaws.NewEnvironment(t)
+		env = common.NewEnvironment(t)
 	})
 	AfterSuite(func() {
 		env.Stop()
 	})
-	RunSpecs(t, "Consolidation")
+	RunSpecs(t, "Chaos")
 }
 
 var _ = BeforeEach(func() { env.BeforeEach() })
@@ -28,4 +63,179 @@ var _ = AfterEach(func() { env.ForceCleanup() })
 var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("Chaos", func() {
+	Describe("Runaway Scale-Up", func() {
+		It("should not produce a runaway scale-up when consolidation is enabled", Label(common.NoWatch), Label(common.NoEvents), func() {
+			ctx, cancel := context.WithCancel(env.Context)
+			defer cancel()
+
+			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{v1alpha5.DiscoveryTagKey: settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{v1alpha5.DiscoveryTagKey: settings.FromContext(env.Context).ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha5.LabelCapacityType,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{v1alpha5.CapacityTypeSpot},
+					},
+				},
+				Consolidation: &v1alpha5.Consolidation{
+					Enabled: lo.ToPtr(true),
+				},
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+			})
+			numPods := 1
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "my-app"},
+					},
+					TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+				},
+			})
+			// Start a controller that adds taints to nodes after creation
+			Expect(startTaintAdder(ctx, env.Config)).To(Succeed())
+			startNodeCountMonitor(ctx, env.Client)
+
+			// Create a deployment with a single pod
+			env.ExpectCreated(provider, provisioner, dep)
+
+			// Expect that we never get over a high number of nodes
+			Consistently(func(g Gomega) {
+				list := &v1.NodeList{}
+				g.Expect(env.Client.List(env.Context, list, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+				g.Expect(len(list.Items)).To(BeNumerically("<", 35))
+			}, time.Minute*5).Should(Succeed())
+		})
+		It("should not produce a runaway scale-up when ttlSecondsAfterEmpty is enabled", Label(common.NoWatch), Label(common.NoEvents), func() {
+			ctx, cancel := context.WithCancel(env.Context)
+			defer cancel()
+
+			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{v1alpha5.DiscoveryTagKey: settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{v1alpha5.DiscoveryTagKey: settings.FromContext(env.Context).ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha5.LabelCapacityType,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{v1alpha5.CapacityTypeSpot},
+					},
+				},
+				TTLSecondsAfterEmpty: lo.ToPtr[int64](30),
+				ProviderRef:          &v1alpha5.ProviderRef{Name: provider.Name},
+			})
+			numPods := 1
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "my-app"},
+					},
+					TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
+				},
+			})
+			// Start a controller that adds taints to nodes after creation
+			Expect(startTaintAdder(ctx, env.Config)).To(Succeed())
+			startNodeCountMonitor(ctx, env.Client)
+
+			// Create a deployment with a single pod
+			env.ExpectCreated(provider, provisioner, dep)
+
+			// Expect that we never get over a high number of nodes
+			Consistently(func(g Gomega) {
+				list := &v1.NodeList{}
+				g.Expect(env.Client.List(env.Context, list, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+				g.Expect(len(list.Items)).To(BeNumerically("<", 35))
+			}, time.Minute*5).Should(Succeed())
+		})
+	})
 })
+
+type taintAdder struct {
+	kubeClient client.Client
+}
+
+func (t *taintAdder) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	node := &v1.Node{}
+	if err := t.kubeClient.Get(ctx, req.NamespacedName, node); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	mergeFrom := client.MergeFrom(node.DeepCopy())
+	taint := v1.Taint{
+		Key:    "test",
+		Value:  "true",
+		Effect: v1.TaintEffectNoExecute,
+	}
+	if !lo.Contains(node.Spec.Taints, taint) {
+		node.Spec.Taints = append(node.Spec.Taints, taint)
+		if err := t.kubeClient.Patch(ctx, node, mergeFrom); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (t *taintAdder) Builder(mgr manager.Manager) *controllerruntime.Builder {
+	return controllerruntime.NewControllerManagedBy(mgr).
+		For(&v1.Node{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			node := obj.(*v1.Node)
+			if _, ok := node.Labels[test.DiscoveryLabel]; !ok {
+				return false
+			}
+			return true
+		}))
+}
+
+func startTaintAdder(ctx context.Context, config *rest.Config) error {
+	mgr, err := controllerruntime.NewManager(config, controllerruntime.Options{})
+	if err != nil {
+		return err
+	}
+	adder := &taintAdder{kubeClient: mgr.GetClient()}
+	if err = adder.Builder(mgr).Complete(adder); err != nil {
+		return err
+	}
+	go func() {
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+	return nil
+}
+
+func startNodeCountMonitor(ctx context.Context, kubeClient client.Client) {
+	createdNodes := atomic.Int64{}
+	deletedNodes := atomic.Int64{}
+
+	factory := informers.NewSharedInformerFactoryWithOptions(env.KubeClient, time.Second*30,
+		informers.WithTweakListOptions(func(l *metav1.ListOptions) { l.LabelSelector = v1alpha5.ProvisionerNameLabelKey }))
+	nodeInformer := factory.Core().V1().Nodes().Informer()
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(_ interface{}) {
+			createdNodes.Add(1)
+		},
+		DeleteFunc: func(_ interface{}) {
+			deletedNodes.Add(1)
+		},
+	})
+	factory.Start(ctx.Done())
+	go func() {
+		for {
+			list := &v1.NodeList{}
+			if err := kubeClient.List(ctx, list, client.HasLabels{test.DiscoveryLabel}); err == nil {
+				readyCount := lo.CountBy(list.Items, func(n v1.Node) bool {
+					return nodeutils.GetCondition(&n, v1.NodeReady).Status == v1.ConditionTrue
+				})
+				fmt.Printf("[NODE COUNT] CURRENT: %d | READY: %d | CREATED: %d | DELETED: %d\n", len(list.Items), readyCount, createdNodes.Load(), deletedNodes.Load())
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second * 5):
+			}
+		}
+	}()
+}

--- a/test/suites/chaos/suite_test.go
+++ b/test/suites/chaos/suite_test.go
@@ -1,0 +1,31 @@
+package chaos
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	environmentaws "github.com/aws/karpenter/test/pkg/environment/aws"
+)
+
+var env *environmentaws.Environment
+
+func TestConsolidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = environmentaws.NewEnvironment(t)
+	})
+	AfterSuite(func() {
+		env.Stop()
+	})
+	RunSpecs(t, "Consolidation")
+}
+
+var _ = BeforeEach(func() { env.BeforeEach() })
+var _ = AfterEach(func() { env.Cleanup() })
+var _ = AfterEach(func() { env.ForceCleanup() })
+var _ = AfterEach(func() { env.AfterEach() })
+
+var _ = Describe("Chaos", func() {
+})

--- a/test/suites/common/setup.yaml
+++ b/test/suites/common/setup.yaml
@@ -119,6 +119,5 @@ spec:
         --set settings.aws.clusterName=$(params.cluster-name) \
         --set settings.aws.clusterEndpoint=$(cat /root/.kube/config | grep server | awk '{print $2}') \
         --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-$(params.cluster-name) \
-        --set settings.batchIdleDuration=10s \
         --set settings.aws.enableInterruptionHandling=true \
         --wait

--- a/test/suites/upgrade/pre-upgrade-setup.yaml
+++ b/test/suites/upgrade/pre-upgrade-setup.yaml
@@ -122,6 +122,5 @@ spec:
           --set clusterName=$(params.cluster-name) \
           --set clusterEndpoint=$(cat /root/.kube/config | grep server | awk '{print $2}') \
           --set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-$(params.cluster-name) \
-          --set controller.batchIdleDuration=10s \
           --set controller.enableInterruptionHandling=true \
           --wait


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Creates chaos tests that validate that we stay under some node count while constantly tainting a node after creation

Relates to #2821 

**How was this change tested?**

* `FOCUS=Chaos make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
