### PR TITLE
BREAKING CHANGE: Refactor controller image values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,16 @@ setup: ## Sets up the IAM roles needed prior to deploying the karpenter-controll
 
 build: ## Build the Karpenter controller images using ko build
 	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) KO_DOCKER_REPO="$(KO_DOCKER_REPO)" ko build -B github.com/aws/karpenter/cmd/controller))
+	$(eval IMG_REPOSITORY=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 1))
+	$(eval IMG_VERSION=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 2 -s))
+	$(eval IMG_DIGEST=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 2))
 
 apply: build ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
 	helm upgrade --install karpenter charts/karpenter --namespace ${SYSTEM_NAMESPACE} \
 		$(HELM_OPTS) \
-		--set controller.image=$(CONTROLLER_IMG)
+		--set controller.image.repository=$(IMG_REPOSITORY) \
+		--set controller.image.version=$(IMG_VERSION) \
+		--set controller.image.digest=$(IMG_DIGEST)
 
 install:  ## Deploy the latest released version into your ~/.kube/config cluster
 	@echo Upgrading to ${KARPENTER_VERSION}

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -36,7 +36,9 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.errorOutputPaths | list | `["stderr"]` | Controller errorOutputPaths - default to stderr only |
 | controller.extraVolumeMounts | list | `[]` | Additional volumeMounts for the controller pod. |
 | controller.healthProbe.port | int | `8081` | The container port to use for http health probe. |
-| controller.image | string | `"public.ecr.aws/karpenter/controller:v0.25.0@sha256:fefae2739efa1c4d9561069d1683a0ed201e41771351da1ef504c805941f0bf2"` | Controller image. |
+| controller.image.repository | string | `"public.ecr.aws/karpenter/controller"` | Controller repository. |
+| controller.image.tag | string | `"v0.25.0"` | Controller tag. |
+| controller.image.digest | string | `"sha256:fefae2739efa1c4d9561069d1683a0ed201e41771351da1ef504c805941f0bf2"` | Controller digest. |
 | controller.logEncoding | string | `""` | Controller log encoding, defaults to the global log encoding |
 | controller.logLevel | string | `""` | Controller log level, defaults to the global log level |
 | controller.metrics.port | int | `8080` | The container port to use for metrics. |

--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -64,6 +64,18 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Karpenter image to use
+*/}}
+{{- define "karpenter.controller.image" -}}
+{{- if .Values.controller.image.digest }}
+{{- printf "%s:%s@%s" .Values.controller.image.repository  (default (printf "v%s" .Chart.AppVersion) .Values.controller.image.tag) .Values.controller.image.digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.controller.image.repository  (default (printf "v%s" .Chart.AppVersion) .Values.controller.image.tag) }}
+{{- end }}
+{{- end }}
+
+
 {{/* Get PodDisruptionBudget API Version */}}
 {{- define "karpenter.pdb.apiVersion" -}}
 {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: {{ .Values.controller.image }}
+          image: {{ include "karpenter.controller.image" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: KUBERNETES_MIN_VERSION

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -106,7 +106,10 @@ extraObjects: []
 
 controller:
   # -- Controller image.
-  image: "public.ecr.aws/karpenter/controller:v0.25.0@sha256:fefae2739efa1c4d9561069d1683a0ed201e41771351da1ef504c805941f0bf2"
+  image: 
+    repository: public.ecr.aws/karpenter/controller
+    tag: v0.25.0
+    digest: sha256:fefae2739efa1c4d9561069d1683a0ed201e41771351da1ef504c805941f0bf2
   # -- SecurityContext for the controller container.
   securityContext: {}
   # -- Additional environment variables for the controller pod.

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -35,12 +35,12 @@ Helm Chart Version $(helmChartVersion $RELEASE_VERSION)"
   cosignImages
   publishHelmChart "karpenter" "${RELEASE_VERSION}" "${RELEASE_REPO_ECR}"
   publishHelmChart "karpenter-crd" "${RELEASE_VERSION}" "${RELEASE_REPO_ECR}"
-  notifyRelease $RELEASE_VERSION $PR_NUMBER
-  pullPrivateReplica $RELEASE_VERSION
+  notifyRelease "$RELEASE_VERSION" $PR_NUMBER
+  pullPrivateReplica "$RELEASE_VERSION"
 }
 
 authenticate() {
-  aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${RELEASE_REPO_ECR}
+  aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${RELEASE_REPO_ECR}"
 }
 
 authenticatePrivateRepo() {
@@ -48,9 +48,14 @@ authenticatePrivateRepo() {
 }
 
 buildImages() {
-    CONTROLLER_DIGEST=$(GOFLAGS=${GOFLAGS} KO_DOCKER_REPO=${RELEASE_REPO_ECR} ko publish -B -t ${RELEASE_VERSION} ${RELEASE_PLATFORM} ./cmd/controller)
-    HELM_CHART_VERSION=$(helmChartVersion $RELEASE_VERSION)
-    yq e -i ".controller.image = \"${CONTROLLER_DIGEST}\"" charts/karpenter/values.yaml
+    CONTROLLER_IMG=$(GOFLAGS=${GOFLAGS} KO_DOCKER_REPO=${RELEASE_REPO_ECR} ko publish -B -t "${RELEASE_VERSION}" "${RELEASE_PLATFORM}" ./cmd/controller)
+    HELM_CHART_VERSION=$(helmChartVersion "$RELEASE_VERSION")
+    IMG_REPOSITORY=$(echo "$CONTROLLER_IMG" | cut -d "@" -f 1 | cut -d ":" -f 1)
+    IMG_VERSION=$(echo "$CONTROLLER_IMG" | cut -d "@" -f 1 | cut -d ":" -f 2 -s)
+    IMG_DIGEST=$(echo "$CONTROLLER_IMG" | cut -d "@" -f 2)
+    yq e -i ".controller.image.repository = \"${IMG_REPOSITORY}\"" charts/karpenter/values.yaml
+    yq e -i ".controller.image.version = \"${IMG_VERSION}\"" charts/karpenter/values.yaml
+    yq e -i ".controller.image.digest = \"${IMG_DIGEST}\"" charts/karpenter/values.yaml
     yq e -i ".appVersion = \"${RELEASE_VERSION#v}\"" charts/karpenter/Chart.yaml
     yq e -i ".version = \"${HELM_CHART_VERSION#v}\"" charts/karpenter/Chart.yaml
     yq e -i ".appVersion = \"${RELEASE_VERSION#v}\"" charts/karpenter-crd/Chart.yaml

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -100,6 +100,7 @@ By adopting this practice we allow our users who are early adopters to test out 
 ## Upgrading to v0.26.0+
 * The `karpenter.sh/do-not-evict` annotation no longer blocks node termination when running `kubectl delete node`. This annotation on pods will only block automatic deprovisioning that is considered "voluntary," that is, disruptions that can be avoided. Disruptions that Karpenter deems as "involuntary" and will ignore the `karpenter.sh/do-not-evict` annotation include spot interruption and manual deletion of the node. See [Disabling Deprovisioning]({{<ref "./concepts/deprovisioning#disabling-deprovisioning" >}}) for more details.
 * Default resources `requests` and `limits` are removed from the Karpenter's controller deployment through the Helm chart. If you have not set custom resource `requests` or `limits` in your helm values and are using Karpenter's defaults, you will now need to set these values in your helm chart deployment.
+* The `controller.image` value in the helm chart has been broken out to a map consisting of `controller.image.repository`, `controller.image.tag`, and `controller.image.digest`. If manually overriding the `controller.image`, you will need to update your values to the new design.
 
 ## Upgrading to v0.25.0+
 * Cluster Endpoint can now be automatically discovered. If you are using Amazon Elastic Kubernetes Service (EKS), you can now omit the `clusterEndpoint` field in your configuration. In order to allow the resolving, you have to add the permission `eks:DescribeCluster` to the Karpenter Controller IAM role.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

**Description**
This updates the `controller.image` value in the helm chart to be broken out to a map consisting of `controller.image.repository`, `controller.image.tag`, and `controller.image.digest`.

This enables users to provide just a repository override while leaving the tag and digest as the chart default. This is a very common approach that can be found in other widely adopted open source charts such as the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L490) and [cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/charts/cluster-autoscaler/values.yaml#L235)

**How was this change tested?**

* `helm lint`
* `helm template` with test values

**Does this change impact docs?**
- [x] Yes, PR includes docs updates (upgrade guide)
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Breaking the helm `controller.image` value out to a map consisting of `controller.image.repository`, `controller.image.tag`, and `controller.image.digest`.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
