### PR TITLE
chore: Update go mod for v0.24.0 and also add the missing files to stable-pr.sh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.195
-	github.com/aws/karpenter-core v0.23.1-0.20230207002141-6abab235df9c
+	github.com/aws/karpenter-core v0.24.0
 	github.com/go-playground/validator/v10 v10.11.2
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.195 h1:d5xFL0N83Fpsq2LFiHgtBUHknCRUPGHdOlCWt/jtOJs=
 github.com/aws/aws-sdk-go v1.44.195/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.23.1-0.20230207002141-6abab235df9c h1:O6Ky8h1cqdodlW0Wo65bVP8jNDdH8OWocpVK2iu8004=
-github.com/aws/karpenter-core v0.23.1-0.20230207002141-6abab235df9c/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
+github.com/aws/karpenter-core v0.24.0 h1:OZ0tlWPS28cGp1gS55rM16RFw222zxu8NdDQbQDR0bw=
+github.com/aws/karpenter-core v0.24.0/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/hack/release/stable-pr.sh
+++ b/hack/release/stable-pr.sh
@@ -21,6 +21,10 @@ git config pull.rebase false
 
 BRANCH_NAME="release-${GIT_TAG}"
 git checkout -b "${BRANCH_NAME}"
+git add go.mod
+git add go.sum
+git add test/go.mod
+git add test/go.sum
 git add website
 git add charts/karpenter/Chart.yaml
 git add charts/karpenter/Chart.lock

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.195
 	github.com/aws/aws-sdk-go-v2/config v1.18.12
 	github.com/aws/karpenter v0.22.0
-	github.com/aws/karpenter-core v0.23.1-0.20230207002141-6abab235df9c
+	github.com/aws/karpenter-core v0.24.0
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.26.0
 	github.com/samber/lo v1.37.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -85,8 +85,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.1 h1:0bLhH6DRAqox+g0LatcjGKjj
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.1/go.mod h1:O1YSOg3aekZibh2SngvCRRG+cRHKKlYgxf/JBF/Kr/k=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.3 h1:s49mSnsBZEXjfGBkRfmK+nPqzT7Lt3+t2SmAKNyHblw=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.3/go.mod h1:b+psTJn33Q4qGoDaM7ZiOVVG8uVjGI6HaZ8WBHdgDgU=
-github.com/aws/karpenter-core v0.23.1-0.20230207002141-6abab235df9c h1:O6Ky8h1cqdodlW0Wo65bVP8jNDdH8OWocpVK2iu8004=
-github.com/aws/karpenter-core v0.23.1-0.20230207002141-6abab235df9c/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
+github.com/aws/karpenter-core v0.24.0 h1:OZ0tlWPS28cGp1gS55rM16RFw222zxu8NdDQbQDR0bw=
+github.com/aws/karpenter-core v0.24.0/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

* Adds git add for `go.mod` and `go.sub` files so that they can be part of the opened PR, should have been part of https://github.com/aws/karpenter/pull/3366
* Updates values for v0.24.0

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
