### PR TITLE
feat: instanceProfileSelector-enhancement

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
@@ -189,6 +189,10 @@ spec:
                       credentials are not available."
                     type: string
                 type: object
+              role:
+                description: Role is the AWS Role associated with the InstanceProfile
+                  which should be used
+                type: string
               securityGroupSelector:
                 additionalProperties:
                   type: string

--- a/pkg/apis/v1alpha1/provider.go
+++ b/pkg/apis/v1alpha1/provider.go
@@ -40,6 +40,9 @@ type AWS struct {
 	// InstanceProfile is the AWS identity that instances use.
 	// +optional
 	InstanceProfile *string `json:"instanceProfile,omitempty"`
+	// Role is the AWS Role associated with the InstanceProfile which should be used
+	// +optional
+	Role *string `json:"role,omitempty"`
 	// SubnetSelector discovers subnets by tags. A value of "" is a wildcard.
 	// +optional
 	SubnetSelector map[string]string `json:"subnetSelector,omitempty"`

--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -1514,6 +1514,15 @@ var _ = Describe("LaunchTemplates", func() {
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
 				Expect(*input.LaunchTemplateData.IamInstanceProfile.Name).To(Equal("test-instance-profile"))
 			})
+			It("should lookup the InstanceProfile if Role specified on the Provisioner", func() {
+				provider.Role = aws.String("overridden-role")
+				ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
+				pod := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, coretest.UnschedulablePod())[0]
+				ExpectScheduled(ctx, env.Client, pod)
+				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
+				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
+				Expect(*input.LaunchTemplateData.IamInstanceProfile.Name).To(Equal("test-role-instance-profile"))
+			})
 			It("should use the instance profile on the Provisioner when specified", func() {
 				provider.InstanceProfile = aws.String("overridden-profile")
 				ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -68,6 +68,7 @@ var unavailableOfferingsCache *awscache.UnavailableOfferings
 var instanceTypeCache *cache.Cache
 var instanceTypeProvider *InstanceTypeProvider
 var fakeEC2API *fake.EC2API
+var fakeIAMAPI *fake.IAMAPI
 var fakePricingAPI *fake.PricingAPI
 var prov *provisioning.Provisioner
 var controller *provisioning.Controller
@@ -104,6 +105,7 @@ var _ = BeforeSuite(func() {
 	ec2Cache = cache.New(awscontext.CacheTTL, awscontext.CacheCleanupInterval)
 	instanceTypeCache = cache.New(InstanceTypesAndZonesCacheTTL, awscontext.CacheCleanupInterval)
 	fakeEC2API = &fake.EC2API{}
+	fakeIAMAPI = &fake.IAMAPI{}
 	fakePricingAPI = &fake.PricingAPI{}
 	pricingProvider = NewPricingProvider(ctx, fakePricingAPI, fakeEC2API, "", false, make(chan struct{}))
 	subnetProvider := &SubnetProvider{
@@ -128,6 +130,7 @@ var _ = BeforeSuite(func() {
 		instanceTypeProvider: instanceTypeProvider,
 		instanceProvider: NewInstanceProvider(ctx, fakeEC2API, instanceTypeProvider, subnetProvider, &LaunchTemplateProvider{
 			ec2api:                fakeEC2API,
+			iamapi:                fakeIAMAPI,
 			amiFamily:             amifamily.New(env.Client, fake.SSMAPI{}, fakeEC2API, ssmCache, ec2Cache),
 			kubernetesInterface:   env.KubernetesInterface,
 			securityGroupProvider: securityGroupProvider,

--- a/pkg/fake/iamapi.go
+++ b/pkg/fake/iamapi.go
@@ -1,0 +1,62 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+)
+
+// IAMBehavior must be reset between tests otherwise tests will
+// pollute each other.
+type IAMBehavior struct {
+	ListInstanceProfilesForRoleOutput AtomicPtr[iam.ListInstanceProfilesForRoleOutput]
+	NextError                         AtomicError
+}
+
+type IAMAPI struct {
+	iamiface.IAMAPI
+	IAMBehavior
+}
+
+// Reset must be called between tests otherwise tests will pollute
+// each other.
+func (e *IAMAPI) Reset() {
+	e.ListInstanceProfilesForRoleOutput.Reset()
+	e.NextError.Reset()
+}
+
+// ListInstanceProfilesForRoleWithContext mocks the call
+// nolint: gocyclo
+func (e *IAMAPI) ListInstanceProfilesForRoleWithContext(_ context.Context, input *iam.ListInstanceProfilesForRoleInput, _ ...request.Option) (*iam.ListInstanceProfilesForRoleOutput, error) {
+	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
+		return nil, e.NextError.Get()
+	}
+	if !e.ListInstanceProfilesForRoleOutput.IsNil() {
+		return e.ListInstanceProfilesForRoleOutput.Clone(), nil
+	}
+	return &iam.ListInstanceProfilesForRoleOutput{
+		InstanceProfiles: []*iam.InstanceProfile{
+			{
+				InstanceProfileName: aws.String("test-role-instance-profile"),
+			},
+		},
+	}, nil
+}

--- a/website/content/en/preview/AWS/provisioning.md
+++ b/website/content/en/preview/AWS/provisioning.md
@@ -62,6 +62,16 @@ spec:
   instanceProfile: MyInstanceProfile
 ```
 
+### Role
+
+A `Role` which should be associated with the ec2 instance.
+Can be used instead of defining an `InstanceProfile` - the `InstanceProfile` will be looked up automatically from this `Role`.
+
+```
+spec:
+  role: MyIAMRole
+```
+
 ### SubnetSelector (required)
 
 Karpenter discovers subnets using [AWS tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
@@ -58,6 +58,7 @@ Resources:
               - ec2:DescribeInstanceTypeOfferings
               - ec2:DescribeAvailabilityZones
               - ec2:DescribeSpotPriceHistory
+              - iam:ListInstanceProfilesForRole
               - ssm:GetParameter
               - pricing:GetProducts
           - Effect: Allow


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Ability to configure `role` instead of `instanceProfile`
*  `instanceProfile` are difficult to look up in AWS
*  easier to configure as `role` name is more well known
* this is more aligned with how nodeGroups are set up - you provide a role name
* more resilient - if you delete a role and recreate it with the same name this code will auto-detect the new instance profile
   *  this is much safer as otherwise the nodes will not be able to join the cluster with the wrong instance profile

Role is not "guaranteed" to work since....per the docs - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
_An instance profile can contain only one IAM role, although a role can be included in multiple instance profiles._

**Aside from the above, role is safer and more convenient as it protects against the underlying instance profile of a role changing.  Using a role is much easier to wire up and maintain considering the role is not created or maintained by karpenter.**



**How was this change tested?**

* Unit tests

**Does this change impact docs?**
- [X ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
