### PR TITLE
Feat: Support comma separated tag values in subnetSelector

### DIFF
--- a/pkg/cloudprovider/subnets.go
+++ b/pkg/cloudprovider/subnets.go
@@ -98,9 +98,10 @@ func getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {
 				Values: []*string{aws.String(key)},
 			})
 		} else {
+			filterValues := functional.SplitCommaSeparatedString(value)
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
-				Values: []*string{aws.String(value)},
+				Values: aws.StringSlice(filterValues),
 			})
 		}
 	}

--- a/pkg/cloudprovider/subnets.go
+++ b/pkg/cloudprovider/subnets.go
@@ -87,10 +87,9 @@ func getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {
 	// Filter by subnet
 	for key, value := range nodeTemplate.Spec.SubnetSelector {
 		if key == "aws-ids" {
-			filterValues := functional.SplitCommaSeparatedString(value)
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String("subnet-id"),
-				Values: aws.StringSlice(filterValues),
+				Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
 			})
 		} else if value == "*" {
 			filters = append(filters, &ec2.Filter{
@@ -98,10 +97,9 @@ func getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {
 				Values: []*string{aws.String(key)},
 			})
 		} else {
-			filterValues := functional.SplitCommaSeparatedString(value)
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
-				Values: aws.StringSlice(filterValues),
+				Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
 			})
 		}
 	}

--- a/pkg/cloudprovider/subnets_test.go
+++ b/pkg/cloudprovider/subnets_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Subnets", func() {
 	})
 	It("should discover subnets by a single tag", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1"}
-		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		createFleetInput := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
@@ -136,7 +136,7 @@ var _ = Describe("Subnets", func() {
 	})
 	It("should discover subnets by tags", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1,test-subnet-2"}
-		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		createFleetInput := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()

--- a/pkg/cloudprovider/subnets_test.go
+++ b/pkg/cloudprovider/subnets_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Subnets", func() {
 			"subnet-test1",
 		))
 	})
-	It("should discover subnets by tags", func() {
+	It("should discover subnets by multiple tag values", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1,test-subnet-2"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]

--- a/pkg/cloudprovider/subnets_test.go
+++ b/pkg/cloudprovider/subnets_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 var _ = Describe("Subnets", func() {
+	// Note when debugging these tests -
+	// hard coded fixture data (ex. what the aws api will return) is maintained in fake/ec2api.go
 	It("should default to the cluster's subnets", func() {
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod(
@@ -115,6 +117,27 @@ var _ = Describe("Subnets", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test1,subnet-test2", "foo": "bar"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
+		ExpectScheduled(ctx, env.Client, pod)
+		createFleetInput := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
+		Expect(fake.SubnetsFromFleetRequest(createFleetInput)).To(ConsistOf(
+			"subnet-test1",
+			"subnet-test2",
+		))
+	})
+	It("should discover subnets by a single tag", func() {
+		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1"}
+		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
+		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
+		ExpectScheduled(ctx, env.Client, pod)
+		createFleetInput := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
+		Expect(fake.SubnetsFromFleetRequest(createFleetInput)).To(ConsistOf(
+			"subnet-test1",
+		))
+	})
+	It("should discover subnets by tags", func() {
+		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1,test-subnet-2"}
+		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
+		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		createFleetInput := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
 		Expect(fake.SubnetsFromFleetRequest(createFleetInput)).To(ConsistOf(

--- a/pkg/cloudprovider/subnets_test.go
+++ b/pkg/cloudprovider/subnets_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Subnets", func() {
 	It("should discover subnets by a single tag", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		createFleetInput := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
 		Expect(fake.SubnetsFromFleetRequest(createFleetInput)).To(ConsistOf(
@@ -137,7 +137,7 @@ var _ = Describe("Subnets", func() {
 	It("should discover subnets by tags", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1,test-subnet-2"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		createFleetInput := fakeEC2API.CreateFleetBehavior.CalledWithInput.Pop()
 		Expect(fake.SubnetsFromFleetRequest(createFleetInput)).To(ConsistOf(

--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -55,6 +55,29 @@ var _ = Describe("Subnets", func() {
 		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SubnetId", HaveValue(Equal(firstSubnet))))
 	})
 
+	It("should use the subnet tag selector", func() {
+		// Get all the subnets for the cluster
+		subnets := getSubnetNameAndIds(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
+		Expect(len(subnets)).To(BeNumerically(">", 1))
+		firstSubnet := subnets[0]
+		lastSubnet := subnets[len(subnets)-1]
+
+		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+			AWS: v1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{"Name": fmt.Sprintf("%s,%s", firstSubnet.Name, lastSubnet.Name)},
+			},
+		})
+		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
+		pod := test.Pod()
+
+		env.ExpectCreated(pod, provider, provisioner)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SubnetId", HaveValue(BeElementOf(firstSubnet.ID, lastSubnet.ID))))
+	})
+
 	It("should use a subnet within the AZ requested", func() {
 		subnets := getSubnets(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
 		Expect(len(subnets)).ToNot(Equal(0))
@@ -107,4 +130,36 @@ func getSubnets(tags map[string]string) map[string][]string {
 	})
 	Expect(err).To(BeNil())
 	return subnets
+}
+
+// SubnetInfo is a simple struct for testing
+type SubnetInfo struct {
+	Name string
+	ID   string
+}
+
+// getSubnetNameAndIds returns all subnets matching the label selector
+func getSubnetNameAndIds(tags map[string]string) []SubnetInfo {
+	var filters []*ec2.Filter
+	for key, val := range tags {
+		filters = append(filters, &ec2.Filter{
+			Name:   aws.String(fmt.Sprintf("tag:%s", key)),
+			Values: []*string{aws.String(val)},
+		})
+	}
+	var subnetInfo []SubnetInfo
+	err := env.EC2API.DescribeSubnetsPages(&ec2.DescribeSubnetsInput{Filters: filters}, func(dso *ec2.DescribeSubnetsOutput, _ bool) bool {
+		for _, subnet := range dso.Subnets {
+			for k := range subnet.Tags {
+				if aws.StringValue(subnet.Tags[k].Key) == "Name" {
+					subnetInfo = append(subnetInfo, SubnetInfo{ID: aws.StringValue(subnet.SubnetId), Name: aws.StringValue(subnet.Tags[k].Value)})
+					break
+				}
+			}
+		}
+		return true
+	})
+
+	Expect(err).To(BeNil())
+	return subnetInfo
 }

--- a/test/suites/integration/subnet_test.go
+++ b/test/suites/integration/subnet_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Subnets", func() {
 		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SubnetId", HaveValue(Equal(firstSubnet))))
 	})
 
-	It("should use the subnet tag selector", func() {
+	It("should use the subnet tag selector with multiple tag values", func() {
 		// Get all the subnets for the cluster
 		subnets := getSubnetNameAndIds(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
 		Expect(len(subnets)).To(BeNumerically(">", 1))

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -63,7 +63,7 @@ Select subnets by name:
 Select subnets using comma separated tag values:
 ```yaml
   subnetSelector:
-    Name: "Name1,Name2"
+    Name: "my-subnet-1,my-subnet-2"
 ```
 
 Select subnets by an arbitrary AWS tag key/value pair:

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -63,7 +63,7 @@ Select subnets by name:
 Select subnets using comma separated tag values:
 ```yaml
   subnetSelector:
-    Name: "Public1,Public2"
+    Name: "Name1,Name2"
 ```
 
 Select subnets by an arbitrary AWS tag key/value pair:

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -60,6 +60,12 @@ Select subnets by name:
     Name: my-subnet
 ```
 
+Select subnets using comma separated tag values:
+```yaml
+  subnetSelector:
+    Name: "Public1,Public2"
+```
+
 Select subnets by an arbitrary AWS tag key/value pair:
 ```yaml
   subnetSelector:
@@ -101,21 +107,21 @@ If multiple securityGroups are printed, you will need a more specific securityGr
 **Examples**
 
 Select all security groups with a specified tag:
-```
+```yaml
 spec:
   securityGroupSelector:
     karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select security groups by name, or another tag (all criteria must match):
-```
+```yaml
  securityGroupSelector:
    Name: my-security-group
    MySecurityTag: '' # matches all resources with the tag
 ```
 
 Select security groups by name using a wildcard:
-```
+```yaml
  securityGroupSelector:
    Name: "*Public*"
 ```

--- a/website/content/en/v0.20.0/concepts/node-templates.md
+++ b/website/content/en/v0.20.0/concepts/node-templates.md
@@ -73,12 +73,6 @@ Select subnets using wildcards:
 
 ```
 
-Select subnets using comma separated tag values:
-```
-  subnetSelector:
-    Name: "Public1,Public2"
-```
-
 Specify subnets explicitly by ID:
 ```yaml
   subnetSelector:

--- a/website/content/en/v0.20.0/concepts/node-templates.md
+++ b/website/content/en/v0.20.0/concepts/node-templates.md
@@ -73,6 +73,12 @@ Select subnets using wildcards:
 
 ```
 
+Select subnets using comma separated tag values:
+```
+  subnetSelector:
+    Name: "Public1,Public2"
+```
+
 Specify subnets explicitly by ID:
 ```yaml
   subnetSelector:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Closing out: https://github.com/aws/karpenter/pull/2859

Support comma separated tag values in subnetSelector - (wildcard search is not flexible enough.)
Consider the use case where Private1,Private2 subnets should be used but Private3 excluded.
This is a simple enough change to split the string and supported by the ec2 tag filters.
It is done this same exact way for aws-ids searches.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
