### PR TITLE
fix: clean -dirty release on stable release commit hash

### DIFF
--- a/hack/release/release.sh
+++ b/hack/release/release.sh
@@ -9,6 +9,9 @@ source "${SCRIPT_DIR}/common.sh"
 
 config
 release $HEAD_HASH #release a snapshot version
+## Reset changes if it's a snapshot since we don't need to track these changes
+## and results in a -dirty commit hash for a stable release
+git reset --hard
 
 if [[ $(releaseType $GIT_TAG) == $RELEASE_TYPE_STABLE ]]; then
   release $GIT_TAG


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

https://github.com/aws/karpenter/issues/3414

**Description**
 - The `-dirty` suffix on the commit hash of releases is because the snapshot changes are still present when building the stable release. 
 - Fix by Resetting all tracked files after the snapshot release process since it modifies the Chart.yaml and values.yaml of the charts it publishes. Snapshots do not PR chart changes back into the repo, so it is safe to reset all tracked files. 

**How was this change tested?**


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
