### PR TITLE
fix: Round up when launching a node with block device mappings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.189
-	github.com/aws/karpenter-core v0.23.1-0.20230131022723-53e783dcaf19
+	github.com/aws/karpenter-core v0.23.1-0.20230131200554-558e8c538723
 	github.com/go-playground/validator/v10 v10.11.2
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.189 h1:9PBrjndH1uL5AN8818qI3duhQ4hgkMuLvqkJlg9MRyk=
 github.com/aws/aws-sdk-go v1.44.189/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.23.1-0.20230131022723-53e783dcaf19 h1:XyKV4kfgGaEARqxS+/Gj32ipl/jTwX19VRTOTAGY5tU=
-github.com/aws/karpenter-core v0.23.1-0.20230131022723-53e783dcaf19/go.mod h1:WJQJrJR0uxiCxZPD8ooSA8AvY/39pDotFaVFod0dV0g=
+github.com/aws/karpenter-core v0.23.1-0.20230131200554-558e8c538723 h1:Za+AfCA1ioffVGubRscWCVhyof1VdQjF5/i9MZguKbs=
+github.com/aws/karpenter-core v0.23.1-0.20230131200554-558e8c538723/go.mod h1:WJQJrJR0uxiCxZPD8ooSA8AvY/39pDotFaVFod0dV0g=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/apis/v1alpha1/provider.go
+++ b/pkg/apis/v1alpha1/provider.go
@@ -177,7 +177,7 @@ type BlockDevice struct {
 	//    * st1 and sc1: 125-16,384
 	//
 	//    * standard: 1-1,024
-	VolumeSize *resource.Quantity `json:"volumeSize,omitempty"`
+	VolumeSize *resource.Quantity `json:"volumeSize,omitempty" hash:"string"`
 
 	// VolumeType of the block device.
 	// For more information, see Amazon EBS volume types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)

--- a/pkg/cloudprovider/launchtemplate.go
+++ b/pkg/cloudprovider/launchtemplate.go
@@ -239,7 +239,7 @@ func (p *LaunchTemplateProvider) blockDeviceMappings(blockDeviceMappings []*v1al
 		// The EC2 API fails with empty slices and expects nil.
 		return nil
 	}
-	blockDeviceMappingsRequest := []*ec2.LaunchTemplateBlockDeviceMappingRequest{}
+	var blockDeviceMappingsRequest []*ec2.LaunchTemplateBlockDeviceMappingRequest
 	for _, blockDeviceMapping := range blockDeviceMappings {
 		blockDeviceMappingsRequest = append(blockDeviceMappingsRequest, &ec2.LaunchTemplateBlockDeviceMappingRequest{
 			DeviceName: blockDeviceMapping.DeviceName,
@@ -263,7 +263,8 @@ func (p *LaunchTemplateProvider) volumeSize(quantity *resource.Quantity) *int64 
 	if quantity == nil {
 		return nil
 	}
-	return aws.Int64(int64(quantity.AsApproximateFloat64() / math.Pow(2, 30)))
+	// Converts the value to Gi and rounds up the value to the nearest Gi
+	return aws.Int64(int64(math.Ceil(quantity.AsApproximateFloat64() / math.Pow(2, 30))))
 }
 
 // hydrateCache queries for existing Launch Templates created by Karpenter for the current cluster and adds to the LT cache.

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.189
 	github.com/aws/aws-sdk-go-v2/config v1.18.10
 	github.com/aws/karpenter v0.22.0
-	github.com/aws/karpenter-core v0.23.1-0.20230131022723-53e783dcaf19
+	github.com/aws/karpenter-core v0.23.1-0.20230131200554-558e8c538723
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.26.0
 	github.com/samber/lo v1.37.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -85,8 +85,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0 h1:Jfly6mRxk2ZOSlbCvZfKNS7T
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0/go.mod h1:TZSH7xLO7+phDtViY/KUp9WGCJMQkLJ/VpgkTFd5gh8=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.2 h1:J/4wIaGInCEYCGhTSruxCxeoA5cy91a+JT7cHFKFSHQ=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.2/go.mod h1:+lGbb3+1ugwKrNTWcf2RT05Xmp543B06zDFTwiTLp7I=
-github.com/aws/karpenter-core v0.23.1-0.20230131022723-53e783dcaf19 h1:XyKV4kfgGaEARqxS+/Gj32ipl/jTwX19VRTOTAGY5tU=
-github.com/aws/karpenter-core v0.23.1-0.20230131022723-53e783dcaf19/go.mod h1:WJQJrJR0uxiCxZPD8ooSA8AvY/39pDotFaVFod0dV0g=
+github.com/aws/karpenter-core v0.23.1-0.20230131200554-558e8c538723 h1:Za+AfCA1ioffVGubRscWCVhyof1VdQjF5/i9MZguKbs=
+github.com/aws/karpenter-core v0.23.1-0.20230131200554-558e8c538723/go.mod h1:WJQJrJR0uxiCxZPD8ooSA8AvY/39pDotFaVFod0dV0g=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3302

**Description**

- Round up when launching a node with block device mappings
- Include the blockDeviceMapping volumeSize requests in the hashing to notice a change in the volume size

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
