### PR TITLE
test: fix expiration test flake

### DIFF
--- a/test/suites/integration/expiration_test.go
+++ b/test/suites/integration/expiration_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Expiration", func() {
 		// Eventually expect the node to be gone and a new one to come up
 		env.EventuallyExpectNotFound(node)
 		env.EventuallyExpectCreatedNodeCount("==", 1)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(dep.Spec.Selector.MatchLabels), 1)
 	})
 	It("should replace expired node with a single node and schedule all pods", func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 - Fix test flake where the replacement node from the previous expiration test is not bootstrapped yet, so when we delete the node object for the cleanup stage of the test, it re-registers via eks bootstrap on node startup and hangs around for the next test where we fail the expectation of 1 node exists at the end.  
 - Fix by waiting for the pod to go healthy on the replacement node in the first test.
 - 
**How was this change tested?**

* `FOCUS=Expiration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
