### PR TITLE
fix: add aggregate-to-view for helm chart

### DIFF
--- a/charts/karpenter/templates/aggregate-clusterrole.yaml
+++ b/charts/karpenter/templates/aggregate-clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["awsnodetemplates"]
     verbs: ["get", "list", "watch", "create", "delete", "patch"]
+{{- if .Values.rbac.aggregateToViewEnabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -35,3 +36,4 @@ rules:
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["awsnodetemplates"]
     verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/charts/karpenter/templates/aggregate-clusterrole.yaml
+++ b/charts/karpenter/templates/aggregate-clusterrole.yaml
@@ -16,3 +16,22 @@ rules:
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["awsnodetemplates"]
     verbs: ["get", "list", "watch", "create", "delete", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "karpenter.fullname" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- include "karpenter.labels" . | nindent 4 }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["karpenter.sh"]
+    resources: ["provisioners", "provisioners/status"]
+    verbs: ["get", "list", "watch",]
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["awsnodetemplates"]
+    verbs: ["get", "list", "watch"]

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -159,3 +159,8 @@ settings:
     interruptionQueueName: ""
     # -- The global tags to use on all AWS infrastructure resources (launch templates, instances, SQS queue, etc.)
     tags:
+
+rbac:
+  # -- aggregateToViewEnabled allows all users in the cluster to view provisioners and awsnodetemplates
+  # DO NOT enable if your awsnodetemplates contains sensative userdata
+  aggregateToViewEnabled: false


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->


**Description**
Sometimes users need to view what provisioners are avialable. With kubernetes default view permissions they cant even see these today. 

**How was this change tested?**
applied to local cluster and granted only "readonly" permissions role. 

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

- add aggregate-to-view for provisioners

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
