### PR TITLE
fix: Replace consolidation panel for deprovisioning panel in karpenter capacity dashboard

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
@@ -112,7 +112,7 @@
                     },
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(action, cluster) (karpenter_consolidation_actions_performed)",
+                    "expr": "sum by(action, cluster) (karpenter_deprovisioning_actions_performed)",
                     "format": "time_series",
                     "instant": false,
                     "legendFormat": "{{cluster}}: {{action}}",
@@ -120,7 +120,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Consolidation Actions Performed",
+            "title": "Deprovisioning Actions Performed",
             "type": "timeseries"
         },
         {

--- a/website/content/en/v0.19.3/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
+++ b/website/content/en/v0.19.3/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
@@ -112,7 +112,7 @@
                     },
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(action, cluster) (karpenter_consolidation_actions_performed)",
+                    "expr": "sum by(action, cluster) (karpenter_deprovisioning_actions_performed)",
                     "format": "time_series",
                     "instant": false,
                     "legendFormat": "{{cluster}}: {{action}}",
@@ -120,7 +120,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Consolidation Actions Performed",
+            "title": "Deprovisioning Actions Performed",
             "type": "timeseries"
         },
         {

--- a/website/content/en/v0.20.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
+++ b/website/content/en/v0.20.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json
@@ -112,7 +112,7 @@
                     },
                     "editorMode": "builder",
                     "exemplar": false,
-                    "expr": "sum by(action, cluster) (karpenter_consolidation_actions_performed)",
+                    "expr": "sum by(action, cluster) (karpenter_deprovisioning_actions_performed)",
                     "format": "time_series",
                     "instant": false,
                     "legendFormat": "{{cluster}}: {{action}}",
@@ -120,7 +120,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Consolidation Actions Performed",
+            "title": "Deprovisioning Actions Performed",
             "type": "timeseries"
         },
         {


### PR DESCRIPTION
Fixes [kubernetes slack-link](https://kubernetes.slack.com/archives/C02SFFZSA2K/p1669673009999729)

**Description**

**How was this change tested?**

* local grafana dashboard
![Screen Shot 2022-12-19 at 6 12 19 PM](https://user-images.githubusercontent.com/9098149/208565197-6b11a15d-58ff-4f37-8217-ca79b220aeaa.png)
oard


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

```release-note
Replaced deprecated `karpenter_consolidation_actions_performed` metric with `karpenter_deprovisioning_actions_performed` on Karpenter Capacity grafana dashboard.

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
