### PR TITLE
docs: Add Astradot to Adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -18,6 +18,7 @@ If you are open to others contacting you about your use of Karpenter on Slack, a
 | Amazon, Inc. | Scaling production workloads and batch jobs in all AWS regions | `@Alex Kestner`, `@Ellis Tarn` | [Introducing Karpenter](https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler/) |
 | Airtel Digital Ltd. | Karpenter for all kind of spiky and base workload and to increase spot coverage. | `@Sagar Arora` | [Homepage](https://www.wynk.in)
 | Anthropic | Better utilizing mixes of instance types for more reliable capacity | N/A | [Homepage](https://anthropic.com) |
+| Astradot | Using Karpenter on all K8s clusters in production and staging | N/A | [Homepage](https://astradot.com) |
 | Beeswax | Using Karpenter to scale our high load AdTech platform efficiently | `@James Wojewoda` | [Homepage](https://www.beeswax.com)
 | Codefresh | Juggling workloads for the SAAS CD/GitOps offering | `@Vadim Gusev` | [Codefresh](https://codefresh.io/) |
 | Cordial   | Using Karpenter to scale multiple EKS clusters quickly | `@dschaaff` | [Cordial](https://cordial.com) |


### PR DESCRIPTION
Astradot is using Karpenter to power our entire backend on K8s. Adding ourselves to the adopters list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
