### PR TITLE
Use Spot Price-Capacity-Optimized in China regions

### DIFF
--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -160,8 +159,6 @@ func (p *InstanceProvider) Delete(ctx context.Context, machine *v1alpha5.Machine
 	return nil
 }
 
-// can remove cyclo ignore after China launch price-capacity-optimized
-// nolint: gocyclo
 func (p *InstanceProvider) launchInstance(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType) (*string, error) {
 	capacityType := p.getCapacityType(machine, instanceTypes)
 	// Get Launch Template Configs, which may differ due to GPU or Architecture requirements
@@ -188,9 +185,7 @@ func (p *InstanceProvider) launchInstance(ctx context.Context, nodeTemplate *v1a
 			{ResourceType: aws.String(ec2.ResourceTypeFleet), Tags: tags},
 		},
 	}
-	if capacityType == v1alpha5.CapacityTypeSpot && strings.HasPrefix(p.region, "cn-") {
-		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{AllocationStrategy: aws.String(ec2.AllocationStrategyCapacityOptimizedPrioritized)}
-	} else if capacityType == v1alpha5.CapacityTypeSpot {
+	if capacityType == v1alpha5.CapacityTypeSpot {
 		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{AllocationStrategy: aws.String(ec2.AllocationStrategyPriceCapacityOptimized)}
 	} else {
 		createFleetInput.OnDemandOptions = &ec2.OnDemandOptionsRequest{AllocationStrategy: aws.String(ec2.FleetOnDemandAllocationStrategyLowestPrice)}
@@ -299,13 +294,8 @@ func (p *InstanceProvider) getOverrides(instanceTypes []*cloudprovider.InstanceT
 		unwrappedOfferings = append(unwrappedOfferings, ofs...)
 	}
 
-	// Sort all the potential offerings by each individual offering price
-	sort.Slice(unwrappedOfferings, func(i, j int) bool {
-		return unwrappedOfferings[i].Price < unwrappedOfferings[j].Price
-	})
-
 	var overrides []*ec2.FleetLaunchTemplateOverridesRequest
-	for i, offering := range unwrappedOfferings {
+	for _, offering := range unwrappedOfferings {
 		if capacityType != offering.CapacityType {
 			continue
 		}
@@ -316,23 +306,13 @@ func (p *InstanceProvider) getOverrides(instanceTypes []*cloudprovider.InstanceT
 		if !ok {
 			continue
 		}
-		override := &ec2.FleetLaunchTemplateOverridesRequest{
+		overrides = append(overrides, &ec2.FleetLaunchTemplateOverridesRequest{
 			InstanceType: aws.String(offering.parentInstanceTypeName),
 			SubnetId:     subnet.SubnetId,
 			// This is technically redundant, but is useful if we have to parse insufficient capacity errors from
 			// CreateFleet so that we can figure out the zone rather than additional API calls to look up the subnet
 			AvailabilityZone: subnet.AvailabilityZone,
-		}
-
-		// For China regions (until price-capacity-optimized is released)
-		// Add a priority for spot requests since we are using the capacity-optimized-prioritized spot allocation strategy
-		// to reduce the likelihood of getting an excessively large instance type.
-		// InstanceTypes are sorted by vcpus and memory so this prioritizes smaller instance types.
-		if capacityType == v1alpha5.CapacityTypeSpot && strings.HasPrefix(p.region, "cn-") {
-			override.Priority = aws.Float64(float64(i))
-		}
-
-		overrides = append(overrides, override)
+		})
 	}
 	return overrides
 }


### PR DESCRIPTION
This reverts commit 470aa83476d121f9215d7a209d6725b2d0e11738.

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - This change reverts a previous commit that special cased the spot allocation strategy used in regions within China since the Price Capacity Optimized allocation strategy had not been released there yet. It is now available, so removing this special case. 

**How was this change tested?**


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
