### PR TITLE
fix: Fix Bottlerocket Image GC conversion

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -17,7 +17,9 @@ package bootstrap
 import (
 	"encoding/base64"
 	"fmt"
+	"strconv"
 
+	"github.com/samber/lo"
 	"knative.dev/pkg/ptr"
 
 	"github.com/aws/karpenter-core/pkg/utils/resources"
@@ -29,6 +31,7 @@ type Bottlerocket struct {
 	Options
 }
 
+// nolint:gocyclo
 func (b Bottlerocket) Script() (string, error) {
 	s, err := NewBottlerocketConfig(b.CustomUserData)
 	if err != nil {
@@ -55,8 +58,13 @@ func (b Bottlerocket) Script() (string, error) {
 		s.Settings.Kubernetes.SystemReserved = resources.StringMap(b.KubeletConfig.SystemReserved)
 		s.Settings.Kubernetes.KubeReserved = resources.StringMap(b.KubeletConfig.KubeReserved)
 		s.Settings.Kubernetes.EvictionHard = b.KubeletConfig.EvictionHard
-		s.Settings.Kubernetes.ImageGCLowThresholdPercent = b.KubeletConfig.ImageGCLowThresholdPercent
-		s.Settings.Kubernetes.ImageGCHighThresholdPercent = b.KubeletConfig.ImageGCHighThresholdPercent
+		if b.KubeletConfig.ImageGCHighThresholdPercent != nil {
+			s.Settings.Kubernetes.ImageGCHighThresholdPercent = lo.ToPtr(strconv.FormatInt(int64(*b.KubeletConfig.ImageGCHighThresholdPercent), 10))
+		}
+		if b.KubeletConfig.ImageGCLowThresholdPercent != nil {
+			s.Settings.Kubernetes.ImageGCLowThresholdPercent = lo.ToPtr(strconv.FormatInt(int64(*b.KubeletConfig.ImageGCLowThresholdPercent), 10))
+		}
+
 	}
 
 	s.Settings.Kubernetes.NodeTaints = map[string][]string{}

--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -67,8 +67,8 @@ type BottlerocketKubernetes struct {
 	CPUManagerPolicy            *string                          `toml:"cpu-manager-policy,omitempty"`
 	CPUManagerReconcilePeriod   *string                          `toml:"cpu-manager-reconcile-period,omitempty"`
 	TopologyManagerScope        *string                          `toml:"topology-manager-scope,omitempty"`
-	ImageGCLowThresholdPercent  *int32                           `toml:"image-gc-high-threshold-percent,omitempty"`
-	ImageGCHighThresholdPercent *int32                           `toml:"image-gc-low-threshold-percent,omitempty"`
+	ImageGCHighThresholdPercent *string                          `toml:"image-gc-high-threshold-percent,omitempty"`
+	ImageGCLowThresholdPercent  *string                          `toml:"image-gc-low-threshold-percent,omitempty"`
 }
 
 type BottlerocketStaticPod struct {

--- a/test/suites/integration/kubelet_config_test.go
+++ b/test/suites/integration/kubelet_config_test.go
@@ -96,6 +96,65 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 		env.EventuallyExpectHealthy(pod)
 		env.ExpectCreatedNodeCount("==", 1)
 	})
+	It("should startup successfully with all kubelet configuration set (Bottlerocket)", func() {
+		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+			AMIFamily:             &v1alpha1.AMIFamilyBottlerocket,
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+		}})
+
+		// MaxPods needs to account for the daemonsets that will run on the nodes
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef: &v1alpha5.ProviderRef{Name: provider.Name},
+			Kubelet: &v1alpha5.KubeletConfiguration{
+				ContainerRuntime: ptr.String("containerd"),
+				MaxPods:          ptr.Int32(110),
+				PodsPerCore:      ptr.Int32(10),
+				SystemReserved: v1.ResourceList{
+					v1.ResourceCPU:              resource.MustParse("200m"),
+					v1.ResourceMemory:           resource.MustParse("200Mi"),
+					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+				},
+				KubeReserved: v1.ResourceList{
+					v1.ResourceCPU:              resource.MustParse("200m"),
+					v1.ResourceMemory:           resource.MustParse("200Mi"),
+					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+				},
+				EvictionHard: map[string]string{
+					"memory.available":   "5%",
+					"nodefs.available":   "5%",
+					"nodefs.inodesFree":  "5%",
+					"imagefs.available":  "5%",
+					"imagefs.inodesFree": "5%",
+					"pid.available":      "3%",
+				},
+				EvictionSoft: map[string]string{
+					"memory.available":   "10%",
+					"nodefs.available":   "10%",
+					"nodefs.inodesFree":  "10%",
+					"imagefs.available":  "10%",
+					"imagefs.inodesFree": "10%",
+					"pid.available":      "6%",
+				},
+				EvictionSoftGracePeriod: map[string]metav1.Duration{
+					"memory.available":   {Duration: time.Minute * 2},
+					"nodefs.available":   {Duration: time.Minute * 2},
+					"nodefs.inodesFree":  {Duration: time.Minute * 2},
+					"imagefs.available":  {Duration: time.Minute * 2},
+					"imagefs.inodesFree": {Duration: time.Minute * 2},
+					"pid.available":      {Duration: time.Minute * 2},
+				},
+				EvictionMaxPodGracePeriod:   ptr.Int32(120),
+				ImageGCHighThresholdPercent: ptr.Int32(50),
+				ImageGCLowThresholdPercent:  ptr.Int32(10),
+			},
+		})
+
+		pod := test.Pod()
+		env.ExpectCreated(provisioner, provider, pod)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+	})
 	It("should schedule pods onto separate nodes when maxPods is set", func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3563 

**Description**

Conversion to Bottlerocket settings and userData from `kubeletConfiguration` for `imageGCHighThresholdPercent` and `imageGCLowThresholdPercent` was broken prior to this change.

If you specified either in your `kubeletConfiguration`, a Bottlerocket instance would fail to connect to the cluster due to kubelet not starting

Relates to https://github.com/bottlerocket-os/bottlerocket/issues/2883

**How was this change tested?**

* Manual deployment of Bottlerocket instance
* `make presubmit`
* `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
