### PR TITLE
test: use last stable release version in upgrade tests

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -7,7 +7,6 @@ config(){
   ECR_GALLERY_NAME="karpenter"
   RELEASE_REPO=${RELEASE_REPO:-public.ecr.aws/${ECR_GALLERY_NAME}/}
   RELEASE_REPO_GH=${RELEASE_REPO_GH:-ghcr.io/${GITHUB_ACCOUNT}/karpenter}
-  LAST_STABLE_RELEASE_TAG=$(git describe --tags --abbrev=0)
 
   PRIVATE_PULL_THROUGH_HOST="${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com"
   SNS_TOPIC_ARN="arn:aws:sns:us-east-1:${AWS_ACCOUNT_ID}:KarpenterReleases"

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -7,6 +7,7 @@ config(){
   ECR_GALLERY_NAME="karpenter"
   RELEASE_REPO=${RELEASE_REPO:-public.ecr.aws/${ECR_GALLERY_NAME}/}
   RELEASE_REPO_GH=${RELEASE_REPO_GH:-ghcr.io/${GITHUB_ACCOUNT}/karpenter}
+  LAST_STABLE_RELEASE_TAG=$(git describe --tags --abbrev=0)
 
   PRIVATE_PULL_THROUGH_HOST="${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com"
   SNS_TOPIC_ARN="arn:aws:sns:us-east-1:${AWS_ACCOUNT_ID}:KarpenterReleases"
@@ -94,7 +95,7 @@ notifyRelease() {
     RELEASE_VERSION=$1
     PR_NUMBER=$2
     RELEASE_TYPE=$(releaseType $RELEASE_VERSION)
-    MESSAGE="{\"releaseType\":\"${RELEASE_TYPE}\",\"releaseIdentifier\":\"${RELEASE_VERSION}\",\"prNumber\":\"${PR_NUMBER}\"}"
+    MESSAGE="{\"releaseType\":\"${RELEASE_TYPE}\",\"releaseIdentifier\":\"${RELEASE_VERSION}\",\"prNumber\":\"${PR_NUMBER}\",\"githubAccount\":\"${GITHUB_ACCOUNT}\",\"lastStableReleaseTag\":\"${LAST_STABLE_RELEASE_TAG}\"}"
     aws sns publish \
         --topic-arn ${SNS_TOPIC_ARN} \
         --message ${MESSAGE} \

--- a/test/cmd/release-notification-listener/listener/listener.go
+++ b/test/cmd/release-notification-listener/listener/listener.go
@@ -24,6 +24,7 @@ const (
 	envVarQueueAWSRegion    = "QUEUE_AWS_REGION"
 	envVarAWSRegion         = "AWS_REGION"
 	envVarTektonClusterName = "CLUSTER_NAME"
+	envGithubAccount        = "GITHUB_ACCOUNT"
 )
 
 type config struct {
@@ -31,6 +32,7 @@ type config struct {
 	queueRegion       string
 	region            string
 	tektonClusterName string
+	githubAccount     string
 }
 
 // Start configures clients and starts listening for messages containing release notifications
@@ -48,5 +50,6 @@ func getConfig() *config {
 		queueRegion:       os.Getenv(envVarQueueAWSRegion),
 		region:            os.Getenv(envVarAWSRegion),
 		tektonClusterName: os.Getenv(envVarTektonClusterName),
+		githubAccount:     os.Getenv(envGithubAccount),
 	}
 }

--- a/test/cmd/release-notification-listener/listener/message.go
+++ b/test/cmd/release-notification-listener/listener/message.go
@@ -39,9 +39,11 @@ const (
 )
 
 type notificationMessage struct {
-	ReleaseType       string `json:"releaseType"`
-	ReleaseIdentifier string `json:"releaseIdentifier"`
-	PrNumber          string `json:"prNumber"`
+	ReleaseType          string `json:"releaseType"`
+	ReleaseIdentifier    string `json:"releaseIdentifier"`
+	PrNumber             string `json:"prNumber"`
+	GithubAccount        string `json:"githubAccount"`
+	LastStableReleaseTag string `json:"lastStableReleaseTag"`
 }
 
 var (
@@ -58,6 +60,10 @@ func processMessage(queueMessage *sqs.Message, config *config) {
 	notificationMessage, err := newNotificationMessage(queueMessage)
 	if err != nil {
 		log.Fatalf("failed parsing message. %#v, %s", notificationMessage, err)
+	}
+	if notificationMessage.GithubAccount != config.githubAccount { // Ignore fork messages
+		log.Printf("github account %s does not match expected %s", notificationMessage.GithubAccount, config.githubAccount)
+		return
 	}
 	log.Printf("running tests for notification message %#v", notificationMessage)
 

--- a/test/cmd/release-notification-listener/listener/message.go
+++ b/test/cmd/release-notification-listener/listener/message.go
@@ -31,7 +31,8 @@ const (
 	maxNumberOfMessages               = 1
 	delayBetweenMessageReads          = time.Minute * 3
 	maxNotificationMessageParamLength = 40 // Length of a git SHA
-	visibilityTimeOutS                = 60
+	visibilityTimeOutS            = 60
+	defaultKnownLastStableRelease = "v0.22.1"
 
 	releaseTypeStable   = "stable"
 	releaseTypeSnapshot = "snapshot"
@@ -54,6 +55,7 @@ var (
 		releaseTypeSnapshot: {},
 		releaseTypePeriodic: {},
 	}
+	lastKnownLastStableRelease
 )
 
 func processMessage(queueMessage *sqs.Message, config *config) {
@@ -104,6 +106,17 @@ func newNotificationMessage(msg *sqs.Message) (*notificationMessage, error) {
 		queueMessage.PrNumber = noPrNumber
 	}
 	return queueMessage, nil
+}
+
+func (n *notificationMessage) lastStableReleaseTagOrDefault() string {
+	if n.LastStableReleaseTag != "" {
+		lastKnownLastStableRelease = n.LastStableReleaseTag
+		return n.LastStableReleaseTag
+	}
+	if lastKnownLastStableRelease != "" {
+		return lastKnownLastStableRelease
+	}
+	return defaultKnownLastStableRelease
 }
 
 func (n *notificationMessage) validate() error {

--- a/test/cmd/release-notification-listener/listener/message.go
+++ b/test/cmd/release-notification-listener/listener/message.go
@@ -31,8 +31,8 @@ const (
 	maxNumberOfMessages               = 1
 	delayBetweenMessageReads          = time.Minute * 3
 	maxNotificationMessageParamLength = 40 // Length of a git SHA
-	visibilityTimeOutS            = 60
-	defaultKnownLastStableRelease = "v0.22.1"
+	visibilityTimeOutS                = 60
+	defaultKnownLastStableRelease     = "v0.22.1"
 
 	releaseTypeStable   = "stable"
 	releaseTypeSnapshot = "snapshot"
@@ -55,7 +55,7 @@ var (
 		releaseTypeSnapshot: {},
 		releaseTypePeriodic: {},
 	}
-	lastKnownLastStableRelease
+	lastKnownLastStableRelease string
 )
 
 func processMessage(queueMessage *sqs.Message, config *config) {

--- a/test/cmd/release-notification-listener/listener/tekton.go
+++ b/test/cmd/release-notification-listener/listener/tekton.go
@@ -111,9 +111,7 @@ func tknArgs(message *notificationMessage, pipelineName, testFilter string) []st
 		pipelineParams = append(pipelineParams, "ip-family=IPv6")
 		pipelineParams = append(pipelineParams, "git-ref="+gitRef)
 	case pipelineUpgrade:
-		// TODO: Consider having this as part of the notification message `git describe --tags`
-		// So that it doesn't have to be hard coded
-		pipelineParams = append(pipelineParams, "from-git-ref=v0.21.0")
+		pipelineParams = append(pipelineParams, "from-git-ref="+message.LastStableReleaseTag)
 		pipelineParams = append(pipelineParams, "to-git-ref="+message.ReleaseIdentifier)
 	}
 

--- a/test/cmd/release-notification-listener/listener/tekton.go
+++ b/test/cmd/release-notification-listener/listener/tekton.go
@@ -111,7 +111,7 @@ func tknArgs(message *notificationMessage, pipelineName, testFilter string) []st
 		pipelineParams = append(pipelineParams, "ip-family=IPv6")
 		pipelineParams = append(pipelineParams, "git-ref="+gitRef)
 	case pipelineUpgrade:
-		pipelineParams = append(pipelineParams, "from-git-ref="+message.LastStableReleaseTag)
+		pipelineParams = append(pipelineParams, "from-git-ref="+message.lastStableReleaseTagOrDefault())
 		pipelineParams = append(pipelineParams, "to-git-ref="+message.ReleaseIdentifier)
 	}
 

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -39,7 +39,7 @@ data:
     set -euo pipefail
 
     export AWS_REGION=us-east-1
-    MESSAGE="{\"releaseType\":\"periodic\",\"releaseIdentifier\":\"HEAD\",\"prNumber\":\"none\"}"
+    MESSAGE="{\"releaseType\":\"periodic\",\"releaseIdentifier\":\"HEAD\",\"prNumber\":\"none\",\"githubAccount\":\"aws\"}"
     QUEUE_URL=https://sqs.us-east-1.amazonaws.com/958073914028/ReleaseQueue
     aws sqs send-message --queue-url $QUEUE_URL --message-body $MESSAGE
 ---

--- a/test/infrastructure/clusters/test-infra/release-notification-listener/release-notification-listener.yaml
+++ b/test/infrastructure/clusters/test-infra/release-notification-listener/release-notification-listener.yaml
@@ -71,3 +71,5 @@ spec:
               value: "us-east-2"
             - name: CLUSTER_NAME
               value: "KITInfrastructure"
+            - name: GITHUB_ACCOUNT
+              value: "aws"


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

* In the upgrade tests uses the last stable version from the message, previously we used to hard code this and had to keep maintaining it
* Remembers the last stable releases from the last message and uses it when it's not given
* Ignores the message if it's not coming from the main repo


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
