### PR TITLE
chore: Use Machine Spec in Memory for `cloudprovider.Create`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.154
-	github.com/aws/karpenter-core v0.0.2-0.20221205173459-064a52f2f9e1
+	github.com/aws/karpenter-core v0.0.2-0.20221207071807-fae4eac425cc
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.154 h1:2TaEC8JIM/t7Fu+FBmdOBK5jFUAVL07tbpfJsLuVo3Q=
 github.com/aws/aws-sdk-go v1.44.154/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.0.2-0.20221205173459-064a52f2f9e1 h1:/UHr8IYWo23pQgPOM39FikZpYKz9ZsiEITUu6IB3imA=
-github.com/aws/karpenter-core v0.0.2-0.20221205173459-064a52f2f9e1/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
+github.com/aws/karpenter-core v0.0.2-0.20221207071807-fae4eac425cc h1:F1qEvMtKCnSUOG8CIPN7s68SgWPsyJaen7eeQDb7AMY=
+github.com/aws/karpenter-core v0.0.2-0.20221207071807-fae4eac425cc/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/apis/v1alpha1/provider.go
+++ b/pkg/apis/v1alpha1/provider.go
@@ -15,13 +15,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 )
 
 // AWS contains parameters specific to this cloud provider
@@ -190,12 +185,9 @@ type BlockDevice struct {
 	VolumeType *string `json:"volumeType,omitempty"`
 }
 
-func Deserialize(provider *v1alpha5.Provider) (*AWS, error) {
-	if provider == nil {
-		return nil, fmt.Errorf("invariant violated: spec.provider is not defined. Is the validating webhook installed?")
-	}
+func DeserializeProvider(raw []byte) (*AWS, error) {
 	a := &AWS{}
-	_, gvk, err := codec.UniversalDeserializer().Decode(provider.Raw, nil, a)
+	_, gvk, err := codec.UniversalDeserializer().Decode(raw, nil, a)
 	if err != nil {
 		return nil, err
 	}
@@ -203,16 +195,4 @@ func Deserialize(provider *v1alpha5.Provider) (*AWS, error) {
 		a.SetGroupVersionKind(*gvk)
 	}
 	return a, nil
-}
-
-func (a *AWS) Serialize(provider *v1alpha5.Provider) error {
-	if provider == nil {
-		return fmt.Errorf("invariant violated: spec.provider is not defined. Is the validating webhook installed?")
-	}
-	bytes, err := json.Marshal(a)
-	if err != nil {
-		return err
-	}
-	provider.Raw = bytes
-	return nil
 }

--- a/pkg/apis/v1alpha5/provisioner.go
+++ b/pkg/apis/v1alpha5/provisioner.go
@@ -35,7 +35,7 @@ func (p *Provisioner) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if p.Spec.Provider == nil {
 		return nil
 	}
-	provider, err := v1alpha1.Deserialize(p.Spec.Provider)
+	provider, err := v1alpha1.DeserializeProvider(p.Spec.Provider.Raw)
 	if err != nil {
 		return apis.ErrGeneric(err.Error())
 	}

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Provisioner", func() {
 
 		Context("SubnetSelector", func() {
 			It("should not allow empty string keys or values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 				Expect(err).ToNot(HaveOccurred())
 				for key, value := range map[string]string{
 					"":    "value",
@@ -147,14 +147,14 @@ var _ = Describe("Provisioner", func() {
 		})
 		Context("SecurityGroupSelector", func() {
 			It("should not allow with a custom launch template", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 				Expect(err).ToNot(HaveOccurred())
 				provider.LaunchTemplateName = aws.String("my-lt")
 				provider.SecurityGroupSelector = map[string]string{"key": "value"}
 				Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 			})
 			It("should not allow empty string keys or values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 				Expect(err).ToNot(HaveOccurred())
 				for key, value := range map[string]string{
 					"":    "value",
@@ -191,7 +191,7 @@ var _ = Describe("Provisioner", func() {
 		})
 		Context("MetadataOptions", func() {
 			It("should not allow with a custom launch template", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 				Expect(err).ToNot(HaveOccurred())
 				provider.LaunchTemplateName = aws.String("my-lt")
 				provider.MetadataOptions = &v1alpha1.MetadataOptions{}
@@ -199,7 +199,7 @@ var _ = Describe("Provisioner", func() {
 				Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 			})
 			It("should allow missing values", func() {
-				provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+				provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 				Expect(err).ToNot(HaveOccurred())
 				provider.MetadataOptions = &v1alpha1.MetadataOptions{}
 				provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
@@ -207,7 +207,7 @@ var _ = Describe("Provisioner", func() {
 			})
 			Context("HTTPEndpoint", func() {
 				It("should allow enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					for i := range ec2.LaunchTemplateInstanceMetadataEndpointState_Values() {
 						value := ec2.LaunchTemplateInstanceMetadataEndpointState_Values()[i]
@@ -219,7 +219,7 @@ var _ = Describe("Provisioner", func() {
 					}
 				})
 				It("should not allow non-enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.MetadataOptions = &v1alpha1.MetadataOptions{
 						HTTPEndpoint: aws.String(randomdata.SillyName()),
@@ -230,7 +230,7 @@ var _ = Describe("Provisioner", func() {
 			})
 			Context("HTTPProtocolIpv6", func() {
 				It("should allow enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					for i := range ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values() {
 						value := ec2.LaunchTemplateInstanceMetadataProtocolIpv6_Values()[i]
@@ -242,7 +242,7 @@ var _ = Describe("Provisioner", func() {
 					}
 				})
 				It("should not allow non-enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.MetadataOptions = &v1alpha1.MetadataOptions{
 						HTTPProtocolIPv6: aws.String(randomdata.SillyName()),
@@ -253,7 +253,7 @@ var _ = Describe("Provisioner", func() {
 			})
 			Context("HTTPPutResponseHopLimit", func() {
 				It("should validate inside accepted range", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.MetadataOptions = &v1alpha1.MetadataOptions{
 						HTTPPutResponseHopLimit: aws.Int64(int64(randomdata.Number(1, 65))),
@@ -262,7 +262,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(provisioner.Validate(ctx)).To(Succeed())
 				})
 				It("should not validate outside accepted range", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.MetadataOptions = &v1alpha1.MetadataOptions{}
 					// We expect to be able to invalidate any hop limit between
@@ -284,7 +284,7 @@ var _ = Describe("Provisioner", func() {
 			})
 			Context("HTTPTokens", func() {
 				It("should allow enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					for _, value := range ec2.LaunchTemplateHttpTokensState_Values() {
 						provider.MetadataOptions = &v1alpha1.MetadataOptions{
@@ -295,7 +295,7 @@ var _ = Describe("Provisioner", func() {
 					}
 				})
 				It("should not allow non-enum values", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.MetadataOptions = &v1alpha1.MetadataOptions{
 						HTTPTokens: aws.String(randomdata.SillyName()),
@@ -305,7 +305,7 @@ var _ = Describe("Provisioner", func() {
 			})
 			Context("BlockDeviceMappings", func() {
 				It("should not allow with a custom launch template", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.LaunchTemplateName = aws.String("my-lt")
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
@@ -317,7 +317,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 				It("should validate minimal device mapping", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
@@ -328,7 +328,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 				It("should validate ebs device mapping with snapshotID only", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
@@ -339,7 +339,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 				It("should not allow volume size below minimum", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
@@ -350,7 +350,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 				It("should not allow volume size above max", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
@@ -361,7 +361,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 				It("should not allow nil device name", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
 						EBS: &v1alpha1.BlockDevice{
@@ -371,7 +371,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 				It("should not allow nil volume size", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),
@@ -380,7 +380,7 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 				It("should not allow empty ebs block", func() {
-					provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
 					provider.BlockDeviceMappings = []*v1alpha1.BlockDeviceMapping{{
 						DeviceName: aws.String("/dev/xvda"),

--- a/pkg/cloudprovider/amifamily/ami.go
+++ b/pkg/cloudprovider/amifamily/ami.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -56,7 +55,9 @@ type AMI struct {
 
 // Get returns a set of AMIIDs and corresponding instance types. AMI may vary due to architecture, accelerator, etc
 // If AMI overrides are specified in the AWSNodeTemplate, then only those AMIs will be chosen.
-func (p *AMIProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *cloudprovider.Machine, options *Options, amiFamily AMIFamily) (map[string][]*cloudprovider.InstanceType, error) {
+func (p *AMIProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate,
+	instanceTypes []*cloudprovider.InstanceType, options *Options, amiFamily AMIFamily) (map[string][]*cloudprovider.InstanceType, error) {
+
 	amiIDs := map[string][]*cloudprovider.InstanceType{}
 	amiRequirements, err := p.getAMIRequirements(ctx, nodeTemplate)
 	if err != nil {
@@ -65,7 +66,7 @@ func (p *AMIProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 	if len(amiRequirements) > 0 {
 		// Iterate through AMIs in order of creation date to use latest AMI
 		amis := sortAMIsByCreationDate(amiRequirements)
-		for _, instanceType := range machine.InstanceTypes {
+		for _, instanceType := range instanceTypes {
 			for _, ami := range amis {
 				if err := instanceType.Requirements.Compatible(amiRequirements[ami]); err == nil {
 					amiIDs[ami.AmiID] = append(amiIDs[ami.AmiID], instanceType)
@@ -77,7 +78,7 @@ func (p *AMIProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 			return nil, fmt.Errorf("no instance types satisfy requirements of amis %v,", lo.Keys(amiRequirements))
 		}
 	} else {
-		for _, instanceType := range machine.InstanceTypes {
+		for _, instanceType := range instanceTypes {
 			amiID, err := p.getDefaultAMIFromSSM(ctx, amiFamily.SSMAlias(options.KubernetesVersion, instanceType))
 			if err != nil {
 				return nil, err

--- a/pkg/cloudprovider/amifamily/resolver.go
+++ b/pkg/cloudprovider/amifamily/resolver.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider/amifamily/bootstrap"
 
@@ -115,9 +116,9 @@ func New(kubeClient client.Client, ssm ssmiface.SSMAPI, ec2api ec2iface.EC2API, 
 
 // Resolve generates launch templates using the static options and dynamically generates launch template parameters.
 // Multiple ResolvedTemplates are returned based on the instanceTypes passed in to support special AMIs for certain instance types like GPUs.
-func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *cloudprovider.Machine, options *Options) ([]*LaunchTemplate, error) {
+func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *corev1alpha1.Machine, instanceTypes []*cloudprovider.InstanceType, options *Options) ([]*LaunchTemplate, error) {
 	amiFamily := GetAMIFamily(nodeTemplate.Spec.AMIFamily, options)
-	amiIDs, err := r.amiProvider.Get(ctx, nodeTemplate, machine, options, amiFamily)
+	amiIDs, err := r.amiProvider.Get(ctx, nodeTemplate, instanceTypes, options, amiFamily)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/amifamily/resolver.go
+++ b/pkg/cloudprovider/amifamily/resolver.go
@@ -115,9 +115,9 @@ func New(kubeClient client.Client, ssm ssmiface.SSMAPI, ec2api ec2iface.EC2API, 
 
 // Resolve generates launch templates using the static options and dynamically generates launch template parameters.
 // Multiple ResolvedTemplates are returned based on the instanceTypes passed in to support special AMIs for certain instance types like GPUs.
-func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, nodeRequest *cloudprovider.NodeRequest, options *Options) ([]*LaunchTemplate, error) {
+func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *cloudprovider.Machine, options *Options) ([]*LaunchTemplate, error) {
 	amiFamily := GetAMIFamily(nodeTemplate.Spec.AMIFamily, options)
-	amiIDs, err := r.amiProvider.Get(ctx, nodeTemplate, nodeRequest, options, amiFamily)
+	amiIDs, err := r.amiProvider.Get(ctx, nodeTemplate, machine, options, amiFamily)
 	if err != nil {
 		return nil, err
 	}
@@ -126,8 +126,8 @@ func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 		resolved := &LaunchTemplate{
 			Options: options,
 			UserData: amiFamily.UserData(
-				nodeRequest.Template.KubeletConfiguration,
-				append(nodeRequest.Template.Taints, nodeRequest.Template.StartupTaints...),
+				machine.Spec.Kubelet,
+				append(machine.Spec.Taints, machine.Spec.StartupTaints...),
 				options.Labels,
 				options.CABundle,
 				instanceTypes,

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -125,10 +125,7 @@ func (c *CloudProvider) Create(ctx context.Context, machine *corev1alpha1.Machin
 	if err != nil {
 		return nil, fmt.Errorf("resolving instance types, %w", err)
 	}
-	return c.instanceProvider.Create(ctx, nodeTemplate, &cloudprovider.Machine{
-		Machine:       machine,
-		InstanceTypes: instanceTypes,
-	})
+	return c.instanceProvider.Create(ctx, nodeTemplate, machine, instanceTypes)
 }
 
 func (c *CloudProvider) LivenessProbe(req *http.Request) error {

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -30,7 +31,6 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -39,12 +39,14 @@ import (
 	"knative.dev/pkg/ptr"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider/amifamily"
 	awscontext "github.com/aws/karpenter/pkg/context"
 
 	coreapis "github.com/aws/karpenter-core/pkg/apis"
+	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
@@ -112,12 +114,21 @@ func checkEC2Connectivity(ctx context.Context, api *ec2.EC2) error {
 }
 
 // Create a node given the constraints.
-func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.NodeRequest) (*v1.Node, error) {
-	nodeTemplate, err := c.resolveNodeTemplate(ctx, nodeRequest.Template.Provider, nodeRequest.Template.ProviderRef)
+func (c *CloudProvider) Create(ctx context.Context, machine *corev1alpha1.Machine) (*v1.Node, error) {
+	nodeTemplate, err := c.resolveNodeTemplate(ctx, []byte(machine.
+		Annotations[v1alpha5.ProviderCompatabilityAnnotationKey]), machine.
+		Spec.MachineTemplateRef)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolving node template, %w", err)
 	}
-	return c.instanceProvider.Create(ctx, nodeTemplate, nodeRequest)
+	instanceTypes, err := c.resolveInstanceTypes(ctx, machine)
+	if err != nil {
+		return nil, fmt.Errorf("resolving instance types, %w", err)
+	}
+	return c.instanceProvider.Create(ctx, nodeTemplate, &cloudprovider.Machine{
+		Machine:       machine,
+		InstanceTypes: instanceTypes,
+	})
 }
 
 func (c *CloudProvider) LivenessProbe(req *http.Request) error {
@@ -129,7 +140,17 @@ func (c *CloudProvider) LivenessProbe(req *http.Request) error {
 
 // GetInstanceTypes returns all available InstanceTypes
 func (c *CloudProvider) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
-	nodeTemplate, err := c.resolveNodeTemplate(ctx, provisioner.Spec.Provider, provisioner.Spec.ProviderRef)
+	var nodeTemplate *v1alpha1.AWSNodeTemplate
+	var err error
+	if provisioner.Spec.ProviderRef != nil {
+		nodeTemplate, err = c.resolveNodeTemplate(ctx, nil, &v1.ObjectReference{
+			APIVersion: provisioner.Spec.ProviderRef.APIVersion,
+			Kind:       provisioner.Spec.ProviderRef.Kind,
+			Name:       provisioner.Spec.ProviderRef.Name,
+		})
+	} else {
+		nodeTemplate, err = c.resolveNodeTemplate(ctx, provisioner.Spec.Provider.Raw, nil)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -181,18 +202,40 @@ func kubeDNSIP(ctx context.Context, kubernetesInterface kubernetes.Interface) (n
 	return kubeDNSIP, nil
 }
 
-func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, provider *runtime.RawExtension, providerRef *v1alpha5.ProviderRef) (*v1alpha1.AWSNodeTemplate, error) {
+func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, raw []byte, objRef *v1.ObjectReference) (*v1alpha1.AWSNodeTemplate, error) {
 	nodeTemplate := &v1alpha1.AWSNodeTemplate{}
-	if providerRef != nil {
-		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: providerRef.Name}, nodeTemplate); err != nil {
+	if objRef != nil {
+		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: objRef.Name}, nodeTemplate); err != nil {
 			return nil, fmt.Errorf("getting providerRef, %w", err)
 		}
 		return nodeTemplate, nil
 	}
-	aws, err := v1alpha1.Deserialize(provider)
+	aws, err := v1alpha1.DeserializeProvider(raw)
 	if err != nil {
 		return nil, err
 	}
 	nodeTemplate.Spec.AWS = lo.FromPtr(aws)
 	return nodeTemplate, nil
+}
+
+func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, machine *corev1alpha1.Machine) ([]*cloudprovider.InstanceType, error) {
+	owner, ok := lo.Find(machine.OwnerReferences, func(o metav1.OwnerReference) bool {
+		return o.APIVersion == v1alpha5.SchemeGroupVersion.String() &&
+			o.Kind == reflect.TypeOf(v1alpha5.Provisioner{}).Name()
+	})
+	if !ok {
+		return nil, fmt.Errorf("finding provisioner owner")
+	}
+	provisioner := &v1alpha5.Provisioner{}
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: owner.Name}, provisioner); err != nil {
+		return nil, fmt.Errorf("getting provisioner owner, %w", err)
+	}
+	instanceTypes, err := c.GetInstanceTypes(ctx, provisioner)
+	if err != nil {
+		return nil, fmt.Errorf("getting instance types, %w", err)
+	}
+	reqs := scheduling.NewNodeSelectorRequirements(machine.Spec.Requirements...)
+	return lo.Filter(instanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
+		return reqs.Get(v1.LabelInstanceTypeStable).Has(i.Name)
+	}), nil
 }

--- a/pkg/cloudprovider/instancetypes_test.go
+++ b/pkg/cloudprovider/instancetypes_test.go
@@ -16,6 +16,7 @@ package cloudprovider
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -29,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/ptr"
 
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter/pkg/test"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -81,11 +84,16 @@ var _ = Describe("Instance Types", func() {
 			ExpectNotScheduled(ctx, env.Client, pod)
 		}
 	})
-	It("should order instance types by price", func() {
-		// TODO: validate that we are considering the top offerings by price using auto-generated data from the larger
-		// describe instance types API
+	It("should order the instance types by price and only consider the cheapest ones", func() {
+		instances := makeFakeInstances()
+		fakeEC2API.DescribeInstanceTypesOutput.Set(&ec2.DescribeInstanceTypesOutput{
+			InstanceTypes: makeFakeInstances(),
+		})
+		fakeEC2API.DescribeInstanceTypeOfferingsOutput.Set(&ec2.DescribeInstanceTypeOfferingsOutput{
+			InstanceTypeOfferings: makeFakeInstanceOfferings(instances),
+		})
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			coretest.UnschedulablePod(coretest.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
@@ -94,19 +102,31 @@ var _ = Describe("Instance Types", func() {
 			})) {
 			ExpectScheduled(ctx, env.Client, pod)
 		}
-		it, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+		its, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
 		Expect(err).To(BeNil())
-		fmt.Println(it)
-		Expect(fakeEC2API.CalledWithCreateFleetInput.Len()).To(Equal(1))
-		call := fakeEC2API.CalledWithCreateFleetInput.Pop()
-		_ = call
-		for _, ltc := range call.LaunchTemplateConfigs {
-			for _, ovr := range ltc.Overrides {
-
-				Expect(strings.HasSuffix(aws.StringValue(ovr.InstanceType), "metal")).To(BeFalse())
+		// Order all the instances by their price
+		// We need some way to deterministically order them if their prices match
+		reqs := scheduling.NewNodeSelectorRequirements(provisioner.Spec.Requirements...)
+		sort.Slice(its, func(i, j int) bool {
+			iPrice := its[i].Offerings.Requirements(reqs).Cheapest().Price
+			jPrice := its[j].Offerings.Requirements(reqs).Cheapest().Price
+			if iPrice == jPrice {
+				return its[i].Name < its[j].Name
 			}
-		}
+			return iPrice < jPrice
+		})
+		// Expect that the launch template overrides gives the 60 cheapest instance types
+		expected := sets.NewString(lo.Map(its[:MaxInstanceTypes], func(i *cloudprovider.InstanceType, _ int) string {
+			return i.Name
+		})...)
+		Expect(fakeEC2API.CreateFleetBehavior.CalledWithInput.Len()).To(Equal(1))
+		call := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
+		Expect(call.LaunchTemplateConfigs).To(HaveLen(1))
 
+		Expect(call.LaunchTemplateConfigs[0].Overrides).To(HaveLen(MaxInstanceTypes))
+		for _, override := range call.LaunchTemplateConfigs[0].Overrides {
+			Expect(expected.Has(aws.StringValue(override.InstanceType))).To(BeTrue(), fmt.Sprintf("expected %s to exist in set", aws.StringValue(override.InstanceType)))
+		}
 	})
 	It("should de-prioritize metal", func() {
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
@@ -121,7 +141,6 @@ var _ = Describe("Instance Types", func() {
 		}
 		Expect(fakeEC2API.CreateFleetBehavior.CalledWithInput.Len()).To(Equal(1))
 		call := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
-		_ = call
 		for _, ltc := range call.LaunchTemplateConfigs {
 			for _, ovr := range ltc.Overrides {
 				Expect(strings.HasSuffix(aws.StringValue(ovr.InstanceType), "metal")).To(BeFalse())
@@ -141,7 +160,6 @@ var _ = Describe("Instance Types", func() {
 		}
 		Expect(fakeEC2API.CreateFleetBehavior.CalledWithInput.Len()).To(Equal(1))
 		call := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
-		_ = call
 		for _, ltc := range call.LaunchTemplateConfigs {
 			for _, ovr := range ltc.Overrides {
 				Expect(strings.HasPrefix(aws.StringValue(ovr.InstanceType), "g")).To(BeFalse())
@@ -973,3 +991,43 @@ var _ = Describe("Instance Types", func() {
 		})
 	})
 })
+
+func makeFakeInstances() []*ec2.InstanceTypeInfo {
+	var instanceTypes []*ec2.InstanceTypeInfo
+	// Use keys from the static pricing data so that we guarantee pricing for the data
+	// Create uniform instance data so all of them schedule for a given pod
+	for k := range initialOnDemandPrices {
+		instanceTypes = append(instanceTypes, &ec2.InstanceTypeInfo{
+			InstanceType: aws.String(k),
+			ProcessorInfo: &ec2.ProcessorInfo{
+				SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
+			},
+			VCpuInfo: &ec2.VCpuInfo{
+				DefaultCores: aws.Int64(1),
+				DefaultVCpus: aws.Int64(2),
+			},
+			MemoryInfo: &ec2.MemoryInfo{
+				SizeInMiB: aws.Int64(8192),
+			},
+			NetworkInfo: &ec2.NetworkInfo{
+				MaximumNetworkInterfaces:  aws.Int64(3),
+				Ipv4AddressesPerInterface: aws.Int64(10),
+			},
+			SupportedUsageClasses: fake.DefaultSupportedUsageClasses,
+		})
+	}
+	return instanceTypes
+}
+
+func makeFakeInstanceOfferings(instanceTypes []*ec2.InstanceTypeInfo) []*ec2.InstanceTypeOffering {
+	var instanceTypeOfferings []*ec2.InstanceTypeOffering
+
+	// Create uniform instance offering data so all of them schedule for a given pod
+	for _, instanceType := range instanceTypes {
+		instanceTypeOfferings = append(instanceTypeOfferings, &ec2.InstanceTypeOffering{
+			InstanceType: instanceType.InstanceType,
+			Location:     aws.String("test-zone-1a"),
+		})
+	}
+	return instanceTypeOfferings
+}

--- a/pkg/cloudprovider/launchtemplate.go
+++ b/pkg/cloudprovider/launchtemplate.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 
+	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	awssettings "github.com/aws/karpenter/pkg/apis/config/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider/amifamily"
@@ -95,12 +96,14 @@ func launchTemplateName(options *amifamily.LaunchTemplate) string {
 	return fmt.Sprintf(launchTemplateNameFormat, options.ClusterName, fmt.Sprint(hash))
 }
 
-func (p *LaunchTemplateProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *cloudprovider.Machine, additionalLabels map[string]string) (map[string][]*cloudprovider.InstanceType, error) {
+func (p *LaunchTemplateProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *corev1alpha1.Machine,
+	instanceTypes []*cloudprovider.InstanceType, additionalLabels map[string]string) (map[string][]*cloudprovider.InstanceType, error) {
+
 	p.Lock()
 	defer p.Unlock()
 	// If Launch Template is directly specified then just use it
 	if nodeTemplate.Spec.LaunchTemplateName != nil {
-		return map[string][]*cloudprovider.InstanceType{ptr.StringValue(nodeTemplate.Spec.LaunchTemplateName): machine.InstanceTypes}, nil
+		return map[string][]*cloudprovider.InstanceType{ptr.StringValue(nodeTemplate.Spec.LaunchTemplateName): instanceTypes}, nil
 	}
 	instanceProfile, err := p.getInstanceProfile(ctx, nodeTemplate)
 	if err != nil {
@@ -115,7 +118,7 @@ func (p *LaunchTemplateProvider) Get(ctx context.Context, nodeTemplate *v1alpha1
 	if err != nil {
 		return nil, err
 	}
-	resolvedLaunchTemplates, err := p.amiFamily.Resolve(ctx, nodeTemplate, machine, &amifamily.Options{
+	resolvedLaunchTemplates, err := p.amiFamily.Resolve(ctx, nodeTemplate, machine, instanceTypes, &amifamily.Options{
 		ClusterName:             awssettings.FromContext(ctx).ClusterName,
 		ClusterEndpoint:         awssettings.FromContext(ctx).ClusterEndpoint,
 		AWSENILimitedPodDensity: awssettings.FromContext(ctx).EnableENILimitedPodDensity,

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -191,6 +191,10 @@ var _ = BeforeEach(func() {
 		},
 	})
 
+	// Reset the pricing provider, so we don't cross-pollinate pricing data
+	pricingProvider = NewPricingProvider(ctx, fakePricingAPI, fakeEC2API, "", false, make(chan struct{}))
+	instanceTypeProvider.pricingProvider = pricingProvider
+
 	recorder.Reset()
 	fakeEC2API.Reset()
 	fakePricingAPI.Reset()

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Allocation", func() {
 		// Intent here is that if updates occur on the provisioningController, the Provisioner doesn't need to be recreated
 		It("should not set the InstanceProfile with the default if none provided in Provisioner", func() {
 			provisioner.SetDefaults(ctx)
-			constraints, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+			constraints, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(constraints.InstanceProfile).To(BeNil())
 		})
@@ -233,7 +233,7 @@ var _ = Describe("Allocation", func() {
 	})
 	Context("EC2 Context", func() {
 		It("should set context on the CreateFleet request if specified on the Provisioner", func() {
-			provider, err := v1alpha1.Deserialize(provisioner.Spec.Provider)
+			provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 			Expect(err).ToNot(HaveOccurred())
 			provider.Context = aws.String("context-1234")
 			provisioner = coretest.Provisioner(coretest.ProvisionerOptions{Provider: provider})

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.154
 	github.com/aws/aws-sdk-go-v2/config v1.18.3
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.0.2-0.20221205173459-064a52f2f9e1
+	github.com/aws/karpenter-core v0.0.2-0.20221207071807-fae4eac425cc
 	github.com/onsi/ginkgo/v2 v2.5.1
 	github.com/onsi/gomega v1.24.1
 	github.com/samber/lo v1.36.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -84,8 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 h1:jcw6kKZrtNfBPJkaHrscDOZo
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8/go.mod h1:er2JHN+kBY6FcMfcBBKNGCT3CarImmdFzishsqBmSRI=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.5 h1:60SJ4lhvn///8ygCzYy2l53bFW/Q15bVfyjyAWo6zuw=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.5/go.mod h1:bXcN3koeVYiJcdDU89n3kCYILob7Y34AeLopUbZgLT4=
-github.com/aws/karpenter-core v0.0.2-0.20221205173459-064a52f2f9e1 h1:/UHr8IYWo23pQgPOM39FikZpYKz9ZsiEITUu6IB3imA=
-github.com/aws/karpenter-core v0.0.2-0.20221205173459-064a52f2f9e1/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
+github.com/aws/karpenter-core v0.0.2-0.20221207071807-fae4eac425cc h1:F1qEvMtKCnSUOG8CIPN7s68SgWPsyJaen7eeQDb7AMY=
+github.com/aws/karpenter-core v0.0.2-0.20221207071807-fae4eac425cc/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.4 h1:/RN2z1txIJWeXeOkzX+Hk/4Uuvv7dWtCjbmVJcrskyk=
 github.com/aws/smithy-go v1.13.4/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=

--- a/test/suites/integration/backwards_compatability_test.go
+++ b/test/suites/integration/backwards_compatability_test.go
@@ -1,0 +1,54 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	"github.com/aws/karpenter-core/pkg/test"
+	"github.com/aws/karpenter/pkg/apis/config/settings"
+	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+)
+
+var _ = Describe("BackwardsCompatability", func() {
+	It("should succeed to launch a node by specifying a provider in the Provisioner", func() {
+		provisioner := test.Provisioner(
+			test.ProvisionerOptions{
+				Provider: &v1alpha1.AWS{
+					SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+					SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+					Tags: map[string]string{
+						"custom-tag":  "custom-value",
+						"custom-tag2": "custom-value2",
+					},
+				},
+			},
+		)
+		pod := test.Pod()
+		env.ExpectCreated(pod, provisioner)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		nodes := env.Monitor.CreatedNodes()
+		Expect(nodes).To(HaveLen(1))
+		Expect(env.GetInstance(nodes[0].Name).Tags).To(ContainElements(
+			&ec2.Tag{Key: lo.ToPtr("custom-tag"), Value: lo.ToPtr("custom-value")},
+			&ec2.Tag{Key: lo.ToPtr("custom-tag2"), Value: lo.ToPtr("custom-value2")},
+		))
+	})
+})

--- a/test/suites/integration/kubelet_config_test.go
+++ b/test/suites/integration/kubelet_config_test.go
@@ -28,10 +28,11 @@ import (
 	"knative.dev/pkg/ptr"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter/pkg/apis/config/settings"
 	awstest "github.com/aws/karpenter/pkg/test"
 
-	"github.com/aws/karpenter-core/pkg/scheduling"
+	pscheduling "github.com/aws/karpenter-core/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 )
@@ -241,7 +242,7 @@ func getDaemonSetPodCount(provisioner *v1alpha5.Provisioner) int {
 	count := 0
 	for _, daemonSet := range daemonSetList.Items {
 		p := &v1.Pod{Spec: daemonSet.Spec.Template.Spec}
-		nodeTemplate := scheduling.NewNodeTemplate(provisioner)
+		nodeTemplate := pscheduling.NewMachineTemplate(provisioner)
 		if err := nodeTemplate.Taints.Tolerates(p); err != nil {
 			continue
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Use Machine spec in memory to launch instances through `cloudprovider.Create`

This is a buddy change for: https://github.com/aws/karpenter-core/pull/102

**How was this change tested?**

* `make presubmit`
* `FOCUS="Scheduling" make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
