### PR TITLE
docs: Fix metrics titling from gen code

### DIFF
--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -27,6 +27,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/samber/lo"
+
 	"github.com/aws/karpenter-core/pkg/metrics"
 )
 
@@ -78,7 +80,10 @@ description: >
 	previousSubsystem := ""
 	for _, metric := range allMetrics {
 		if metric.subsystem != previousSubsystem {
-			fmt.Fprintf(f, "## %s%s Metrics\n", strings.ToTitle(metric.subsystem[0:1]), metric.subsystem[1:])
+			subsystemTitle := strings.Join(lo.Map(strings.Split(metric.subsystem, "_"), func(s string, _ int) string {
+				return fmt.Sprintf("%s%s", strings.ToTitle(s[0:1]), s[1:])
+			}), " ")
+			fmt.Fprintf(f, "## %s Metrics\n", subsystemTitle)
 			previousSubsystem = metric.subsystem
 			fmt.Fprintln(f)
 		}

--- a/website/content/en/preview/tasks/globalsettings.md
+++ b/website/content/en/preview/tasks/globalsettings.md
@@ -14,6 +14,7 @@ There are two main configuration mechanisms that can be used to configure Karpen
 
 | Environment Variable | CLI Flag | Description |
 |--|--|--|
+| DISABLE_WEBHOOK | \-\-disable-webhook | Disable the admission and validation webhooks (default = false)|
 | ENABLE_PROFILING | \-\-enable-profiling | Enable the profiling on the metric endpoint (default = false)|
 | HEALTH_PROBE_PORT | \-\-health-probe-port | The port the health probe endpoint binds to for reporting controller health (default = 8081)|
 | KARPENTER_SERVICE | \-\-karpenter-service | The Karpenter Service name for the dynamic webhook certificate|

--- a/website/content/en/preview/tasks/metrics.md
+++ b/website/content/en/preview/tasks/metrics.md
@@ -92,7 +92,7 @@ Pod state is the current state of pods. This metric can be used several ways as 
 ### `karpenter_cloudprovider_duration_seconds`
 Duration of cloud provider method calls. Labeled by the controller, method name and provider.
 
-## Allocation_controller Metrics
+## Allocation Controller Metrics
 
 ### `karpenter_allocation_controller_scheduling_duration_seconds`
 Duration of scheduling process in seconds. Broken down by provisioner and error.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Fix metrics titling so all titles in `metrics.md` are capitalized correctly

**How was this change tested?**

* `make docgen`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
