### PR TITLE
test: remove failure notification on cleanup

### DIFF
--- a/test/suites/common/suite.yaml
+++ b/test/suites/common/suite.yaml
@@ -100,7 +100,7 @@ spec:
           - "true"
   - name: notify-cleanup-failure
     when:
-      - input: $(tasks.status)
+      - input: $(tasks.cleanup.status)
         operator: in
         values: ["Failed"]
     taskRef:

--- a/test/suites/common/suite.yaml
+++ b/test/suites/common/suite.yaml
@@ -98,15 +98,3 @@ spec:
         operator: in
         values:
           - "true"
-  - name: notify-cleanup-failure
-    when:
-      - input: $(tasks.cleanup.status)
-        operator: in
-        values: ["Failed"]
-    taskRef:
-      name: notify-slack
-    params:
-      - name: webhook-secret
-        value: slack-webhook-secret
-      - name: message
-        value: ":x: $(context.pipelineRun.name) cleanup failed"

--- a/test/suites/ipv6/pipeline.yaml
+++ b/test/suites/ipv6/pipeline.yaml
@@ -106,7 +106,7 @@ spec:
           - "true"
   - name: notify-cleanup-failure
     when:
-      - input: $(tasks.status)
+      - input: $(tasks.cleanup.status)
         operator: in
         values: ["Failed"]
     taskRef:

--- a/test/suites/ipv6/pipeline.yaml
+++ b/test/suites/ipv6/pipeline.yaml
@@ -104,15 +104,3 @@ spec:
         operator: in
         values:
           - "true"
-  - name: notify-cleanup-failure
-    when:
-      - input: $(tasks.cleanup.status)
-        operator: in
-        values: ["Failed"]
-    taskRef:
-      name: notify-slack
-    params:
-      - name: webhook-secret
-        value: slack-webhook-secret
-      - name: message
-        value: ":x: $(context.pipelineRun.name) cleanup failed"

--- a/test/suites/upgrade/pipeline.yaml
+++ b/test/suites/upgrade/pipeline.yaml
@@ -123,15 +123,3 @@ spec:
         operator: in
         values:
           - "true"
-  - name: notify-cleanup-failure
-    when:
-      - input: $(tasks.cleanup.status)
-        operator: in
-        values: ["Failed"]
-    taskRef:
-      name: notify-slack
-    params:
-      - name: webhook-secret
-        value: slack-webhook-secret
-      - name: message
-        value: ":x: $(context.pipelineRun.name) cleanup failed"

--- a/test/suites/upgrade/pipeline.yaml
+++ b/test/suites/upgrade/pipeline.yaml
@@ -125,7 +125,7 @@ spec:
           - "true"
   - name: notify-cleanup-failure
     when:
-      - input: $(tasks.status)
+      - input: $(tasks.cleanup.status)
         operator: in
         values: ["Failed"]
     taskRef:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Removing the cleanup notification failure. Since task status only reflects the status of the tasks not those under the finally this does not work as expected. It would not cause a notification when a failure occurs. It also causes a double notification each time any of the tasks e.g. tests fail.


**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
