### PR TITLE
fix: retrieve account id for release queue

### DIFF
--- a/test/cmd/release-notification-listener/listener/listener.go
+++ b/test/cmd/release-notification-listener/listener/listener.go
@@ -15,12 +15,18 @@ limitations under the License.
 package listener
 
 import (
+	"fmt"
 	"log"
 	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 const (
-	envVarQueueURL          = "QUEUE_URL"
+	envVarAWSAccountID      = "AWS_ACCOUNT_ID"
+	envVarQueueName         = "QUEUE_NAME"
 	envVarQueueAWSRegion    = "QUEUE_AWS_REGION"
 	envVarAWSRegion         = "AWS_REGION"
 	envVarTektonClusterName = "CLUSTER_NAME"
@@ -28,7 +34,9 @@ const (
 )
 
 type config struct {
+	accountID         string
 	queueURL          string
+	queueName         string
 	queueRegion       string
 	region            string
 	tektonClusterName string
@@ -45,11 +53,24 @@ func Start() {
 }
 
 func getConfig() *config {
-	return &config{
-		queueURL:          os.Getenv(envVarQueueURL),
+	cfg := &config{
+		accountID:         os.Getenv(envVarAWSAccountID),
+		queueName:         os.Getenv(envVarQueueName),
 		queueRegion:       os.Getenv(envVarQueueAWSRegion),
 		region:            os.Getenv(envVarAWSRegion),
 		tektonClusterName: os.Getenv(envVarTektonClusterName),
 		githubAccount:     os.Getenv(envGithubAccount),
 	}
+	if cfg.accountID == "" {
+		stsSvc := sts.New(session.Must(session.NewSessionWithOptions(
+			session.Options{Config: aws.Config{Region: aws.String(cfg.region)}},
+		)))
+		callerID, err := stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+		if err != nil {
+			log.Fatalf("unable to lookup AWS Account ID: %v", err)
+		}
+		cfg.accountID = *callerID.Account
+	}
+	cfg.queueURL = fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/ReleaseQueue", cfg.queueRegion, cfg.accountID)
+	return cfg
 }

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -39,8 +39,9 @@ data:
     set -euo pipefail
 
     export AWS_REGION=us-east-1
+    export AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
     MESSAGE="{\"releaseType\":\"periodic\",\"releaseIdentifier\":\"HEAD\",\"prNumber\":\"none\",\"githubAccount\":\"aws\"}"
-    QUEUE_URL=https://sqs.us-east-1.amazonaws.com/958073914028/ReleaseQueue
+    QUEUE_URL=https://sqs.us-east-1.amazonaws.com/${AWS_ACCOUNT_ID}/ReleaseQueue
     aws sqs send-message --queue-url $QUEUE_URL --message-body $MESSAGE
 ---
 apiVersion: batch/v1

--- a/test/infrastructure/clusters/test-infra/release-notification-listener/release-notification-listener.yaml
+++ b/test/infrastructure/clusters/test-infra/release-notification-listener/release-notification-listener.yaml
@@ -63,8 +63,8 @@ spec:
         - name: release-notification-listener
           image: public.ecr.aws/karpenter/release-notification-listener:latest
           env:
-            - name: QUEUE_URL
-              value: "https://sqs.us-east-1.amazonaws.com/958073914028/ReleaseQueue"
+            - name: QUEUE_NAME
+              value: "ReleaseQueue"
             - name: QUEUE_AWS_REGION
               value: "us-east-1"
             - name: AWS_REGION


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
  - Retrieve the account id that the test is running in to link to the right release queue. 

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
