### PR TITLE
test: Deflake cloudprovider testing by moving pricing provider reset after api and cache clear

### DIFF
--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-go-and-dependencies
-      - name: Running tests 10 times to find flaky tests
+      - name: Running tests 5 times to find flaky tests
         run: make deflake
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ clean-run: ## Clean resources deployed by the run target
 	kubectl delete configmap -n ${SYSTEM_NAMESPACE} karpenter-global-settings --ignore-not-found
 
 test: ## Run tests
-	go test -v ./pkg/... --ginkgo.focus="${FOCUS}"
+	go test -v ./pkg/... --ginkgo.focus="${FOCUS}" --ginkgo.v
 
 battletest: ## Run randomized, racing, code coveraged, tests
 	go test -v ./pkg/... \
@@ -66,16 +66,23 @@ battletest: ## Run randomized, racing, code coveraged, tests
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./pkg/... \
 		--ginkgo.focus="${FOCUS}" \
 		--ginkgo.randomize-all \
+		--ginkgo.v \
 		-tags random_test_delay
 
 e2etests: ## Run the e2e suite against your local cluster
-	cd test && CLUSTER_NAME=${CLUSTER_NAME} go test -p 1 -count 1 -timeout 180m -v ./suites/... --ginkgo.timeout=180m --ginkgo.focus="${FOCUS}"
+	cd test && CLUSTER_NAME=${CLUSTER_NAME} go test -p 1 -count 1 -timeout 180m -v ./suites/... --ginkgo.timeout=180m --ginkgo.focus="${FOCUS}" --gingko.v
 
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...
 
-deflake:
-	for i in $(shell seq 1 5); do make battletest || exit 1; done
+deflake: ## Run randomized, racing tests until the test fails to catch flakes
+	ginkgo \
+		--race \
+		--focus="${FOCUS}" \
+		--randomize-all \
+		--until-it-fails \
+		-v \
+		./pkg/...
 
 coverage:
 	go tool cover -html coverage.out -o coverage.html

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean-run: ## Clean resources deployed by the run target
 test: ## Run tests
 	go test -v ./pkg/... --ginkgo.focus="${FOCUS}" --ginkgo.v
 
-battletest: ## Run randomized, racing, code coveraged, tests
+battletest: ## Run randomized, racing, code-covered tests
 	go test -v ./pkg/... \
 		-race \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./pkg/... \
@@ -75,7 +75,10 @@ e2etests: ## Run the e2e suite against your local cluster
 benchmark:
 	go test -tags=test_performance -run=NoTests -bench=. ./...
 
-deflake: ## Run randomized, racing tests until the test fails to catch flakes
+deflake: ## Run randomized, racing, code-covered tests to deflake failures
+	for i in $(shell seq 1 5); do make battletest || exit 1; done
+
+deflake-until-it-fails: ## Run randomized, racing tests until the test fails to catch flakes
 	ginkgo \
 		--race \
 		--focus="${FOCUS}" \

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -20,6 +20,7 @@ tools() {
     go install github.com/sigstore/cosign/cmd/cosign@v1.13.1
     go install github.com/gohugoio/hugo@v0.97.3+extended
     go install golang.org/x/vuln/cmd/govulncheck@v0.0.0-20220902211423-27dd78d2ca39
+    go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
         echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -238,7 +238,7 @@ func (c *CloudProvider) isAMIDrifted(ctx context.Context, machine *corev1alpha1.
 		return instType.Name == machine.Labels[v1.LabelInstanceTypeStable]
 	})
 	if !found {
-		return false, fmt.Errorf("getting node instance type")
+		return false, fmt.Errorf(`finding node instance type "%s"`, machine.Labels[v1.LabelInstanceTypeStable])
 	}
 	if nodeTemplate.Spec.LaunchTemplateName != nil {
 		return false, nil


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Deflake cloudprovider testing by moving pricing provider reset after api and cache clear

**How was this change tested?**

* `make deflake-until-it-fails`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
