### PR TITLE
test: fix test settings flakes

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -107,6 +107,12 @@ func (env *Environment) ExpectSettingsOverridden(data ...map[string]string) {
 	cm := env.ExpectSettings()
 	cm.Data = lo.Assign(append([]map[string]string{cm.Data}, data...)...)
 	env.ExpectCreatedOrUpdated(cm)
+	// Wait for updated settings to be injected into context since the batching logic
+	// may be using stale settings.
+	// While this doesn't ensure the issue doesn't happen, the default BatchIdleTime is
+	// 1 second. Since we control the provisioning logic in tests, 5 seconds is sufficient
+	// to significantly reduce the chance that any races will occur with stale settings.
+	time.Sleep(5 * time.Second)
 }
 
 func (env *Environment) ExpectFound(obj client.Object) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
Add sleep to allow settings to be injected in tests when changing settings.
**How was this change tested?**

* make apply && make e2etests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
