### PR TITLE
fix: SideCar config in chart

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -40,7 +40,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
 | controller.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | Resources for the controller pod. |
 | controller.securityContext | object | `{}` | SecurityContext for the controller container. |
-| controller.sidecarContainer | list | `[]` | Additional sideCarContainer config |
+| controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |
 | controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecars - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
 | dnsPolicy | string | `"Default"` | Configure the DNS Policy for the pod |

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -40,7 +40,8 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
 | controller.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | Resources for the controller pod. |
 | controller.securityContext | object | `{}` | SecurityContext for the controller container. |
-| controller.sidecarContainer | object | `{}` | Additional sideCarContainer config - this will also inherit volume mounts from deployment |
+| controller.sidecarContainer | list | `[]` | Additional sideCarContainer config |
+| controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecars - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
 | dnsPolicy | string | `"Default"` | Configure the DNS Policy for the pod |
 | extraVolumes | list | `[]` | Additional volumes for the pod. |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -114,11 +114,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with .Values.controller.sidecarContainer }}
-          {{- with .Values.controller.extraVolumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if and (.Values.controller.sidecarContainer) (or .Values.controller.extraVolumeMounts .Values.controller.sidecarVolumeMounts) }}
+          volumeMounts:
+          {{- with .Values.controller.extraVolumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.controller.sidecarVolumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -123,39 +123,10 @@ controller:
   # - name: aws-iam-token
   #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
   #   readOnly: true
-  # -- Additional sideCarContainer config
+  # -- Additional sidecarContainer config
   sidecarContainer: []
-  # - name: fluent-bit
-  #   image: "cr.fluentbit.io/fluent/fluent-bit:2.0.8"
-  #   imagePullPolicy: Always
-  #   ports:
-  #     - name: http
-  #       containerPort: 2020
-  #       protocol: TCP
-  #   livenessProbe:
-  #     httpGet:
-  #       path: /
-  #       port: http
-  #   readinessProbe:
-  #     httpGet:
-  #       path: /api/v1/health
-  #       port: http
-  # -- Additional volumeMounts for the sidecars - this will be added to the volume mounts on top of extraVolumeMounts
+  # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
   sidecarVolumeMounts: []
-  # - mountPath: /fluent-bit/etc/fluent-bit.conf
-  #   name: config
-  #   subPath: fluent-bit.conf
-  # - mountPath: /fluent-bit/etc/custom_parsers.conf
-  #   name: config
-  #   subPath: custom_parsers.conf
-  # - mountPath: /var/log
-  #   name: varlog
-  # - mountPath: /var/lib/docker/containers
-  #   name: varlibdockercontainers
-  #   readOnly: true
-  # - mountPath: /etc/machine-id
-  #   name: etcmachineid
-  #   readOnly: true
 webhook:
   logLevel: error
   # -- The container port to use for the webhook.

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -123,8 +123,39 @@ controller:
   # - name: aws-iam-token
   #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
   #   readOnly: true
-  # -- Additional sideCarContainer config - this will also inherit volume mounts from deployment
-  sidecarContainer: {}
+  # -- Additional sideCarContainer config
+  sidecarContainer: []
+  # - name: fluent-bit
+  #   image: "cr.fluentbit.io/fluent/fluent-bit:2.0.8"
+  #   imagePullPolicy: Always
+  #   ports:
+  #     - name: http
+  #       containerPort: 2020
+  #       protocol: TCP
+  #   livenessProbe:
+  #     httpGet:
+  #       path: /
+  #       port: http
+  #   readinessProbe:
+  #     httpGet:
+  #       path: /api/v1/health
+  #       port: http
+  # -- Additional volumeMounts for the sidecars - this will be added to the volume mounts on top of extraVolumeMounts
+  sidecarVolumeMounts: []
+  # - mountPath: /fluent-bit/etc/fluent-bit.conf
+  #   name: config
+  #   subPath: fluent-bit.conf
+  # - mountPath: /fluent-bit/etc/custom_parsers.conf
+  #   name: config
+  #   subPath: custom_parsers.conf
+  # - mountPath: /var/log
+  #   name: varlog
+  # - mountPath: /var/lib/docker/containers
+  #   name: varlibdockercontainers
+  #   readOnly: true
+  # - mountPath: /etc/machine-id
+  #   name: etcmachineid
+  #   readOnly: true
 webhook:
   logLevel: error
   # -- The container port to use for the webhook.


### PR DESCRIPTION
Fixes #3220

**Description**
Fix sidecar config. Unfortunately did not spend enough time testing it the first time so sending a fixed version now.

This is now tested and included commented out test values. Once uncommented it creates a proper sidecarContainer now and depending if set volumeMounts will contain any volume mounts specified in extraVolumeMounts or sidecarVolumeMounts.

Unfortunately didn't find any nice way of merging the volume mounts without creating a separate value for it.

**How was this change tested?**

* Uncommented all the values for sidecar / helm template -f values.yaml .
* See sidecar config making it to the chart
* See volume mounts when extraVolumeMounts uncommented added to the sidecar VolumeMounts

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
