### PR TITLE
chore: Bump karpenter/core for compatability with new cluster `state.Node`

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -62,7 +62,7 @@ func main() {
 			operator.Clock,
 			operator.GetClient(),
 			operator.KubernetesInterface,
-			state.NewCluster(ctx, operator.Clock, operator.GetClient(), cloudProvider),
+			state.NewCluster(operator.Clock, operator.GetClient(), cloudProvider),
 			operator.EventRecorder,
 			operator.SettingsStore,
 			cloudProvider,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.154
-	github.com/aws/karpenter-core v0.21.1-0.20230105184032-4d4444bc342f
+	github.com/aws/karpenter-core v0.21.1-0.20230106175449-a4b051311ca7
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.154 h1:2TaEC8JIM/t7Fu+FBmdOBK5jFUAVL07tbpfJsLuVo3Q=
 github.com/aws/aws-sdk-go v1.44.154/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.21.1-0.20230105184032-4d4444bc342f h1:zVrQInXSw+e/EVDaiaf/hC3qRZkRLMLcijN3PivLHLM=
-github.com/aws/karpenter-core v0.21.1-0.20230105184032-4d4444bc342f/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
+github.com/aws/karpenter-core v0.21.1-0.20230106175449-a4b051311ca7 h1:Rk3Uj9BhYlqPnVZvzflS0bJfSVJUadWuZQmf6lnTgwg=
+github.com/aws/karpenter-core v0.21.1-0.20230106175449-a4b051311ca7/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -45,10 +45,11 @@ import (
 	"knative.dev/pkg/ptr"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/scheduling"
 	awssettings "github.com/aws/karpenter/pkg/apis/config/settings"
 	"github.com/aws/karpenter/pkg/cloudprovider/amifamily"
 	awscontext "github.com/aws/karpenter/pkg/context"
+
+	"github.com/aws/karpenter-core/pkg/scheduling"
 
 	coreapis "github.com/aws/karpenter-core/pkg/apis"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"

--- a/pkg/cloudprovider/instancetypes_test.go
+++ b/pkg/cloudprovider/instancetypes_test.go
@@ -30,9 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/ptr"
 
+	"github.com/aws/karpenter/pkg/test"
+
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
-	"github.com/aws/karpenter/pkg/test"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	coretest "github.com/aws/karpenter-core/pkg/test"

--- a/pkg/cloudprovider/launchtemplate.go
+++ b/pkg/cloudprovider/launchtemplate.go
@@ -33,13 +33,14 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	awssettings "github.com/aws/karpenter/pkg/apis/config/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider/amifamily"
 	awscontext "github.com/aws/karpenter/pkg/context"
 	awserrors "github.com/aws/karpenter/pkg/errors"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/utils/pretty"

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -37,7 +37,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "knative.dev/pkg/logging/testing"
 
-	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/apis"
 	awssettings "github.com/aws/karpenter/pkg/apis/config/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -46,10 +45,14 @@ import (
 	awscontext "github.com/aws/karpenter/pkg/context"
 	"github.com/aws/karpenter/pkg/test"
 
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ssm"
+
+	"github.com/aws/karpenter/pkg/fake"
 
 	"github.com/aws/karpenter-core/pkg/apis/config/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -62,7 +65,6 @@ import (
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
 	"github.com/aws/karpenter-core/pkg/utils/pretty"
-	"github.com/aws/karpenter/pkg/fake"
 
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
@@ -158,7 +160,7 @@ var _ = BeforeSuite(func() {
 		kubeClient:           env.Client,
 	}
 	fakeClock = clock.NewFakeClock(time.Now())
-	cluster = state.NewCluster(ctx, fakeClock, env.Client, cloudProvider)
+	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	recorder = coretest.NewEventRecorder()
 	prov = provisioning.NewProvisioner(ctx, env.Client, env.KubernetesInterface.CoreV1(), recorder, cloudProvider, cluster)
 	provisioningController = provisioning.NewController(env.Client, prov, recorder)
@@ -205,6 +207,7 @@ var _ = BeforeEach(func() {
 		},
 	})
 
+	cluster.Reset()
 	recorder.Reset()
 	fakeEC2API.Reset()
 	fakeSSMAPI.Reset()

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -21,10 +21,11 @@ import (
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/controllers/drift"
 
-	"github.com/aws/karpenter-core/pkg/operator/controller"
 	awscontext "github.com/aws/karpenter/pkg/context"
 	"github.com/aws/karpenter/pkg/controllers/interruption"
 	"github.com/aws/karpenter/pkg/utils/project"
+
+	"github.com/aws/karpenter-core/pkg/operator/controller"
 )
 
 func NewControllers(ctx awscontext.Context, cloudProvider *cloudprovider.CloudProvider) []controller.Controller {

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.154
 	github.com/aws/aws-sdk-go-v2/config v1.18.7
 	github.com/aws/karpenter v0.18.0
-	github.com/aws/karpenter-core v0.21.1-0.20230105184032-4d4444bc342f
+	github.com/aws/karpenter-core v0.21.1-0.20230106175449-a4b051311ca7
 	github.com/onsi/ginkgo/v2 v2.6.1
 	github.com/onsi/gomega v1.24.2
 	github.com/samber/lo v1.37.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -85,8 +85,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.11 h1:KCacyVSs/wlcPGx37hcbT3I
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.11/go.mod h1:TZSH7xLO7+phDtViY/KUp9WGCJMQkLJ/VpgkTFd5gh8=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.7 h1:9Mtq1KM6nD8/+HStvWcvYnixJ5N85DX+P+OY3kI3W2k=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.7/go.mod h1:+lGbb3+1ugwKrNTWcf2RT05Xmp543B06zDFTwiTLp7I=
-github.com/aws/karpenter-core v0.21.1-0.20230105184032-4d4444bc342f h1:zVrQInXSw+e/EVDaiaf/hC3qRZkRLMLcijN3PivLHLM=
-github.com/aws/karpenter-core v0.21.1-0.20230105184032-4d4444bc342f/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
+github.com/aws/karpenter-core v0.21.1-0.20230106175449-a4b051311ca7 h1:Rk3Uj9BhYlqPnVZvzflS0bJfSVJUadWuZQmf6lnTgwg=
+github.com/aws/karpenter-core v0.21.1-0.20230106175449-a4b051311ca7/go.mod h1:qWQu8B7Tc2sPDNdIG9JZRl642ofccXtgj89is04Z5U8=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Bump karpenter/core for compatability with new cluster `state.Node`

**How was this change tested?**

* `make presubmit`
* `FOCUS=Scheduling make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
