### PR TITLE
Fix image signing args parsing in `make release`

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -94,8 +94,11 @@ buildDate(){
 }
 
 cosignImages() {
-    COSIGN_FLAGS="-a GIT_HASH=$(git rev-parse HEAD) -a GIT_VERSION=${RELEASE_VERSION} -a BUILD_DATE=$(buildDate)}"
-    COSIGN_EXPERIMENTAL=1 cosign sign "${COSIGN_FLAGS}" "${CONTROLLER_IMG}"
+    COSIGN_EXPERIMENTAL=1 cosign sign \
+        -a GIT_HASH="$(git rev-parse HEAD)" \
+        -a GIT_VERSION="${RELEASE_VERSION}" \
+        -a BUILD_DATE="$(buildDate)" \
+        "${CONTROLLER_IMG}"
 }
 
 notifyRelease() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Fix image signing args parsing in `make release`

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
