### PR TITLE
fix: Ignore K8s NotFound error on interruption delete

### DIFF
--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -38,7 +38,6 @@ import (
 	interruptionevents "github.com/aws/karpenter/pkg/controllers/interruption/events"
 	"github.com/aws/karpenter/pkg/controllers/interruption/messages"
 	"github.com/aws/karpenter/pkg/controllers/interruption/messages/statechange"
-	"github.com/aws/karpenter/pkg/errors"
 	"github.com/aws/karpenter/pkg/utils"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -203,10 +202,7 @@ func (c *Controller) handleNode(ctx context.Context, msg messages.Message, node 
 // deleteNode removes the node from the api-server
 func (c *Controller) deleteNode(ctx context.Context, node *v1.Node) error {
 	if err := c.kubeClient.Delete(ctx, node); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("deleting the node on interruption message, %w", err)
+		return client.IgnoreNotFound(fmt.Errorf("deleting the node on interruption message, %w", err))
 	}
 	logging.FromContext(ctx).Infof("deleted node from interruption message")
 	c.recorder.Publish(interruptionevents.NodeTerminatingOnInterruption(node))

--- a/pkg/controllers/interruption/suite_test.go
+++ b/pkg/controllers/interruption/suite_test.go
@@ -273,6 +273,10 @@ var _ = Describe("AWSInterruption", func() {
 			sqsapi.ReceiveMessageBehavior.Error.Set(awsErrWithCode("AccessDenied"), fake.MaxCalls(0))
 			ExpectReconcileFailed(ctx, controller, types.NamespacedName{})
 		})
+		It("should not return an error when deleting a node that is already deleted", func() {
+			ExpectMessagesCreated(spotInterruptionMessage(defaultInstanceID))
+			ExpectReconcileSucceeded(ctx, controller, types.NamespacedName{})
+		})
 	})
 	Context("Configuration", func() {
 		It("should not poll SQS if interruption queue is disabled", func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Ignore K8s NotFound error on interruption delete
- The wrong error type was checked prior to this fix. We were checking for the `awserrors.NotFound` error rather than the K8s NotFound error

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
