### PR TITLE
fix: remove panic on IsMachineDrifted on provider ref nil reference

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -175,6 +175,9 @@ func (c *CloudProvider) IsMachineDrifted(ctx context.Context, machine *corev1alp
 	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: machine.Labels[v1alpha5.ProvisionerNameLabelKey]}, provisioner); err != nil {
 		return false, k8sClient.IgnoreNotFound(fmt.Errorf("getting provisioner, %w", err))
 	}
+	if provisioner.Spec.ProviderRef == nil {
+		return false, fmt.Errorf("providerRef must be defined for Drift")
+	}
 	nodeTemplate, err := c.resolveNodeTemplate(ctx, nil, &v1.ObjectReference{
 		APIVersion: provisioner.Spec.ProviderRef.APIVersion,
 		Kind:       provisioner.Spec.ProviderRef.Kind,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- Adds a check to make sure that providerRef is defined for IsMachineDrifted()

**How was this change tested?**

* make presubmit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
