### PR TITLE
feat: support additional rules in -core clusterrole

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -30,6 +30,7 @@ helm upgrade --install --namespace karpenter --create-namespace \
 |-----|------|---------|-------------|
 | additionalAnnotations | object | `{}` | Additional annotations to add into metadata. |
 | additionalLabels | object | `{}` | Additional labels to add into metadata. |
+| additionalRulesForClusterRole | object | `[]` | Specifies additional rules for the core ClusterRole. |
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"karpenter.sh/provisioner-name","operator":"DoesNotExist"}]}]}}}` | Affinity rules for scheduling the pod. |
 | controller.env | list | `[]` | Additional environment variables for the controller pod. |
 | controller.errorOutputPaths | list | `["stderr"]` | Controller errorOutputPaths - default to stderr only |

--- a/charts/karpenter/templates/clusterrole-core.yaml
+++ b/charts/karpenter/templates/clusterrole-core.yaml
@@ -68,3 +68,6 @@ rules:
     resources: ["mutatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["defaulting.webhook.karpenter.sh"]
+  {{- with .Values.additionalRulesForClusterRole -}}
+  {{ toYaml . | nindent 2 }}
+  {{- end -}}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -20,6 +20,8 @@ serviceAccount:
   name: ""
   # -- Additional annotations for the ServiceAccount.
   annotations: {}
+# -- Specifies additional rules for the core ClusterRole.
+additionalRulesForClusterRole: []
 serviceMonitor:
   # -- Specifies whether a ServiceMonitor should be created.
   enabled: false


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3353

**Description**
Adding support for specifying additional rules in the `-core` ClusterRole.

**How was this change tested?**

* Run `helm template` with test values.
* For the syntax, I copy-pasted how it is done in the `kube-prometheus-stack` chart: [link](https://github.com/prometheus-community/helm-charts/blob/2c3113586607a53252fdb3d2583bb3e44e107121/charts/kube-prometheus-stack/values.yaml#L3224)


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
