### PR TITLE
chore: Migrate to `v1alpha5` and cleanup some provider cross-pollination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.154
-	github.com/aws/karpenter-core v0.21.0
+	github.com/aws/karpenter-core v0.21.1-0.20221229043026-9b38f8c39e87
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.154 h1:2TaEC8JIM/t7Fu+FBmdOBK5jFUAVL07tbpfJsLuVo3Q=
 github.com/aws/aws-sdk-go v1.44.154/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.21.0 h1:U9P70R52eURcoNMe694/rTeQJYmLD7nWgQ6GncdxdME=
-github.com/aws/karpenter-core v0.21.0/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
+github.com/aws/karpenter-core v0.21.1-0.20221229043026-9b38f8c39e87 h1:nAtLXlsNUbTuH6IBVqxA0tUz+L14L3c8zFHavRd36b0=
+github.com/aws/karpenter-core v0.21.1-0.20221229043026-9b38f8c39e87/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cloudprovider/amifamily/resolver.go
+++ b/pkg/cloudprovider/amifamily/resolver.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider/amifamily/bootstrap"
 
@@ -105,7 +104,7 @@ func New(kubeClient client.Client, amiProvider *AMIProvider) *Resolver {
 
 // Resolve generates launch templates using the static options and dynamically generates launch template parameters.
 // Multiple ResolvedTemplates are returned based on the instanceTypes passed in to support special AMIs for certain instance types like GPUs.
-func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *corev1alpha1.Machine, instanceTypes []*cloudprovider.InstanceType, options *Options) ([]*LaunchTemplate, error) {
+func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType, options *Options) ([]*LaunchTemplate, error) {
 	amiFamily := GetAMIFamily(nodeTemplate.Spec.AMIFamily, options)
 	amiIDs, err := r.amiProvider.Get(ctx, nodeTemplate, instanceTypes, amiFamily)
 	if err != nil {

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -47,7 +48,6 @@ import (
 	awscontext "github.com/aws/karpenter/pkg/context"
 
 	coreapis "github.com/aws/karpenter-core/pkg/apis"
-	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 )
@@ -91,7 +91,13 @@ func New(ctx awscontext.Context) *CloudProvider {
 		kubeClient:           ctx.KubeClient,
 		instanceTypeProvider: instanceTypeProvider,
 		amiProvider:          amiProvider,
-		instanceProvider: NewInstanceProvider(ctx, ec2api, instanceTypeProvider, subnetProvider,
+		instanceProvider: NewInstanceProvider(
+			ctx,
+			aws.StringValue(ctx.Session.Config.Region),
+			ec2api,
+			ctx.UnavailableOfferingsCache,
+			instanceTypeProvider,
+			subnetProvider,
 			NewLaunchTemplateProvider(
 				ctx,
 				ec2api,
@@ -117,7 +123,7 @@ func checkEC2Connectivity(ctx context.Context, api *ec2.EC2) error {
 }
 
 // Create a node given the constraints.
-func (c *CloudProvider) Create(ctx context.Context, machine *corev1alpha1.Machine) (*v1.Node, error) {
+func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (*v1.Node, error) {
 	nodeTemplate, err := c.resolveNodeTemplate(ctx, []byte(machine.
 		Annotations[v1alpha5.ProviderCompatabilityAnnotationKey]), machine.
 		Spec.MachineTemplateRef)
@@ -131,7 +137,11 @@ func (c *CloudProvider) Create(ctx context.Context, machine *corev1alpha1.Machin
 	if len(instanceTypes) == 0 {
 		return nil, fmt.Errorf("all requested instance types were unavailable during launch")
 	}
-	return c.instanceProvider.Create(ctx, nodeTemplate, machine, instanceTypes)
+	instance, err := c.instanceProvider.Create(ctx, nodeTemplate, machine, instanceTypes)
+	if err != nil {
+		return nil, fmt.Errorf("creating instance, %w", err)
+	}
+	return c.instanceToNode(instance, instanceTypes), nil
 }
 
 func (c *CloudProvider) LivenessProbe(req *http.Request) error {
@@ -143,33 +153,27 @@ func (c *CloudProvider) LivenessProbe(req *http.Request) error {
 
 // GetInstanceTypes returns all available InstanceTypes
 func (c *CloudProvider) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
-	var nodeTemplate *v1alpha1.AWSNodeTemplate
-	var err error
-	if provisioner.Spec.ProviderRef != nil {
-		nodeTemplate, err = c.resolveNodeTemplate(ctx, nil, &v1.ObjectReference{
-			APIVersion: provisioner.Spec.ProviderRef.APIVersion,
-			Kind:       provisioner.Spec.ProviderRef.Kind,
-			Name:       provisioner.Spec.ProviderRef.Name,
-		})
-	} else {
-		nodeTemplate, err = c.resolveNodeTemplate(ctx, provisioner.Spec.Provider.Raw, nil)
+	var rawProvider []byte
+	if provisioner.Spec.Provider != nil {
+		rawProvider = provisioner.Spec.Provider.Raw
 	}
+	nodeTemplate, err := c.resolveNodeTemplate(ctx, rawProvider, provisioner.Spec.ProviderRef)
 	if err != nil {
 		return nil, err
 	}
 	// TODO, break this coupling
-	instanceTypes, err := c.instanceTypeProvider.Get(ctx, provisioner.Spec.KubeletConfiguration, nodeTemplate)
+	instanceTypes, err := c.instanceTypeProvider.List(ctx, provisioner.Spec.KubeletConfiguration, nodeTemplate)
 	if err != nil {
 		return nil, err
 	}
 	return instanceTypes, nil
 }
 
-func (c *CloudProvider) Delete(ctx context.Context, machine *corev1alpha1.Machine) error {
-	return c.instanceProvider.Terminate(ctx, machine)
+func (c *CloudProvider) Delete(ctx context.Context, machine *v1alpha5.Machine) error {
+	return c.instanceProvider.Delete(ctx, machine)
 }
 
-func (c *CloudProvider) IsMachineDrifted(ctx context.Context, machine *corev1alpha1.Machine) (bool, error) {
+func (c *CloudProvider) IsMachineDrifted(ctx context.Context, machine *v1alpha5.Machine) (bool, error) {
 	// Not needed when GetInstanceTypes removes provisioner dependency
 	provisioner := &v1alpha5.Provisioner{}
 	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: machine.Labels[v1alpha5.ProvisionerNameLabelKey]}, provisioner); err != nil {
@@ -178,11 +182,7 @@ func (c *CloudProvider) IsMachineDrifted(ctx context.Context, machine *corev1alp
 	if provisioner.Spec.ProviderRef == nil {
 		return false, nil
 	}
-	nodeTemplate, err := c.resolveNodeTemplate(ctx, nil, &v1.ObjectReference{
-		APIVersion: provisioner.Spec.ProviderRef.APIVersion,
-		Kind:       provisioner.Spec.ProviderRef.Kind,
-		Name:       provisioner.Spec.ProviderRef.Name,
-	})
+	nodeTemplate, err := c.resolveNodeTemplate(ctx, nil, provisioner.Spec.ProviderRef)
 	if err != nil {
 		return false, k8sClient.IgnoreNotFound(fmt.Errorf("resolving node template, %w", err))
 	}
@@ -229,7 +229,7 @@ func kubeDNSIP(ctx context.Context, kubernetesInterface kubernetes.Interface) (n
 	return kubeDNSIP, nil
 }
 
-func (c *CloudProvider) isAMIDrifted(ctx context.Context, machine *corev1alpha1.Machine, provisioner *v1alpha5.Provisioner, nodeTemplate *v1alpha1.AWSNodeTemplate) (bool, error) {
+func (c *CloudProvider) isAMIDrifted(ctx context.Context, machine *v1alpha5.Machine, provisioner *v1alpha5.Provisioner, nodeTemplate *v1alpha1.AWSNodeTemplate) (bool, error) {
 	instanceTypes, err := c.GetInstanceTypes(ctx, provisioner)
 	if err != nil {
 		return false, fmt.Errorf("getting instanceTypes, %w", err)
@@ -253,14 +253,14 @@ func (c *CloudProvider) isAMIDrifted(ctx context.Context, machine *corev1alpha1.
 	if err != nil {
 		return false, err
 	}
-	instance, err := c.instanceProvider.getInstance(ctx, instanceID)
+	instance, err := c.instanceProvider.Get(ctx, instanceID)
 	if err != nil {
 		return false, fmt.Errorf("getting instance, %w", err)
 	}
 	return !lo.Contains(lo.Keys(amis), *instance.ImageId), nil
 }
 
-func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, raw []byte, objRef *v1.ObjectReference) (*v1alpha1.AWSNodeTemplate, error) {
+func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, raw []byte, objRef *v1alpha5.ProviderRef) (*v1alpha1.AWSNodeTemplate, error) {
 	nodeTemplate := &v1alpha1.AWSNodeTemplate{}
 	if objRef != nil {
 		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: objRef.Name}, nodeTemplate); err != nil {
@@ -276,7 +276,7 @@ func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, raw []byte, obj
 	return nodeTemplate, nil
 }
 
-func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, machine *corev1alpha1.Machine) ([]*cloudprovider.InstanceType, error) {
+func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, machine *v1alpha5.Machine) ([]*cloudprovider.InstanceType, error) {
 	provisionerName, ok := machine.Labels[v1alpha5.ProvisionerNameLabelKey]
 	if !ok {
 		return nil, fmt.Errorf("finding provisioner owner")
@@ -293,4 +293,32 @@ func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, machine *corev
 	return lo.Filter(instanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
 		return reqs.Get(v1.LabelInstanceTypeStable).Has(i.Name) && len(i.Offerings.Requirements(reqs).Available()) > 0
 	}), nil
+}
+
+func (c *CloudProvider) instanceToNode(instance *ec2.Instance, instanceTypes []*cloudprovider.InstanceType) *v1.Node {
+	for _, instanceType := range instanceTypes {
+		if instanceType.Name == aws.StringValue(instance.InstanceType) {
+			nodeName := strings.ToLower(aws.StringValue(instance.PrivateDnsName))
+			labels := map[string]string{}
+			for key, req := range instanceType.Requirements {
+				if req.Len() == 1 {
+					labels[key] = req.Values()[0]
+				}
+			}
+			labels[v1alpha1.LabelInstanceAMIID] = aws.StringValue(instance.ImageId)
+			labels[v1.LabelTopologyZone] = aws.StringValue(instance.Placement.AvailabilityZone)
+			labels[v1alpha5.LabelCapacityType] = getCapacityType(instance)
+
+			return &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: labels,
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: fmt.Sprintf("aws:///%s/%s", aws.StringValue(instance.Placement.AvailabilityZone), aws.StringValue(instance.InstanceId)),
+				},
+			}
+		}
+	}
+	panic(fmt.Sprintf("unrecognized instance type %s", aws.StringValue(instance.InstanceType)))
 }

--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -31,13 +31,12 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 
-	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	awssettings "github.com/aws/karpenter/pkg/apis/config/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/cache"
 	awserrors "github.com/aws/karpenter/pkg/errors"
 	"github.com/aws/karpenter/pkg/utils"
 
@@ -53,16 +52,20 @@ var (
 )
 
 type InstanceProvider struct {
+	region                 string
 	ec2api                 ec2iface.EC2API
+	unavailableOfferings   *cache.UnavailableOfferings
 	instanceTypeProvider   *InstanceTypeProvider
 	subnetProvider         *SubnetProvider
 	launchTemplateProvider *LaunchTemplateProvider
 	createFleetBatcher     *CreateFleetBatcher
 }
 
-func NewInstanceProvider(ctx context.Context, ec2api ec2iface.EC2API, instanceTypeProvider *InstanceTypeProvider, subnetProvider *SubnetProvider, launchTemplateProvider *LaunchTemplateProvider) *InstanceProvider {
+func NewInstanceProvider(ctx context.Context, region string, ec2api ec2iface.EC2API, unavailableOfferings *cache.UnavailableOfferings, instanceTypeProvider *InstanceTypeProvider, subnetProvider *SubnetProvider, launchTemplateProvider *LaunchTemplateProvider) *InstanceProvider {
 	return &InstanceProvider{
+		region:                 region,
 		ec2api:                 ec2api,
+		unavailableOfferings:   unavailableOfferings,
 		instanceTypeProvider:   instanceTypeProvider,
 		subnetProvider:         subnetProvider,
 		launchTemplateProvider: launchTemplateProvider,
@@ -74,7 +77,7 @@ func NewInstanceProvider(ctx context.Context, ec2api ec2iface.EC2API, instanceTy
 // instanceTypes should be sorted by priority for spot capacity type.
 // If spot is not used, the instanceTypes are not required to be sorted
 // because we are using ec2 fleet's lowest-price OD allocation strategy
-func (p *InstanceProvider) Create(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *corev1alpha1.Machine, instanceTypes []*cloudprovider.InstanceType) (*v1.Node, error) {
+func (p *InstanceProvider) Create(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType) (*ec2.Instance, error) {
 	instanceTypes = filterInstanceTypes(instanceTypes)
 	instanceTypes = orderInstanceTypesByPrice(instanceTypes, scheduling.NewNodeSelectorRequirements(machine.Spec.Requirements...))
 	if len(instanceTypes) > MaxInstanceTypes {
@@ -93,7 +96,7 @@ func (p *InstanceProvider) Create(ctx context.Context, nodeTemplate *v1alpha1.AW
 	// Get Instance with backoff retry since EC2 is eventually consistent
 	instance := &ec2.Instance{}
 	if err := retry.Do(
-		func() (err error) { instance, err = p.getInstance(ctx, aws.StringValue(id)); return err },
+		func() (err error) { instance, err = p.Get(ctx, aws.StringValue(id)); return err },
 		retry.Delay(1*time.Second),
 		retry.Attempts(6),
 		retry.LastErrorOnly(true),
@@ -107,11 +110,31 @@ func (p *InstanceProvider) Create(ctx context.Context, nodeTemplate *v1alpha1.AW
 		"zone", aws.StringValue(instance.Placement.AvailabilityZone),
 		"capacity-type", getCapacityType(instance)).Infof("launched new instance")
 
-	// Convert Instance to Node
-	return p.instanceToNode(instance, instanceTypes), nil
+	return instance, nil
 }
 
-func (p *InstanceProvider) Terminate(ctx context.Context, machine *corev1alpha1.Machine) error {
+func (p *InstanceProvider) Get(ctx context.Context, id string) (*ec2.Instance, error) {
+	describeInstancesOutput, err := p.ec2api.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice([]string{id})})
+	if awserrors.IsNotFound(err) {
+		return nil, err
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe ec2 instances, %w", err)
+	}
+	if len(describeInstancesOutput.Reservations) != 1 || len(describeInstancesOutput.Reservations[0].Instances) != 1 {
+		return nil, awserrors.InstanceTerminatedError{Err: fmt.Errorf("expected instance but got 0")}
+	}
+	instance := describeInstancesOutput.Reservations[0].Instances[0]
+	if *instance.State.Name == ec2.InstanceStateNameTerminated {
+		return nil, awserrors.InstanceTerminatedError{Err: fmt.Errorf("instance is in terminated state")}
+	}
+	if len(aws.StringValue(instance.PrivateDnsName)) == 0 {
+		return nil, multierr.Append(err, fmt.Errorf("got instance %s but PrivateDnsName was not set", aws.StringValue(instance.InstanceId)))
+	}
+	return instance, nil
+}
+
+func (p *InstanceProvider) Delete(ctx context.Context, machine *v1alpha5.Machine) error {
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("machine", machine.Name))
 	id, err := utils.ParseInstanceID(machine.Status.ProviderID)
 	if err != nil {
@@ -123,7 +146,7 @@ func (p *InstanceProvider) Terminate(ctx context.Context, machine *corev1alpha1.
 		if awserrors.IsNotFound(err) {
 			return nil
 		}
-		if _, errMsg := p.getInstance(ctx, id); err != nil {
+		if _, errMsg := p.Get(ctx, id); err != nil {
 			if awserrors.IsInstanceTerminated(errMsg) || awserrors.IsNotFound(errMsg) {
 				logging.FromContext(ctx).Debugf("instance already terminated")
 				return nil
@@ -138,7 +161,7 @@ func (p *InstanceProvider) Terminate(ctx context.Context, machine *corev1alpha1.
 
 // can remove cyclo ignore after China launch price-capacity-optimized
 // nolint: gocyclo
-func (p *InstanceProvider) launchInstance(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *corev1alpha1.Machine, instanceTypes []*cloudprovider.InstanceType) (*string, error) {
+func (p *InstanceProvider) launchInstance(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType) (*string, error) {
 	capacityType := p.getCapacityType(machine, instanceTypes)
 	// Get Launch Template Configs, which may differ due to GPU or Architecture requirements
 	launchTemplateConfigs, err := p.getLaunchTemplateConfigs(ctx, nodeTemplate, machine, instanceTypes, capacityType)
@@ -164,7 +187,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, nodeTemplate *v1a
 			{ResourceType: aws.String(ec2.ResourceTypeFleet), Tags: tags},
 		},
 	}
-	if capacityType == v1alpha5.CapacityTypeSpot && strings.HasPrefix(p.instanceTypeProvider.region, "cn-") {
+	if capacityType == v1alpha5.CapacityTypeSpot && strings.HasPrefix(p.region, "cn-") {
 		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{AllocationStrategy: aws.String(ec2.AllocationStrategyCapacityOptimizedPrioritized)}
 	} else if capacityType == v1alpha5.CapacityTypeSpot {
 		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{AllocationStrategy: aws.String(ec2.AllocationStrategyPriceCapacityOptimized)}
@@ -193,7 +216,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, nodeTemplate *v1a
 	return createFleetOutput.Instances[0].InstanceIds[0], nil
 }
 
-func (p *InstanceProvider) checkODFallback(machine *corev1alpha1.Machine, instanceTypes []*cloudprovider.InstanceType, launchTemplateConfigs []*ec2.FleetLaunchTemplateConfigRequest) error {
+func (p *InstanceProvider) checkODFallback(machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType, launchTemplateConfigs []*ec2.FleetLaunchTemplateConfigRequest) error {
 	// only evaluate for on-demand fallback if the capacity type for the request is OD and both OD and spot are allowed in requirements
 	if p.getCapacityType(machine, instanceTypes) != v1alpha5.CapacityTypeOnDemand || !scheduling.NewNodeSelectorRequirements(machine.Spec.Requirements...).Get(v1alpha5.LabelCapacityType).Has(v1alpha5.CapacityTypeSpot) {
 		return nil
@@ -215,16 +238,16 @@ func (p *InstanceProvider) checkODFallback(machine *corev1alpha1.Machine, instan
 	return nil
 }
 
-func (p *InstanceProvider) getLaunchTemplateConfigs(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *corev1alpha1.Machine,
+func (p *InstanceProvider) getLaunchTemplateConfigs(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *v1alpha5.Machine,
 	instanceTypes []*cloudprovider.InstanceType, capacityType string) ([]*ec2.FleetLaunchTemplateConfigRequest, error) {
 
 	// Get subnets given the constraints
-	subnets, err := p.subnetProvider.Get(ctx, nodeTemplate)
+	subnets, err := p.subnetProvider.List(ctx, nodeTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("getting subnets, %w", err)
 	}
 	var launchTemplateConfigs []*ec2.FleetLaunchTemplateConfigRequest
-	launchTemplates, err := p.launchTemplateProvider.Get(ctx, nodeTemplate, machine, instanceTypes, map[string]string{v1alpha5.LabelCapacityType: capacityType})
+	launchTemplates, err := p.launchTemplateProvider.EnsureAll(ctx, nodeTemplate, machine, instanceTypes, map[string]string{v1alpha5.LabelCapacityType: capacityType})
 	if err != nil {
 		return nil, fmt.Errorf("getting launch templates, %w", err)
 	}
@@ -304,7 +327,7 @@ func (p *InstanceProvider) getOverrides(instanceTypes []*cloudprovider.InstanceT
 		// Add a priority for spot requests since we are using the capacity-optimized-prioritized spot allocation strategy
 		// to reduce the likelihood of getting an excessively large instance type.
 		// InstanceTypes are sorted by vcpus and memory so this prioritizes smaller instance types.
-		if capacityType == v1alpha5.CapacityTypeSpot && strings.HasPrefix(p.instanceTypeProvider.region, "cn-") {
+		if capacityType == v1alpha5.CapacityTypeSpot && strings.HasPrefix(p.region, "cn-") {
 			override.Priority = aws.Float64(float64(i))
 		}
 
@@ -313,59 +336,10 @@ func (p *InstanceProvider) getOverrides(instanceTypes []*cloudprovider.InstanceT
 	return overrides
 }
 
-func (p *InstanceProvider) getInstance(ctx context.Context, id string) (*ec2.Instance, error) {
-	describeInstancesOutput, err := p.ec2api.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice([]string{id})})
-	if awserrors.IsNotFound(err) {
-		return nil, err
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to describe ec2 instances, %w", err)
-	}
-	if len(describeInstancesOutput.Reservations) != 1 || len(describeInstancesOutput.Reservations[0].Instances) != 1 {
-		return nil, awserrors.InstanceTerminatedError{Err: fmt.Errorf("expected instance but got 0")}
-	}
-	instance := describeInstancesOutput.Reservations[0].Instances[0]
-	if *instance.State.Name == ec2.InstanceStateNameTerminated {
-		return nil, awserrors.InstanceTerminatedError{Err: fmt.Errorf("instance is in terminated state")}
-	}
-	if len(aws.StringValue(instance.PrivateDnsName)) == 0 {
-		return nil, multierr.Append(err, fmt.Errorf("got instance %s but PrivateDnsName was not set", aws.StringValue(instance.InstanceId)))
-	}
-	return instance, nil
-}
-
-func (p *InstanceProvider) instanceToNode(instance *ec2.Instance, instanceTypes []*cloudprovider.InstanceType) *v1.Node {
-	for _, instanceType := range instanceTypes {
-		if instanceType.Name == aws.StringValue(instance.InstanceType) {
-			nodeName := strings.ToLower(aws.StringValue(instance.PrivateDnsName))
-			labels := map[string]string{}
-			for key, req := range instanceType.Requirements {
-				if req.Len() == 1 {
-					labels[key] = req.Values()[0]
-				}
-			}
-			labels[v1alpha1.LabelInstanceAMIID] = aws.StringValue(instance.ImageId)
-			labels[v1.LabelTopologyZone] = aws.StringValue(instance.Placement.AvailabilityZone)
-			labels[v1alpha5.LabelCapacityType] = getCapacityType(instance)
-
-			return &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   nodeName,
-					Labels: labels,
-				},
-				Spec: v1.NodeSpec{
-					ProviderID: fmt.Sprintf("aws:///%s/%s", aws.StringValue(instance.Placement.AvailabilityZone), aws.StringValue(instance.InstanceId)),
-				},
-			}
-		}
-	}
-	panic(fmt.Sprintf("unrecognized instance type %s", aws.StringValue(instance.InstanceType)))
-}
-
 func (p *InstanceProvider) updateUnavailableOfferingsCache(ctx context.Context, errors []*ec2.CreateFleetError, capacityType string) {
 	for _, err := range errors {
 		if awserrors.IsUnfulfillableCapacity(err) {
-			p.instanceTypeProvider.unavailableOfferings.MarkUnavailableForFleetErr(ctx, err, capacityType)
+			p.unavailableOfferings.MarkUnavailableForFleetErr(ctx, err, capacityType)
 		}
 	}
 }
@@ -373,7 +347,7 @@ func (p *InstanceProvider) updateUnavailableOfferingsCache(ctx context.Context, 
 // getCapacityType selects spot if both constraints are flexible and there is an
 // available offering. The AWS Cloud Provider defaults to [ on-demand ], so spot
 // must be explicitly included in capacity type requirements.
-func (p *InstanceProvider) getCapacityType(machine *corev1alpha1.Machine, instanceTypes []*cloudprovider.InstanceType) string {
+func (p *InstanceProvider) getCapacityType(machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType) string {
 	requirements := scheduling.NewNodeSelectorRequirements(machine.
 		Spec.Requirements...)
 	if requirements.Get(v1alpha5.LabelCapacityType).Has(v1alpha5.CapacityTypeSpot) {

--- a/pkg/cloudprovider/instancetypes.go
+++ b/pkg/cloudprovider/instancetypes.go
@@ -85,8 +85,7 @@ func NewInstanceTypeProvider(ctx context.Context, sess *session.Session, ec2api 
 	}
 }
 
-// Get all instance type options
-func (p *InstanceTypeProvider) Get(ctx context.Context, kc *v1alpha5.KubeletConfiguration, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*cloudprovider.InstanceType, error) {
+func (p *InstanceTypeProvider) List(ctx context.Context, kc *v1alpha5.KubeletConfiguration, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*cloudprovider.InstanceType, error) {
 	p.Lock()
 	defer p.Unlock()
 	// Get InstanceTypes from EC2
@@ -163,7 +162,7 @@ func (p *InstanceTypeProvider) getInstanceTypeZones(ctx context.Context, nodeTem
 	}
 
 	// Constrain AZs from subnets
-	subnets, err := p.subnetProvider.Get(ctx, nodeTemplate)
+	subnets, err := p.subnetProvider.List(ctx, nodeTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -951,7 +951,7 @@ var _ = Describe("LaunchTemplates", func() {
 			Expect(string(userData)).To(ContainSubstring("--container-runtime containerd"))
 		})
 		It("should specify --dns-cluster-ip and --ip-family when running in an ipv6 cluster", func() {
-			cloudProvider.instanceProvider.launchTemplateProvider.kubeDNSIP = net.ParseIP("fd4b:121b:812b::a")
+			launchTemplateProvider.kubeDNSIP = net.ParseIP("fd4b:121b:812b::a")
 			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
 			ExpectScheduled(ctx, env.Client, pod)

--- a/pkg/cloudprovider/securitygroups.go
+++ b/pkg/cloudprovider/securitygroups.go
@@ -48,7 +48,7 @@ func NewSecurityGroupProvider(ec2api ec2iface.EC2API) *SecurityGroupProvider {
 	}
 }
 
-func (p *SecurityGroupProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]string, error) {
+func (p *SecurityGroupProvider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]string, error) {
 	p.Lock()
 	defer p.Unlock()
 	// Get SecurityGroups

--- a/pkg/cloudprovider/subnets.go
+++ b/pkg/cloudprovider/subnets.go
@@ -49,7 +49,7 @@ func NewSubnetProvider(ec2api ec2iface.EC2API) *SubnetProvider {
 	}
 }
 
-func (p *SubnetProvider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*ec2.Subnet, error) {
+func (p *SubnetProvider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*ec2.Subnet, error) {
 	p.Lock()
 	defer p.Unlock()
 	filters := getFilters(nodeTemplate)

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -52,8 +52,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 
 	"github.com/aws/karpenter-core/pkg/apis/config/settings"
-	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
-	corev1alpha5 "github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/operator/injection"
@@ -61,6 +60,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	coretest "github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
+	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
 	"github.com/aws/karpenter-core/pkg/utils/pretty"
 	"github.com/aws/karpenter/pkg/fake"
 )
@@ -79,6 +79,8 @@ var internalUnavailableOfferingsCache *cache.Cache
 var unavailableOfferingsCache *awscache.UnavailableOfferings
 var instanceTypeCache *cache.Cache
 var instanceTypeProvider *InstanceTypeProvider
+var launchTemplateProvider *LaunchTemplateProvider
+var subnetProvider *SubnetProvider
 var amiProvider *amifamily.AMIProvider
 var fakeEC2API *fake.EC2API
 var fakeSSMAPI *fake.SSMAPI
@@ -89,7 +91,7 @@ var cloudProvider *CloudProvider
 var cluster *state.Cluster
 var recorder *coretest.EventRecorder
 var fakeClock *clock.FakeClock
-var provisioner *corev1alpha5.Provisioner
+var provisioner *v1alpha5.Provisioner
 var nodeTemplate *v1alpha1.AWSNodeTemplate
 var pricingProvider *PricingProvider
 var settingsStore coretest.SettingsStore
@@ -127,7 +129,7 @@ var _ = BeforeSuite(func() {
 	fakePricingAPI = &fake.PricingAPI{}
 	pricingProvider = NewPricingProvider(ctx, fakePricingAPI, fakeEC2API, "", false, make(chan struct{}))
 	amiProvider = amifamily.NewAMIProvider(env.Client, env.KubernetesInterface, fakeSSMAPI, fakeEC2API, ssmCache, ec2Cache, kubernetesVersionCache)
-	subnetProvider := &SubnetProvider{
+	subnetProvider = &SubnetProvider{
 		ec2api: fakeEC2API,
 		cache:  subnetCache,
 		cm:     pretty.NewChangeMonitor(),
@@ -145,18 +147,19 @@ var _ = BeforeSuite(func() {
 		cache:  securityGroupCache,
 		cm:     pretty.NewChangeMonitor(),
 	}
+	launchTemplateProvider = &LaunchTemplateProvider{
+		ec2api:                fakeEC2API,
+		amiFamily:             amifamily.New(env.Client, amiProvider),
+		securityGroupProvider: securityGroupProvider,
+		cache:                 launchTemplateCache,
+		caBundle:              ptr.String("ca-bundle"),
+		cm:                    pretty.NewChangeMonitor(),
+	}
 	cloudProvider = &CloudProvider{
 		instanceTypeProvider: instanceTypeProvider,
 		amiProvider:          amiProvider,
-		instanceProvider: NewInstanceProvider(ctx, fakeEC2API, instanceTypeProvider, subnetProvider, &LaunchTemplateProvider{
-			ec2api:                fakeEC2API,
-			amiFamily:             amifamily.New(env.Client, amiProvider),
-			securityGroupProvider: securityGroupProvider,
-			cache:                 launchTemplateCache,
-			caBundle:              ptr.String("ca-bundle"),
-			cm:                    pretty.NewChangeMonitor(),
-		}),
-		kubeClient: env.Client,
+		instanceProvider:     NewInstanceProvider(ctx, "", fakeEC2API, unavailableOfferingsCache, instanceTypeProvider, subnetProvider, launchTemplateProvider),
+		kubeClient:           env.Client,
 	}
 	fakeClock = clock.NewFakeClock(time.Now())
 	cluster = state.NewCluster(ctx, fakeClock, env.Client, cloudProvider)
@@ -199,7 +202,7 @@ var _ = BeforeEach(func() {
 			Key:      v1alpha1.LabelInstanceCategory,
 			Operator: v1.NodeSelectorOpExists,
 		}},
-		ProviderRef: &corev1alpha5.ProviderRef{
+		ProviderRef: &v1alpha5.ProviderRef{
 			APIVersion: nodeTemplate.APIVersion,
 			Kind:       nodeTemplate.Kind,
 			Name:       nodeTemplate.Name,
@@ -218,11 +221,17 @@ var _ = BeforeEach(func() {
 	ec2Cache.Flush()
 	kubernetesVersionCache.Flush()
 	instanceTypeCache.Flush()
-	cloudProvider.instanceProvider.launchTemplateProvider.kubeDNSIP = net.ParseIP("10.0.100.10")
+	launchTemplateProvider.kubeDNSIP = net.ParseIP("10.0.100.10")
 
 	// Reset the pricing provider, so we don't cross-pollinate pricing data
-	pricingProvider = NewPricingProvider(ctx, fakePricingAPI, fakeEC2API, "", false, make(chan struct{}))
-	instanceTypeProvider.pricingProvider = pricingProvider
+	instanceTypeProvider = &InstanceTypeProvider{
+		ec2api:               fakeEC2API,
+		subnetProvider:       subnetProvider,
+		cache:                instanceTypeCache,
+		pricingProvider:      NewPricingProvider(ctx, fakePricingAPI, fakeEC2API, "", false, make(chan struct{})),
+		unavailableOfferings: unavailableOfferingsCache,
+		cm:                   pretty.NewChangeMonitor(),
+	}
 })
 
 var _ = AfterEach(func() {
@@ -241,14 +250,14 @@ var _ = Describe("Allocation", func() {
 		It("should default requirements", func() {
 			provisioner.SetDefaults(ctx)
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
-				Key:      corev1alpha5.LabelCapacityType,
+				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{corev1alpha5.CapacityTypeOnDemand},
+				Values:   []string{v1alpha5.CapacityTypeOnDemand},
 			}))
 			Expect(provisioner.Spec.Requirements).To(ContainElement(v1.NodeSelectorRequirement{
 				Key:      v1.LabelArchStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{corev1alpha5.ArchitectureAmd64},
+				Values:   []string{v1alpha5.ArchitectureAmd64},
 			}))
 		})
 	})
@@ -314,12 +323,12 @@ var _ = Describe("Allocation", func() {
 				ProviderID: makeProviderID(lo.FromPtr(instance.InstanceId)),
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						corev1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceTypeStable:           selectedInstanceType.Name,
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       selectedInstanceType.Name,
 					},
 				},
 			})
-			drifted, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+			drifted, err := cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeFalse())
 		})
@@ -330,12 +339,12 @@ var _ = Describe("Allocation", func() {
 				ProviderID: makeProviderID(lo.FromPtr(instance.InstanceId)),
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						corev1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceTypeStable:           selectedInstanceType.Name,
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       selectedInstanceType.Name,
 					},
 				},
 			})
-			drifted, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+			drifted, err := cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeFalse())
 		})
@@ -345,12 +354,12 @@ var _ = Describe("Allocation", func() {
 				ProviderID: makeProviderID(lo.FromPtr(instance.InstanceId)),
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						corev1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceTypeStable:           selectedInstanceType.Name,
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       selectedInstanceType.Name,
 					},
 				},
 			})
-			drifted, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+			drifted, err := cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeFalse())
 		})
@@ -359,14 +368,14 @@ var _ = Describe("Allocation", func() {
 				ProviderID: makeProviderID(lo.FromPtr(instance.InstanceId)),
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						corev1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceTypeStable:           selectedInstanceType.Name,
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       selectedInstanceType.Name,
 					},
 				},
 			})
 			// Instance is a reference to what we return in the GetInstances call
 			instance.ImageId = aws.String(makeImageID())
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(BeTrue())
 		})
@@ -375,12 +384,12 @@ var _ = Describe("Allocation", func() {
 				ProviderID: makeProviderID(lo.FromPtr(instance.InstanceId)),
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						corev1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceTypeStable:           selectedInstanceType.Name,
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       selectedInstanceType.Name,
 					},
 				},
 			})
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(BeFalse())
 		})
@@ -389,23 +398,23 @@ var _ = Describe("Allocation", func() {
 				ProviderID: makeProviderID(lo.FromPtr(instance.InstanceId)),
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						corev1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 					},
 				},
 			})
-			_, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+			_, err := cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 			Expect(err).To(HaveOccurred())
 		})
 		It("should error drift if node doesn't have provider id", func() {
 			node := coretest.Node(coretest.NodeOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						corev1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceTypeStable:           selectedInstanceType.Name,
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       selectedInstanceType.Name,
 					},
 				},
 			})
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 			Expect(err).To(HaveOccurred())
 			Expect(isDrifted).To(BeFalse())
 		})

--- a/pkg/controllers/drift/controller.go
+++ b/pkg/controllers/drift/controller.go
@@ -35,10 +35,10 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-core/pkg/apis/config/settings"
-	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
 	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 )
 
@@ -83,7 +83,7 @@ func (c *Controller) Reconcile(ctx context.Context, node *v1.Node) (reconcile.Re
 		return reconcile.Result{}, fmt.Errorf("getting provisioner, %w", err)
 	}
 
-	drifted, err := c.cloudProvider.IsMachineDrifted(ctx, corev1alpha1.MachineFromNode(node))
+	drifted, err := c.cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNode(node))
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("getting drift for node, %w", err)
 	}

--- a/pkg/fake/cloudprovider.go
+++ b/pkg/fake/cloudprovider.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
-	corev1alpha1 "github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -46,7 +45,7 @@ func NewCloudProvider(validAMIs ...string) *CloudProvider {
 	}
 }
 
-func (c *CloudProvider) Create(_ context.Context, _ *corev1alpha1.Machine) (*v1.Node, error) {
+func (c *CloudProvider) Create(_ context.Context, _ *v1alpha5.Machine) (*v1.Node, error) {
 	name := test.RandomName()
 	n := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -68,7 +67,7 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provisio
 	}, nil
 }
 
-func (c *CloudProvider) IsMachineDrifted(_ context.Context, machine *corev1alpha1.Machine) (bool, error) {
+func (c *CloudProvider) IsMachineDrifted(_ context.Context, machine *v1alpha5.Machine) (bool, error) {
 	nodeAMI := machine.Labels[v1alpha1.LabelInstanceAMIID]
 	for _, ami := range c.ValidAMIs {
 		if nodeAMI == ami {
@@ -78,7 +77,7 @@ func (c *CloudProvider) IsMachineDrifted(_ context.Context, machine *corev1alpha
 	return true, nil
 }
 
-func (c *CloudProvider) Delete(context.Context, *corev1alpha1.Machine) error {
+func (c *CloudProvider) Delete(context.Context, *v1alpha5.Machine) error {
 	return nil
 }
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.154
 	github.com/aws/aws-sdk-go-v2/config v1.18.3
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.21.0
+	github.com/aws/karpenter-core v0.21.1-0.20221229043026-9b38f8c39e87
 	github.com/onsi/ginkgo/v2 v2.5.1
 	github.com/onsi/gomega v1.24.1
 	github.com/samber/lo v1.36.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -84,8 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 h1:jcw6kKZrtNfBPJkaHrscDOZo
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8/go.mod h1:er2JHN+kBY6FcMfcBBKNGCT3CarImmdFzishsqBmSRI=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.5 h1:60SJ4lhvn///8ygCzYy2l53bFW/Q15bVfyjyAWo6zuw=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.5/go.mod h1:bXcN3koeVYiJcdDU89n3kCYILob7Y34AeLopUbZgLT4=
-github.com/aws/karpenter-core v0.21.0 h1:U9P70R52eURcoNMe694/rTeQJYmLD7nWgQ6GncdxdME=
-github.com/aws/karpenter-core v0.21.0/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
+github.com/aws/karpenter-core v0.21.1-0.20221229043026-9b38f8c39e87 h1:nAtLXlsNUbTuH6IBVqxA0tUz+L14L3c8zFHavRd36b0=
+github.com/aws/karpenter-core v0.21.1-0.20221229043026-9b38f8c39e87/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.4 h1:/RN2z1txIJWeXeOkzX+Hk/4Uuvv7dWtCjbmVJcrskyk=
 github.com/aws/smithy-go v1.13.4/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Abstract provider calls into interface to enable the underlying implementation to be swapped out for use-cases like for testing. This also makes the public API smaller and the interface cleaner

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
