### PR TITLE
test: Run reboot after running the EKS bootstrap script

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"strings"
@@ -31,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/transport"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -313,4 +315,17 @@ func (env *Environment) ExpectDaemonSetEnvironmentVariableUpdatedWithOffset(offs
 		})
 	}
 	ExpectWithOffset(offset+1, env.Client.Patch(env.Context, ds, patch)).To(Succeed())
+}
+
+func (env *Environment) ExpectCABundle() string {
+	// Discover CA Bundle from the REST client. We could alternatively
+	// have used the simpler client-go InClusterConfig() method.
+	// However, that only works when Karpenter is running as a Pod
+	// within the same cluster it's managing.
+	transportConfig, err := env.Config.TransportConfig()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	_, err = transport.TLSConfigFor(transportConfig) // fills in CAData!
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	logging.FromContext(env.Context).Debugf("Discovered caBundle, length %d", len(transportConfig.TLS.CAData))
+	return base64.StdEncoding.EncodeToString(transportConfig.TLS.CAData)
 }

--- a/test/suites/integration/testdata/amd_driver_input.sh
+++ b/test/suites/integration/testdata/amd_driver_input.sh
@@ -8,6 +8,8 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 cd
 sudo amazon-linux-extras install epel -y
 sudo yum update -y
+
+# Create a script to install the AMD Radeon GPU
 cat << EOF > /tmp/amd-install.sh
 #!/bin/bash
 export echo PATH=/usr/local/bin:$PATH
@@ -19,6 +21,8 @@ systemctl disable amd-install.service
 reboot
 EOF
 sudo chmod +x /tmp/amd-install.sh
+
+# Create a service that will run on system reboot
 cat << EOF > /etc/systemd/system/amd-install.service
 [Unit]
 Description=install amd drivers
@@ -30,5 +34,13 @@ ExecStart=/bin/bash /tmp/amd-install.sh
 WantedBy=multi-user.target
 EOF
 sudo systemctl enable amd-install.service
-(sleep 60; sudo reboot) &
+
+# Run the EKS bootstrap script and then reboot
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+/etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' --b64-cluster-ca '%s' \
+--use-max-pods false \
+--container-runtime containerd \
+--kubelet-extra-args '--node-labels=karpenter.sh/provisioner-name=%s,testing.karpenter.sh/test-id=unspecified'
+
+reboot
 --BOUNDARY-- 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Updates the `userData` to reboot after bootstrapping the node to EKS

**How was this change tested?**

* `FOCUS=ExtendedResources make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
