### PR TITLE
docs: Add status section for subnet and securityGroups

### DIFF
--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -35,8 +35,8 @@ spec:
   blockDeviceMappings: [ ... ]   # optional, configures storage devices for the instance
   detailedMonitoring: "..."      # optional, configures detailed monitoring for the instance
 status:
-  subnets: { ... }               # optional, resolved subnet
-  securityGroups: { ... }        # optional, resolved security groups
+  subnets: { ... }               # resolved subnets
+  securityGroups: { ... }        # resolved security groups
 ```
 Refer to the [Provisioner docs]({{<ref "./provisioners" >}}) for settings applicable to all providers.
 See below for other AWS provider-specific parameters.
@@ -502,7 +502,7 @@ status:
 ```
 
 ## status.securityGroups
-status.securityGroups contains the id of the security groups utilized during node launch.
+`status.securityGroups` contains the `id` of the security groups utilized during node launch.
 
 **Examples**
 

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -479,8 +479,8 @@ spec:
 
     --BOUNDARY--
 ```
-## status.subnet
-The status will contain the resolved subnets. The `id` and `zone` are the Subnet ID and Availability Zone respectively. The list is sorted by the on Available IP Address Count in decreasing order.  The `status.subnet` contains resolved Subnet selector values utilized for node launch.
+## status.subnets
+`status.subnets` contains the `id` and `zone` of the subnets utilized during node launch. The subnets are sorted by the available IP address count in decreasing order.
 
 **Examples**
 
@@ -502,7 +502,7 @@ status:
 ```
 
 ## status.securityGroups
-The status will contain the resolved Security Groups. The `id` are the Security Groups ID. The `status.securityGroups` contains resolved Security Group selector values utilized for node launch.
+status.securityGroups contains the id of the security groups utilized during node launch.
 
 **Examples**
 

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -34,6 +34,9 @@ spec:
   metadataOptions: { ... }       # optional, configures IMDS for the instance
   blockDeviceMappings: [ ... ]   # optional, configures storage devices for the instance
   detailedMonitoring: "..."      # optional, configures detailed monitoring for the instance
+status:
+  subnets: { ... }               # optional, resolved subnet
+  securityGroups: { ... }        # optional, resolved security groups
 ```
 Refer to the [Provisioner docs]({{<ref "./provisioners" >}}) for settings applicable to all providers.
 See below for other AWS provider-specific parameters.
@@ -475,4 +478,37 @@ spec:
     echo "$(jq '.kubeAPIQPS=50' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
 
     --BOUNDARY--
+```
+## status.subnet
+The status will contain the resolved subnets. The `id` and `zone` are the Subnet ID and Availability Zone respectively. The list is sorted by the on Available IP Address Count in decreasing order.  The `status.subnet` contains resolved Subnet selector values utilized for node launch.
+
+**Examples**
+
+```yaml
+status:
+  subnets:
+  - id: subnet-0a462d98193ff9fac
+    zone: us-east-2b
+  - id: subnet-0322dfafd76a609b6
+    zone: us-east-2c
+  - id: subnet-0727ef01daf4ac9fe
+    zone: us-east-2b
+  - id: subnet-00c99aeafe2a70304
+    zone: us-east-2a
+  - id: subnet-023b232fd5eb0028e
+    zone: us-east-2c
+  - id: subnet-03941e7ad6afeaa72
+    zone: us-east-2a
+```
+
+## status.securityGroups
+The status will contain the resolved Security Groups. The `id` are the Security Groups ID. The `status.securityGroups` contains resolved Security Group selector values utilized for node launch.
+
+**Examples**
+
+```yaml
+  status:
+    securityGroups:
+    - id: sg-041513b454818610b
+    - id: sg-0286715698b894bca
 ```


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Docs update for AWSNodeTemplate Status. The update are to include the subnet and security groups.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
