### PR TITLE
test: retry aws api calls in tests, up version in upgrade test

### DIFF
--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Scheduling", func() {
 			env.ExpectCreatedNodeCount("==", 1)
 			env.EventuallyExpectCreatedNodesInitialized()
 		})
-		It("should provision nodes for a deployments that requests vpc.amazonaws.com/pod-eni (security groups for pods)", func() {
+		It("should provision nodes for a deployment that requests vpc.amazonaws.com/pod-eni (security groups for pods)", func() {
 			env.ExpectSettingsOverridden(map[string]string{
 				"aws.enablePodENI": "true",
 			})

--- a/test/suites/upgrade/pipeline.yaml
+++ b/test/suites/upgrade/pipeline.yaml
@@ -12,7 +12,7 @@ spec:
       description: Kubernetes version to deploy
       default: "1.23"
     - name: from-git-ref
-      default: v0.17.0
+      default: v0.18.1
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
     - name: git-repo-url
       description: the git repo url can be used to run tests on a fork


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Add 3 retries for AWS API calls that have retryable errors like throttling.
 - Up the starting Karpenter version in the Upgrade test to v0.18.1

**How was this change tested?**

* `make e2etsts`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
