### PR TITLE
perf: Reduce multiple describe instances calls on start

### DIFF
--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -671,6 +671,17 @@ var _ = Describe("LaunchTemplates", func() {
 		})
 	})
 	Context("AL2", func() {
+		var info *ec2.InstanceTypeInfo
+		BeforeEach(func() {
+			var ok bool
+			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+			Expect(err).To(BeNil())
+			info, ok = lo.Find(instanceInfo, func(i *ec2.InstanceTypeInfo) bool {
+				return aws.StringValue(i.InstanceType) == "m5.xlarge"
+			})
+			Expect(ok).To(BeTrue())
+		})
+
 		It("should calculate memory overhead based on eni limited pods when ENI limited", func() {
 			ctx = settings.ToContext(ctx, test.Settings(test.SettingOptions{
 				EnableENILimitedPodDensity: lo.ToPtr(false),
@@ -678,9 +689,7 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			it := NewInstanceType(ctx, instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 		})
@@ -691,14 +700,23 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			it := NewInstanceType(ctx, instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 		})
 	})
 	Context("Bottlerocket", func() {
+		var info *ec2.InstanceTypeInfo
+		BeforeEach(func() {
+			var ok bool
+			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
+			Expect(err).To(BeNil())
+			info, ok = lo.Find(instanceInfo, func(i *ec2.InstanceTypeInfo) bool {
+				return aws.StringValue(i.InstanceType) == "m5.xlarge"
+			})
+			Expect(ok).To(BeTrue())
+		})
+
 		It("should calculate memory overhead based on eni limited pods when ENI limited", func() {
 			ctx = settings.ToContext(ctx, test.Settings(test.SettingOptions{
 				EnableENILimitedPodDensity: lo.ToPtr(true),
@@ -706,9 +724,7 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			it := NewInstanceType(ctx, instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("1093Mi"))
 		})
@@ -719,9 +735,7 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-			instanceInfo, err := instanceTypeProvider.getInstanceTypes(ctx)
-			Expect(err).To(BeNil())
-			it := NewInstanceType(ctx, instanceInfo["m5.xlarge"], provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("1665Mi"))
 		})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Currently, we will hit cache misses on startup for the DescribeInstanceTypes calls due to parallel calls to GetInstanceTypes. This results in a larger memory footprint (> 1GB) at startup that eventually reduces over time to around ~300MB. This ensures that the calls to the API are synchronous so we reduce our cache misses which means we are consistently sitting around 300MB throughout the pod's lifetime.

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
