### PR TITLE
fix: Add pr number to notification

### DIFF
--- a/.github/workflows/approval-comment-snapshot.yml
+++ b/.github/workflows/approval-comment-snapshot.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: ./.github/actions/install-go-and-dependencies
       - uses: ./.github/actions/authenticate-aws
       - run: make release
+        env:
+          GH_PR_NUMBER: ${{env.PR_NUMBER}}
       - uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/approval-comment.yml
+++ b/.github/workflows/approval-comment.yml
@@ -19,8 +19,3 @@ jobs:
           echo ${{ github.event.review.commit_id }} >> /tmp/artifacts/metadata.txt
           cat /tmp/artifacts/metadata.txt
       - uses: ./.github/actions/upload-artifact
-      - uses: ./.github/actions/authenticate-ghcr
-        with:
-          actor: ${{ github.actor }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-      - run: make release-crd

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -24,11 +24,17 @@ Release Version: ${RELEASE_VERSION}
 Commit: $(git rev-parse HEAD)
 Helm Chart Version $(helmChartVersion $RELEASE_VERSION)"
 
+
+  PR_NUMBER=${GH_PR_NUMBER:-}
+  if [ "${GH_PR_NUMBER+defined}" != defined ]; then
+   PR_NUMBER="none"
+  fi
+
   authenticate
   buildImages
   cosignImages
   publishHelmChart
-  notifyRelease $RELEASE_VERSION
+  notifyRelease $RELEASE_VERSION $PR_NUMBER
   pullPrivateReplica $RELEASE_VERSION
 }
 
@@ -86,8 +92,9 @@ cosignImages() {
 
 notifyRelease() {
     RELEASE_VERSION=$1
+    PR_NUMBER=$2
     RELEASE_TYPE=$(releaseType $RELEASE_VERSION)
-    MESSAGE="{\"releaseType\":\"${RELEASE_TYPE}\",\"releaseIdentifier\":\"${RELEASE_VERSION}\"}"
+    MESSAGE="{\"releaseType\":\"${RELEASE_TYPE}\",\"releaseIdentifier\":\"${RELEASE_VERSION}\",\"prNumber\":\"${PR_NUMBER}\"}"
     aws sns publish \
         --topic-arn ${SNS_TOPIC_ARN} \
         --message ${MESSAGE} \

--- a/hack/release/release.sh
+++ b/hack/release/release.sh
@@ -7,7 +7,6 @@ HEAD_HASH=$(git rev-parse HEAD)
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "${SCRIPT_DIR}/common.sh"
 
-
 config
 release $HEAD_HASH #release a snapshot version
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

* Adds PR number to the notification message where available
* Removes crd release from the GHA because it was shown to not work in some cases

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
