### PR TITLE
fix: improve createfleet batching by caching fully initialized instance types

### DIFF
--- a/pkg/cloudprovider/createfleetbatcher.go
+++ b/pkg/cloudprovider/createfleetbatcher.go
@@ -107,15 +107,15 @@ func (b *CreateFleetBatcher) run() {
 }
 
 func (b *CreateFleetBatcher) waitForIdle() {
-	timeout := time.NewTimer(100 * time.Millisecond)
-	idle := time.NewTimer(10 * time.Millisecond)
+	timeout := time.NewTimer(1 * time.Second)
+	idle := time.NewTimer(50 * time.Millisecond)
 	for {
 		select {
 		case <-b.trigger:
 			if !idle.Stop() {
 				<-idle.C
 			}
-			idle.Reset(10 * time.Millisecond)
+			idle.Reset(50 * time.Millisecond)
 		case <-timeout.C:
 			return
 		case <-idle.C:

--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -77,10 +77,6 @@ func NewInstanceProvider(ctx context.Context, region string, ec2api ec2iface.EC2
 	}
 }
 
-// Create an instance given the constraints.
-// instanceTypes should be sorted by priority for spot capacity type.
-// If spot is not used, the instanceTypes are not required to be sorted
-// because we are using ec2 fleet's lowest-price OD allocation strategy
 func (p *InstanceProvider) Create(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType) (*ec2.Instance, error) {
 	instanceTypes = filterInstanceTypes(instanceTypes)
 	instanceTypes = orderInstanceTypesByPrice(instanceTypes, scheduling.NewNodeSelectorRequirements(machine.Spec.Requirements...))

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -53,7 +53,7 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 	p.Lock()
 	defer p.Unlock()
 	filters := getFilters(nodeTemplate)
-	hash, err := hashstructure.Hash(filters, hashstructure.FormatV2, nil)
+	hash, err := hashstructure.Hash(filters, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,15 +19,18 @@ import (
 	"regexp"
 )
 
+var (
+	instanceIDRegex = regexp.MustCompile(`aws:///(?P<AZ>.*)/(?P<InstanceID>.*)`)
+)
+
 // ParseInstanceID parses the provider ID stored on the node to get the instance ID
 // associated with a node
 func ParseInstanceID(providerID string) (string, error) {
-	r := regexp.MustCompile(`aws:///(?P<AZ>.*)/(?P<InstanceID>.*)`)
-	matches := r.FindStringSubmatch(providerID)
+	matches := instanceIDRegex.FindStringSubmatch(providerID)
 	if matches == nil {
 		return "", fmt.Errorf("parsing instance id %s", providerID)
 	}
-	for i, name := range r.SubexpNames() {
+	for i, name := range instanceIDRegex.SubexpNames() {
 		if name == "InstanceID" {
 			return matches[i], nil
 		}


### PR DESCRIPTION
and adjusting the batching window parameters

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->
https://github.com/aws/karpenter/issues/2756

**Description**

 - Removes the vcpu resource limit on the Karpenter controller
 - Fixes the subnet filter hashing to use slicesAsSets
 - Moves the regex compilation to a pkg var
 - Remove unneeded lock when Listing instance types
 - Cache fully initialized instance types per all instance types, zones, unavailableOfferings cache, node template, and kubelet configuration from the provisioner
 - Adjust the CreateFleetBatcher idle and max timeout from 10ms / 100ms to 50ms / 1,000ms

Before tuning, scale up inflate with a hostname topology spread (1 pod / node):

```
> kubectl scale deploy/inflate --replicas=250 
```

```
karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:39.427Z	INFO	controller.provisioner	found provisionable pod(s)	{"commit": "4211e21-dirty", "pods": 250}

...

karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:40.464Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 48.552577ms	{"commit": "4211e21-dirty"}
karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:40.464Z	INFO	controller.aws	Requesting 19 Instances!	{"commit": "4211e21-dirty"}

...

karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:42.949Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 69.797246ms	{"commit": "4211e21-dirty"}
karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:42.949Z	INFO	controller.aws	Requesting 47 Instances!	{"commit": "4211e21-dirty"}

...

karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:46.452Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 19.725944ms	{"commit": "4211e21-dirty"}
karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:46.452Z	INFO	controller.aws	Requesting 1 Instances!	{"commit": "4211e21-dirty"}

...

karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:49.048Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 30.515186ms	{"commit": "4211e21-dirty"}
karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:49.048Z	INFO	controller.aws	Requesting 109 Instances!	{"commit": "4211e21-dirty"}

...

karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:53.797Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 17.95906ms	{"commit": "4211e21-dirty"}
karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:53.798Z	INFO	controller.aws	Requesting 2 Instances!	{"commit": "4211e21-dirty"}

...

karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:55.740Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 29.704589ms	{"commit": "4211e21-dirty"}
karpenter-857dc6c5f7-fzct6 controller 2023-01-18T15:42:55.740Z	INFO	controller.aws	Requesting 72 Instances!	{"commit": "4211e21-dirty"}
```

---

After tuning, running the same test:


```
> kubectl scale deploy/inflate --replicas=0
> kubectl scale deploy/inflate --replicas=250 
```

```
karpenter-595b75756f-cmxpf controller 2023-01-18T18:47:38.394Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 550.741081ms	{"commit": "54add37-dirty"}
karpenter-595b75756f-cmxpf controller 2023-01-18T18:47:38.394Z	INFO	controller.aws	Requesting 250 Instances!	{"commit": "54add37-dirty"}
```

And maybe a few more nodes:

```
> kubectl scale deploy/inflate --replicas=0
> kubectl scale deploy/inflate --replicas=500
```

```
karpenter-8445fb5dbd-7kcvj controller 2023-01-18T20:10:13.373Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 681.27277ms	{"commit": "54add37-dirty"}
karpenter-8445fb5dbd-7kcvj controller 2023-01-18T20:10:13.373Z	INFO	controller.aws	Requesting 500 Instances!	{"commit": "54add37-dirty"}
```

And maybe a few more more nodes:

```
> kubectl scale deploy/inflate --replicas=0
> kubectl scale deploy/inflate --replicas=1000
```

```
karpenter-b86db4659-vts4l controller 2023-01-18T22:13:29.761Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 830.376223ms	{"commit": "54add37-dirty"}
karpenter-b86db4659-vts4l controller 2023-01-18T22:13:29.762Z	INFO	controller.aws	Requesting 49 Instances!	{"commit": "54add37-dirty"}

...

karpenter-b86db4659-vts4l controller 2023-01-18T22:13:33.571Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 367.591553ms	{"commit": "54add37-dirty"}
karpenter-b86db4659-vts4l controller 2023-01-18T22:13:42.074Z	INFO	controller.aws	Requesting 948 Instances!	{"commit": "54add37-dirty"}

...

karpenter-b86db4659-vts4l controller 2023-01-18T22:14:14.582Z	INFO	controller.aws	CreateFleetBatcher Idle Timed out at: 84.086174ms	{"commit": "54add37-dirty"}
karpenter-b86db4659-vts4l controller 2023-01-18T22:14:14.582Z	INFO	controller.aws	Requesting 3 Instances!	{"commit": "54add37-dirty"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
