### PR TITLE
chore: Add Machine Link Tagging to Link Flow

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -151,6 +151,17 @@ func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (
 	return c.instanceToMachine(ctx, instance, instanceType), nil
 }
 
+// Link adds a tag to the cloudprovider machine to tell the cloudprovider that it's now owned by a Machine
+func (c *CloudProvider) Link(ctx context.Context, machine *v1alpha5.Machine) error {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("machine", machine.Name))
+	id, err := utils.ParseInstanceID(machine.Status.ProviderID)
+	if err != nil {
+		return fmt.Errorf("getting instance ID, %w", err)
+	}
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("id", id))
+	return c.instanceProvider.Link(ctx, id)
+}
+
 func (c *CloudProvider) List(ctx context.Context) ([]*v1alpha5.Machine, error) {
 	instances, err := c.instanceProvider.List(ctx)
 	if err != nil {

--- a/pkg/controllers/machine/link/suite_test.go
+++ b/pkg/controllers/machine/link/suite_test.go
@@ -262,9 +262,9 @@ var _ = Describe("MachineLink", func() {
 			ec2API.Reset() // Reset so we don't store the extra instance
 			ExpectApplied(ctx, env.Client, provisioner)
 
-			// Generate 1000 instances that have different instanceIDs
+			// Generate 500 instances that have different instanceIDs
 			var ids []string
-			for i := 0; i < 1000; i++ {
+			for i := 0; i < 500; i++ {
 				instanceID = fake.InstanceID()
 				ec2API.EC2Behavior.Instances.Store(
 					instanceID,
@@ -298,7 +298,7 @@ var _ = Describe("MachineLink", func() {
 
 			machineList := &v1alpha5.MachineList{}
 			Expect(env.Client.List(ctx, machineList)).To(Succeed())
-			Expect(machineList.Items).To(HaveLen(1000))
+			Expect(machineList.Items).To(HaveLen(500))
 
 			machineInstanceIDs := sets.New[string](lo.Map(machineList.Items, func(m v1alpha5.Machine, _ int) string {
 				return lo.Must(utils.ParseInstanceID(m.Annotations[v1alpha5.MachineLinkedAnnotationKey]))


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Add tagging of `karpenter.sh/managed-by` after attaching the existing instance to a machine to bring tagging parity with new machines that are launched

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
