### PR TITLE
fix: security group selector wildcard key

### DIFF
--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -100,7 +100,7 @@ func matchTags(tags []*ec2.Tag, filter *ec2.Filter) bool {
 		tagKey := strings.Split(*filter.Name, ":")[1]
 		for _, val := range filter.Values {
 			for _, tag := range tags {
-				if (tagKey == "*" || tagKey == *tag.Key) && (*val == "*" || *val == *tag.Value) {
+				if tagKey == *tag.Key && (*val == "*" || *val == *tag.Value) {
 					return true
 				}
 			}

--- a/pkg/providers/securitygroup/securitygroup.go
+++ b/pkg/providers/securitygroup/securitygroup.go
@@ -81,6 +81,11 @@ func (p *Provider) getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Fil
 				Name:   aws.String("group-id"),
 				Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
 			})
+		} else if value == "*" {
+			filters = append(filters, &ec2.Filter{
+				Name:   aws.String("tag-key"),
+				Values: []*string{aws.String(key)},
+			})
 		} else {
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String(fmt.Sprintf("tag:%s", key)),


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Fixes a case on processing the security group selector to ec2 filter where a wildcard key was not transformed to a tag-key filter and instead was a full `tag:key -> value` filter which never returned security groups since wildcards are not supported within the Filter name, only Values.

**How was this change tested?**

* Fixed the ec2 mock for security groups to correctly evaluate wildcard filters. Ran the tests before the fix, observed failure, and after the fix, passed. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
