### PR TITLE
fix: do not error for drift if disabled or using provider

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -176,7 +176,7 @@ func (c *CloudProvider) IsMachineDrifted(ctx context.Context, machine *corev1alp
 		return false, k8sClient.IgnoreNotFound(fmt.Errorf("getting provisioner, %w", err))
 	}
 	if provisioner.Spec.ProviderRef == nil {
-		return false, fmt.Errorf("providerRef must be defined for Drift")
+		return false, nil
 	}
 	nodeTemplate, err := c.resolveNodeTemplate(ctx, nil, &v1.ObjectReference{
 		APIVersion: provisioner.Spec.ProviderRef.APIVersion,

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Allocation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeFalse())
 		})
-		It("should error if providerRef is not defined", func() {
+		It("should return false if providerRef is not defined", func() {
 			provisioner.Spec.ProviderRef = nil
 			ExpectApplied(ctx, env.Client, provisioner)
 			node := coretest.Node(coretest.NodeOptions{
@@ -336,7 +336,7 @@ var _ = Describe("Allocation", func() {
 				},
 			})
 			drifted, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeFalse())
 		})
 		It("should not fail if provisioner does not exist", func() {

--- a/pkg/controllers/drift/controller.go
+++ b/pkg/controllers/drift/controller.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/aws/karpenter-core/pkg/apis/config/settings"
 	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -61,6 +62,9 @@ func (c *Controller) Name() string {
 }
 
 func (c *Controller) Reconcile(ctx context.Context, node *v1.Node) (reconcile.Result, error) {
+	if !settings.FromContext(ctx).DriftEnabled {
+		return reconcile.Result{}, nil
+	}
 	provisionerName, provisionerExists := node.Labels[v1alpha5.ProvisionerNameLabelKey]
 	if !provisionerExists {
 		return reconcile.Result{}, nil


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3120

**Description**
No longer errors on drift controller if a provider is not set. Also disables the drift controller if the drift feature flag is not enabled. 

**How was this change tested?**

* `make presubmit`
* `make apply` and validate described behavior.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
