### PR TITLE
docs: Retain current path in new version docs link

### DIFF
--- a/website/assets/js/versionWarning/index.js
+++ b/website/assets/js/versionWarning/index.js
@@ -11,13 +11,15 @@ export function versionWarning() {
   ].map(el => el.dataset.docsVersion)[0]
 
   if (viewingVersion !== latestVersion) {
+    // keep the current path if user is viewing and old version of the docs
+    const newPath = window.location.pathname.replace(viewingVersion, latestVersion).replace(/^\//g, '')
     const alertElement = document.createElement('div')
     alertElement.classList.add('alert', 'alert-warning')
     alertElement.innerHTML = `
       <h3>You are viewing Karpenter's <strong>${viewingVersion}</strong> documentation</h3>
       <p>
         Karpenter <strong>${viewingVersion}</strong> is not the latest stable release. 
-        For up-to-date documentation, see the <a href="/${latestVersion}">latest version</a>.
+        For up-to-date documentation, see the <a href="/${newPath}">latest version</a>.
       </p>
     `
     document.querySelector('.td-content').prepend(alertElement)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
When clicking on "latest verison" from the old version pop-up this should retain the current path so the user isn't send back to the main docs page. If the path doesn't exist in the new version they'll get the standard 404 page.

**How was this change tested?**

* running docs locally with multiple versions

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
