### PR TITLE
test: Test that instances are able to initialize for extended resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.135
-	github.com/aws/karpenter-core v0.0.2-0.20221114224806-cf29e8bdd8e9
+	github.com/aws/karpenter-core v0.0.2-0.20221115203101-bc3be551a819
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.135 h1:DJJP/CkEpgafA5p5jlY9VzDRyKrfABVixzIxrK/3tWU=
 github.com/aws/aws-sdk-go v1.44.135/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.0.2-0.20221114224806-cf29e8bdd8e9 h1:Zsfyb4KX7HsdE+uZjtucuY1wm0nwgtfXYRkjvBSeTQY=
-github.com/aws/karpenter-core v0.0.2-0.20221114224806-cf29e8bdd8e9/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
+github.com/aws/karpenter-core v0.0.2-0.20221115203101-bc3be551a819 h1:VCKw9DNsgMEb1ZNCxENnPoBES9Kq9dJPR+tPwNhCpLA=
+github.com/aws/karpenter-core v0.0.2-0.20221115203101-bc3be551a819/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.135
 	github.com/aws/aws-sdk-go-v2/config v1.17.10
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.0.2-0.20221114224806-cf29e8bdd8e9
+	github.com/aws/karpenter-core v0.0.2-0.20221115203101-bc3be551a819
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.24.0
 	github.com/samber/lo v1.33.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -84,8 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 h1:jcw6kKZrtNfBPJkaHrscDOZo
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8/go.mod h1:er2JHN+kBY6FcMfcBBKNGCT3CarImmdFzishsqBmSRI=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.1 h1:KRAix/KHvjGODaHAMXnxRk9t0D+4IJVUuS/uwXxngXk=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.1/go.mod h1:bXcN3koeVYiJcdDU89n3kCYILob7Y34AeLopUbZgLT4=
-github.com/aws/karpenter-core v0.0.2-0.20221114224806-cf29e8bdd8e9 h1:Zsfyb4KX7HsdE+uZjtucuY1wm0nwgtfXYRkjvBSeTQY=
-github.com/aws/karpenter-core v0.0.2-0.20221114224806-cf29e8bdd8e9/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
+github.com/aws/karpenter-core v0.0.2-0.20221115203101-bc3be551a819 h1:VCKw9DNsgMEb1ZNCxENnPoBES9Kq9dJPR+tPwNhCpLA=
+github.com/aws/karpenter-core v0.0.2-0.20221115203101-bc3be551a819/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.4 h1:/RN2z1txIJWeXeOkzX+Hk/4Uuvv7dWtCjbmVJcrskyk=
 github.com/aws/smithy-go v1.13.4/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -20,7 +20,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/pkg/ptr"
@@ -205,4 +207,206 @@ var _ = Describe("Scheduling", func() {
 		Expect(ptr.StringValue(env.GetInstance(pod.Spec.NodeName).InstanceType)).To(Equal("c4.large"))
 		Expect(env.GetNode(pod.Spec.NodeName).Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisionerHighPri.Name))
 	})
+	Context("Extended Resources", func() {
+		It("should provision nodes for a deployment that requests nvidia.com/gpu", func() {
+			ExpectNvidiaDevicePluginCreated()
+			DeferCleanup(func() {
+				ExpectNvidiaDevicePluginDeleted()
+			})
+
+			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha1.LabelInstanceCategory,
+						Operator: v1.NodeSelectorOpExists,
+					},
+				},
+			})
+			numPods := 1
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "large-app"},
+					},
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+						Limits: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			})
+			selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+			env.ExpectCreated(provisioner, provider, dep)
+			env.EventuallyExpectHealthyPodCount(selector, numPods)
+			env.ExpectCreatedNodeCount("==", 1)
+			env.EventuallyExpectCreatedNodesInitialized()
+		})
+		It("should provision nodes for a deployment that requests nvidia.com/gpu (Bottlerocket)", func() {
+			// For Bottlerocket, we are testing that resources are initialized without needing a device plugin
+			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+				AMIFamily:             &v1alpha1.AMIFamilyBottlerocket,
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha1.LabelInstanceCategory,
+						Operator: v1.NodeSelectorOpExists,
+					},
+				},
+			})
+			numPods := 1
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "large-app"},
+					},
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+						Limits: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+					},
+				},
+			})
+			selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+			env.ExpectCreated(provisioner, provider, dep)
+			env.EventuallyExpectHealthyPodCount(selector, numPods)
+			env.ExpectCreatedNodeCount("==", 1)
+			env.EventuallyExpectCreatedNodesInitialized()
+		})
+		It("should provision nodes for a deployments that requests vpc.amazonaws.com/pod-eni (security groups for pods)", func() {
+			env.ExpectSettingsOverridden(map[string]string{
+				"aws.enablePodENI": "true",
+			})
+			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+			}})
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha1.LabelInstanceCategory,
+						Operator: v1.NodeSelectorOpExists,
+					},
+				},
+			})
+			numPods := 1
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: int32(numPods),
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "large-app"},
+					},
+					ResourceRequirements: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							"vpc.amazonaws.com/pod-eni": resource.MustParse("1"),
+						},
+						Limits: v1.ResourceList{
+							"vpc.amazonaws.com/pod-eni": resource.MustParse("1"),
+						},
+					},
+				},
+			})
+			selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
+			env.ExpectCreated(provisioner, provider, dep)
+			env.EventuallyExpectHealthyPodCount(selector, numPods)
+			env.ExpectCreatedNodeCount("==", 1)
+			env.EventuallyExpectCreatedNodesInitialized()
+		})
+	})
 })
+
+func ExpectNvidiaDevicePluginCreated() {
+	env.ExpectCreatedWithOffset(1, &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nvidia-device-plugin-daemonset",
+			Namespace: "kube-system",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": "nvidia-device-plugin-ds",
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": "nvidia-device-plugin-ds",
+					},
+				},
+				Spec: v1.PodSpec{
+					Tolerations: []v1.Toleration{
+						{
+							Key:      "nvidia.com/gpu",
+							Operator: v1.TolerationOpExists,
+							Effect:   v1.TaintEffectNoSchedule,
+						},
+					},
+					PriorityClassName: "system-node-critical",
+					Containers: []v1.Container{
+						{
+							Name:  "nvidia-device-plugin-ctr",
+							Image: "nvcr.io/nvidia/k8s-device-plugin:v0.12.3",
+							Env: []v1.EnvVar{
+								{
+									Name:  "FAIL_ON_INIT_ERROR",
+									Value: "false",
+								},
+							},
+							SecurityContext: &v1.SecurityContext{
+								AllowPrivilegeEscalation: lo.ToPtr(false),
+								Capabilities: &v1.Capabilities{
+									Drop: []v1.Capability{"ALL"},
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "device-plugin",
+									MountPath: "/var/lib/kubelet/device-plugins",
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "device-plugin",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/var/lib/kubelet/device-plugins",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func ExpectNvidiaDevicePluginDeleted() {
+	env.ExpectDeletedWithOffset(1, &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nvidia-device-plugin-daemonset",
+			Namespace: "kube-system",
+		},
+	})
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Tests E2E for node initialization when extended resources are expected on the node

Buddy change and testing for https://github.com/aws/karpenter-core/pull/69

**How was this change tested?**

* `FOCUS="Extended Resources" make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
