### PR TITLE
feat: default user-data as a shellscript if no mime format is provided

### DIFF
--- a/pkg/cloudprovider/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/amifamily/bootstrap/eksbootstrap.go
@@ -195,6 +195,19 @@ func copyCustomUserDataParts(writer *multipart.Writer, customUserData *string) e
 		// No custom user data specified, so nothing to copy over.
 		return nil
 	}
+	if !strings.HasPrefix(*customUserData, "MIME-Version:") {
+		partWriter, err := writer.CreatePart(textproto.MIMEHeader{
+			"Content-Type": []string{`text/x-shellscript; charset="us-ascii"`},
+		})
+		if err != nil {
+			return fmt.Errorf("creating multi-part section from custom user-data: %w", err)
+		}
+		_, err = partWriter.Write([]byte(*customUserData))
+		if err != nil {
+			return fmt.Errorf("writing custom user-data input: %w", err)
+		}
+		return nil
+	}
 	reader, err := getMultiPartReader(*customUserData)
 	if err != nil {
 		return fmt.Errorf("parsing custom user data input %w", err)

--- a/pkg/cloudprovider/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/cloudprovider/amifamily/bootstrap/eksbootstrap.go
@@ -48,8 +48,20 @@ const (
 	MIMEContentTypeHeaderTemplate = "Content-Type: multipart/mixed; boundary=\"%s\""
 )
 
-//nolint:gocyclo
 func (e EKS) Script() (string, error) {
+	bootstrapScript := e.eksBootstrapScript()
+	customUserData := lo.FromPtr(e.CustomUserData)
+	userData, err := e.mergeCustomUserData(customUserData, bootstrapScript)
+	if err != nil {
+		return "", err
+	}
+	// The mime/multipart package adds carriage returns, while the rest of our logic does not. Remove all
+	// carriage returns for consistency.
+	return base64.StdEncoding.EncodeToString([]byte(strings.ReplaceAll(userData, "\r", ""))), nil
+}
+
+//nolint:gocyclo
+func (e EKS) eksBootstrapScript() string {
 	var caBundleArg string
 	if e.CABundle != nil {
 		caBundleArg = fmt.Sprintf("--b64-cluster-ca '%s'", *e.CABundle)
@@ -106,14 +118,7 @@ func (e EKS) Script() (string, error) {
 	if e.KubeletConfig != nil && len(e.KubeletConfig.ClusterDNS) > 0 {
 		userData.WriteString(fmt.Sprintf(" \\\n--dns-cluster-ip '%s'", e.KubeletConfig.ClusterDNS[0]))
 	}
-	userDataMerged, err := e.mergeCustomUserData(&userData)
-	if err != nil {
-		return "", err
-	}
-	// The mime/multipart package adds carriage returns, while the rest of our logic does not. Remove all
-	// carriage returns for consistency.
-	userDataBytes := bytes.Replace(userDataMerged.Bytes(), []byte{13}, []byte{}, -1)
-	return base64.StdEncoding.EncodeToString(userDataBytes), nil
+	return userData.String()
 }
 
 func (e EKS) nodeTaintArg() string {
@@ -157,30 +162,36 @@ func joinParameterArgs[K comparable, V any](name string, m map[K]V, separator st
 	return ""
 }
 
-func (e EKS) mergeCustomUserData(userData *bytes.Buffer) (*bytes.Buffer, error) {
+func (e EKS) mergeCustomUserData(customUserData string, bootstrap string) (string, error) {
 	var outputBuffer bytes.Buffer
 	writer := multipart.NewWriter(&outputBuffer)
 	if err := writer.SetBoundary(Boundary); err != nil {
-		return nil, fmt.Errorf("defining boundary for merged user data %w", err)
+		return "", fmt.Errorf("defining boundary for merged user data %w", err)
 	}
 	outputBuffer.WriteString(MIMEVersionHeader + "\n")
 	outputBuffer.WriteString(fmt.Sprintf(MIMEContentTypeHeaderTemplate, Boundary) + "\n\n")
-	// Step 1 - Copy over customer bootstrapping
-	if err := copyCustomUserDataParts(writer, e.Options.CustomUserData); err != nil {
-		return nil, err
+	// add customUserdata to the multi-part mime, if necessary
+	if customUserData != "" {
+		mimedCustomUserData, err := e.mimeify(customUserData)
+		if err != nil {
+			return "", err
+		}
+		if err := copyCustomUserDataParts(writer, mimedCustomUserData); err != nil {
+			return "", err
+		}
 	}
-	// Step 2 - Add Karpenter's bootstrapping logic
-	shellScriptContentHeader := textproto.MIMEHeader{"Content-Type": []string{"text/x-shellscript; charset=\"us-ascii\""}}
-	partWriter, err := writer.CreatePart(shellScriptContentHeader)
+	// Add Karpenter's bootstrapping logic to the final user-data part
+	partWriter, err := writer.CreatePart(textproto.MIMEHeader{
+		"Content-Type": []string{"text/x-shellscript; charset=\"us-ascii\""}})
 	if err != nil {
-		return nil, fmt.Errorf("unable to add Karpenter managed user data %w", err)
+		return "", fmt.Errorf("unable to add Karpenter managed user data %w", err)
 	}
-	_, err = partWriter.Write(userData.Bytes())
+	_, err = partWriter.Write([]byte(bootstrap))
 	if err != nil {
-		return nil, fmt.Errorf("unable to create merged user data content %w", err)
+		return "", fmt.Errorf("unable to create merged user data content %w", err)
 	}
 	writer.Close()
-	return &outputBuffer, nil
+	return outputBuffer.String(), nil
 }
 
 func (e EKS) isIPv6() bool {
@@ -190,25 +201,38 @@ func (e EKS) isIPv6() bool {
 	return net.ParseIP(e.KubeletConfig.ClusterDNS[0]).To4() == nil
 }
 
-func copyCustomUserDataParts(writer *multipart.Writer, customUserData *string) error {
-	if customUserData == nil || *customUserData == "" {
+// mimeify returns userData in a mime format
+// if the userData passed in is already in a mime format, then the input is returned without modification
+func (e EKS) mimeify(customUserData string) (string, error) {
+	if strings.HasPrefix(strings.TrimSpace(customUserData), "MIME-Version:") {
+		return customUserData, nil
+	}
+	var outputBuffer bytes.Buffer
+	writer := multipart.NewWriter(&outputBuffer)
+	outputBuffer.WriteString(MIMEVersionHeader + "\n")
+	outputBuffer.WriteString(fmt.Sprintf(MIMEContentTypeHeaderTemplate, writer.Boundary()) + "\n\n")
+	partWriter, err := writer.CreatePart(textproto.MIMEHeader{
+		"Content-Type": []string{`text/x-shellscript; charset="us-ascii"`},
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating multi-part section from custom user-data: %w", err)
+	}
+	_, err = partWriter.Write([]byte(customUserData))
+	if err != nil {
+		return "", fmt.Errorf("writing custom user-data input: %w", err)
+	}
+	writer.Close()
+	return outputBuffer.String(), nil
+}
+
+// copyCustomUserDataParts reads the mime parts in the userData passed in and writes
+// to a new mime part in the passed in writer.
+func copyCustomUserDataParts(writer *multipart.Writer, customUserData string) error {
+	if customUserData == "" {
 		// No custom user data specified, so nothing to copy over.
 		return nil
 	}
-	if !strings.HasPrefix(*customUserData, "MIME-Version:") {
-		partWriter, err := writer.CreatePart(textproto.MIMEHeader{
-			"Content-Type": []string{`text/x-shellscript; charset="us-ascii"`},
-		})
-		if err != nil {
-			return fmt.Errorf("creating multi-part section from custom user-data: %w", err)
-		}
-		_, err = partWriter.Write([]byte(*customUserData))
-		if err != nil {
-			return fmt.Errorf("writing custom user-data input: %w", err)
-		}
-		return nil
-	}
-	reader, err := getMultiPartReader(*customUserData)
+	reader, err := getMultiPartReader(customUserData)
 	if err != nil {
 		return fmt.Errorf("parsing custom user data input %w", err)
 	}

--- a/pkg/cloudprovider/launchtemplate_test.go
+++ b/pkg/cloudprovider/launchtemplate_test.go
@@ -748,7 +748,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).NotTo(ContainSubstring("--use-max-pods false"))
 		})
 		It("should specify --use-max-pods=false when not using ENI-based pod density", func() {
@@ -762,7 +763,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--use-max-pods false"))
 			Expect(string(userData)).To(ContainSubstring("--max-pods=110"))
 		})
@@ -774,7 +776,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--use-max-pods false"))
 			Expect(string(userData)).To(ContainSubstring("--max-pods=10"))
 		})
@@ -792,7 +795,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 
 			// Check whether the arguments are there for --system-reserved
 			arg := "--system-reserved="
@@ -817,7 +821,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 
 			// Check whether the arguments are there for --kube-reserved
 			arg := "--kube-reserved="
@@ -842,7 +847,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 
 			// Check whether the arguments are there for --kube-reserved
 			arg := "--eviction-hard="
@@ -867,7 +873,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 
 			// Check whether the arguments are there for --kube-reserved
 			arg := "--eviction-soft="
@@ -892,7 +899,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 
 			// Check whether the arguments are there for --kube-reserved
 			arg := "--eviction-soft-grace-period="
@@ -913,7 +921,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 
 			Expect(string(userData)).To(ContainSubstring(fmt.Sprintf("--eviction-max-pod-grace-period=%d", 300)))
 		})
@@ -927,7 +936,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring(fmt.Sprintf("--pods-per-core=%d", 2)))
 		})
 		It("should specify --pods-per-core with --max-pods enabled", func() {
@@ -941,7 +951,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring(fmt.Sprintf("--pods-per-core=%d", 2)))
 			Expect(string(userData)).To(ContainSubstring(fmt.Sprintf("--max-pods=%d", 100)))
 		})
@@ -952,7 +963,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--container-runtime containerd"))
 		})
 		It("should specify dockerd if specified in the provisionerSpec", func() {
@@ -963,7 +975,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--container-runtime dockerd"))
 		})
 		It("should specify --container-runtime containerd when using Neuron GPUs", func() {
@@ -984,7 +997,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--container-runtime containerd"))
 		})
 		It("should specify --container-runtime containerd when using Nvidia GPUs", func() {
@@ -1005,7 +1019,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--container-runtime containerd"))
 		})
 		It("should specify --dns-cluster-ip and --ip-family when running in an ipv6 cluster", func() {
@@ -1016,7 +1031,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--dns-cluster-ip 'fd4b:121b:812b::a'"))
 			Expect(string(userData)).To(ContainSubstring("--ip-family ipv6"))
 			Expect(*input.LaunchTemplateData.MetadataOptions.HttpProtocolIpv6).To(Equal(ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled))
@@ -1031,7 +1047,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--image-gc-high-threshold=50"))
 		})
 		It("should pass ImageGCLowThresholdPercent when specified", func() {
@@ -1044,7 +1061,8 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 			Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 			input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-			userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+			Expect(err).To(BeNil())
 			Expect(string(userData)).To(ContainSubstring("--image-gc-low-threshold=50"))
 		})
 		Context("Bottlerocket", func() {
@@ -1053,7 +1071,8 @@ var _ = Describe("LaunchTemplates", func() {
 					EnableENILimitedPodDensity: lo.ToPtr(false),
 				}))
 
-				content, _ := os.ReadFile("testdata/br_userdata_input.golden")
+				content, err := os.ReadFile("testdata/br_userdata_input.golden")
+				Expect(err).To(BeNil())
 				nodeTemplate.Spec.UserData = aws.String(string(content))
 				nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
 				provisioner.Spec.Taints = []v1.Taint{{Key: "foo", Value: "bar", Effect: v1.TaintEffectNoExecute}}
@@ -1067,8 +1086,10 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-				content, _ = os.ReadFile("testdata/br_userdata_merged.golden")
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
+				content, err = os.ReadFile("testdata/br_userdata_merged.golden")
+				Expect(err).To(BeNil())
 				// Newlines are always added for missing TOML fields, so strip them out before comparisons.
 				actualUserData := strings.Replace(string(userData), "\n", "", -1)
 				expectedUserData := strings.Replace(fmt.Sprintf(string(content), provisioner.Name), "\n", "", -1)
@@ -1090,8 +1111,10 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-				content, _ := os.ReadFile("testdata/br_userdata_unmerged.golden")
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
+				content, err := os.ReadFile("testdata/br_userdata_unmerged.golden")
+				Expect(err).To(BeNil())
 				actualUserData := strings.Replace(string(userData), "\n", "", -1)
 				expectedUserData := strings.Replace(fmt.Sprintf(string(content), provisioner.Name), "\n", "", -1)
 				Expect(expectedUserData).To(Equal(actualUserData))
@@ -1140,7 +1163,8 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
 				config := &bootstrap.BottlerocketConfig{}
 				Expect(config.UnmarshalTOML(userData)).To(Succeed())
 				Expect(len(config.Settings.Kubernetes.SystemReserved)).To(Equal(3))
@@ -1169,7 +1193,8 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
 				config := &bootstrap.BottlerocketConfig{}
 				Expect(config.UnmarshalTOML(userData)).To(Succeed())
 				Expect(len(config.Settings.Kubernetes.KubeReserved)).To(Equal(3))
@@ -1198,7 +1223,8 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
 				config := &bootstrap.BottlerocketConfig{}
 				Expect(config.UnmarshalTOML(userData)).To(Succeed())
 				Expect(len(config.Settings.Kubernetes.EvictionHard)).To(Equal(3))
@@ -1222,7 +1248,8 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
 				config := &bootstrap.BottlerocketConfig{}
 				Expect(config.UnmarshalTOML(userData)).To(Succeed())
 				Expect(config.Settings.Kubernetes.MaxPods).ToNot(BeNil())
@@ -1235,7 +1262,8 @@ var _ = Describe("LaunchTemplates", func() {
 					EnableENILimitedPodDensity: lo.ToPtr(false),
 				}))
 
-				content, _ := os.ReadFile("testdata/al2_userdata_input.golden")
+				content, err := os.ReadFile("testdata/al2_userdata_input.golden")
+				Expect(err).To(BeNil())
 				nodeTemplate.Spec.UserData = aws.String(string(content))
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
@@ -1245,8 +1273,10 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-				content, _ = os.ReadFile("testdata/al2_userdata_merged.golden")
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
+				content, err = os.ReadFile("testdata/al2_userdata_merged.golden")
+				Expect(err).To(BeNil())
 				expectedUserData := fmt.Sprintf(string(content), newProvisioner.Name)
 				Expect(expectedUserData).To(Equal(string(userData)))
 			})
@@ -1255,7 +1285,8 @@ var _ = Describe("LaunchTemplates", func() {
 					EnableENILimitedPodDensity: lo.ToPtr(false),
 				}))
 
-				content, _ := os.ReadFile("testdata/al2_no_mime_userdata_input.golden")
+				content, err := os.ReadFile("testdata/al2_no_mime_userdata_input.golden")
+				Expect(err).To(BeNil())
 				nodeTemplate.Spec.UserData = aws.String(string(content))
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.ProviderRef{Name: nodeTemplate.Name}})
@@ -1265,8 +1296,10 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-				content, _ = os.ReadFile("testdata/al2_userdata_merged.golden")
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
+				content, err = os.ReadFile("testdata/al2_userdata_merged.golden")
+				Expect(err).To(BeNil())
 				expectedUserData := fmt.Sprintf(string(content), newProvisioner.Name)
 				Expect(expectedUserData).To(Equal(string(userData)))
 			})
@@ -1283,8 +1316,10 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
-				content, _ := os.ReadFile("testdata/al2_userdata_unmerged.golden")
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
+				content, err := os.ReadFile("testdata/al2_userdata_unmerged.golden")
+				Expect(err).To(BeNil())
 				expectedUserData := fmt.Sprintf(string(content), newProvisioner.Name)
 				Expect(expectedUserData).To(Equal(string(userData)))
 			})
@@ -1326,7 +1361,8 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
 				Expect("special user data").To(Equal(string(userData)))
 			})
 			It("should correctly use ami selector with specific IDs in AWSNodeTemplate", func() {
@@ -1475,7 +1511,8 @@ var _ = Describe("LaunchTemplates", func() {
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(fakeEC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(1))
 				input := fakeEC2API.CalledWithCreateLaunchTemplateInput.Pop()
-				userData, _ := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				userData, err := base64.StdEncoding.DecodeString(*input.LaunchTemplateData.UserData)
+				Expect(err).To(BeNil())
 				Expect(string(userData)).To(ContainSubstring("--dns-cluster-ip '10.0.10.100'"))
 			})
 		})

--- a/pkg/cloudprovider/testdata/al2_no_mime_userdata_input.golden
+++ b/pkg/cloudprovider/testdata/al2_no_mime_userdata_input.golden
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Running custom user data script"

--- a/test/suites/integration/testdata/al2_no_mime_userdata_input.sh
+++ b/test/suites/integration/testdata/al2_no_mime_userdata_input.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Running custom user data script"

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -416,7 +416,7 @@ Your UserData -
 echo "Running custom user data script"
 ```
 
-or equialently in MIME format:
+or equivalently in MIME format:
 
 ```
 MIME-Version: 1.0

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -335,12 +335,6 @@ spec:
   securityGroupSelector:
     karpenter.sh/discovery: my-cluster
   userData: |
-    MIME-Version: 1.0
-    Content-Type: multipart/mixed; boundary="BOUNDARY"
-
-    --BOUNDARY
-    Content-Type: text/x-shellscript; charset="us-ascii"
-
     #!/bin/bash
     mkdir -p ~ec2-user/.ssh/
     touch ~ec2-user/.ssh/authorized_keys
@@ -349,7 +343,6 @@ spec:
     EOF
     chmod -R go-w ~ec2-user/.ssh/authorized_keys
     chown -R ec2-user ~ec2-user/.ssh
-    --BOUNDARY--
 ```
 
 For more examples on configuring these fields for different AMI families, see the [examples here](https://github.com/aws/karpenter/blob/main/examples/provisioner/launchtemplates).
@@ -410,13 +403,20 @@ cluster-name = 'cluster'
 
 #### AL2 and Ubuntu
 
-* Your UserData must be in the [MIME multi part archive](https://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-archive) format.
-* Karpenter will merge a final MIME part to the end of your UserData parts which will bootstrap the worker node. Karpenter will have full control over all the parameters being passed to the bootstrap script.
+* Your UserData can be in the [MIME multi part archive](https://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-archive) format.
+* Karpenter will transform your custom user-data as a MIME part, if necessary, and then merge a final MIME part to the end of your UserData parts which will bootstrap the worker node. Karpenter will have full control over all the parameters being passed to the bootstrap script.
   * Karpenter will continue to set MaxPods, ClusterDNS and all other parameters defined in `spec.kubeletConfiguration` as before.
 
 Consider the following example to understand how your custom UserData will be merged -
 
 Your UserData -
+
+```
+#!/bin/bash
+echo "Running custom user data script"
+```
+
+or equialently in MIME format:
 
 ```
 MIME-Version: 1.0
@@ -468,16 +468,8 @@ spec:
   securityGroupSelector:
     karpenter.sh/discovery: my-cluster
   userData: |
-    MIME-Version: 1.0
-    Content-Type: multipart/mixed; boundary="BOUNDARY"
-
-    --BOUNDARY
-    Content-Type: text/x-shellscript; charset="us-ascii"
-
     #!/bin/bash
     echo "$(jq '.kubeAPIQPS=50' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
-
-    --BOUNDARY--
 ```
 ## status.subnets
 `status.subnets` contains the `id` and `zone` of the subnets utilized during node launch. The subnets are sorted by the available IP address count in decreasing order.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Allow for a standard shell script to be passed in and default to a shellscript mime format. Multi-part mime input will still work but should be the exception (if using more advanced cloud-init features) rather than the normal. 

**How was this change tested?**

Applied the following user-data and observed  a proper multi-part mime conversion and launched with the kubelet-config mutated to use 150 QPS.
```
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate
 metadata:
   name: default
 spec:
   securityGroupSelector:
     karpenter.sh/discovery: wagnerbm-karpenter-dev-us-east-2
   subnetSelector:
     Name: test-ips
   userData: |
     #!/bin/bash
     echo "$(jq '.kubeAPIQPS=150' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
```

Launch template was correctly generated as shown below:

```
MIME-Version: 1.0
Content-Type: multipart/mixed; boundary="//"

--//
Content-Type: text/x-shellscript; charset="us-ascii"

#!/bin/bash
echo "$(jq '.kubeAPIQPS=150' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json

--//
Content-Type: text/x-shellscript; charset="us-ascii"

#!/bin/bash -xe
exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
/etc/eks/bootstrap.sh 'wagnerbm-karpenter-dev-us-east-2' --apiserver-endpoint 'https://<cid>.gr7.us-east-2.eks.amazonaws.com' --b64-cluster-ca '<ca>==' \
--container-runtime containerd \
--kubelet-extra-args '--node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=default'
--//--
```

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
