### PR TITLE
docs: Add PlanetScale to list of adopters.

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -25,6 +25,7 @@ If you are open to others contacting you about your use of Karpenter on Slack, a
 | idealo | Scaling multi-arch IPv6 clusters hosting web and event-driven applications | `@Heiko Rothe` | [Homepage](https://www.idealo.de) |
 | Nirvana Money | Building healthy, happy financial lives - Using Karpenter to manage all-Spot clusters | `@DWSR` | [Homepage](https://www.nirvana.money/) |
 | Omaze | Intelligently using Karpenter's autoscaling to power our platforms | `@devopsidiot` | [Homepage](https://www.omaze.com/) |
+| PlanetScale | Leveraging Karpenter to dynamically deploy serverless MySQL workloads. | `@jtcunning` | [Homepage](https://www.planetscale.com/) |
 | Sendcloud | Using Karpenter to scale our k8s clusters for Europe’s #1 shipping automation platform  | N/A | [Homepage](https://www.sendcloud.com/) |
 | Stytch | Powering the scaling needs of Stytch's authentication and user-management APIs  | `@Elijah Chanakira`, `@Ovadia Harary` | [Homepage](https://www.stytch.com/) |
 | Tyk Cloud | Scaling workloads for the Cloud Free plan  | `@Artem Hluvchynskyi`, `@gowtham` | [Tyk Cloud](https://tyk.io/cloud/) |


### PR DESCRIPTION
**Description**

Adds PlanetScale to list of adopters. 🎊 

While we've not completely migrated our workloads, Karpenter has launched more than 50% of our node globally, so I'll consider that an official adoption if I've ever seen one.

**How was this change tested?**

* Human eyeballs.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
Added PlanetScale to list of adopters.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
