### PR TITLE
docs: Update step11-create-provisioner.sh

### DIFF
--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
@@ -5,7 +5,7 @@ metadata:
   name: default
 spec:
   requirements:
-    - key: karpenter.k8s.aws/instance-family
+    - key: karpenter.k8s.aws/instance-category
       operator: In
       values: [c, m, r]
     - key: karpenter.k8s.aws/instance-generation

--- a/website/content/en/v0.19.3/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
+++ b/website/content/en/v0.19.3/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
@@ -5,7 +5,7 @@ metadata:
   name: default
 spec:
   requirements:
-    - key: karpenter.k8s.aws/instance-family
+    - key: karpenter.k8s.aws/instance-category
       operator: In
       values: [c, m, r]
     - key: karpenter.k8s.aws/instance-generation

--- a/website/content/en/v0.20.0/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
+++ b/website/content/en/v0.20.0/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
@@ -10,7 +10,7 @@ spec:
       values: [c, m, r]
     - key: karpenter.k8s.aws/instance-generation
       operator: Gt
-      values: ["4"]
+      values: ["2"]
   providerRef:
     name: default
 ---

--- a/website/content/en/v0.20.0/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
+++ b/website/content/en/v0.20.0/getting-started/migrating-from-cas/scripts/step11-create-provisioner.sh
@@ -5,12 +5,12 @@ metadata:
   name: default
 spec:
   requirements:
-    - key: karpenter.k8s.aws/instance-family
+    - key: karpenter.k8s.aws/instance-category
       operator: In
       values: [c, m, r]
     - key: karpenter.k8s.aws/instance-generation
       operator: Gt
-      values: ["2"]
+      values: ["4"]
   providerRef:
     name: default
 ---


### PR DESCRIPTION
* Changed key `karpenter.k8s.aws/instance-family` to `karpenter.k8s.aws/instance-category`, current example configuration gives "no instance type satisfied resources" error. 
* Bump `karpenter.k8s.aws/instance-generation` value from `2` to `4`, as per AWS current generation doc.  
  > https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3078 <!-- issue number -->

**Description**

**How was this change tested?**

* Read rendered doc to make sure correct example configuration appears.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [x] Yes, issue opened: #3078  <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Changed key `karpenter.k8s.aws/instance-family` to `karpenter.k8s.aws/instance-category`, current example configuration gives "no instance type satisfied resources" error. 
* Bump `karpenter.k8s.aws/instance-generation` value from `2` to `4`, as per AWS current generation doc.  
  > https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
