### PR TITLE
Fix resource-based naming node names 

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -46,6 +46,7 @@ import (
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/scheduling"
+	awssettings "github.com/aws/karpenter/pkg/apis/config/settings"
 	"github.com/aws/karpenter/pkg/cloudprovider/amifamily"
 	awscontext "github.com/aws/karpenter/pkg/context"
 
@@ -143,7 +144,7 @@ func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (
 	if err != nil {
 		return nil, fmt.Errorf("creating instance, %w", err)
 	}
-	return c.instanceToNode(instance, instanceTypes), nil
+	return c.instanceToNode(ctx, instance, instanceTypes), nil
 }
 
 func (c *CloudProvider) LivenessProbe(req *http.Request) error {
@@ -297,10 +298,13 @@ func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, machine *v1alp
 	}), nil
 }
 
-func (c *CloudProvider) instanceToNode(instance *ec2.Instance, instanceTypes []*cloudprovider.InstanceType) *v1.Node {
+func (c *CloudProvider) instanceToNode(ctx context.Context, instance *ec2.Instance, instanceTypes []*cloudprovider.InstanceType) *v1.Node {
 	for _, instanceType := range instanceTypes {
 		if instanceType.Name == aws.StringValue(instance.InstanceType) {
 			nodeName := strings.ToLower(aws.StringValue(instance.PrivateDnsName))
+			if awssettings.FromContext(ctx).NodeNameConvention == awssettings.ResourceName {
+				nodeName = aws.StringValue(instance.InstanceId)
+			}
 			labels := map[string]string{}
 			for key, req := range instanceType.Requirements {
 				if req.Len() == 1 {

--- a/website/content/en/preview/concepts/settings.md
+++ b/website/content/en/preview/concepts/settings.md
@@ -58,7 +58,7 @@ data:
   # If true, then assume we can't reach AWS services which don't have a VPC endpoint
   # This also has the effect of disabling look-ups to the AWS pricing endpoint
   aws.isolatedVPC: "false"
-  # The node naming convention (either "ip-name" or "resource-name")
+  # The node naming convention (either "ip-name" or "resource-name"; use "ip-name" for resource DNS names such as i-0123456789.ec2.internal and "resource-name" when using the external cloud provider)
   aws.nodeNameConvention: ip-name
   # The VM memory overhead as a percent that will be subtracted
   # from the total memory for all instance types


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
There are 3-possible node naming conventions:
 - IP name: `ip-10-0-2-200.ec2.internal`
 - Resource Based DNS Name: `i-0123456789.ec2.internal`
 - Resource Based Naming w/ External Cloud Provider: `i-0123456789`

This change supports all 3 with the previous Karpenter configuration of `nodeNameConvention`. `ip-name` will refer to both dns-based naming since this is the default and is by far the most common configuration. If using the external AWS Cloud Provider with node naming enabled, then the `resource-name` value can be used for the `nodeNameConvention` to name nodes without the DNS suffix. 

This change updates the docs to clarify the nodeNameConvention parameter.

**How was this change tested?**

* Tested on an EKS cluster by:
  * Launching nodes in subnets with RBN disabled. Observed nodes being created with ip-10-0-200-3.ec2.internal node names. 
  * Launching nodes in subnets with RBN enabled. Observed nodes being created with i-0123456789.ec2.internal node names.
  * Launching nodes in subnets with RBN enabled and `settings.aws.nodeNameConvention=resource-name` and observed nodes launching with `i-0123456789` names. 

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
