### PR TITLE
fix!: Fix bug where backslashes couldn't be in global tag keys

### DIFF
--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -74,9 +74,9 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Flatten Values Map using "." syntax
+Flatten Settings Map using "." syntax
 */}}
-{{- define "flattenMap" -}}
+{{- define "flattenSettings" -}}
 {{- $map := first . -}}
 {{- $label := last . -}}
 {{- range $key, $val := $map -}}
@@ -84,8 +84,11 @@ Flatten Values Map using "." syntax
   {{- if $label -}}
   {{- $sublabel = list $label $key | join "." -}}
   {{- end -}}
-  {{- if kindOf $val | eq "map" -}}
-    {{- list $val $sublabel | include "flattenMap" -}}
+  {{/* Special-case "tags" since we want this to be a JSON object */}}
+  {{ if eq $key "tags" }}
+{{ $sublabel | quote }}: {{ $val | toJson | quote }}
+  {{- else if kindOf $val | eq "map" -}}
+    {{- list $val $sublabel | include "flattenSettings" -}}
   {{- else -}}
   {{ if not (kindIs "invalid" $val) }}
 {{ $sublabel | quote }}: {{ $val | quote }}

--- a/charts/karpenter/templates/configmap.yaml
+++ b/charts/karpenter/templates/configmap.yaml
@@ -10,4 +10,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{- list .Values.settings "" | include "flattenMap" | indent 2 }}
+  {{- list .Values.settings "" | include "flattenSettings" | indent 2 }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -167,5 +167,5 @@ settings:
     # -- interruptionQueueName is currently in ALPHA and is disabled by default. Enabling interruption handling may
     # require additional permissions on the controller service account. Additional permissions are outlined in the docs.
     interruptionQueueName: ""
-    # -- The global tags to use on all AWS infrastructure resources (launch templates, instances, SQS queue, etc.)
+    # -- The global tags to use on all AWS infrastructure resources (launch templates, instances, etc.) across node templates
     tags:

--- a/pkg/apis/settings/suite_test.go
+++ b/pkg/apis/settings/suite_test.go
@@ -64,8 +64,7 @@ var _ = Describe("Validation", func() {
 				"aws.isolatedVPC":                "true",
 				"aws.nodeNameConvention":         "resource-name",
 				"aws.vmMemoryOverheadPercent":    "0.1",
-				"aws.tags.tag1":                  "value1",
-				"aws.tags.tag2":                  "value2",
+				"aws.tags":                       `{"tag1": "value1", "tag2": "value2", "example.com/tag": "my-value"}`,
 			},
 		}
 		ctx, err := (&settings.Settings{}).Inject(ctx, cm)
@@ -77,9 +76,10 @@ var _ = Describe("Validation", func() {
 		Expect(s.IsolatedVPC).To(BeTrue())
 		Expect(s.NodeNameConvention).To(Equal(settings.ResourceName))
 		Expect(s.VMMemoryOverheadPercent).To(Equal(0.1))
-		Expect(len(s.Tags)).To(Equal(2))
+		Expect(len(s.Tags)).To(Equal(3))
 		Expect(s.Tags).To(HaveKeyWithValue("tag1", "value1"))
 		Expect(s.Tags).To(HaveKeyWithValue("tag2", "value2"))
+		Expect(s.Tags).To(HaveKeyWithValue("example.com/tag", "my-value"))
 	})
 	It("should fail validation with panic when clusterName not included", func() {
 		cm := &v1.ConfigMap{

--- a/test/suites/integration/tags_test.go
+++ b/test/suites/integration/tags_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Tags", func() {
 		})
 
 		env.ExpectSettingsOverridden(map[string]string{
-			"aws.tags.TestTag": "TestVal",
+			"aws.tags": `{"TestTag": "TestVal", "example.com/tag": "custom-value"}`,
 		})
 		provisioner := test.Provisioner(test.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name}})
 		pod := test.Pod()
@@ -73,6 +73,8 @@ var _ = Describe("Tags", func() {
 
 		Expect(instanceTags).To(HaveKeyWithValue("TestTag", "TestVal"))
 		Expect(volumeTags).To(HaveKeyWithValue("TestTag", "TestVal"))
+		Expect(instanceTags).To(HaveKeyWithValue("example.com/tag", "custom-value"))
+		Expect(volumeTags).To(HaveKeyWithValue("example.com/tag", "custom-value"))
 	})
 })
 

--- a/website/content/en/preview/concepts/settings.md
+++ b/website/content/en/preview/concepts/settings.md
@@ -66,10 +66,8 @@ data:
   # Interruption Handling is currently in ALPHA and is disabled by default. Enabling interruption handling may
   # require additional permissions on the controller service account. Additional permissions are outlined in the docs
   aws.interruptionQueueName: karpenter-cluster
-  # Any global tag value can be specified by including the "aws.tags.<tag-key>" prefix
-  # associated with the value in the key-value tag pair
-  aws.tags.custom-tag: custom-tag-value
-  aws.tags.custom-tag2: custom-tag-value
+  # Global tags are specified by including a JSON object of string to string from tag key to tag value
+  aws.tags: '{"custom-tag1": "custom-tag-value", "custom-tag2": "custom-tag-value"}'
 ```
 
 ### Feature Gates

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -93,8 +93,8 @@ By adopting this practice we allow our users who are early adopters to test out 
 
 ## Upgrading to v0.24.0+
 * Settings are no longer updated dynamically while Karpenter is running. If you manually make a change to the `karpenter-global-settings` ConfigMap, you will need to reload the containers by restarting the deployment with `kubectl rollout restart -n karpenter deploy/karpenter`
-
 * Karpenter no longer filters out instance types internally. Previously, `g2` (not supported by the NVIDIA device plugin) and FPGA instance types were filtered. The only way to filter instance types now is to set requirements on your provisioner or pods using well-known node labels described [here]({{<ref "./concepts/scheduling#selecting-nodes" >}}). If you are currently using overly broad requirements that allows all of the `g` instance-category, you will want to tighten the requirement, or add an instance-generation requirement. 
+* `aws.tags` in `karpenter-global-settings` ConfigMap is now a top-level field and expects the value associated with this key to be a JSON object of string to string. This is change from previous versions where keys were given implicitly by providing the key-value pair `aws.tags.<key>: value` in the ConfigMap.
 
 ## Upgrading to v0.22.0+
 * Do not upgrade to this version unless you are on Kubernetes >= v1.21. Karpenter no longer supports Kubernetes v1.20, but now supports Kubernetes v1.25. This change is due to the v1 PDB API, which was introduced in K8s v1.20 and subsequent removal of the v1beta1 API in K8s v1.25.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3197 

**Description**

- Fix bug where backslashes couldn't be in global tag keys

**How was this change tested?**

* `make presubmit`
* `FOCUS=Tags make e2etests`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
