### PR TITLE
fix: amd test flake

### DIFF
--- a/test/suites/integration/testdata/amd_driver_input.sh
+++ b/test/suites/integration/testdata/amd_driver_input.sh
@@ -8,9 +8,27 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 cd
 sudo amazon-linux-extras install epel -y
 sudo yum update -y
+cat << EOF > /tmp/amd-install.sh
+#!/bin/bash
+export echo PATH=/usr/local/bin:$PATH
 aws s3 cp --recursive s3://ec2-amd-linux-drivers/latest/ . --no-sign-request
 tar -xf amdgpu-pro-*rhel*.tar.xz
 cd amdgpu-pro-20.20-1184451-rhel-7.8
 ./amdgpu-pro-install -y --opencl=pal,legacy
+systemctl disable amd-install.service
+reboot
+EOF
+sudo chmod +x /tmp/amd-install.sh
+cat << EOF > /etc/systemd/system/amd-install.service
+[Unit]
+Description=install amd drivers
+
+[Service]
+ExecStart=/bin/bash /tmp/amd-install.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl enable amd-install.service
 (sleep 30; sudo reboot) &
 --BOUNDARY-- 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Fix AMD test flake when the kernel is updated

**How was this change tested?**
```
FOCUS="should provision nodes for a deployment that requests amd.com/gpu" make e2etests
``` 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
