### PR TITLE
fix: e2etests for node templates

### DIFF
--- a/pkg/test/awsnodetemplate.go
+++ b/pkg/test/awsnodetemplate.go
@@ -17,9 +17,10 @@ package test
 import (
 	"fmt"
 
+	"github.com/imdario/mergo"
+
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
-	"github.com/imdario/mergo"
 )
 
 func AWSNodeTemplate(overrides ...v1alpha1.AWSNodeTemplateSpec) *v1alpha1.AWSNodeTemplate {

--- a/pkg/test/awsnodetemplate.go
+++ b/pkg/test/awsnodetemplate.go
@@ -15,18 +15,31 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
+
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/imdario/mergo"
 )
 
 func AWSNodeTemplate(overrides ...v1alpha1.AWSNodeTemplateSpec) *v1alpha1.AWSNodeTemplate {
+	options := v1alpha1.AWSNodeTemplateSpec{}
+	for _, override := range overrides {
+		if err := mergo.Merge(&options, override, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("Failed to merge settings: %s", err))
+		}
+	}
+
+	if options.AWS.SecurityGroupSelector == nil {
+		options.AWS.SecurityGroupSelector = map[string]string{"*": "*"}
+	}
+
+	if options.AWS.SubnetSelector == nil {
+		options.AWS.SubnetSelector = map[string]string{"*": "*"}
+	}
+
 	return &v1alpha1.AWSNodeTemplate{
 		ObjectMeta: test.ObjectMeta(),
-		Spec: test.MustMerge(v1alpha1.AWSNodeTemplateSpec{
-			AWS: v1alpha1.AWS{
-				SubnetSelector:        map[string]string{"*": "*"},
-				SecurityGroupSelector: map[string]string{"*": "*"},
-			},
-		}, overrides...),
+		Spec:       options,
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

* Test awsnodetemplates should only have one kay value pair  for  SecuirtyGroup and Subnets

**How was this change tested?**

* `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
