### PR TITLE
Revert "docs: Retain current path in new version docs link"

### DIFF
--- a/website/assets/js/versionWarning/index.js
+++ b/website/assets/js/versionWarning/index.js
@@ -11,15 +11,13 @@ export function versionWarning() {
   ].map(el => el.dataset.docsVersion)[0]
 
   if (viewingVersion !== latestVersion) {
-    // keep the current path if user is viewing and old version of the docs
-    const newPath = window.location.pathname.replace(viewingVersion, latestVersion).replace(/^\//g, '')
     const alertElement = document.createElement('div')
     alertElement.classList.add('alert', 'alert-warning')
     alertElement.innerHTML = `
       <h3>You are viewing Karpenter's <strong>${viewingVersion}</strong> documentation</h3>
       <p>
         Karpenter <strong>${viewingVersion}</strong> is not the latest stable release. 
-        For up-to-date documentation, see the <a href="/${newPath}">latest version</a>.
+        For up-to-date documentation, see the <a href="/${latestVersion}">latest version</a>.
       </p>
     `
     document.querySelector('.td-content').prepend(alertElement)


### PR DESCRIPTION
Reverts aws/karpenter#3013

Avoid DOM-based cross site scripting risk