### PR TITLE
feat: make ports configurable with chart values

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -38,12 +38,12 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.image | string | `"public.ecr.aws/karpenter/controller:v0.23.0@sha256:40aea3b25a33ff2cb44bdecf0417a2642e2a785b4fd30067634ef8f1bd48383c"` | Controller image. |
 | controller.logEncoding | string | `""` | Controller log encoding, defaults to the global log encoding |
 | controller.logLevel | string | `""` | Controller log level, defaults to the global log level |
-| controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
 | controller.metrics.port | int | `8080` | The container port to use for metrics. |
+| controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
 | controller.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | Resources for the controller pod. |
 | controller.securityContext | object | `{}` | SecurityContext for the controller container. |
 | controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |
-| controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecars - this will be added to the volume mounts on top of extraVolumeMounts |
+| controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
 | dnsPolicy | string | `"Default"` | Configure the DNS Policy for the pod |
 | extraVolumes | list | `[]` | Additional volumes for the pod. |
@@ -79,7 +79,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | settings.aws.interruptionQueueName | string | `""` | interruptionQueueName is currently in ALPHA and is disabled by default. Enabling interruption handling may require additional permissions on the controller service account. Additional permissions are outlined in the docs. |
 | settings.aws.isolatedVPC | bool | `false` | If true then assume we can't reach AWS services which don't have a VPC endpoint This also has the effect of disabling look-ups to the AWS pricing endpoint |
 | settings.aws.nodeNameConvention | string | `"ip-name"` | The node naming convention (either "ip-name" or "resource-name") |
-| settings.aws.tags | string | `nil` | The global tags to use on all AWS infrastructure resources (launch templates, instances, SQS queue, etc.) |
+| settings.aws.tags | string | `nil` | The global tags to use on all AWS infrastructure resources (launch templates, instances, etc.) across node templates |
 | settings.aws.vmMemoryOverheadPercent | float | `0.075` | The VM memory overhead as a percent that will be subtracted from the total memory for all instance types |
 | settings.batchIdleDuration | string | `"1s"` | The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately. |
 | settings.batchMaxDuration | string | `"10s"` | The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes. |

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -34,10 +34,12 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.env | list | `[]` | Additional environment variables for the controller pod. |
 | controller.errorOutputPaths | list | `["stderr"]` | Controller errorOutputPaths - default to stderr only |
 | controller.extraVolumeMounts | list | `[]` | Additional volumeMounts for the controller pod. |
+| controller.healthProbe.port | int | `8081` | The container port to use for http health probe. |
 | controller.image | string | `"public.ecr.aws/karpenter/controller:v0.23.0@sha256:40aea3b25a33ff2cb44bdecf0417a2642e2a785b4fd30067634ef8f1bd48383c"` | Controller image. |
 | controller.logEncoding | string | `""` | Controller log encoding, defaults to the global log encoding |
 | controller.logLevel | string | `""` | Controller log level, defaults to the global log level |
 | controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
+| controller.metrics.port | int | `8080` | The container port to use for metrics. |
 | controller.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | Resources for the controller pod. |
 | controller.securityContext | object | `{}` | SecurityContext for the controller container. |
 | controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -87,10 +87,10 @@ spec:
           {{- end }}
           ports:
             - name: http-metrics
-              containerPort: 8080
+              containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
             - name: http
-              containerPort: 8081
+              containerPort: {{ .Values.controller.http.port }}
               protocol: TCP
             - name: https-webhook
               containerPort: {{ .Values.webhook.port }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
               value: {{ include "karpenter.fullname" . }}
             - name: WEBHOOK_PORT
               value: "{{ .Values.webhook.port }}"
+            - name: METRICS_PORT
+              value: "{{ .Values.controller.metrics.port }}"
+            - name: HEALTH_PROBE_PORT
+              value: "{{ .Values.controller.healthProbe.port }}"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -90,7 +94,7 @@ spec:
               containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
             - name: http
-              containerPort: {{ .Values.controller.http.port }}
+              containerPort: {{ .Values.controller.healthProbe.port }}
               protocol: TCP
             - name: https-webhook
               containerPort: {{ .Values.webhook.port }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -128,11 +128,11 @@ controller:
   # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
   sidecarVolumeMounts: []
 
-  # -- The container port to use for metrics.
   metrics:
+    # -- The container port to use for metrics.
     port: 8080
-  # -- The container port to use for http health probe.
   healthProbe:
+    # -- The container port to use for http health probe.
     port: 8081
 
 webhook:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -127,20 +127,16 @@ controller:
   sidecarContainer: []
   # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
   sidecarVolumeMounts: []
-
   metrics:
     # -- The container port to use for metrics.
     port: 8080
   healthProbe:
     # -- The container port to use for http health probe.
     port: 8081
-
 webhook:
   logLevel: error
   # -- The container port to use for the webhook.
   port: 8443
-
-
 # -- Global log level
 logLevel: debug
 # -- Gloabl log encoding

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -127,10 +127,20 @@ controller:
   sidecarContainer: []
   # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
   sidecarVolumeMounts: []
+
+  # -- The container port to use for metrics.
+  metrics:
+    port: 8080
+  # -- The container port to use for http health probe.
+  healthProbe:
+    port: 8081
+
 webhook:
   logLevel: error
   # -- The container port to use for the webhook.
   port: 8443
+
+
 # -- Global log level
 logLevel: debug
 # -- Gloabl log encoding


### PR DESCRIPTION
Signed-off-by: Robert van Veelen <vanveele@users.noreply.github.com>

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3118 <!-- issue number -->

**Description**
Updates chart to configure custom listening ports. Useful when combined with `hostNetwork: true` in the case where an existing agent or daemonset is using these ports.

**How was this change tested?**
* Deployed chart using the custom values to resolve conflict

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Expose container ports as chart values
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
