### PR TITLE
chore: Add garbage collection controller for Machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
 			--set settings.aws.clusterEndpoint=${CLUSTER_ENDPOINT} \
 			--set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
 			--set settings.aws.interruptionQueueName=${CLUSTER_NAME} \
+			--set settings.featureGates.driftEnabled=true \
 			--create-namespace
 
 # CR for local builds of Karpenter
@@ -48,6 +49,7 @@ run: ## Run Karpenter controller binary against your local cluster
 		--from-literal=aws.clusterEndpoint=${CLUSTER_ENDPOINT} \
 		--from-literal=aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
 		--from-literal=aws.interruptionQueueName=${CLUSTER_NAME} \
+		--from-literal=featureGates.driftEnabled=true \
 		--dry-run=client -o yaml | kubectl apply -f -
 
 

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -47,8 +47,8 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
 | dnsPolicy | string | `"Default"` | Configure the DNS Policy for the pod |
+| extraObjects | list | `[]` | Array of extra K8s manifests to deploy  |
 | extraVolumes | list | `[]` | Additional volumes for the pod. |
-| extraObjects | list | `[]` | Array of extra K8s manifests to deploy. |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname. |
 | hostNetwork | bool | `false` | Bind the pod to the host network. This is required when using a custom CNI. |
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Docker images. |

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.195
-	github.com/aws/karpenter-core v0.24.1-0.20230214183652-19517662d6e0
+	github.com/aws/karpenter-core v0.24.1-0.20230215232304-33f74ed4d625
 	github.com/go-playground/validator/v10 v10.11.2
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.195 h1:d5xFL0N83Fpsq2LFiHgtBUHknCRUPGHdOlCWt/jtOJs=
 github.com/aws/aws-sdk-go v1.44.195/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.24.1-0.20230214183652-19517662d6e0 h1:JufeGqH7NtwU7Bv5+zdebnMHKmtGv/0eDkkJtr5aX+s=
-github.com/aws/karpenter-core v0.24.1-0.20230214183652-19517662d6e0/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
+github.com/aws/karpenter-core v0.24.1-0.20230215232304-33f74ed4d625 h1:AJz17PfL71101TKV0e6yuqV7lAFXCMH3ap/qQoVbLiI=
+github.com/aws/karpenter-core v0.24.1-0.20230215232304-33f74ed4d625/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -168,7 +168,12 @@ func (c *CloudProvider) List(ctx context.Context) ([]*v1alpha5.Machine, error) {
 }
 
 func (c *CloudProvider) Get(ctx context.Context, providerID string) (*v1alpha5.Machine, error) {
-	instance, err := c.instanceProvider.Get(ctx, lo.Must(utils.ParseInstanceID(providerID)))
+	id, err := utils.ParseInstanceID(providerID)
+	if err != nil {
+		return nil, fmt.Errorf("getting instance ID, %w", err)
+	}
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("id", id))
+	instance, err := c.instanceProvider.Get(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("getting instance, %w", err)
 	}

--- a/pkg/controllers/machine/garbagecollect/controller.go
+++ b/pkg/controllers/machine/garbagecollect/controller.go
@@ -1,0 +1,106 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollect
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/utils/sets"
+	"github.com/aws/karpenter/pkg/cloudprovider"
+)
+
+type Controller struct {
+	kubeClient    client.Client
+	cloudProvider *cloudprovider.CloudProvider
+}
+
+func NewController(kubeClient client.Client, cloudProvider *cloudprovider.CloudProvider) *Controller {
+	return &Controller{
+		kubeClient:    kubeClient,
+		cloudProvider: cloudProvider,
+	}
+}
+
+func (c *Controller) Name() string {
+	return "machine.garbagecollection"
+}
+
+func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	machineList := &v1alpha5.MachineList{}
+	if err := c.kubeClient.List(ctx, machineList); err != nil {
+		return reconcile.Result{}, err
+	}
+	nodeList := &v1.NodeList{}
+	if err := c.kubeClient.List(ctx, nodeList); err != nil {
+		return reconcile.Result{}, err
+	}
+	resolvedMachines := lo.Filter(machineList.Items, func(m v1alpha5.Machine, _ int) bool {
+		return m.Status.ProviderID != ""
+	})
+	resolvedProviderIDs := sets.New[string](lo.Map(resolvedMachines, func(m v1alpha5.Machine, _ int) string {
+		return m.Status.ProviderID
+	})...)
+	retrieved, err := c.cloudProvider.List(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("listing cloudprovider machines, %w", err)
+	}
+	managedRetrieved := lo.Filter(retrieved, func(m *v1alpha5.Machine, _ int) bool {
+		return m.Labels[v1alpha5.ManagedByLabelKey] != ""
+	})
+	errs := make([]error, len(retrieved))
+	workqueue.ParallelizeUntil(ctx, 20, len(managedRetrieved), func(i int) {
+		if !resolvedProviderIDs.Has(managedRetrieved[i].Status.ProviderID) && managedRetrieved[i].CreationTimestamp.Add(time.Minute).Before(time.Now()) {
+			errs[i] = c.garbageCollect(ctx, managedRetrieved[i], nodeList)
+		}
+	})
+	return reconcile.Result{RequeueAfter: time.Minute * 5}, multierr.Combine(errs...)
+}
+
+func (c *Controller) garbageCollect(ctx context.Context, machine *v1alpha5.Machine, nodeList *v1.NodeList) error {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", machine.Status.ProviderID))
+	if err := c.cloudProvider.Delete(ctx, machine); err != nil {
+		return corecloudprovider.IgnoreMachineNotFoundError(err)
+	}
+	logging.FromContext(ctx).Debugf("garbage collected cloudprovider machine")
+
+	// Go ahead and cleanup the node if we know that it exists to make scheduling go quicker
+	if node, ok := lo.Find(nodeList.Items, func(n v1.Node) bool {
+		return n.Spec.ProviderID == machine.Status.ProviderID
+	}); ok {
+		if err := c.kubeClient.Delete(ctx, &node); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		logging.FromContext(ctx).With("node", node.Name).Debugf("garbage collected node")
+	}
+	return nil
+}
+
+func (c *Controller) Builder(_ context.Context, m manager.Manager) controller.Builder {
+	return controller.NewSingletonManagedBy(m)
+}

--- a/pkg/controllers/machine/garbagecollect/suite_test.go
+++ b/pkg/controllers/machine/garbagecollect/suite_test.go
@@ -1,0 +1,331 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollect_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting/mock"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"k8s.io/client-go/tools/record"
+	clock "k8s.io/utils/clock/testing"
+	. "knative.dev/pkg/logging/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/events"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	coretest "github.com/aws/karpenter-core/pkg/test"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+	"github.com/aws/karpenter/pkg/apis"
+	"github.com/aws/karpenter/pkg/apis/settings"
+	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	awscache "github.com/aws/karpenter/pkg/cache"
+	"github.com/aws/karpenter/pkg/cloudprovider"
+	awscontext "github.com/aws/karpenter/pkg/context"
+	"github.com/aws/karpenter/pkg/controllers/machine/garbagecollect"
+	"github.com/aws/karpenter/pkg/fake"
+	"github.com/aws/karpenter/pkg/providers/securitygroup"
+	"github.com/aws/karpenter/pkg/providers/subnet"
+	"github.com/aws/karpenter/pkg/test"
+)
+
+var ctx context.Context
+var env *coretest.Environment
+var unavailableOfferingsCache *awscache.UnavailableOfferings
+var ec2API *fake.EC2API
+var cloudProvider *cloudprovider.CloudProvider
+var garbageCollectController controller.Controller
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Machine")
+}
+
+var _ = BeforeSuite(func() {
+	ctx = coresettings.ToContext(ctx, coretest.Settings())
+	ctx = settings.ToContext(ctx, test.Settings())
+	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
+	unavailableOfferingsCache = awscache.NewUnavailableOfferings()
+	ec2API = &fake.EC2API{}
+	cloudProvider = cloudprovider.New(awscontext.Context{
+		Context: corecloudprovider.Context{
+			Context:             ctx,
+			RESTConfig:          env.Config,
+			KubernetesInterface: env.KubernetesInterface,
+			KubeClient:          env.Client,
+			EventRecorder:       events.NewRecorder(&record.FakeRecorder{}),
+			Clock:               &clock.FakeClock{},
+			StartAsync:          nil,
+		},
+		SubnetProvider:            subnet.NewProvider(ec2API),
+		SecurityGroupProvider:     securitygroup.NewProvider(ec2API),
+		Session:                   mock.Session,
+		UnavailableOfferingsCache: unavailableOfferingsCache,
+		EC2API:                    ec2API,
+	})
+	garbageCollectController = garbagecollect.NewController(env.Client, cloudProvider)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("MachineGarbageCollect", func() {
+	var instance *ec2.Instance
+	var providerID string
+
+	BeforeEach(func() {
+		ec2API.Reset()
+		instanceID := fake.InstanceID()
+		providerID = fmt.Sprintf("aws:///test-zone-1a/%s", instanceID)
+		nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{})
+		provisioner := test.Provisioner(coretest.ProvisionerOptions{
+			ProviderRef: &v1alpha5.ProviderRef{
+				APIVersion: v1alpha5.TestingGroup + "v1alpha1",
+				Kind:       "NodeTemplate",
+				Name:       nodeTemplate.Name,
+			},
+		})
+		instance = &ec2.Instance{
+			State: &ec2.InstanceState{
+				Name: aws.String(ec2.InstanceStateNameRunning),
+			},
+			Tags: []*ec2.Tag{
+				{
+					Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", settings.FromContext(ctx).ClusterName)),
+					Value: aws.String("owned"),
+				},
+				{
+					Key:   aws.String(v1alpha5.ProvisionerNameLabelKey),
+					Value: aws.String(provisioner.Name),
+				},
+				{
+					Key:   aws.String(v1alpha5.ManagedByLabelKey),
+					Value: aws.String(settings.FromContext(ctx).ClusterName),
+				},
+			},
+			PrivateDnsName: aws.String(fake.PrivateDNSName()),
+			Placement: &ec2.Placement{
+				AvailabilityZone: aws.String("test-zone-1a"),
+			},
+			InstanceId:   aws.String(instanceID),
+			InstanceType: aws.String("m5.large"),
+		}
+	})
+	AfterEach(func() {
+		ExpectCleanedUp(ctx, env.Client)
+	})
+
+	It("should delete an instance if there is no machine owner", func() {
+		// Launch time was 10m ago
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		ec2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
+
+		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
+		_, err := cloudProvider.Get(ctx, providerID)
+		Expect(err).To(HaveOccurred())
+		Expect(corecloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+	})
+	It("should delete an instance along with the node if there is no machine owner (to quicken scheduling)", func() {
+		// Launch time was 10m ago
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		ec2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
+
+		node := coretest.Node(coretest.NodeOptions{
+			ProviderID: providerID,
+		})
+		ExpectApplied(ctx, env.Client, node)
+
+		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
+		_, err := cloudProvider.Get(ctx, providerID)
+		Expect(err).To(HaveOccurred())
+		Expect(corecloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+
+		ExpectNotFound(ctx, env.Client, node)
+	})
+	It("should delete many instances if they all don't have machine owners", func() {
+		// Generate 500 instances that have different instanceIDs
+		var ids []string
+		for i := 0; i < 500; i++ {
+			instanceID := fake.InstanceID()
+			ec2API.Instances.Store(
+				instanceID,
+				&ec2.Instance{
+					State: &ec2.InstanceState{
+						Name: aws.String(ec2.InstanceStateNameRunning),
+					},
+					Tags: []*ec2.Tag{
+						{
+							Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", settings.FromContext(ctx).ClusterName)),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String(v1alpha5.ProvisionerNameLabelKey),
+							Value: aws.String("default"),
+						},
+						{
+							Key:   aws.String(v1alpha5.ManagedByLabelKey),
+							Value: aws.String(settings.FromContext(ctx).ClusterName),
+						},
+					},
+					PrivateDnsName: aws.String(fake.PrivateDNSName()),
+					Placement: &ec2.Placement{
+						AvailabilityZone: aws.String("test-zone-1a"),
+					},
+					// Launch time was 10m ago
+					LaunchTime:   aws.Time(time.Now().Add(-time.Minute * 10)),
+					InstanceId:   aws.String(instanceID),
+					InstanceType: aws.String("m5.large"),
+				},
+			)
+			ids = append(ids, instanceID)
+		}
+		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
+
+		wg := sync.WaitGroup{}
+		for _, id := range ids {
+			wg.Add(1)
+			go func(id string) {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				_, err := cloudProvider.Get(ctx, fmt.Sprintf("aws:///test-zone-1a/%s", id))
+				Expect(err).To(HaveOccurred())
+				Expect(corecloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+			}(id)
+		}
+		wg.Wait()
+	})
+	It("should not delete all instances if they all have machine owners", func() {
+		// Generate 500 instances that have different instanceIDs
+		var ids []string
+		var machines []*v1alpha5.Machine
+		for i := 0; i < 500; i++ {
+			instanceID := fake.InstanceID()
+			ec2API.Instances.Store(
+				instanceID,
+				&ec2.Instance{
+					State: &ec2.InstanceState{
+						Name: aws.String(ec2.InstanceStateNameRunning),
+					},
+					Tags: []*ec2.Tag{
+						{
+							Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", settings.FromContext(ctx).ClusterName)),
+							Value: aws.String("owned"),
+						},
+						{
+							Key:   aws.String(v1alpha5.ProvisionerNameLabelKey),
+							Value: aws.String("default"),
+						},
+						{
+							Key:   aws.String(v1alpha5.ManagedByLabelKey),
+							Value: aws.String(settings.FromContext(ctx).ClusterName),
+						},
+					},
+					PrivateDnsName: aws.String(fake.PrivateDNSName()),
+					Placement: &ec2.Placement{
+						AvailabilityZone: aws.String("test-zone-1a"),
+					},
+					// Launch time was 10m ago
+					LaunchTime:   aws.Time(time.Now().Add(-time.Minute * 10)),
+					InstanceId:   aws.String(instanceID),
+					InstanceType: aws.String("m5.large"),
+				},
+			)
+			machine := coretest.Machine(v1alpha5.Machine{
+				Status: v1alpha5.MachineStatus{
+					ProviderID: fmt.Sprintf("aws:///test-zone-1a/%s", instanceID),
+				},
+			})
+			ExpectApplied(ctx, env.Client, machine)
+			machines = append(machines, machine)
+			ids = append(ids, instanceID)
+		}
+		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
+
+		wg := sync.WaitGroup{}
+		for _, id := range ids {
+			wg.Add(1)
+			go func(id string) {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				_, err := cloudProvider.Get(ctx, fmt.Sprintf("aws:///test-zone-1a/%s", id))
+				Expect(err).ToNot(HaveOccurred())
+			}(id)
+		}
+		wg.Wait()
+
+		for _, machine := range machines {
+			ExpectExists(ctx, env.Client, machine)
+		}
+	})
+	It("should not delete an instance if it is within the machine resolution window (1m)", func() {
+		// Launch time just happened
+		instance.LaunchTime = aws.Time(time.Now())
+		ec2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
+
+		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
+		_, err := cloudProvider.Get(ctx, providerID)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("should not delete an instance if it was not launched by a machine", func() {
+		// Remove the "karpenter.sh/managed-by" tag (this isn't launched by a machine)
+		instance.Tags = lo.Reject(instance.Tags, func(t *ec2.Tag, _ int) bool {
+			return aws.StringValue(t.Key) == v1alpha5.ManagedByLabelKey
+		})
+
+		// Launch time was 10m ago
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		ec2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
+
+		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
+		_, err := cloudProvider.Get(ctx, providerID)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	It("should not delete the instance or node if it already has a machine that matches it", func() {
+		// Launch time was 10m ago
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		ec2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
+
+		machine := coretest.Machine(v1alpha5.Machine{
+			Status: v1alpha5.MachineStatus{
+				ProviderID: providerID,
+			},
+		})
+		node := coretest.Node(coretest.NodeOptions{
+			ProviderID: providerID,
+		})
+		ExpectApplied(ctx, env.Client, machine, node)
+
+		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
+		_, err := cloudProvider.Get(ctx, providerID)
+		Expect(err).ToNot(HaveOccurred())
+		ExpectExists(ctx, env.Client, node)
+	})
+})

--- a/test/go.mod
+++ b/test/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.195
 	github.com/aws/aws-sdk-go-v2/config v1.18.12
 	github.com/aws/karpenter v0.22.0
-	github.com/aws/karpenter-core v0.24.1-0.20230214183652-19517662d6e0
+	github.com/aws/karpenter-core v0.24.1-0.20230215232304-33f74ed4d625
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.26.0
 	github.com/samber/lo v1.37.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -85,8 +85,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.1 h1:0bLhH6DRAqox+g0LatcjGKjj
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.1/go.mod h1:O1YSOg3aekZibh2SngvCRRG+cRHKKlYgxf/JBF/Kr/k=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.3 h1:s49mSnsBZEXjfGBkRfmK+nPqzT7Lt3+t2SmAKNyHblw=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.3/go.mod h1:b+psTJn33Q4qGoDaM7ZiOVVG8uVjGI6HaZ8WBHdgDgU=
-github.com/aws/karpenter-core v0.24.1-0.20230214183652-19517662d6e0 h1:JufeGqH7NtwU7Bv5+zdebnMHKmtGv/0eDkkJtr5aX+s=
-github.com/aws/karpenter-core v0.24.1-0.20230214183652-19517662d6e0/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
+github.com/aws/karpenter-core v0.24.1-0.20230215232304-33f74ed4d625 h1:AJz17PfL71101TKV0e6yuqV7lAFXCMH3ap/qQoVbLiI=
+github.com/aws/karpenter-core v0.24.1-0.20230215232304-33f74ed4d625/go.mod h1:gCI5P23KEa095lVX70KAJDs5M3fMwEif6rRZXJcm2ME=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=

--- a/test/suites/integration/backwards_compatability_test.go
+++ b/test/suites/integration/backwards_compatability_test.go
@@ -16,8 +16,10 @@ package integration_test
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -25,6 +27,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -60,11 +65,13 @@ var _ = Describe("BackwardsCompatability", func() {
 			&ec2.Tag{Key: lo.ToPtr("custom-tag2"), Value: lo.ToPtr("custom-value2")},
 		))
 	})
-	Context("MachineHydration", func() {
+	Context("MachineLink", func() {
 		var customAMI string
 		var instanceInput *ec2.RunInstancesInput
+		var provisioner *v1alpha5.Provisioner
 
 		BeforeEach(func() {
+			provisioner = test.Provisioner()
 			securityGroups := env.GetSecurityGroups(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
 			subnets := env.GetSubnetNameAndIds(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
 			Expect(securityGroups).ToNot(HaveLen(0))
@@ -100,6 +107,10 @@ var _ = Describe("BackwardsCompatability", func() {
 								Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", settings.FromContext(env.Context).ClusterName)),
 								Value: aws.String("owned"),
 							},
+							{
+								Key:   aws.String(v1alpha5.ProvisionerNameLabelKey),
+								Value: aws.String(provisioner.Name),
+							},
 						},
 					},
 				},
@@ -107,8 +118,8 @@ var _ = Describe("BackwardsCompatability", func() {
 				MaxCount: aws.Int64(1),
 			}
 		})
-		It("should succeed to hydrate a Machine for an existing instance launched by Karpenter", func() {
-			Skip("machine hydration is not yet enabled")
+		It("should succeed to link a Machine for an existing instance launched by Karpenter", func() {
+			Skip("machine linking is not yet enabled")
 
 			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 				AWS: v1alpha1.AWS{
@@ -117,15 +128,13 @@ var _ = Describe("BackwardsCompatability", func() {
 					SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 				},
 			})
-			provisioner := test.Provisioner(test.ProvisionerOptions{
-				ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
-				Requirements: []v1.NodeSelectorRequirement{
-					{
-						Key:      v1alpha1.LabelInstanceCategory,
-						Operator: v1.NodeSelectorOpExists,
-					},
+			provisioner.Spec.ProviderRef = &v1alpha5.ProviderRef{Name: provider.Name}
+			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+				{
+					Key:      v1alpha1.LabelInstanceCategory,
+					Operator: v1.NodeSelectorOpExists,
 				},
-			})
+			}
 			env.ExpectCreated(provider, provisioner)
 
 			// Update the userData for the instance input with the correct provisionerName
@@ -147,22 +156,23 @@ var _ = Describe("BackwardsCompatability", func() {
 			Expect(machine.Spec.Requirements).To(Equal(provisioner.Spec.Requirements))
 			Expect(machine.Spec.MachineTemplateRef.Name).To(Equal(provider.Name))
 		})
-		It("should succeed to hydrate a Machine for an existing instance launched by Karpenter with provider", func() {
-			Skip("machine hydration is not yet enabled")
+		It("should succeed to link a Machine for an existing instance launched by Karpenter with provider", func() {
+			Skip("machine linking is not yet enabled")
 
-			provisioner := test.Provisioner(test.ProvisionerOptions{
-				Provider: &v1alpha1.AWS{
-					AMIFamily:             &v1alpha1.AMIFamilyAL2,
-					SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
-					SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+			raw := &runtime.RawExtension{}
+			lo.Must0(raw.UnmarshalJSON(lo.Must(json.Marshal(&v1alpha1.AWS{
+				AMIFamily:             &v1alpha1.AMIFamilyAL2,
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+			}))))
+			provisioner.Spec.Provider = raw
+			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+				{
+					Key:      v1alpha1.LabelInstanceCategory,
+					Operator: v1.NodeSelectorOpExists,
 				},
-				Requirements: []v1.NodeSelectorRequirement{
-					{
-						Key:      v1alpha1.LabelInstanceCategory,
-						Operator: v1.NodeSelectorOpExists,
-					},
-				},
-			})
+			}
+
 			env.ExpectCreated(provisioner)
 
 			// Update the userData for the instance input with the correct provisionerName
@@ -183,6 +193,96 @@ var _ = Describe("BackwardsCompatability", func() {
 			// Expect the machine's fields are properly populated
 			Expect(machine.Spec.Requirements).To(Equal(provisioner.Spec.Requirements))
 			Expect(machine.Annotations).To(HaveKeyWithValue(v1alpha5.ProviderCompatabilityAnnotationKey, v1alpha5.ProviderAnnotation(provisioner.Spec.Provider)[v1alpha5.ProviderCompatabilityAnnotationKey]))
+		})
+	})
+	Context("MachineGarbageCollect", func() {
+		var customAMI string
+		var instanceInput *ec2.RunInstancesInput
+		var provisioner *v1alpha5.Provisioner
+
+		BeforeEach(func() {
+			provisioner = test.Provisioner()
+			securityGroups := env.GetSecurityGroups(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
+			subnets := env.GetSubnetNameAndIds(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
+			Expect(securityGroups).ToNot(HaveLen(0))
+			Expect(subnets).ToNot(HaveLen(0))
+
+			customAMI = env.GetCustomAMI("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", 1)
+			instanceInput = &ec2.RunInstancesInput{
+				InstanceType: aws.String("c5.large"),
+				IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+					Name: aws.String(settings.FromContext(env.Context).DefaultInstanceProfile),
+				},
+				SecurityGroupIds: lo.Map(securityGroups, func(s environmentaws.SecurityGroup, _ int) *string {
+					return s.GroupIdentifier.GroupId
+				}),
+				SubnetId: aws.String(subnets[0].ID),
+				BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/xvda"),
+						Ebs: &ec2.EbsBlockDevice{
+							Encrypted:           aws.Bool(true),
+							DeleteOnTermination: aws.Bool(true),
+							VolumeType:          aws.String(ec2.VolumeTypeGp3),
+							VolumeSize:          aws.Int64(20),
+						},
+					},
+				},
+				ImageId: aws.String(customAMI), // EKS AL2-based AMI
+				TagSpecifications: []*ec2.TagSpecification{
+					{
+						ResourceType: aws.String(ec2.ResourceTypeInstance),
+						Tags: []*ec2.Tag{
+							{
+								Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", settings.FromContext(env.Context).ClusterName)),
+								Value: aws.String("owned"),
+							},
+							{
+								Key:   aws.String(v1alpha5.ProvisionerNameLabelKey),
+								Value: aws.String(provisioner.Name),
+							},
+						},
+					},
+				},
+				MinCount: aws.Int64(1),
+				MaxCount: aws.Int64(1),
+			}
+		})
+		It("should succeed to garbage collect a Machine that was launched by a Machine but has no Machine mapping", func() {
+			Skip("machine garbage collection is not yet enabled")
+
+			// Update the userData for the instance input with the correct provisionerName
+			rawContent, err := os.ReadFile("testdata/al2_manual_launch_userdata_input.sh")
+			Expect(err).ToNot(HaveOccurred())
+			instanceInput.UserData = lo.ToPtr(base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(string(rawContent), settings.FromContext(env.Context).ClusterName,
+				settings.FromContext(env.Context).ClusterEndpoint, env.ExpectCABundle(), provisioner.Name))))
+
+			// Create an instance manually to mock Karpenter launching an instance
+			out, err := env.EC2API.RunInstances(instanceInput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.Instances).To(HaveLen(1))
+
+			// Wait for the node to register with the cluster
+			node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
+
+			// Update the tags to add the karpenter.sh/managed-by tag
+			_, err = env.EC2API.CreateTagsWithContext(env.Context, &ec2.CreateTagsInput{
+				Resources: []*string{out.Instances[0].InstanceId},
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String(v1alpha5.ManagedByLabelKey),
+						Value: aws.String(settings.FromContext(env.Context).ClusterName),
+					},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Eventually expect the node and the instance to be removed (shutting-down)
+			// It could take up to 6 minutes since we re-reconcile on a 5-minute interval
+			Eventually(func(g Gomega) {
+				g.Expect(errors.IsNotFound(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node))).To(BeTrue())
+				g.Expect(lo.FromPtr(env.GetInstanceByID(aws.StringValue(out.Instances[0].InstanceId)).State.Name)).To(Equal("shutting-down"))
+			}, time.Minute*7).Should(Succeed())
 		})
 	})
 })

--- a/website/content/en/preview/concepts/instance-types.md
+++ b/website/content/en/preview/concepts/instance-types.md
@@ -9337,6 +9337,214 @@ below are the resources available with some assumptions and after the instance o
  |memory|476943Mi|
  |pods|688|
  |vpc.amazonaws.com/pod-eni|108|
+## m7g Family
+### `m7g.medium`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|1|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|4096|
+ |karpenter.k8s.aws/instance-pods|8|
+ |karpenter.k8s.aws/instance-size|medium|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.medium|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|840m|
+ |ephemeral-storage|18Gi|
+ |memory|3245Mi|
+ |pods|8|
+### `m7g.large`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|2|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|8192|
+ |karpenter.k8s.aws/instance-pods|29|
+ |karpenter.k8s.aws/instance-size|large|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.large|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|1830m|
+ |ephemeral-storage|18Gi|
+ |memory|6803Mi|
+ |pods|29|
+### `m7g.xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|4|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|16384|
+ |karpenter.k8s.aws/instance-pods|58|
+ |karpenter.k8s.aws/instance-size|xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|3820m|
+ |ephemeral-storage|18Gi|
+ |memory|14062Mi|
+ |pods|58|
+### `m7g.2xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|8|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|32768|
+ |karpenter.k8s.aws/instance-pods|58|
+ |karpenter.k8s.aws/instance-size|2xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.2xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|7810m|
+ |ephemeral-storage|18Gi|
+ |memory|29217Mi|
+ |pods|58|
+### `m7g.4xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|16|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|65536|
+ |karpenter.k8s.aws/instance-pods|234|
+ |karpenter.k8s.aws/instance-size|4xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.4xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|15790m|
+ |ephemeral-storage|18Gi|
+ |memory|57591Mi|
+ |pods|234|
+### `m7g.8xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|32|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|131072|
+ |karpenter.k8s.aws/instance-pods|234|
+ |karpenter.k8s.aws/instance-size|8xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.8xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|31750m|
+ |ephemeral-storage|18Gi|
+ |memory|118212Mi|
+ |pods|234|
+### `m7g.12xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|48|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|196608|
+ |karpenter.k8s.aws/instance-pods|234|
+ |karpenter.k8s.aws/instance-size|12xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.12xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|47710m|
+ |ephemeral-storage|18Gi|
+ |memory|178833Mi|
+ |pods|234|
+### `m7g.16xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|64|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|262144|
+ |karpenter.k8s.aws/instance-pods|737|
+ |karpenter.k8s.aws/instance-size|16xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.16xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|63670m|
+ |ephemeral-storage|18Gi|
+ |memory|233921Mi|
+ |pods|737|
+### `m7g.metal`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|m|
+ |karpenter.k8s.aws/instance-cpu|64|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|m7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor||
+ |karpenter.k8s.aws/instance-memory|262144|
+ |karpenter.k8s.aws/instance-pods|737|
+ |karpenter.k8s.aws/instance-size|metal|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|m7g.metal|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|63670m|
+ |ephemeral-storage|18Gi|
+ |memory|233921Mi|
+ |pods|737|
 ## p2 Family
 ### `p2.xlarge`
 #### Labels
@@ -12967,6 +13175,214 @@ below are the resources available with some assumptions and after the instance o
  |memory|961909Mi|
  |pods|688|
  |vpc.amazonaws.com/pod-eni|108|
+## r7g Family
+### `r7g.medium`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|1|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|8192|
+ |karpenter.k8s.aws/instance-pods|8|
+ |karpenter.k8s.aws/instance-size|medium|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.medium|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|840m|
+ |ephemeral-storage|18Gi|
+ |memory|7034Mi|
+ |pods|8|
+### `r7g.large`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|2|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|16384|
+ |karpenter.k8s.aws/instance-pods|29|
+ |karpenter.k8s.aws/instance-size|large|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.large|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|1830m|
+ |ephemeral-storage|18Gi|
+ |memory|14381Mi|
+ |pods|29|
+### `r7g.xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|4|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|32768|
+ |karpenter.k8s.aws/instance-pods|58|
+ |karpenter.k8s.aws/instance-size|xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|3820m|
+ |ephemeral-storage|18Gi|
+ |memory|29217Mi|
+ |pods|58|
+### `r7g.2xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|8|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|65536|
+ |karpenter.k8s.aws/instance-pods|58|
+ |karpenter.k8s.aws/instance-size|2xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.2xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|7810m|
+ |ephemeral-storage|18Gi|
+ |memory|59527Mi|
+ |pods|58|
+### `r7g.4xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|16|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|131072|
+ |karpenter.k8s.aws/instance-pods|234|
+ |karpenter.k8s.aws/instance-size|4xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.4xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|15790m|
+ |ephemeral-storage|18Gi|
+ |memory|118212Mi|
+ |pods|234|
+### `r7g.8xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|32|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|262144|
+ |karpenter.k8s.aws/instance-pods|234|
+ |karpenter.k8s.aws/instance-size|8xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.8xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|31750m|
+ |ephemeral-storage|18Gi|
+ |memory|239454Mi|
+ |pods|234|
+### `r7g.12xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|48|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|393216|
+ |karpenter.k8s.aws/instance-pods|234|
+ |karpenter.k8s.aws/instance-size|12xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.12xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|47710m|
+ |ephemeral-storage|18Gi|
+ |memory|360695Mi|
+ |pods|234|
+### `r7g.16xlarge`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|64|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor|nitro|
+ |karpenter.k8s.aws/instance-memory|524288|
+ |karpenter.k8s.aws/instance-pods|737|
+ |karpenter.k8s.aws/instance-size|16xlarge|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.16xlarge|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|63670m|
+ |ephemeral-storage|18Gi|
+ |memory|476404Mi|
+ |pods|737|
+### `r7g.metal`
+#### Labels
+ | Label | Value |
+ |--|--|
+ |karpenter.k8s.aws/instance-category|r|
+ |karpenter.k8s.aws/instance-cpu|64|
+ |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
+ |karpenter.k8s.aws/instance-family|r7g|
+ |karpenter.k8s.aws/instance-generation|7|
+ |karpenter.k8s.aws/instance-hypervisor||
+ |karpenter.k8s.aws/instance-memory|524288|
+ |karpenter.k8s.aws/instance-pods|737|
+ |karpenter.k8s.aws/instance-size|metal|
+ |kubernetes.io/arch|arm64|
+ |kubernetes.io/os|linux|
+ |node.kubernetes.io/instance-type|r7g.metal|
+#### Resources
+ | Resource | Quantity |
+ |--|--|
+ |cpu|63670m|
+ |ephemeral-storage|18Gi|
+ |memory|476404Mi|
+ |pods|737|
 ## t1 Family
 ### `t1.micro`
 #### Labels


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Adds a garbage collection controller for cloudprovider Machines that have been launched but have not stored their providerID inside of their Machine owner (due to crashing or upgrade)

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
