### PR TITLE
test: add drift into e2e test suites cron

### DIFF
--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -37,7 +37,7 @@ data:
   pipelines-trigger.sh: |+
     #!/usr/bin/env bash
     set -euo pipefail
-    for suite in "Integration" "Consolidation" "Utilization" "Interruption" "Chaos"; do
+    for suite in "Integration" "Consolidation" "Utilization" "Interruption" "Chaos" "Drift"; do
        cat <<EOF | kubectl create -f -
      apiVersion: tekton.dev/v1beta1
      kind: PipelineRun


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
Adds the e2e drift test into the e2e testing suites.

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
