### PR TITLE
fix: Scope cloudformation for queue operations

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
@@ -48,7 +48,6 @@ Resources:
               - ec2:CreateTags
               - ec2:TerminateInstances
               - ec2:DeleteLaunchTemplate
-              - sqs:DeleteMessage
               # Read Operations
               - ec2:DescribeLaunchTemplates
               - ec2:DescribeInstances
@@ -61,9 +60,15 @@ Resources:
               - ec2:DescribeSpotPriceHistory
               - ssm:GetParameter
               - pricing:GetProducts
+          - Effect: Allow
+            Action:
+              # Write Operations
+              - sqs:DeleteMessage
+              # Read Operations
               - sqs:GetQueueUrl
               - sqs:GetQueueAttributes
               - sqs:ReceiveMessage
+            Resource: !GetAtt KarpenterInterruptionQueue.Arn
           - Effect: Allow
             Action:
               - iam:PassRole


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Scopes Cloudformation down to only operate on the InterruptionQueue

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
