### PR TITLE
docs: Adding QuestDB to the adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -26,6 +26,7 @@ If you are open to others contacting you about your use of Karpenter on Slack, a
 | Nirvana Money | Building healthy, happy financial lives - Using Karpenter to manage all-Spot clusters | `@DWSR` | [Homepage](https://www.nirvana.money/) |
 | Omaze | Intelligently using Karpenter's autoscaling to power our platforms | `@devopsidiot` | [Homepage](https://www.omaze.com/) |
 | PlanetScale | Leveraging Karpenter to dynamically deploy serverless MySQL workloads. | `@jtcunning` | [Homepage](https://www.planetscale.com/) |
+| QuestDB | Using Karpenter for the service nodes of the QuestBD Cloud (time-series database). | [questdb slack group](https://slack.questdb.io/) | [QuestDB](https://questdb.io/) |
 | Sendcloud | Using Karpenter to scale our k8s clusters for Europe’s #1 shipping automation platform  | N/A | [Homepage](https://www.sendcloud.com/) |
 | Stytch | Powering the scaling needs of Stytch's authentication and user-management APIs  | `@Elijah Chanakira`, `@Ovadia Harary` | [Homepage](https://www.stytch.com/) |
 | Tyk Cloud | Scaling workloads for the Cloud Free plan  | `@Artem Hluvchynskyi`, `@gowtham` | [Tyk Cloud](https://tyk.io/cloud/) |


### PR DESCRIPTION
QuestDB is using Karpenter to power our service nodes for the managed version of our open source time-series database. Adding ourselves to the adopters list and happy to chat in our slack group about our experience



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
