### PR TITLE
fix: Add missing additional annotations

### DIFF
--- a/charts/karpenter/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter/templates/poddisruptionbudget.yaml
@@ -3,6 +3,10 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ .Values.podDisruptionBudget.name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   selector:

--- a/charts/karpenter/templates/webhooks-core.yaml
+++ b/charts/karpenter/templates/webhooks-core.yaml
@@ -35,6 +35,10 @@ metadata:
   name: validation.webhook.karpenter.sh
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 webhooks:
   - name: validation.webhook.karpenter.sh
     admissionReviewVersions: ["v1"]
@@ -63,6 +67,10 @@ metadata:
   name: validation.webhook.config.karpenter.sh
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 webhooks:
   - name: validation.webhook.config.karpenter.sh
     admissionReviewVersions: ["v1"]

--- a/charts/karpenter/templates/webhooks.yaml
+++ b/charts/karpenter/templates/webhooks.yaml
@@ -46,6 +46,10 @@ metadata:
   name: validation.webhook.karpenter.k8s.aws
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 webhooks:
   - name: validation.webhook.karpenter.k8s.aws
     admissionReviewVersions: ["v1"]


### PR DESCRIPTION
**Description**
Added additional annotations to all Kubernetes resources.

**How was this change tested?**
* Rendering helm chart manually

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
