### PR TITLE
test: dump controller logs on failures

### DIFF
--- a/test/suites/common/dump-logs.yaml
+++ b/test/suites/common/dump-logs.yaml
@@ -22,11 +22,17 @@ spec:
       script: |
         aws eks update-kubeconfig --name $(params.cluster-name)
         POD_NAME=$(kubectl get pods -n karpenter --no-headers -o custom-columns=":metadata.name" | tail -n 1)
-        echo "Controller logs from pod ${POD_NAME}: $(kubectl logs "${POD_NAME}" -n karpenter -c controller)"
+        echo "logs from pod ${POD_NAME}"
+        kubectl logs "${POD_NAME}" -n karpenter -c controller
 
-    - name: describe
+    - name: describe-karpenter-pods
       image: public.ecr.aws/karpenter-testing/tools:latest
       script: |
         aws eks update-kubeconfig --name $(params.cluster-name)
-        echo "Describe nodes: $(kubectl describe nodes)"
-        echo "Describe pods running in the cluster: $(kubectl describe pods -n karpenter)"
+        kubectl describe pods -n karpenter
+
+    - name: describe-nodes
+      image: public.ecr.aws/karpenter-testing/tools:latest
+      script: |
+        aws eks update-kubeconfig --name $(params.cluster-name)
+        kubectl describe nodes

--- a/test/suites/common/dump-logs.yaml
+++ b/test/suites/common/dump-logs.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: dump-logs
+  namespace: karpenter-tests
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Messaging
+    tekton.dev/tags: messaging
+    tekton.dev/displayName: "Dump logs on error"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: Dump logs on failures to help troubleshooting
+  params:
+    - name: cluster-name
+      description: Name of the cluster under test.
+  steps:
+    - name: controller-logs
+      image: public.ecr.aws/karpenter-testing/tools:latest
+      script: |
+        aws eks update-kubeconfig --name $(params.cluster-name)
+        POD_NAME=$(kubectl get pods -n karpenter --no-headers -o custom-columns=":metadata.name" | tail -n 1)
+        echo "Controller logs from pod ${POD_NAME}: $(kubectl logs "${POD_NAME}" -n karpenter -c controller)"
+
+    - name: describe
+      image: public.ecr.aws/karpenter-testing/tools:latest
+      script: |
+        aws eks update-kubeconfig --name $(params.cluster-name)
+        echo "Describe nodes: $(kubectl describe nodes)"
+        echo "Describe pods running in the cluster: $(kubectl describe pods -n karpenter)"

--- a/test/suites/common/suite.yaml
+++ b/test/suites/common/suite.yaml
@@ -53,6 +53,16 @@ spec:
     - setup
 
   finally:
+  - name: dump-logs-on-failure
+    taskRef:
+      name: dump-logs
+    params:
+      - name: cluster-name
+        value: $(params.cluster-name)
+    when:
+      - input: $(tasks.status)
+        operator: in
+        values: [ "Failed" ]
   - name: cleanup
     taskRef:
       name: cleanup

--- a/test/suites/ipv6/pipeline.yaml
+++ b/test/suites/ipv6/pipeline.yaml
@@ -59,6 +59,16 @@ spec:
     - setup
 
   finally:
+  - name: dump-logs-on-failure
+    taskRef:
+      name: dump-logs
+    params:
+      - name: cluster-name
+        value: $(params.cluster-name)
+    when:
+      - input: $(tasks.status)
+        operator: in
+        values: [ "Failed" ]
   - name: cleanup
     taskRef:
       name: cleanup

--- a/test/suites/upgrade/pipeline.yaml
+++ b/test/suites/upgrade/pipeline.yaml
@@ -78,6 +78,16 @@ spec:
     - upgrade-crds
 
   finally:
+  - name: dump-logs-on-failure
+    taskRef:
+      name: dump-logs
+    params:
+      - name: cluster-name
+        value: $(params.cluster-name)
+    when:
+      - input: $(tasks.status)
+        operator: in
+        values: [ "Failed" ]
   - name: cleanup
     taskRef:
       name: cleanup


### PR DESCRIPTION
…f Karpenter pods, and nodes to help troubleshooting failures before the cluster is cleaned up

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

* Keeps controlelr and node logs when a step fails. These are currently inaccessible for troubleshooting since the cluster is removed as a next step.

**How was this change tested?**

* running in my own fork

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
