### PR TITLE
fix: a crash when instance can't be looked up on node creation

### DIFF
--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -105,7 +105,7 @@ func (p *InstanceProvider) Create(ctx context.Context, nodeTemplate *v1alpha1.AW
 		retry.Attempts(6),
 		retry.LastErrorOnly(true),
 	); err != nil {
-		return nil, fmt.Errorf("retrieving node name for instance %s, %w", aws.StringValue(instance.InstanceId), err)
+		return nil, fmt.Errorf("retrieving node name for instance %s, %w", aws.StringValue(id), err)
 	}
 	logging.FromContext(ctx).With(
 		"id", aws.StringValue(instance.InstanceId),


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->
N/A

**Description**
 - If the DescribeInstances call fails after 6 tries, the err message tries to dereference the `instance` which is nil if it can't be looked up which results in Karpenter crashing rather than just reporting an error back to the provisioner. 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
