### PR TITLE
test: Bump time before the reboot to give kubelet enough time to start

### DIFF
--- a/test/suites/integration/testdata/amd_driver_input.sh
+++ b/test/suites/integration/testdata/amd_driver_input.sh
@@ -30,5 +30,5 @@ ExecStart=/bin/bash /tmp/amd-install.sh
 WantedBy=multi-user.target
 EOF
 sudo systemctl enable amd-install.service
-(sleep 30; sudo reboot) &
+(sleep 60; sudo reboot) &
 --BOUNDARY-- 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Bumps the time before we restart to 60s for the eks bootstrap script to get started so we have enough time for the kubelet service to get setup before reboot

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
