### PR TITLE
fix: update Karpenter core to track pending pods when consolidating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,11 @@ tidy: ## Recursively "go mod tidy" on all directories where go.mod exists
 download: ## Recursively "go mod download" on all directories where go.mod exists
 	$(foreach dir,$(MOD_DIRS),cd $(dir) && go mod download $(newline))
 
+update-core: ## Update karpenter-core to latest
+	go get -u github.com/aws/karpenter-core
+	go mod tidy
+	cd test/ && go get -u github.com/aws/karpenter-core && go mod tidy 
+
 .PHONY: help dev ci release test battletest e2etests verify tidy download docgen apply delete toolchain licenses vulncheck issues website nightly snapshot
 
 define newline

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.135
-	github.com/aws/karpenter-core v0.0.2-0.20221118021604-bfef8348f7ec
+	github.com/aws/karpenter-core v0.0.2-0.20221118200725-6e02c5aefdab
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.135 h1:DJJP/CkEpgafA5p5jlY9VzDRyKrfABVixzIxrK/3tWU=
 github.com/aws/aws-sdk-go v1.44.135/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.0.2-0.20221118021604-bfef8348f7ec h1:tUxLM+1BmIxGDdLE1zoMd5o4OUGPA+DBzsis51CX8cA=
-github.com/aws/karpenter-core v0.0.2-0.20221118021604-bfef8348f7ec/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
+github.com/aws/karpenter-core v0.0.2-0.20221118200725-6e02c5aefdab h1:8VWHjXEOvn+l6Y08IVzgxBFt0k8K0wrNz3/BBdq5Cs0=
+github.com/aws/karpenter-core v0.0.2-0.20221118200725-6e02c5aefdab/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.135
 	github.com/aws/aws-sdk-go-v2/config v1.17.10
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.0.2-0.20221118021604-bfef8348f7ec
+	github.com/aws/karpenter-core v0.0.2-0.20221118200725-6e02c5aefdab
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.24.0
 	github.com/samber/lo v1.33.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -84,8 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 h1:jcw6kKZrtNfBPJkaHrscDOZo
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8/go.mod h1:er2JHN+kBY6FcMfcBBKNGCT3CarImmdFzishsqBmSRI=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.1 h1:KRAix/KHvjGODaHAMXnxRk9t0D+4IJVUuS/uwXxngXk=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.1/go.mod h1:bXcN3koeVYiJcdDU89n3kCYILob7Y34AeLopUbZgLT4=
-github.com/aws/karpenter-core v0.0.2-0.20221118021604-bfef8348f7ec h1:tUxLM+1BmIxGDdLE1zoMd5o4OUGPA+DBzsis51CX8cA=
-github.com/aws/karpenter-core v0.0.2-0.20221118021604-bfef8348f7ec/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
+github.com/aws/karpenter-core v0.0.2-0.20221118200725-6e02c5aefdab h1:8VWHjXEOvn+l6Y08IVzgxBFt0k8K0wrNz3/BBdq5Cs0=
+github.com/aws/karpenter-core v0.0.2-0.20221118200725-6e02c5aefdab/go.mod h1:pL62Soi1AxZ0uZxdr78PXZCjxKnJpCug60gjzGFtMog=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.4 h1:/RN2z1txIJWeXeOkzX+Hk/4Uuvv7dWtCjbmVJcrskyk=
 github.com/aws/smithy-go v1.13.4/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Update Karpenter core to pull in "track pending pods when consolidating https://github.com/aws/karpenter-core/pull/79" 
 - Add make target to update karpenter-core in the main go module and the test module. 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
