### PR TITLE
docs: Update README to account for other regions

### DIFF
--- a/website/content/en/v0.20.0/getting-started/getting-started-with-terraform/_index.md
+++ b/website/content/en/v0.20.0/getting-started/getting-started-with-terraform/_index.md
@@ -46,7 +46,7 @@ After setting up the tools, set the following environment variables to store
 commonly used values.
 
 ```bash
-export AWS_DEFAULT_REGION="us-east-1"
+export AWS_DEFAULT_REGION="eu-west-1"
 ```
 
 The first thing we need to do is create our `main.tf` file and place the following in it.
@@ -72,7 +72,12 @@ terraform {
 }
 
 provider "aws" {
+  region = "eu-west-1"
+}
+
+provider "aws" {
   region = "us-east-1"
+  alias = "virginia"
 }
 
 locals {
@@ -87,7 +92,9 @@ locals {
 
 data "aws_partition" "current" {}
 data "aws_availability_zones" "available" {}
-data "aws_ecrpublic_authorization_token" "token" {}
+data "aws_ecrpublic_authorization_token" "token" {
+  provider = aws.virginia
+}
 ```
 
 ### Create a Cluster


### PR DESCRIPTION
Hello, I updated the README default region to somewhere other than us-east-1, which allows us to create a secondary provider pointing to the us-east-1 where the ECR registry is stored. Covering varied use-cases

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [X ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
