### PR TITLE
fix: use containerd for neuron

### DIFF
--- a/pkg/cloudprovider/amifamily/al2.go
+++ b/pkg/cloudprovider/amifamily/al2.go
@@ -49,7 +49,7 @@ func (a AL2) SSMAlias(version string, instanceType *cloudprovider.InstanceType) 
 // guaranteeing it won't cause spurious hash differences.
 // AL2 userdata also works on Ubuntu
 func (a AL2) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, instanceTypes []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
-	containerRuntime := aws.String(a.containerRuntime(instanceTypes))
+	containerRuntime := aws.String("containerd")
 	if kubeletConfig != nil && kubeletConfig.ContainerRuntime != nil {
 		containerRuntime = kubeletConfig.ContainerRuntime
 	}
@@ -66,17 +66,6 @@ func (a AL2) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.
 			CustomUserData:          customUserData,
 		},
 	}
-}
-
-// containerRuntime will return the proper container runtime based on the capabilities of the
-// instanceTypes passed in since the AL2 EKS Optimized AMI does not support inferentia instances w/ containerd.
-// this should be removed once the EKS Optimized AMI supports all GPUs.
-func (a AL2) containerRuntime(instanceTypes []*cloudprovider.InstanceType) string {
-	instanceResources := instanceTypes[0].Capacity
-	if resources.IsZero(instanceResources[v1alpha1.ResourceAWSNeuron]) {
-		return "containerd"
-	}
-	return "dockerd"
 }
 
 func (a AL2) defaultIPv6DNS(kubeletConfig *v1alpha5.KubeletConfiguration) *v1alpha5.KubeletConfiguration {

--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -910,7 +910,7 @@ var _ = Describe("LaunchTemplates", func() {
 			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
 			Expect(string(userData)).To(ContainSubstring("--container-runtime dockerd"))
 		})
-		It("should specify --container-runtime docker when using Neuron GPUs", func() {
+		It("should specify --container-runtime containerd when using Neuron GPUs", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists}}
 			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod(coretest.PodOptions{
@@ -928,7 +928,7 @@ var _ = Describe("LaunchTemplates", func() {
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
 			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-			Expect(string(userData)).To(ContainSubstring("--container-runtime docker"))
+			Expect(string(userData)).To(ContainSubstring("--container-runtime containerd"))
 		})
 		It("should specify --container-runtime containerd when using Nvidia GPUs", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists}}

--- a/website/content/en/preview/concepts/provisioning.md
+++ b/website/content/en/preview/concepts/provisioning.md
@@ -246,10 +246,9 @@ spec:
 
 ☁️ **AWS**
 
-You can specify the container runtime to be either `dockerd` or `containerd`.
+You can specify the container runtime to be either `dockerd` or `containerd`. By default, `containerd` is used.
 
-* `dockerd` will be chosen by default for [Inferentia instanceTypes](https://aws.amazon.com/ec2/instance-types/inf1/). For all other instances `containerd` is the default.
-* You can only use `containerd` with the Bottlerocket AMI Family.
+* `containerd` is the only valid container runtime when using the Bottlerocket AMI Family or when using the AL2 AMI Family and K8s version 1.24+
 
 ### Reserved Resources
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Previously, neuron (inferentia) instance types needed to use dockerd rather than containerd. This was fixed though so that the neuron device plugin works with containerd now, so removing this weird logic of different defaults for different instance types and using containerd as the default always. This also fixes inferentia support for K8s 1.24+ since docker is no longer available. 

**How was this change tested?**

* Deployed an inf1 and neuron workload on containerd

```
> kgpa
NAMESPACE     NAME                                   READY   STATUS    RESTARTS   AGE
default       eks-neuron-test-6574755847-6kg7d       1/1     Running   0          11m
default       eks-neuron-test-6574755847-gmr4g       1/1     Running   0          11m
default       inflate-75b4f74469-nfps6               1/1     Running   0          18m
karpenter     karpenter-5987f49cfb-4986c             1/1     Running   0          18m
karpenter     karpenter-5987f49cfb-zfvk2             1/1     Running   0          18m
kube-system   aws-node-626jk                         1/1     Running   0          10d
kube-system   aws-node-kgxkh                         1/1     Running   0          18m
kube-system   aws-node-rdnnz                         1/1     Running   0          10d
kube-system   aws-node-xrbf9                         1/1     Running   0          3m4s
kube-system   coredns-5948f55769-9cqk7               1/1     Running   0          15d
kube-system   coredns-5948f55769-np758               1/1     Running   0          15d
kube-system   kube-proxy-6gj62                       1/1     Running   0          3m4s
kube-system   kube-proxy-gw5dh                       1/1     Running   0          15d
kube-system   kube-proxy-jvl7p                       1/1     Running   0          18m
kube-system   kube-proxy-qgkvz                       1/1     Running   0          15d
kube-system   neuron-device-plugin-daemonset-rdmhb   1/1     Running   0          3m4s
```

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
