### PR TITLE
feat: Allow to deploy chart without any cpu limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
 			--set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
 			--set settings.aws.interruptionQueueName=${CLUSTER_NAME} \
 			--set settings.featureGates.driftEnabled=true \
+			--set controller.resources.requests.cpu=1 \
+			--set controller.resources.requests.memory=1Gi \
+			--set controller.resources.limits.cpu=1 \
+			--set controller.resources.limits.memory=1Gi \
 			--create-namespace
 
 # CR for local builds of Karpenter

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -115,12 +115,18 @@ controller:
   #   value: eu-west-1
 
   # -- Resources for the controller pod.
-  #resources:
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   #  requests:
   #    cpu: 1
   #    memory: 1Gi
   #  limits:
+  #    cpu: 1
   #    memory: 1Gi
+
   # -- Controller outputPaths - default to stdout only
   outputPaths:
     - stdout

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -115,13 +115,12 @@ controller:
   #   value: eu-west-1
 
   # -- Resources for the controller pod.
-  resources:
-    requests:
-      cpu: 1
-      memory: 1Gi
-    limits:
-      cpu: 1
-      memory: 1Gi
+  #resources:
+  #  requests:
+  #    cpu: 1
+  #    memory: 1Gi
+  #  limits:
+  #    memory: 1Gi
   # -- Controller outputPaths - default to stdout only
   outputPaths:
     - stdout

--- a/test/manifests/pre-upgrade-setup.yaml
+++ b/test/manifests/pre-upgrade-setup.yaml
@@ -127,4 +127,8 @@ spec:
           --set settings.aws.clusterEndpoint=$(cat /root/.kube/config | grep server | awk '{print $2}') \
           --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-$(params.cluster-name) \
           --set settings.aws.interruptionQueueName=$(params.cluster-name) \
+          --set controller.resources.requests.cpu=1 \
+          --set controller.resources.requests.memory=1Gi \
+          --set controller.resources.limits.cpu=1 \
+          --set controller.resources.limits.memory=1Gi \
           --wait

--- a/test/manifests/setup.yaml
+++ b/test/manifests/setup.yaml
@@ -123,6 +123,10 @@ spec:
         --set settings.aws.clusterEndpoint=$(cat /root/.kube/config | grep server | awk '{print $2}') \
         --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-$(params.cluster-name) \
         --set settings.aws.interruptionQueueName=$(params.cluster-name) \
+        --set controller.resources.requests.cpu=1 \
+        --set controller.resources.requests.memory=1Gi \
+        --set controller.resources.limits.cpu=1 \
+        --set controller.resources.limits.memory=1Gi \
         --wait
 
   - name: diff-karpenter

--- a/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh
@@ -4,4 +4,8 @@ helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --vers
   --set settings.aws.clusterName=${CLUSTER_NAME} \
   --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
   --set settings.aws.interruptionQueueName=${CLUSTER_NAME} \
+  --set controller.resources.requests.cpu=1 \
+  --set controller.resources.requests.memory=1Gi \
+  --set controller.resources.limits.cpu=1 \
+  --set controller.resources.limits.memory=1Gi \
   --wait

--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step09-generate-chart.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step09-generate-chart.sh
@@ -3,4 +3,8 @@ helm template karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KAR
     --set settings.aws.clusterEndpoint="${CLUSTER_ENDPOINT}" \
     --set settings.aws.clusterName=${CLUSTER_NAME} \
     --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${AWS_ACCOUNT_ID}:role/KarpenterControllerRole-${CLUSTER_NAME}" \
+    --set controller.resources.requests.cpu=1 \
+    --set controller.resources.requests.memory=1Gi \
+    --set controller.resources.limits.cpu=1 \
+    --set controller.resources.limits.memory=1Gi \
     --version ${KARPENTER_VERSION} > karpenter.yaml

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -102,6 +102,7 @@ By adopting this practice we allow our users who are early adopters to test out 
 
 ## Upgrading to v0.25.0+
 * Cluster Endpoint can now be automatically discovered. If you are using Amazon Elastic Kubernetes Service (EKS), you can now omit the `clusterEndpoint` field in your configuration. In order to allow the resolving, you have to add the permission `eks:DescribeCluster` to the Karpenter Controller IAM role.
+* Default resources parameters are removed from Karpenter's Helm chart. Make sure to update your configuration to include them depending your needs.
 
 ## Upgrading to v0.24.0+
 * Settings are no longer updated dynamically while Karpenter is running. If you manually make a change to the `karpenter-global-settings` ConfigMap, you will need to reload the containers by restarting the deployment with `kubectl rollout restart -n karpenter deploy/karpenter`

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -99,10 +99,10 @@ By adopting this practice we allow our users who are early adopters to test out 
 
 ## Upgrading to v0.26.0+
 * The `karpenter.sh/do-not-evict` annotation no longer blocks node termination when running `kubectl delete node`. This annotation on pods will only block automatic deprovisioning that is considered "voluntary," that is, disruptions that can be avoided. Disruptions that Karpenter deems as "involuntary" and will ignore the `karpenter.sh/do-not-evict` annotation include spot interruption and manual deletion of the node. See [Disabling Deprovisioning]({{<ref "./concepts/deprovisioning#disabling-deprovisioning" >}}) for more details.
+* Default resources `requests` and `limits` are removed from the Karpenter's controller deployment through the Helm chart. If you have not set custom resource `requests` or `limits` in your helm values and are using Karpenter's defaults, you will now need to set these values in your helm chart deployment.
 
 ## Upgrading to v0.25.0+
 * Cluster Endpoint can now be automatically discovered. If you are using Amazon Elastic Kubernetes Service (EKS), you can now omit the `clusterEndpoint` field in your configuration. In order to allow the resolving, you have to add the permission `eks:DescribeCluster` to the Karpenter Controller IAM role.
-* Default resources parameters are removed from Karpenter's Helm chart. Make sure to update your configuration to include them depending your needs.
 
 ## Upgrading to v0.24.0+
 * Settings are no longer updated dynamically while Karpenter is running. If you manually make a change to the `karpenter-global-settings` ConfigMap, you will need to reload the containers by restarting the deployment with `kubectl rollout restart -n karpenter deploy/karpenter`


### PR DESCRIPTION
feat: Allow to deploy chart without any cpu limit

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

* Removing the default cpu limit as can't be removed if used as dependency
* CPU limit should be removed on every deployment (not requests)
  [#1](https://medium.com/omio-engineering/cpu-limits-and-aggressive-throttling-in-kubernetes-c5b20bd8a718)
  [#2](https://www.howtogeek.com/devops/should-you-set-kubernetes-cpu-limits/)
  [#3](https://home.robusta.dev/blog/stop-using-cpu-limits)
* Other examples / writings can be found around that, still possible for someone to add back the cpu limit

**How was this change tested?**

Can't remove this param by using the chart as a dependency.

Removing it here is the only way and follows some good practices.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
