### PR TITLE
Do no fail when EC2 credentials are missing

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -78,7 +78,7 @@ func New(ctx awscontext.Context) *CloudProvider {
 	}
 	ec2api := ec2.New(ctx.Session)
 	if err := checkEC2Connectivity(ctx, ec2api); err != nil {
-		logging.FromContext(ctx).Fatalf("Checking EC2 API connectivity, %s", err)
+		logging.FromContext(ctx).Errorf("Checking EC2 API connectivity, %s", err)
 	}
 	subnetProvider := NewSubnetProvider(ec2api)
 	instanceTypeProvider := NewInstanceTypeProvider(ctx, ctx.Session, ec2api, subnetProvider, ctx.UnavailableOfferingsCache, ctx.StartAsync)


### PR DESCRIPTION
fix: karpenter crashing with kube2iam

**Description**

issue was introduced in https://github.com/aws/karpenter/pull/1605
with the good intention of making broken ec2 api fail fast

we run kube2iam to get ec2 permissions for our pods, but that seems to count as "Checking EC2 API connectivity, NoCredentialProviders: no valid providers in chain. Deprecated.\n\tFor verbose messaging see aws.Config.CredentialsChainVerboseErrors"

TODO: inspect the actual error type or message an then decide if it's error or fatal

**How was this change tested?**

deploy to cluster, see if it crashes

**Does this change impact docs?**
- [X] No

**Release Note**

```release-note
Fix: do not fail when using ec2 api without credential chain
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
