### PR TITLE
feat: add support for "karpenter.k8s.aws/instance-encryption-in-transit-supported" label

### DIFF
--- a/hack/code/instancetype_testdata_gen.go
+++ b/hack/code/instancetype_testdata_gen.go
@@ -156,6 +156,7 @@ func getInstanceTypeInfo(info *ec2.InstanceTypeInfo) string {
 	fmt.Fprintf(src, "NetworkInfo: &ec2.NetworkInfo{\n")
 	fmt.Fprintf(src, "MaximumNetworkInterfaces: aws.Int64(%d),\n", lo.FromPtr(info.NetworkInfo.MaximumNetworkInterfaces))
 	fmt.Fprintf(src, "Ipv4AddressesPerInterface: aws.Int64(%d),\n", lo.FromPtr(info.NetworkInfo.Ipv4AddressesPerInterface))
+	fmt.Fprintf(src, "EncryptionInTransitSupported: aws.Bool(%t),\n", lo.FromPtr(info.NetworkInfo.EncryptionInTransitSupported))
 	fmt.Fprintf(src, "},\n")
 	return src.String()
 }

--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -59,20 +59,21 @@ var (
 	ResourceHabanaGaudi v1.ResourceName = "habana.ai/gaudi"
 	ResourceAWSPodENI   v1.ResourceName = "vpc.amazonaws.com/pod-eni"
 
-	LabelInstanceHypervisor      = LabelDomain + "/instance-hypervisor"
-	LabelInstanceCategory        = LabelDomain + "/instance-category"
-	LabelInstanceFamily          = LabelDomain + "/instance-family"
-	LabelInstanceGeneration      = LabelDomain + "/instance-generation"
-	LabelInstanceLocalNVME       = LabelDomain + "/instance-local-nvme"
-	LabelInstanceSize            = LabelDomain + "/instance-size"
-	LabelInstanceCPU             = LabelDomain + "/instance-cpu"
-	LabelInstanceMemory          = LabelDomain + "/instance-memory"
-	LabelInstancePods            = LabelDomain + "/instance-pods"
-	LabelInstanceGPUName         = LabelDomain + "/instance-gpu-name"
-	LabelInstanceGPUManufacturer = LabelDomain + "/instance-gpu-manufacturer"
-	LabelInstanceGPUCount        = LabelDomain + "/instance-gpu-count"
-	LabelInstanceGPUMemory       = LabelDomain + "/instance-gpu-memory"
-	LabelInstanceAMIID           = LabelDomain + "/instance-ami-id"
+	LabelInstanceHypervisor                   = LabelDomain + "/instance-hypervisor"
+	LabelInstanceEncryptionInTransitSupported = LabelDomain + "/instance-encryption-in-transit-supported"
+	LabelInstanceCategory                     = LabelDomain + "/instance-category"
+	LabelInstanceFamily                       = LabelDomain + "/instance-family"
+	LabelInstanceGeneration                   = LabelDomain + "/instance-generation"
+	LabelInstanceLocalNVME                    = LabelDomain + "/instance-local-nvme"
+	LabelInstanceSize                         = LabelDomain + "/instance-size"
+	LabelInstanceCPU                          = LabelDomain + "/instance-cpu"
+	LabelInstanceMemory                       = LabelDomain + "/instance-memory"
+	LabelInstancePods                         = LabelDomain + "/instance-pods"
+	LabelInstanceGPUName                      = LabelDomain + "/instance-gpu-name"
+	LabelInstanceGPUManufacturer              = LabelDomain + "/instance-gpu-manufacturer"
+	LabelInstanceGPUCount                     = LabelDomain + "/instance-gpu-count"
+	LabelInstanceGPUMemory                    = LabelDomain + "/instance-gpu-memory"
+	LabelInstanceAMIID                        = LabelDomain + "/instance-ami-id"
 
 	InterruptionInfrastructureFinalizer = Group + "/interruption-infrastructure"
 )
@@ -97,6 +98,7 @@ func init() {
 	v1alpha5.RestrictedLabelDomains = v1alpha5.RestrictedLabelDomains.Insert(RestrictedLabelDomains...)
 	v1alpha5.WellKnownLabels = v1alpha5.WellKnownLabels.Insert(
 		LabelInstanceHypervisor,
+		LabelInstanceEncryptionInTransitSupported,
 		LabelInstanceCategory,
 		LabelInstanceFamily,
 		LabelInstanceGeneration,

--- a/pkg/cloudprovider/instancetype.go
+++ b/pkg/cloudprovider/instancetype.go
@@ -91,6 +91,7 @@ func computeRequirements(ctx context.Context, info *ec2.InstanceTypeInfo, offeri
 		scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(v1alpha1.LabelInstanceGPUMemory, v1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(v1alpha1.LabelInstanceHypervisor, v1.NodeSelectorOpIn, aws.StringValue(info.Hypervisor)),
+		scheduling.NewRequirement(v1alpha1.LabelInstanceEncryptionInTransitSupported, v1.NodeSelectorOpIn, fmt.Sprint(aws.BoolValue(info.NetworkInfo.EncryptionInTransitSupported))),
 	)
 	// Instance Type Labels
 	instanceFamilyParts := instanceTypeScheme.FindStringSubmatch(aws.StringValue(info.InstanceType))

--- a/pkg/cloudprovider/instancetypes_test.go
+++ b/pkg/cloudprovider/instancetypes_test.go
@@ -50,19 +50,20 @@ var _ = Describe("Instance Types", func() {
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 		var pods []*v1.Pod
 		for key, value := range map[string]string{
-			v1alpha1.LabelInstanceHypervisor:      "nitro",
-			v1alpha1.LabelInstanceCategory:        "g",
-			v1alpha1.LabelInstanceFamily:          "g4dn",
-			v1alpha1.LabelInstanceGeneration:      "4",
-			v1alpha1.LabelInstanceSize:            "8xlarge",
-			v1alpha1.LabelInstanceCPU:             "32",
-			v1alpha1.LabelInstanceMemory:          "131072",
-			v1alpha1.LabelInstancePods:            "58",
-			v1alpha1.LabelInstanceGPUName:         "t4",
-			v1alpha1.LabelInstanceGPUManufacturer: "nvidia",
-			v1alpha1.LabelInstanceGPUCount:        "1",
-			v1alpha1.LabelInstanceGPUMemory:       "16384",
-			v1alpha1.LabelInstanceLocalNVME:       "900",
+			v1alpha1.LabelInstanceHypervisor:                   "nitro",
+			v1alpha1.LabelInstanceEncryptionInTransitSupported: "true",
+			v1alpha1.LabelInstanceCategory:                     "g",
+			v1alpha1.LabelInstanceFamily:                       "g4dn",
+			v1alpha1.LabelInstanceGeneration:                   "4",
+			v1alpha1.LabelInstanceSize:                         "8xlarge",
+			v1alpha1.LabelInstanceCPU:                          "32",
+			v1alpha1.LabelInstanceMemory:                       "131072",
+			v1alpha1.LabelInstancePods:                         "58",
+			v1alpha1.LabelInstanceGPUName:                      "t4",
+			v1alpha1.LabelInstanceGPUManufacturer:              "nvidia",
+			v1alpha1.LabelInstanceGPUCount:                     "1",
+			v1alpha1.LabelInstanceGPUMemory:                    "16384",
+			v1alpha1.LabelInstanceLocalNVME:                    "900",
 		} {
 			pods = append(pods, coretest.UnschedulablePod(coretest.PodOptions{NodeSelector: map[string]string{key: value}}))
 		}

--- a/pkg/fake/zz_generated.describe_instance_types.go
+++ b/pkg/fake/zz_generated.describe_instance_types.go
@@ -45,8 +45,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				SizeInMiB: aws.Int64(4096),
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(3),
-				Ipv4AddressesPerInterface: aws.Int64(10),
+				MaximumNetworkInterfaces:     aws.Int64(3),
+				Ipv4AddressesPerInterface:    aws.Int64(10),
+				EncryptionInTransitSupported: aws.Bool(false),
 			},
 		},
 		{
@@ -82,8 +83,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				TotalSizeInGB: aws.Int64(4000),
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(60),
-				Ipv4AddressesPerInterface: aws.Int64(50),
+				MaximumNetworkInterfaces:     aws.Int64(60),
+				Ipv4AddressesPerInterface:    aws.Int64(50),
+				EncryptionInTransitSupported: aws.Bool(true),
 			},
 		},
 		{
@@ -119,8 +121,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				TotalSizeInGB: aws.Int64(900),
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(4),
-				Ipv4AddressesPerInterface: aws.Int64(15),
+				MaximumNetworkInterfaces:     aws.Int64(4),
+				Ipv4AddressesPerInterface:    aws.Int64(15),
+				EncryptionInTransitSupported: aws.Bool(true),
 			},
 		},
 		{
@@ -149,8 +152,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				},
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(4),
-				Ipv4AddressesPerInterface: aws.Int64(10),
+				MaximumNetworkInterfaces:     aws.Int64(4),
+				Ipv4AddressesPerInterface:    aws.Int64(10),
+				EncryptionInTransitSupported: aws.Bool(true),
 			},
 		},
 		{
@@ -179,8 +183,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				},
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(8),
-				Ipv4AddressesPerInterface: aws.Int64(30),
+				MaximumNetworkInterfaces:     aws.Int64(8),
+				Ipv4AddressesPerInterface:    aws.Int64(30),
+				EncryptionInTransitSupported: aws.Bool(true),
 			},
 		},
 		{
@@ -201,8 +206,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				SizeInMiB: aws.Int64(8192),
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(3),
-				Ipv4AddressesPerInterface: aws.Int64(10),
+				MaximumNetworkInterfaces:     aws.Int64(3),
+				Ipv4AddressesPerInterface:    aws.Int64(10),
+				EncryptionInTransitSupported: aws.Bool(false),
 			},
 		},
 		{
@@ -223,8 +229,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				SizeInMiB: aws.Int64(393216),
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(15),
-				Ipv4AddressesPerInterface: aws.Int64(50),
+				MaximumNetworkInterfaces:     aws.Int64(15),
+				Ipv4AddressesPerInterface:    aws.Int64(50),
+				EncryptionInTransitSupported: aws.Bool(false),
 			},
 		},
 		{
@@ -245,8 +252,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				SizeInMiB: aws.Int64(16384),
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(4),
-				Ipv4AddressesPerInterface: aws.Int64(15),
+				MaximumNetworkInterfaces:     aws.Int64(4),
+				Ipv4AddressesPerInterface:    aws.Int64(15),
+				EncryptionInTransitSupported: aws.Bool(false),
 			},
 		},
 		{
@@ -279,8 +287,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				},
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(8),
-				Ipv4AddressesPerInterface: aws.Int64(30),
+				MaximumNetworkInterfaces:     aws.Int64(8),
+				Ipv4AddressesPerInterface:    aws.Int64(30),
+				EncryptionInTransitSupported: aws.Bool(false),
 			},
 		},
 		{
@@ -301,8 +310,9 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				SizeInMiB: aws.Int64(8192),
 			},
 			NetworkInfo: &ec2.NetworkInfo{
-				MaximumNetworkInterfaces:  aws.Int64(3),
-				Ipv4AddressesPerInterface: aws.Int64(12),
+				MaximumNetworkInterfaces:     aws.Int64(3),
+				Ipv4AddressesPerInterface:    aws.Int64(12),
+				EncryptionInTransitSupported: aws.Bool(false),
 			},
 		},
 	},

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -133,26 +133,27 @@ Take care to ensure the label domains are correct. A well known label like `karp
 
 #### Well-Known Labels
 
-| Label                                       | Example     | Description                                                                                                                                 |
-| ------------------------------------------- | ----------  | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| topology.kubernetes.io/zone                 | us-east-2a  | Zones are defined by your cloud provider ([aws](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)) |
-| node.kubernetes.io/instance-type            | g4dn.8xlarge| Instance types are defined by your cloud provider ([aws](https://aws.amazon.com/ec2/instance-types/))                                       |
-| kubernetes.io/os                            | linux       | Operating systems are defined by [GOOS values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L10) on the instance        |
-| kubernetes.io/arch                          | amd64       | Architectures are defined by [GOARCH values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L50) on the instance          |
-| karpenter.sh/capacity-type                  | spot        | Capacity types include `spot`, `on-demand`                                                                                                  |
-| karpenter.k8s.aws/instance-hypervisor       | nitro       | [AWS Specific] Instance types that use a specific hypervisor                                                                                |
-| karpenter.k8s.aws/instance-category         | g           | [AWS Specific] Instance types of the same category, usually the string before the generation number                                         |
-| karpenter.k8s.aws/instance-generation       | 4           | [AWS Specific] Instance type generation number within an instance category                                                                  |
-| karpenter.k8s.aws/instance-family           | g4dn        | [AWS Specific] Instance types of similar properties but different resource quantities                                                       |
-| karpenter.k8s.aws/instance-size             | 8xlarge     | [AWS Specific] Instance types of similar resource quantities but different properties                                                       |
-| karpenter.k8s.aws/instance-cpu              | 32          | [AWS Specific] Number of CPUs on the instance                                                                                               |
-| karpenter.k8s.aws/instance-memory           | 131072      | [AWS Specific] Number of mebibytes of memory on the instance                                                                                |
-| karpenter.k8s.aws/instance-pods             | 110         | [AWS Specific] Number of pods the instance supports                                                                                         |
-| karpenter.k8s.aws/instance-gpu-name         | t4          | [AWS Specific] Name of the GPU on the instance, if available                                                                                |
-| karpenter.k8s.aws/instance-gpu-manufacturer | nvidia      | [AWS Specific] Name of the GPU manufacturer                                                                                                 |
-| karpenter.k8s.aws/instance-gpu-count        | 1           | [AWS Specific] Number of GPUs on the instance                                                                                               |
-| karpenter.k8s.aws/instance-gpu-memory       | 16384       | [AWS Specific] Number of mebibytes of memory on the GPU                                                                                     |
-| karpenter.k8s.aws/instance-local-nvme       | 900         | [AWS Specific] Number of gibibytes of local nvme storage on the instance                                                                    |
+| Label                                                 | Example     | Description                                                                                                                                 |
+| ----------------------------------------------------- | ----------  | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| topology.kubernetes.io/zone                           | us-east-2a  | Zones are defined by your cloud provider ([aws](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)) |
+| node.kubernetes.io/instance-type                      | g4dn.8xlarge| Instance types are defined by your cloud provider ([aws](https://aws.amazon.com/ec2/instance-types/))                                       |
+| kubernetes.io/os                                      | linux       | Operating systems are defined by [GOOS values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L10) on the instance        |
+| kubernetes.io/arch                                    | amd64       | Architectures are defined by [GOARCH values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L50) on the instance          |
+| karpenter.sh/capacity-type                            | spot        | Capacity types include `spot`, `on-demand`                                                                                                  |
+| karpenter.k8s.aws/instance-hypervisor                 | nitro       | [AWS Specific] Instance types that use a specific hypervisor                                                                                |
+| karpenter.k8s.aws/encryption-in-transit-supported     | true        | [AWS Specific] Instance types that support (or not) in-transit encryption                                                                            |
+| karpenter.k8s.aws/instance-category                   | g           | [AWS Specific] Instance types of the same category, usually the string before the generation number                                         |
+| karpenter.k8s.aws/instance-generation                 | 4           | [AWS Specific] Instance type generation number within an instance category                                                                  |
+| karpenter.k8s.aws/instance-family                     | g4dn        | [AWS Specific] Instance types of similar properties but different resource quantities                                                       |
+| karpenter.k8s.aws/instance-size                       | 8xlarge     | [AWS Specific] Instance types of similar resource quantities but different properties                                                       |
+| karpenter.k8s.aws/instance-cpu                        | 32          | [AWS Specific] Number of CPUs on the instance                                                                                               |
+| karpenter.k8s.aws/instance-memory                     | 131072      | [AWS Specific] Number of mebibytes of memory on the instance                                                                                |
+| karpenter.k8s.aws/instance-pods                       | 110         | [AWS Specific] Number of pods the instance supports                                                                                         |
+| karpenter.k8s.aws/instance-gpu-name                   | t4          | [AWS Specific] Name of the GPU on the instance, if available                                                                                |
+| karpenter.k8s.aws/instance-gpu-manufacturer           | nvidia      | [AWS Specific] Name of the GPU manufacturer                                                                                                 |
+| karpenter.k8s.aws/instance-gpu-count                  | 1           | [AWS Specific] Number of GPUs on the instance                                                                                               |
+| karpenter.k8s.aws/instance-gpu-memory                 | 16384       | [AWS Specific] Number of mebibytes of memory on the GPU                                                                                     |
+| karpenter.k8s.aws/instance-local-nvme                 | 900         | [AWS Specific] Number of gibibytes of local nvme storage on the instance                                                                    |
 
 #### User-Defined Labels
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

**Description**
Adds support for "karpenter.k8s.aws/instance-encryption-in-transit-supported" label to allow to select instances that support the in-transit encryption

**How was this change tested?**

* running test suites locally
* on an EKS cluster when specifying "karpenter.k8s.aws/instance-encryption-in-transit-supported" either in provisioner's requirements or pod's nodeSelector / nodeAffinity

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
