### PR TITLE
chore: remove K8s 1.20 from CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          k8sVersion: ["1.20.x", "1.21.x", "1.22.x", "1.23.x", "1.24.x"]
+          k8sVersion: ["1.21.x", "1.22.x", "1.23.x", "1.24.x"]
     env:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:


### PR DESCRIPTION
**Description**

Per docs, AWS stopped supporting 1.20 on November 1, 2022

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
