### PR TITLE
feat: allow enabling detailed monitoring on nodes

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
@@ -126,6 +126,10 @@ spec:
               context:
                 description: Context is a Reserved field in EC2 APIs https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html
                 type: string
+              detailedMonitoring:
+                description: DetailedMonitoring controls if detailed monitoring is
+                  enabled for instances that are launched
+                type: boolean
               instanceProfile:
                 description: InstanceProfile is the AWS identity that instances use.
                 type: string

--- a/pkg/apis/v1alpha1/awsnodetemplate.go
+++ b/pkg/apis/v1alpha1/awsnodetemplate.go
@@ -30,6 +30,9 @@ type AWSNodeTemplateSpec struct {
 	// AMISelector discovers AMIs to be used by Amazon EC2 tags.
 	// +optional
 	AMISelector map[string]string `json:"amiSelector,omitempty"`
+	// DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
+	// +optional
+	DetailedMonitoring *bool `json:"detailedMonitoring,omitempty"`
 }
 
 // AWSNodeTemplate is the Schema for the AWSNodeTemplate API

--- a/pkg/cloudprovider/amifamily/resolver.go
+++ b/pkg/cloudprovider/amifamily/resolver.go
@@ -65,6 +65,7 @@ type LaunchTemplate struct {
 	MetadataOptions     *v1alpha1.MetadataOptions
 	AMIID               string
 	InstanceTypes       []*cloudprovider.InstanceType `hash:"ignore"`
+	DetailedMonitoring  bool
 }
 
 // AMIFamily can be implemented to override the default logic for generating dynamic launch template parameters
@@ -124,6 +125,7 @@ func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 			),
 			BlockDeviceMappings: nodeTemplate.Spec.BlockDeviceMappings,
 			MetadataOptions:     nodeTemplate.Spec.MetadataOptions,
+			DetailedMonitoring:  aws.BoolValue(nodeTemplate.Spec.DetailedMonitoring),
 			AMIID:               amiID,
 			InstanceTypes:       instanceTypes,
 		}

--- a/pkg/cloudprovider/launchtemplate.go
+++ b/pkg/cloudprovider/launchtemplate.go
@@ -201,6 +201,9 @@ func (p *LaunchTemplateProvider) createLaunchTemplate(ctx context.Context, optio
 			IamInstanceProfile: &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{
 				Name: aws.String(options.InstanceProfile),
 			},
+			Monitoring: &ec2.LaunchTemplatesMonitoringRequest{
+				Enabled: aws.Bool(options.DetailedMonitoring),
+			},
 			SecurityGroupIds: aws.StringSlice(options.SecurityGroupsIDs),
 			UserData:         aws.String(userData),
 			ImageId:          aws.String(options.AMIID),

--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -1379,6 +1379,27 @@ var _ = Describe("LaunchTemplates", func() {
 			})
 		})
 	})
+	Context("Detailed Monitoring", func() {
+		It("should default detailed monitoring to off", func() {
+			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
+			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
+			ExpectScheduled(ctx, env.Client, pod)
+			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
+			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
+			Expect(aws.BoolValue(input.LaunchTemplateData.Monitoring.Enabled)).To(BeFalse())
+		})
+		It("should pass detailed monitoring setting to the launch template at creation", func() {
+			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
+			nodeTemplate.Spec.DetailedMonitoring = aws.Bool(true)
+			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, coretest.UnschedulablePod())[0]
+			ExpectScheduled(ctx, env.Client, pod)
+			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
+			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
+			Expect(aws.BoolValue(input.LaunchTemplateData.Monitoring.Enabled)).To(BeTrue())
+		})
+	})
 })
 
 // ExpectTags verifies that the expected tags are a subset of the tags found

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -33,7 +33,7 @@ spec:
   tags: { ... }                  # optional, propagates tags to underlying EC2 resources
   metadataOptions: { ... }       # optional, configures IMDS for the instance
   blockDeviceMappings: [ ... ]   # optional, configures storage devices for the instance
-
+  detailedMonitoring: "..."      # optional, configures detailed monitoring for the instance
 ```
 Refer to the [Provisioner docs]({{<ref "./provisioners" >}}) for settings applicable to all providers.
 See below for other AWS provider-specific parameters.
@@ -148,7 +148,7 @@ An `InstanceProfile` is a way to pass a single IAM role to EC2 instance launched
 A default profile is configured in global settings, but may be overridden here.
 The `AWSNodeTemplate` will not create an `InstanceProfile` automatically.
 The `InstanceProfile` must refer to a `Role` that has permission to connect to the cluster.
-```
+```yaml
 spec:
   instanceProfile: MyInstanceProfile
 ```
@@ -159,7 +159,7 @@ The AMI used when provisioning nodes can be controlled by the `amiFamily` field.
 
 Currently, Karpenter supports `amiFamily` values `AL2`, `Bottlerocket`, `Ubuntu` and `Custom`. GPUs are only supported with `AL2` and `Bottlerocket`.
 
-```
+```yaml
 spec:
   amiFamily: Bottlerocket
 ```
@@ -205,19 +205,19 @@ All labels defined [in the scheduling documentation](./scheduling#supported-labe
 #### Examples
 
 Select all AMIs with a specified tag:
-```
+```yaml
   amiSelector:
     karpenter.sh/discovery/MyClusterName: '*'
 ```
 
 Select AMIs by name:
-```
+```yaml
   amiSelector:
     Name: my-ami
 ```
 
 Select AMIs by an arbitrary AWS tag key/value pair:
-```
+```yaml
   amiSelector:
     MyAMITag: value
 ```
@@ -239,7 +239,7 @@ kubernetes.io/cluster/<cluster-name>: owned
 ```
 
 Additional tags can be added in the AWSNodeTemplate tags section which are merged with and can override the default tag values.
-```
+```yaml
 spec:
   tags:
     InternalAccountingTag: 1234
@@ -255,7 +255,7 @@ Refer to [recommended, security best practices](https://aws.github.io/aws-eks-be
 
 If metadataOptions are omitted from this provisioner, the following default settings will be used.
 
-```
+```yaml
 spec:
   metadataOptions:
     httpEndpoint: enabled
@@ -270,7 +270,7 @@ The `blockDeviceMappings` field in an AWSNodeTemplate can be used to control the
 
 Learn more about [block device mappings](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html).
 
-```
+```yaml
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate
 spec:
@@ -349,6 +349,15 @@ spec:
 ```
 
 For more examples on configuring these fields for different AMI families, see the [examples here](https://github.com/aws/karpenter/blob/main/examples/provisioner/launchtemplates).
+
+## spec.detailedMonitoring
+
+Enabling detailed monitoring on the node template controls the [EC2 detailed monitoring](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) feature. If you enable this option, the Amazon EC2 console displays monitoring graphs with a 1-minute period for the instances that Karpenter launches.
+```yaml
+spec:
+  detailedMonitoring: true
+```
+
 
 ### Merge Semantics
 


### PR DESCRIPTION
Fixes #3246

**Description**

Adds support to the AWS Node Template for enabling detailed monitoring.

**How was this change tested?**

* Unit tests and deploying instances to EKS.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The AWS Node Template now has a detailedMonitoring field that can be used to enable detailed monitoring on EC2 instances that are launched.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
