### PR TITLE
Feat: Support comma separated tag values in securityGroupSelector

### DIFF
--- a/pkg/cloudprovider/securitygroups.go
+++ b/pkg/cloudprovider/securitygroups.go
@@ -72,16 +72,14 @@ func (p *SecurityGroupProvider) getFilters(nodeTemplate *v1alpha1.AWSNodeTemplat
 	filters := []*ec2.Filter{}
 	for key, value := range nodeTemplate.Spec.SecurityGroupSelector {
 		if key == "aws-ids" {
-			filterValues := functional.SplitCommaSeparatedString(value)
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String("group-id"),
-				Values: aws.StringSlice(filterValues),
+				Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
 			})
 		} else {
-			filterValues := functional.SplitCommaSeparatedString(value)
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
-				Values: aws.StringSlice(filterValues),
+				Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
 			})
 		}
 	}

--- a/pkg/cloudprovider/securitygroups.go
+++ b/pkg/cloudprovider/securitygroups.go
@@ -78,9 +78,10 @@ func (p *SecurityGroupProvider) getFilters(nodeTemplate *v1alpha1.AWSNodeTemplat
 				Values: aws.StringSlice(filterValues),
 			})
 		} else {
+			filterValues := functional.SplitCommaSeparatedString(value)
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
-				Values: []*string{aws.String(value)},
+				Values: aws.StringSlice(filterValues),
 			})
 		}
 	}

--- a/pkg/cloudprovider/securitygroups_test.go
+++ b/pkg/cloudprovider/securitygroups_test.go
@@ -20,10 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/aws/karpenter/pkg/test"
-
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-
 	coretest "github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
@@ -57,15 +53,15 @@ var _ = Describe("Security Groups", func() {
 		))
 	})
 	It("should discover security groups by tags", func() {
-		provider.SecurityGroupSelector = map[string]string{"Name": "test-security-group-1,test-security-group-2"}
-		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{Provider: provider}))
-		pod := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, coretest.UnschedulablePod())[0]
+		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"Name": "test-security-group-1,test-security-group-2"}
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 		input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
 		Expect(aws.StringValueSlice(input.LaunchTemplateData.SecurityGroupIds)).To(ConsistOf(
-			"test-sg-1",
-			"test-sg-2",
+			"sg-test1",
+			"sg-test2",
 		))
 	})
 	It("should discover security groups by ID", func() {
@@ -81,11 +77,7 @@ var _ = Describe("Security Groups", func() {
 	})
 	It("should discover security groups by IDs", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1,sg-test2"}
-		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{
-			APIVersion: nodeTemplate.APIVersion,
-			Kind:       nodeTemplate.Kind,
-			Name:       nodeTemplate.Name,
-		}}), nodeTemplate)
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
@@ -97,11 +89,7 @@ var _ = Describe("Security Groups", func() {
 	})
 	It("should discover security groups by IDs and tags", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1,sg-test2", "foo": "bar"}
-		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{
-			APIVersion: nodeTemplate.APIVersion,
-			Kind:       nodeTemplate.Kind,
-			Name:       nodeTemplate.Name,
-		}}), nodeTemplate)
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
@@ -113,11 +101,7 @@ var _ = Describe("Security Groups", func() {
 	})
 	It("should discover security groups by IDs intersected with tags", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test2", "foo": "bar"}
-		ExpectApplied(ctx, env.Client, test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{
-			APIVersion: nodeTemplate.APIVersion,
-			Kind:       nodeTemplate.Kind,
-			Name:       nodeTemplate.Name,
-		}}), nodeTemplate)
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 		Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))

--- a/pkg/cloudprovider/securitygroups_test.go
+++ b/pkg/cloudprovider/securitygroups_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Security Groups", func() {
 			"test-sg-2",
 		))
 	})
-	It("should discover security groups by tags", func() {
+	It("should discover security groups by multiple tag values", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"Name": "test-security-group-1,test-security-group-2"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]

--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -51,7 +51,7 @@ var _ = Describe("SecurityGroups", func() {
 		env.EventuallyExpectHealthy(pod)
 		env.ExpectCreatedNodeCount("==", 1)
 
-		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SecurityGroups", ContainElement(&securityGroups[0])))
+		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SecurityGroups", ConsistOf(&securityGroups[0].GroupIdentifier)))
 	})
 
 	It("should use the security group selector with multiple tag values", func() {
@@ -63,8 +63,8 @@ var _ = Describe("SecurityGroups", func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 			AWS: v1alpha1.AWS{
 				SecurityGroupSelector: map[string]string{"Name": fmt.Sprintf("%s,%s",
-					aws.StringValue(lo.FindOrElse(first.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return aws.StringValue(tag.Key) == "Name" }).Key),
-					aws.StringValue(lo.FindOrElse(last.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return aws.StringValue(tag.Key) == "Name" }).Key),
+					aws.StringValue(lo.FindOrElse(first.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return aws.StringValue(tag.Key) == "Name" }).Value),
+					aws.StringValue(lo.FindOrElse(last.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return aws.StringValue(tag.Key) == "Name" }).Value),
 				)},
 				SubnetSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 			},
@@ -76,7 +76,7 @@ var _ = Describe("SecurityGroups", func() {
 		env.EventuallyExpectHealthy(pod)
 		env.ExpectCreatedNodeCount("==", 1)
 
-		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SecurityGroups", ConsistOf(first.GroupIdentifier, last.GroupIdentifier)))
+		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SecurityGroups", ConsistOf(&first.GroupIdentifier, &last.GroupIdentifier)))
 	})
 })
 

--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -37,7 +37,7 @@ var _ = Describe("SecurityGroups", func() {
 		securityGroups := getSecurityGroups(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
 		Expect(len(securityGroups)).To(BeNumerically(">", 1))
 
-		ids := strings.Join(lo.Map(securityGroups, func(sg SecurityGroup, _ int) string { return *sg.GroupId }), ",")
+		ids := strings.Join([]string{*securityGroups[0].GroupId, *securityGroups[1].GroupId}, ",")
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 			AWS: v1alpha1.AWS{
 				SecurityGroupSelector: map[string]string{"aws-ids": ids},
@@ -51,7 +51,7 @@ var _ = Describe("SecurityGroups", func() {
 		env.EventuallyExpectHealthy(pod)
 		env.ExpectCreatedNodeCount("==", 1)
 
-		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SecurityGroups", ConsistOf(&securityGroups[0].GroupIdentifier)))
+		env.ExpectInstance(pod.Spec.NodeName).To(HaveField("SecurityGroups", ConsistOf(&securityGroups[0].GroupIdentifier, &securityGroups[1].GroupIdentifier)))
 	})
 
 	It("should use the security group selector with multiple tag values", func() {

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -48,39 +48,39 @@ If multiple subnets exist for a zone, the one with the most available IP address
 
 **Examples**
 
-Select all subnets with a specified tag:
+Select all with a specified tag key:
 ```yaml
+spec:
   subnetSelector:
     karpenter.sh/discovery/MyClusterName: '*'
 ```
 
-Select subnets by name:
+Select by name and tag (all criteria must match)::
 ```yaml
+spec:
   subnetSelector:
     Name: my-subnet
+    MyTag: '' # matches all resources with the tag
 ```
 
-Select subnets using comma separated tag values:
+Select using comma separated tag values:
 ```yaml
+spec:
   subnetSelector:
     Name: "my-subnet-1,my-subnet-2"
 ```
 
-Select subnets by an arbitrary AWS tag key/value pair:
+Select using wildcards:
 ```yaml
-  subnetSelector:
-    MySubnetTag: value
-```
-
-Select subnets using wildcards:
-```yaml
+spec:
   subnetSelector:
     Name: "*Public*"
 
 ```
 
-Specify subnets explicitly by ID:
+Specify explicitly by ID:
 ```yaml
+spec:
   subnetSelector:
     aws-ids: "subnet-09fa4a0a8f233a921,subnet-0471ca205b8a129ae"
 ```
@@ -106,28 +106,38 @@ If multiple securityGroups are printed, you will need a more specific securityGr
 
 **Examples**
 
-Select all security groups with a specified tag:
+Select all with a specified tag key:
 ```yaml
 spec:
   securityGroupSelector:
     karpenter.sh/discovery/MyClusterName: '*'
 ```
 
-Select security groups by name, or another tag (all criteria must match):
+Select by name and tag (all criteria must match):
 ```yaml
- securityGroupSelector:
-   Name: my-security-group
-   MySecurityTag: '' # matches all resources with the tag
+spec:
+  securityGroupSelector:
+    Name: my-security-group
+    MyTag: '' # matches all resources with the tag
 ```
 
-Select security groups by name using a wildcard:
+Select by comma-separated tag values:
 ```yaml
- securityGroupSelector:
-   Name: "*Public*"
+spec:
+  securityGroupSelector:
+     Name: "my-security-group-1,my-security-group-2"
 ```
 
-Specify security groups explicitly by ID:
+Select by name using a wildcard:
 ```yaml
+spec:
+  securityGroupSelector:
+    Name: "*Public*"
+```
+
+Specify explicitly by ID:
+```yaml
+spec:
  securityGroupSelector:
    aws-ids: "sg-063d7acfb4b06c82c,sg-06e0cf9c198874591"
 ```

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -135,7 +135,7 @@ spec:
     Name: "*Public*"
 ```
 
-Specify explicitly by ID:
+Select by ID:
 ```yaml
 spec:
  securityGroupSelector:

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -78,7 +78,7 @@ spec:
 
 ```
 
-Specify explicitly by ID:
+Select by ID:
 ```yaml
 spec:
   subnetSelector:

--- a/website/content/en/v0.19.3/AWS/provisioning.md
+++ b/website/content/en/v0.19.3/AWS/provisioning.md
@@ -135,6 +135,13 @@ spec:
     karpenter.sh/discovery/MyClusterName: '*'
 ```
 
+Select security groups by comma-separated tag values:
+```
+spec:
+  securityGroupSelector:
+     Name: my-security-group-1,my-security-group-2
+```
+
 Select security groups by name, or another tag (all criteria must match):
 ```
  securityGroupSelector:

--- a/website/content/en/v0.19.3/AWS/provisioning.md
+++ b/website/content/en/v0.19.3/AWS/provisioning.md
@@ -135,13 +135,6 @@ spec:
     karpenter.sh/discovery/MyClusterName: '*'
 ```
 
-Select security groups by comma-separated tag values:
-```
-spec:
-  securityGroupSelector:
-     Name: my-security-group-1,my-security-group-2
-```
-
 Select security groups by name, or another tag (all criteria must match):
 ```
  securityGroupSelector:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
Finishing out https://github.com/aws/karpenter/pull/2923

Support comma separated tag values in securityGroupSelector - (wildcard search is not flexible enough.)
Consider the use case where sg-1,sg-2 security groups should be used but sg-3 excluded.
This is a simple enough change to split the string and supported by the ec2 tag filters.
It is done this same exact way for aws-ids searches.

Similar to https://github.com/aws/karpenter/pull/2859

**How was this change tested?**

*

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
