### PR TITLE
fix: Rm/add snapshots on cherry picked releases

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -28,7 +28,15 @@ jobs:
           ref: ${{ env.TAG_COMMIT }}
       - uses: ./.github/actions/install-go-and-dependencies
       - uses: ./.github/actions/authenticate-aws
-      - run: make release
+      - name: Publish Snapshot Release
+        run: make release
+      - name: Checkout the repository out again at the given SHA from the artifact
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ env.TAG_COMMIT }}
+      - name: Publish images and Helm chart
+        run: make release
         env:
           RELEASE_VERSION: ${{ env.TAG }}
       - name: Autogenerate and commit files for PR

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -74,7 +74,7 @@ pullPrivateReplica(){
   authenticatePrivateRepo
   RELEASE_TYPE=$1
   RELEASE_IDENTIFIER=$2
-  PULL_THROUGH_CACHE_PATH="${PRIVATE_PULL_THROUGH_HOST}/ecr-public/karpenter/"
+  PULL_THROUGH_CACHE_PATH="${PRIVATE_PULL_THROUGH_HOST}/ecr-public/${ECR_GALLERY_NAME}/"
 
   docker pull "${PULL_THROUGH_CACHE_PATH}controller:${RELEASE_IDENTIFIER}"
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Adds snapshot release on stable releases
This was happening naturally before but now it will happen for cherry picked stable releases as well

**How was this change tested?**

* Different fork

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
