### PR TITLE
docs: cleanup `aws.tags` and `specs.tags` docs

### DIFF
--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -247,7 +247,7 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the AWSNodeTemplate tags section which are merged with and can override the default tag values.
+Additional tags can be added in the AWSNodeTemplate tags section which are merged with global tags in `aws.tags` (located in karpenter-global-settings ConfigMap) and can override the default tag values.
 ```yaml
 spec:
   tags:

--- a/website/content/en/preview/concepts/settings.md
+++ b/website/content/en/preview/concepts/settings.md
@@ -67,7 +67,7 @@ data:
   # require additional permissions on the controller service account. Additional permissions are outlined in the docs
   aws.interruptionQueueName: karpenter-cluster
   # Global tags are specified by including a JSON object of string to string from tag key to tag value
-  aws.tags: '{"custom-tag1": "custom-tag-value", "custom-tag2": "custom-tag-value"}'
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
 ```
 
 ### Feature Gates
@@ -98,13 +98,19 @@ This value is expressed as a string value like `10s`, `1m` or `2h45m`. The valid
 
 ### AWS Parameters
 
-#### `aws.tags.<tag-key>`
+#### `aws.tags`
 
 Global tags are applied to __all__ AWS infrastructure resources deployed by Karpenter. These resources include:
 
 - Launch Templates
 - Volumes
 - Instances
+
+Tags are specified by including a JSON object of string to string from tag key to tag value.
+
+```yaml
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
+```
 
 {{% alert title="Note" color="primary" %}}
 Since you can specify tags at the global level and in the `AWSNodeTemplate` resource, if a key is specified in both locations, the `AWSNodeTemplate` tag value will override the global tag.

--- a/website/content/en/v0.24.0/concepts/node-templates.md
+++ b/website/content/en/v0.24.0/concepts/node-templates.md
@@ -241,7 +241,7 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the AWSNodeTemplate tags section which are merged with and can override the default tag values.
+Additional tags can be added in the AWSNodeTemplate tags section which are merged with global tags in `aws.tags` (located in karpenter-global-settings ConfigMap) and can override the default tag values.
 ```yaml
 spec:
   tags:

--- a/website/content/en/v0.24.0/concepts/settings.md
+++ b/website/content/en/v0.24.0/concepts/settings.md
@@ -67,7 +67,7 @@ data:
   # require additional permissions on the controller service account. Additional permissions are outlined in the docs
   aws.interruptionQueueName: karpenter-cluster
   # Global tags are specified by including a JSON object of string to string from tag key to tag value
-  aws.tags: '{"custom-tag1": "custom-tag-value", "custom-tag2": "custom-tag-value"}'
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
 ```
 
 ### Feature Gates
@@ -98,13 +98,19 @@ This value is expressed as a string value like `10s`, `1m` or `2h45m`. The valid
 
 ### AWS Parameters
 
-#### `aws.tags.<tag-key>`
+#### `aws.tags`
 
 Global tags are applied to __all__ AWS infrastructure resources deployed by Karpenter. These resources include:
 
 - Launch Templates
 - Volumes
 - Instances
+
+Tags are specified by including a JSON object of string to string from tag key to tag value.
+
+```yaml
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
+```
 
 {{% alert title="Note" color="primary" %}}
 Since you can specify tags at the global level and in the `AWSNodeTemplate` resource, if a key is specified in both locations, the `AWSNodeTemplate` tag value will override the global tag.

--- a/website/content/en/v0.25.0/concepts/node-templates.md
+++ b/website/content/en/v0.25.0/concepts/node-templates.md
@@ -241,7 +241,7 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the AWSNodeTemplate tags section which are merged with and can override the default tag values.
+Additional tags can be added in the AWSNodeTemplate tags section which are merged with global tags in `aws.tags` (located in karpenter-global-settings ConfigMap) and can override the default tag values.
 ```yaml
 spec:
   tags:

--- a/website/content/en/v0.25.0/concepts/settings.md
+++ b/website/content/en/v0.25.0/concepts/settings.md
@@ -67,7 +67,7 @@ data:
   # require additional permissions on the controller service account. Additional permissions are outlined in the docs
   aws.interruptionQueueName: karpenter-cluster
   # Global tags are specified by including a JSON object of string to string from tag key to tag value
-  aws.tags: '{"custom-tag1": "custom-tag-value", "custom-tag2": "custom-tag-value"}'
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
 ```
 
 ### Feature Gates
@@ -98,13 +98,19 @@ This value is expressed as a string value like `10s`, `1m` or `2h45m`. The valid
 
 ### AWS Parameters
 
-#### `aws.tags.<tag-key>`
+#### `aws.tags`
 
 Global tags are applied to __all__ AWS infrastructure resources deployed by Karpenter. These resources include:
 
 - Launch Templates
 - Volumes
 - Instances
+
+Tags are specified by including a JSON object of string to string from tag key to tag value.
+
+```yaml
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
+```
 
 {{% alert title="Note" color="primary" %}}
 Since you can specify tags at the global level and in the `AWSNodeTemplate` resource, if a key is specified in both locations, the `AWSNodeTemplate` tag value will override the global tag.

--- a/website/content/en/v0.26.1/concepts/node-templates.md
+++ b/website/content/en/v0.26.1/concepts/node-templates.md
@@ -247,7 +247,7 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the AWSNodeTemplate tags section which are merged with and can override the default tag values.
+Additional tags can be added in the AWSNodeTemplate tags section which are merged with global tags in `aws.tags` (located in karpenter-global-settings ConfigMap) and can override the default tag values.
 ```yaml
 spec:
   tags:

--- a/website/content/en/v0.26.1/concepts/settings.md
+++ b/website/content/en/v0.26.1/concepts/settings.md
@@ -67,7 +67,7 @@ data:
   # require additional permissions on the controller service account. Additional permissions are outlined in the docs
   aws.interruptionQueueName: karpenter-cluster
   # Global tags are specified by including a JSON object of string to string from tag key to tag value
-  aws.tags: '{"custom-tag1": "custom-tag-value", "custom-tag2": "custom-tag-value"}'
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
 ```
 
 ### Feature Gates
@@ -98,13 +98,19 @@ This value is expressed as a string value like `10s`, `1m` or `2h45m`. The valid
 
 ### AWS Parameters
 
-#### `aws.tags.<tag-key>`
+#### `aws.tags`
 
 Global tags are applied to __all__ AWS infrastructure resources deployed by Karpenter. These resources include:
 
 - Launch Templates
 - Volumes
 - Instances
+
+Tags are specified by including a JSON object of string to string from tag key to tag value.
+
+```yaml
+  aws.tags: '{"custom-tag1-key": "custom-tag-value", "custom-tag2-key": "custom-tag-value"}'
+```
 
 {{% alert title="Note" color="primary" %}}
 Since you can specify tags at the global level and in the `AWSNodeTemplate` resource, if a key is specified in both locations, the `AWSNodeTemplate` tag value will override the global tag.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

**Description**
Update docs for `aws.tags` (global tags).

New version of #3530. Applied changes retrospectively to previous versions' docs.

**How was this change tested?**

* n/a

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
