### PR TITLE
fix: track inflight ip usage for subnet selection between ec2 api resyncs

### DIFF
--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -160,7 +160,10 @@ func (e *EC2API) CreateFleetWithContext(_ context.Context, input *ec2.CreateFlee
 		}
 	}
 
-	result := &ec2.CreateFleetOutput{Instances: []*ec2.CreateFleetInstance{{InstanceIds: instanceIds}}}
+	result := &ec2.CreateFleetOutput{Instances: []*ec2.CreateFleetInstance{{
+		InstanceIds:                instanceIds,
+		LaunchTemplateAndOverrides: &ec2.LaunchTemplateAndOverridesResponse{Overrides: &ec2.FleetLaunchTemplateOverrides{SubnetId: input.LaunchTemplateConfigs[0].Overrides[0].SubnetId}},
+	}}}
 	for _, pool := range skippedPools {
 		result.Errors = append(result.Errors, &ec2.CreateFleetError{
 			ErrorCode: aws.String("InsufficientInstanceCapacity"),

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -18,31 +18,32 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/patrickmn/go-cache"
+	"github.com/samber/lo"
 	"knative.dev/pkg/logging"
 
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/utils/functional"
 	"github.com/aws/karpenter-core/pkg/utils/pretty"
 	awscache "github.com/aws/karpenter/pkg/cache"
 )
 
 type Provider struct {
-	sync.Mutex
-	ec2api ec2iface.EC2API
-	cache  *cache.Cache
-	cm     *pretty.ChangeMonitor
+	sync.RWMutex
+	ec2api      ec2iface.EC2API
+	cache       *cache.Cache
+	cm          *pretty.ChangeMonitor
+	inflightIPs map[string]int64
 }
-
-const TTL = 5 * time.Minute
 
 func NewProvider(ec2api ec2iface.EC2API) *Provider {
 	return &Provider{
@@ -51,6 +52,8 @@ func NewProvider(ec2api ec2iface.EC2API) *Provider {
 		// TODO: Remove cache for v1beta1, utilize resolved subnet from the AWSNodeTemplate.status
 		// Subnets are sorted on AvailableIpAddressCount, descending order
 		cache: cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval),
+		// inflightIPs is used to track IPs from known launched instances
+		inflightIPs: map[string]int64{},
 	}
 }
 
@@ -70,6 +73,10 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 		return nil, fmt.Errorf("describing subnets %s, %w", pretty.Concise(filters), err)
 	}
 	p.cache.SetDefault(fmt.Sprint(hash), output.Subnets)
+	// remove any previously tracked IP addresses since we just refreshed from EC2
+	for _, subnet := range output.Subnets {
+		delete(p.inflightIPs, *subnet.SubnetId)
+	}
 	subnetLog := Pretty(output.Subnets)
 	if p.cm.HasChanged("subnets", subnetLog) {
 		logging.FromContext(ctx).With("subnets", subnetLog).Debugf("discovered subnets")
@@ -77,11 +84,118 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 	return output.Subnets, nil
 }
 
+// ZonalSubnetsForLaunch returns a mapping of zone to the subnet with the most available IP addresses and deducts the passed ips from the available count
+func (p *Provider) ZonalSubnetsForLaunch(instanceTypes []*cloudprovider.InstanceType, subnets []*ec2.Subnet, capacityType string) map[string]*ec2.Subnet {
+	p.Lock()
+	defer p.Unlock()
+	// sort subnets in ascending order of available IP addresses and populate map with most available subnet per AZ
+	zonalSubnets := map[string]*ec2.Subnet{}
+	sort.Slice(subnets, func(i, j int) bool {
+		iIPs := aws.Int64Value(subnets[i].AvailableIpAddressCount)
+		jIPs := aws.Int64Value(subnets[j].AvailableIpAddressCount)
+		// override ip count from ec2.Subnet if we've tracked launches
+		if ips, ok := p.inflightIPs[*subnets[i].SubnetId]; ok {
+			iIPs = ips
+		}
+		if ips, ok := p.inflightIPs[*subnets[j].SubnetId]; ok {
+			jIPs = ips
+		}
+		return iIPs < jIPs
+	})
+	for _, subnet := range subnets {
+		zonalSubnets[*subnet.AvailabilityZone] = subnet
+	}
+	for _, subnet := range zonalSubnets {
+		predictedIPsUsed := p.minPods(instanceTypes, *subnet.AvailabilityZone, capacityType)
+		prevIPs := *subnet.AvailableIpAddressCount
+		if trackedIPs, ok := p.inflightIPs[*subnet.SubnetId]; ok {
+			prevIPs = trackedIPs
+		}
+		p.inflightIPs[*subnet.SubnetId] = prevIPs - predictedIPsUsed
+	}
+	return zonalSubnets
+}
+
+// UpdateInflightIPs is used to refresh the in-memory IP usage by adding back unused IPs after a CreateFleet response is returned
+func (p *Provider) UpdateInflightIPs(createFleetInput *ec2.CreateFleetInput, createFleetOutput *ec2.CreateFleetOutput, instanceTypes []*cloudprovider.InstanceType,
+	subnets []*ec2.Subnet, capacityType string) {
+	p.Lock()
+	defer p.Unlock()
+
+	// Process the CreateFleetInput to pull out all the requested subnetIDs
+	fleetInputSubnets := lo.Compact(lo.Uniq(lo.FlatMap(createFleetInput.LaunchTemplateConfigs, func(req *ec2.FleetLaunchTemplateConfigRequest, _ int) []string {
+		return lo.Map(req.Overrides, func(override *ec2.FleetLaunchTemplateOverridesRequest, _ int) string {
+			if override == nil {
+				return ""
+			}
+			return lo.FromPtr(override.SubnetId)
+		})
+	})))
+
+	// Process the CreateFleetOutput to pull out all the fulfilled subnetIDs
+	fleetOutputSubnets := lo.Compact(lo.Uniq(lo.Map(createFleetOutput.Instances, func(fleetInstance *ec2.CreateFleetInstance, _ int) string {
+		if fleetInstance == nil || fleetInstance.LaunchTemplateAndOverrides == nil || fleetInstance.LaunchTemplateAndOverrides.Overrides == nil {
+			return ""
+		}
+		return lo.FromPtr(fleetInstance.LaunchTemplateAndOverrides.Overrides.SubnetId)
+	})))
+
+	// Find the subnets that were included in the input but not chosen by Fleet, so we need to add the inflight IPs back to them
+	subnetIDsToAddBackIPs, _ := lo.Difference(fleetInputSubnets, fleetOutputSubnets)
+
+	// Aggregate all the cached subnets
+	cachedSubnets := lo.UniqBy(lo.Flatten(lo.MapToSlice(p.cache.Items(), func(_ string, item cache.Item) []*ec2.Subnet {
+		return item.Object.([]*ec2.Subnet)
+	})), func(subnet *ec2.Subnet) string { return *subnet.SubnetId })
+
+	// Update the inflight IP tracking of subnets stored in the cache that have not be synchronized since the initial
+	// deduction of IP addresses before the instance launch
+	for _, cachedSubnet := range cachedSubnets {
+		if !lo.Contains(subnetIDsToAddBackIPs, *cachedSubnet.SubnetId) {
+			continue
+		}
+		originalSubnet, ok := lo.Find(subnets, func(subnet *ec2.Subnet) bool {
+			return *subnet.SubnetId == *cachedSubnet.SubnetId
+		})
+		if !ok {
+			continue
+		}
+		// If the cached subnet IP address count hasn't changed from the original subnet used to
+		// launch the instance, then we need to update the tracked IPs
+		if *originalSubnet.AvailableIpAddressCount == *cachedSubnet.AvailableIpAddressCount {
+			// other IPs deducted were opportunistic and need to be readded since Fleet didn't pick those subnets to launch into
+			if ips, ok := p.inflightIPs[*originalSubnet.SubnetId]; ok {
+				minPods := p.minPods(instanceTypes, *originalSubnet.AvailabilityZone, capacityType)
+				p.inflightIPs[*originalSubnet.SubnetId] = ips + minPods
+			}
+		}
+	}
+}
+
 func (p *Provider) LivenessProbe(req *http.Request) error {
 	p.Lock()
 	//nolint: staticcheck
 	p.Unlock()
 	return nil
+}
+
+func (p *Provider) minPods(instanceTypes []*cloudprovider.InstanceType, zone string, capacityType string) int64 {
+	// filter for instance types available in the zone and capacity type being requested
+	filteredInstanceTypes := lo.Filter(instanceTypes, func(it *cloudprovider.InstanceType, _ int) bool {
+		offering, ok := it.Offerings.Get(capacityType, zone)
+		if !ok {
+			return false
+		}
+		return offering.Available
+	})
+	if len(filteredInstanceTypes) == 0 {
+		return 0
+	}
+	// Get minimum pods to use when selecting a subnet and deducting what will be launched
+	pods, _ := lo.MinBy(filteredInstanceTypes, func(i *cloudprovider.InstanceType, j *cloudprovider.InstanceType) bool {
+		return i.Capacity.Pods().Cmp(*j.Capacity.Pods()) < 0
+	}).Capacity.Pods().AsInt64()
+	return pods
 }
 
 func getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {
@@ -118,4 +232,5 @@ func Pretty(subnets []*ec2.Subnet) []string {
 
 func (p *Provider) Reset() {
 	p.cache.Flush()
+	p.inflightIPs = map[string]int64{}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

https://github.com/aws/karpenter/issues/3364
https://github.com/aws/karpenter/issues/3380

**Description**
 - When a provisioner has two subnets within the same AZ, Karpenter selects the subnet with the most available IPs when creating the instance. However, the availableIPs comes from the EC2 DescribeSubnets API which is only synchronized every minute. This causes issues when multiple instances are launched with the stale available IPs such that the IP drops below 0. This PR introduces inflight IP tracking which approximates the IPs that will be used by the instance that is being launched by using the minimum maxPods value in the instance type options list. The inflight IP tracking is best effort and is resynchronized when the subnet cache is updated. The inflight IP tracking can also go negative since it's only an approximation of magnitude of IP usage and is compared relatively. 

**How was this change tested?**

* Created two subnets in the same AZ with a /24 CIDR (251 usable IPs). Scaled up an inflate deployment to 10 with pod anti-affinity so that 1 pod per node is brought up.  Observed that the subnets were draining IPs equally (151 IPs were available in each subnet after the scale-up). The increased IP usage from the 1-pod per node is due to the VPC CNI allocating warm IPs at launch. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
