### PR TITLE
chore: Allow indexing preview and not version specific pages

### DIFF
--- a/website/layouts/robots.txt
+++ b/website/layouts/robots.txt
@@ -2,7 +2,9 @@ User-agent: *
 
 Disallow: /v0.4.3-docs/
 
-Allow: /docs/
 Allow: /index.html
+Allow: /preview
+Disallow: /v0.*
+Disallow: /v1.*
 
 SITEMAP: https://karpenter.sh/sitemap.xml


### PR DESCRIPTION
…e we may remove the version specific pages and we do not want visitors from Google to be lost

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

* Since we are periodically removing old docs from the website we need this so that Google and other search engines don't link to broken pages


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
