### PR TITLE
docs: fix pod density ref links

### DIFF
--- a/website/content/en/preview/concepts/pod-density.md
+++ b/website/content/en/preview/concepts/pod-density.md
@@ -30,13 +30,13 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 
 Static pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
 
-See [Provisioner API Kubelet Configuration](./provisioners/#max-pods) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#max-pods) for more details.
 
 #### Dynamic Pod Density
 
 Dynamic pod density (density that scales with the instance size) can be configured at the provisioner level by specifying `podsPerCore` within the `.spec.kubeletConfiguration`. Karpenter will calculate the expected pod density for each instance based on the instance's number of logical cores (vCPUs) and will account for this during scheduling.
 
-See [Provisioner API Kubelet Configuration](../../provisioner/#pods-per-core) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#pod-density) for more details.
 
 ### Controller-Wide Pod Density
 

--- a/website/content/en/v0.21.1/concepts/pod-density.md
+++ b/website/content/en/v0.21.1/concepts/pod-density.md
@@ -30,13 +30,13 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 
 Static pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
 
-See [Provisioner API Kubelet Configuration](./provisioners/#max-pods) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#max-pods) for more details.
 
 #### Dynamic Pod Density
 
 Dynamic pod density (density that scales with the instance size) can be configured at the provisioner level by specifying `podsPerCore` within the `.spec.kubeletConfiguration`. Karpenter will calculate the expected pod density for each instance based on the instance's number of logical cores (vCPUs) and will account for this during scheduling.
 
-See [Provisioner API Kubelet Configuration](../../provisioner/#pods-per-core) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#pod-density) for more details.
 
 ### Controller-Wide Pod Density
 

--- a/website/content/en/v0.22.1/concepts/pod-density.md
+++ b/website/content/en/v0.22.1/concepts/pod-density.md
@@ -30,13 +30,13 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 
 Static pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
 
-See [Provisioner API Kubelet Configuration](./provisioners/#max-pods) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#max-pods) for more details.
 
 #### Dynamic Pod Density
 
 Dynamic pod density (density that scales with the instance size) can be configured at the provisioner level by specifying `podsPerCore` within the `.spec.kubeletConfiguration`. Karpenter will calculate the expected pod density for each instance based on the instance's number of logical cores (vCPUs) and will account for this during scheduling.
 
-See [Provisioner API Kubelet Configuration](../../provisioner/#pods-per-core) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#pod-density) for more details.
 
 ### Controller-Wide Pod Density
 

--- a/website/content/en/v0.23.0/concepts/pod-density.md
+++ b/website/content/en/v0.23.0/concepts/pod-density.md
@@ -30,13 +30,13 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 
 Static pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
 
-See [Provisioner API Kubelet Configuration](./provisioners/#max-pods) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#max-pods) for more details.
 
 #### Dynamic Pod Density
 
 Dynamic pod density (density that scales with the instance size) can be configured at the provisioner level by specifying `podsPerCore` within the `.spec.kubeletConfiguration`. Karpenter will calculate the expected pod density for each instance based on the instance's number of logical cores (vCPUs) and will account for this during scheduling.
 
-See [Provisioner API Kubelet Configuration](../../provisioner/#pods-per-core) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#pod-density) for more details.
 
 ### Controller-Wide Pod Density
 

--- a/website/content/en/v0.24.0/concepts/pod-density.md
+++ b/website/content/en/v0.24.0/concepts/pod-density.md
@@ -30,13 +30,13 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 
 Static pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
 
-See [Provisioner API Kubelet Configuration](./provisioners/#max-pods) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#max-pods) for more details.
 
 #### Dynamic Pod Density
 
 Dynamic pod density (density that scales with the instance size) can be configured at the provisioner level by specifying `podsPerCore` within the `.spec.kubeletConfiguration`. Karpenter will calculate the expected pod density for each instance based on the instance's number of logical cores (vCPUs) and will account for this during scheduling.
 
-See [Provisioner API Kubelet Configuration](../../provisioner/#pods-per-core) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#pod-density) for more details.
 
 ### Controller-Wide Pod Density
 

--- a/website/content/en/v0.25.0/concepts/pod-density.md
+++ b/website/content/en/v0.25.0/concepts/pod-density.md
@@ -30,13 +30,13 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 
 Static pod density can be configured at the provisioner level by specifying `maxPods` within the `.spec.kubeletConfiguration`. All nodes spawned by this provisioner will set this `maxPods` value on their kubelet and will account for this value during scheduling.
 
-See [Provisioner API Kubelet Configuration](./provisioners/#max-pods) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#max-pods) for more details.
 
 #### Dynamic Pod Density
 
 Dynamic pod density (density that scales with the instance size) can be configured at the provisioner level by specifying `podsPerCore` within the `.spec.kubeletConfiguration`. Karpenter will calculate the expected pod density for each instance based on the instance's number of logical cores (vCPUs) and will account for this during scheduling.
 
-See [Provisioner API Kubelet Configuration](../../provisioner/#pods-per-core) for more details.
+See [Provisioner API Kubelet Configuration](../provisioners/#pod-density) for more details.
 
 ### Controller-Wide Pod Density
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->
https://github.com/aws/karpenter/issues/3461

**Description**
 - Fix docs ref links to provisioner kubelet configuration

**How was this change tested?**

* `make website`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
