### PR TITLE
fix: inflight IP tracking when CreateFleet returns an error

### DIFF
--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -143,12 +143,15 @@ func (p *Provider) UpdateInflightIPs(createFleetInput *ec2.CreateFleetInput, cre
 	})))
 
 	// Process the CreateFleetOutput to pull out all the fulfilled subnetIDs
-	fleetOutputSubnets := lo.Compact(lo.Uniq(lo.Map(createFleetOutput.Instances, func(fleetInstance *ec2.CreateFleetInstance, _ int) string {
-		if fleetInstance == nil || fleetInstance.LaunchTemplateAndOverrides == nil || fleetInstance.LaunchTemplateAndOverrides.Overrides == nil {
-			return ""
-		}
-		return lo.FromPtr(fleetInstance.LaunchTemplateAndOverrides.Overrides.SubnetId)
-	})))
+	var fleetOutputSubnets []string
+	if createFleetOutput != nil {
+		fleetOutputSubnets = lo.Compact(lo.Uniq(lo.Map(createFleetOutput.Instances, func(fleetInstance *ec2.CreateFleetInstance, _ int) string {
+			if fleetInstance == nil || fleetInstance.LaunchTemplateAndOverrides == nil || fleetInstance.LaunchTemplateAndOverrides.Overrides == nil {
+				return ""
+			}
+			return lo.FromPtr(fleetInstance.LaunchTemplateAndOverrides.Overrides.SubnetId)
+		})))
+	}
 
 	// Find the subnets that were included in the input but not chosen by Fleet, so we need to add the inflight IPs back to them
 	subnetIDsToAddBackIPs, _ := lo.Difference(fleetInputSubnets, fleetOutputSubnets)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3512

**Description**
 - Fixes a nil dereference while updating the inflight IPs when CreateFleetOutput is nil due to CreateFleet error

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
