### PR TITLE
docs: Propagate provisioner defaults across all docs versions

### DIFF
--- a/website/content/en/v0.16.3/provisioner.md
+++ b/website/content/en/v0.16.3/provisioner.md
@@ -116,44 +116,18 @@ For example, an instance type may be specified using a nodeSelector in a pod spe
 ### Instance Types
 
 - key: `node.kubernetes.io/instance-type`
+- key: `karpenter.k8s.aws/instance-family`
+- key: `karpenter.k8s.aws/instance-category`
+- key: `karpenter.k8s.aws/instance-generation`
 
-Generally, instance types should be a list and not a single value. Leaving this field undefined is recommended, as it maximizes choices for efficiently placing pods.
+Generally, instance types should be a list and not a single value. Leaving these requirements undefined is recommended, as it maximizes choices for efficiently placing pods.
 
-☁️ **AWS**
-
-Review [AWS instance types](https://aws.amazon.com/ec2/instance-types/).
-
-The default value includes most instance types with the exclusion of [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html).  The full list of supported instance types can be seen [here](../aws/instance-types/)
-
-**Example**
-
-*Set Default with provisioner.yaml*
-
-```yaml
-spec:
-  requirements:
-    - key: node.kubernetes.io/instance-type
-      operator: In
-      values: ["m5.large", "m5.2xlarge"]
-```
-
-*Override with workload manifest (e.g., pod)*
-
-```yaml
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node.kubernetes.io/instance-type: m5.large
-```
+Review [AWS instance types](../AWS/instance-types). Most instance types are supported with the exclusion of [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html).
 
 ### Availability Zones
 
 - key: `topology.kubernetes.io/zone`
 - value example: `us-east-1c`
-
-☁️ **AWS**
-
 - value list: `aws ec2 describe-availability-zones --region <region-name>`
 
 Karpenter can be configured to create nodes in a particular zone. Note that the Availability Zone `us-east-1a` for your AWS account might not have the same location as `us-east-1a` for another AWS account.
@@ -165,27 +139,52 @@ IDs.](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html)
 
 - key: `kubernetes.io/arch`
 - values
-  - `amd64` (default)
+  - `amd64`
   - `arm64`
 
 Karpenter supports `amd64` nodes, and `arm64` nodes.
 
+{{% alert title="Defaults" color="secondary" %}}
+If no architecture constraint is defined, Karpenter will set the default architecture constraint on your Provisioner that supports most common user workloads:
+
+```yaml
+requirements:
+  - key: kubernetes.io/arch
+    operator: In
+    values: ["amd64"]
+```
+{{% /alert %}}
+
+### Operating System
+- key: `kubernetes.io/os`
+- values
+  - `linux`
+
+Karpenter supports only `linux` nodes at this time.
 
 ### Capacity Type
 
 - key: `karpenter.sh/capacity-type`
-
-☁️ **AWS**
-
 - values
   - `spot`
-  - `on-demand` (default)
+  - `on-demand`
 
 Karpenter supports specifying capacity type, which is analogous to [EC2 purchase options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html).
 
 Karpenter prioritizes Spot offerings if the provisioner allows Spot and on-demand instances. If the provider API (e.g. EC2 Fleet's API) indicates Spot capacity is unavailable, Karpenter caches that result across all attempts to provision EC2 capacity for that instance type and zone for the next 45 seconds. If there are no other possible offerings available for Spot, Karpenter will attempt to provision on-demand instances, generally within milliseconds.
 
 Karpenter also allows `karpenter.sh/capacity-type` to be used as a topology key for enforcing topology-spread.
+
+{{% alert title="Defaults" color="secondary" %}}
+If no capacity type constraint is defined, Karpenter will set the default capacity type constraint on your Provisioner that supports most common user workloads:
+
+```yaml
+requirements:
+  - key: karpenter.sh/capacity-type
+    operator: In
+    values: ["on-demand"]
+```
+{{% /alert %}}
 
 ## spec.weight
 

--- a/website/content/en/v0.18.1/provisioner.md
+++ b/website/content/en/v0.18.1/provisioner.md
@@ -131,44 +131,18 @@ For example, an instance type may be specified using a nodeSelector in a pod spe
 ### Instance Types
 
 - key: `node.kubernetes.io/instance-type`
+- key: `karpenter.k8s.aws/instance-family`
+- key: `karpenter.k8s.aws/instance-category`
+- key: `karpenter.k8s.aws/instance-generation`
 
-Generally, instance types should be a list and not a single value. Leaving this field undefined is recommended, as it maximizes choices for efficiently placing pods.
+Generally, instance types should be a list and not a single value. Leaving these requirements undefined is recommended, as it maximizes choices for efficiently placing pods.
 
-☁️ **AWS**
-
-Review [AWS instance types](https://aws.amazon.com/ec2/instance-types/).
-
-The default value includes most instance types with the exclusion of [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html).  The full list of supported instance types can be seen [here](../aws/instance-types/)
-
-**Example**
-
-*Set Default with provisioner.yaml*
-
-```yaml
-spec:
-  requirements:
-    - key: node.kubernetes.io/instance-type
-      operator: In
-      values: ["m5.large", "m5.2xlarge"]
-```
-
-*Override with workload manifest (e.g., pod)*
-
-```yaml
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node.kubernetes.io/instance-type: m5.large
-```
+Review [AWS instance types](../AWS/instance-types). Most instance types are supported with the exclusion of [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html).
 
 ### Availability Zones
 
 - key: `topology.kubernetes.io/zone`
 - value example: `us-east-1c`
-
-☁️ **AWS**
-
 - value list: `aws ec2 describe-availability-zones --region <region-name>`
 
 Karpenter can be configured to create nodes in a particular zone. Note that the Availability Zone `us-east-1a` for your AWS account might not have the same location as `us-east-1a` for another AWS account.
@@ -180,27 +154,52 @@ IDs.](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html)
 
 - key: `kubernetes.io/arch`
 - values
-  - `amd64` (default)
+  - `amd64`
   - `arm64`
 
 Karpenter supports `amd64` nodes, and `arm64` nodes.
 
+{{% alert title="Defaults" color="secondary" %}}
+If no architecture constraint is defined, Karpenter will set the default architecture constraint on your Provisioner that supports most common user workloads:
+
+```yaml
+requirements:
+  - key: kubernetes.io/arch
+    operator: In
+    values: ["amd64"]
+```
+{{% /alert %}}
+
+### Operating System
+- key: `kubernetes.io/os`
+- values
+  - `linux`
+
+Karpenter supports only `linux` nodes at this time.
 
 ### Capacity Type
 
 - key: `karpenter.sh/capacity-type`
-
-☁️ **AWS**
-
 - values
   - `spot`
-  - `on-demand` (default)
+  - `on-demand`
 
 Karpenter supports specifying capacity type, which is analogous to [EC2 purchase options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html).
 
 Karpenter prioritizes Spot offerings if the provisioner allows Spot and on-demand instances. If the provider API (e.g. EC2 Fleet's API) indicates Spot capacity is unavailable, Karpenter caches that result across all attempts to provision EC2 capacity for that instance type and zone for the next 45 seconds. If there are no other possible offerings available for Spot, Karpenter will attempt to provision on-demand instances, generally within milliseconds.
 
 Karpenter also allows `karpenter.sh/capacity-type` to be used as a topology key for enforcing topology-spread.
+
+{{% alert title="Defaults" color="secondary" %}}
+If no capacity type constraint is defined, Karpenter will set the default capacity type constraint on your Provisioner that supports most common user workloads:
+
+```yaml
+requirements:
+  - key: karpenter.sh/capacity-type
+    operator: In
+    values: ["on-demand"]
+```
+{{% /alert %}}
 
 ## spec.weight
 

--- a/website/content/en/v0.19.3/provisioner.md
+++ b/website/content/en/v0.19.3/provisioner.md
@@ -143,44 +143,32 @@ For example, an instance type may be specified using a nodeSelector in a pod spe
 ### Instance Types
 
 - key: `node.kubernetes.io/instance-type`
+- key: `karpenter.k8s.aws/instance-family`
+- key: `karpenter.k8s.aws/instance-category`
+- key: `karpenter.k8s.aws/instance-generation`
 
-Generally, instance types should be a list and not a single value. Leaving this field undefined is recommended, as it maximizes choices for efficiently placing pods.
+Generally, instance types should be a list and not a single value. Leaving these requirements undefined is recommended, as it maximizes choices for efficiently placing pods.
 
-☁️ **AWS**
+Review [AWS instance types](../AWS/instance-types). Most instance types are supported with the exclusion of [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html).
 
-Review [AWS instance types](https://aws.amazon.com/ec2/instance-types/).
-
-The default value includes most instance types with the exclusion of [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html).  The full list of supported instance types can be seen [here](../aws/instance-types/)
-
-**Example**
-
-*Set Default with provisioner.yaml*
+{{% alert title="Defaults" color="secondary" %}}
+If no instance type constraints are defined, Karpenter will set default instance type constraints on your Provisioner that supports most common user workloads:
 
 ```yaml
-spec:
-  requirements:
-    - key: node.kubernetes.io/instance-type
-      operator: In
-      values: ["m5.large", "m5.2xlarge"]
+requirements:
+  - key: karpenter.k8s.aws/instance-category
+    operator: In
+    values: ["c", "m", "r"]
+  - key: karpenter.k8s.aws/instance-generation
+    operator: Gt
+    values: ["2"]
 ```
-
-*Override with workload manifest (e.g., pod)*
-
-```yaml
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node.kubernetes.io/instance-type: m5.large
-```
+{{% /alert %}}
 
 ### Availability Zones
 
 - key: `topology.kubernetes.io/zone`
 - value example: `us-east-1c`
-
-☁️ **AWS**
-
 - value list: `aws ec2 describe-availability-zones --region <region-name>`
 
 Karpenter can be configured to create nodes in a particular zone. Note that the Availability Zone `us-east-1a` for your AWS account might not have the same location as `us-east-1a` for another AWS account.
@@ -192,27 +180,63 @@ IDs.](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html)
 
 - key: `kubernetes.io/arch`
 - values
-  - `amd64` (default)
+  - `amd64`
   - `arm64`
 
 Karpenter supports `amd64` nodes, and `arm64` nodes.
 
+{{% alert title="Defaults" color="secondary" %}}
+If no architecture constraint is defined, Karpenter will set the default architecture constraint on your Provisioner that supports most common user workloads:
+
+```yaml
+requirements:
+  - key: kubernetes.io/arch
+    operator: In
+    values: ["amd64"]
+```
+{{% /alert %}}
+
+### Operating System
+- key: `kubernetes.io/os`
+- values
+  - `linux`
+
+Karpenter supports only `linux` nodes at this time.
+
+{{% alert title="Defaults" color="secondary" %}}
+If no operating system constraint is defined, Karpenter will set the default operating system constraint on your Provisioner that supports most common user workloads:
+
+```yaml
+requirements:
+  - key: kubernetes.io/os
+    operator: In
+    values: ["linux"]
+```
+{{% /alert %}}
 
 ### Capacity Type
 
 - key: `karpenter.sh/capacity-type`
-
-☁️ **AWS**
-
 - values
   - `spot`
-  - `on-demand` (default)
+  - `on-demand`
 
 Karpenter supports specifying capacity type, which is analogous to [EC2 purchase options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html).
 
 Karpenter prioritizes Spot offerings if the provisioner allows Spot and on-demand instances. If the provider API (e.g. EC2 Fleet's API) indicates Spot capacity is unavailable, Karpenter caches that result across all attempts to provision EC2 capacity for that instance type and zone for the next 45 seconds. If there are no other possible offerings available for Spot, Karpenter will attempt to provision on-demand instances, generally within milliseconds.
 
 Karpenter also allows `karpenter.sh/capacity-type` to be used as a topology key for enforcing topology-spread.
+
+{{% alert title="Defaults" color="secondary" %}}
+If no capacity type constraint is defined, Karpenter will set the default capacity type constraint on your Provisioner that supports most common user workloads:
+
+```yaml
+requirements:
+  - key: karpenter.sh/capacity-type
+    operator: In
+    values: ["on-demand"]
+```
+{{% /alert %}}
 
 ## spec.weight
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Propagate provisioner defaults across all docs versions

**How was this change tested?**

*

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
