### PR TITLE
docs: Enrich examples on how to handle AWSNodeTemplates and Provisioners inside the chart

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -101,11 +101,26 @@ extraObjects: []
 #  kind: AWSNodeTemplate
 #  metadata:
 #    name: default
+#    annotations:
+#      "helm.sh/hook": "post-install, post-upgrade"
+#      "helm.sh/hook-weight": "1"
+#      "helm.sh/hook-delete-policy": before-hook-creation
 #  spec:
 #    subnetSelector:
 #      karpenter.sh/discovery: {CLUSTER_NAME}
 #    securityGroupSelector:
 #      karpenter.sh/discovery: {CLUSTER_NAME}
+#- apiVersion: karpenter.sh/v1alpha5
+#  kind: Provisioner
+#  metadata:
+#    name: default
+#    annotations:
+#      "helm.sh/hook": "post-install, post-upgrade"
+#      "helm.sh/hook-weight": "5"
+#      "helm.sh/hook-delete-policy": before-hook-creation
+#  spec:
+#    providerRef:
+#      name: default
 
 controller:
   image:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -114,7 +114,7 @@ extraObjects: []
 #  metadata:
 #    name: default
 #    annotations:
-#      "helm.sh/hook": "post-install, post-upgrade"
+#      "helm.sh/hook": "post-install,post-upgrade"
 #      "helm.sh/hook-delete-policy": before-hook-creation
 #  spec:
 #    providerRef:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -103,7 +103,6 @@ extraObjects: []
 #    name: default
 #    annotations:
 #      "helm.sh/hook": "post-install, post-upgrade"
-#      "helm.sh/hook-weight": "1"
 #      "helm.sh/hook-delete-policy": before-hook-creation
 #  spec:
 #    subnetSelector:
@@ -116,7 +115,6 @@ extraObjects: []
 #    name: default
 #    annotations:
 #      "helm.sh/hook": "post-install, post-upgrade"
-#      "helm.sh/hook-weight": "5"
 #      "helm.sh/hook-delete-policy": before-hook-creation
 #  spec:
 #    providerRef:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -102,7 +102,7 @@ extraObjects: []
 #  metadata:
 #    name: default
 #    annotations:
-#      "helm.sh/hook": "post-install, post-upgrade"
+#      "helm.sh/hook": "post-install,post-upgrade"
 #      "helm.sh/hook-delete-policy": before-hook-creation
 #  spec:
 #    subnetSelector:

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -139,7 +139,6 @@ If you see this issue happens while using the`extraObjects` key from the values 
     name: default
     annotations:
       "helm.sh/hook": "post-install, post-upgrade"
-      "helm.sh/hook-weight": "5"
       "helm.sh/hook-delete-policy": before-hook-creation
 ```
 

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -128,6 +128,21 @@ Your security groups are not blocking you from reaching your webhook.
 This is especially relevant if you have used `terraform-eks-module` version `>=18` since that version changed its security
 approach, and now it's much more restrictive.
 
+If you see this issue happens while using the`extraObjects` key from the values file, ensure that:
+ * The helm install/upgrade command has the `--wait` flag (or `wait: true` when using helmfile)
+ * Your Provisioners and AWSNodeTemplates definitions have the proper [helm hooks annotations](https://helm.sh/docs/topics/charts_hooks/) to install them *after* the karpenter pods are running
+
+```yaml
+- apiVersion: karpenter.sh/v1alpha5
+  kind: Provisioner
+  metadata:
+    name: default
+    annotations:
+      "helm.sh/hook": "post-install, post-upgrade"
+      "helm.sh/hook-weight": "5"
+      "helm.sh/hook-delete-policy": before-hook-creation
+```
+
 ## Provisioning
 
 ### DaemonSets can result in deployment failures

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -138,7 +138,7 @@ If you see this issue happens while using the`extraObjects` key from the values 
   metadata:
     name: default
     annotations:
-      "helm.sh/hook": "post-install, post-upgrade"
+      "helm.sh/hook": "post-install,post-upgrade"
       "helm.sh/hook-delete-policy": before-hook-creation
 ```
 

--- a/website/content/en/v0.27.0/troubleshooting.md
+++ b/website/content/en/v0.27.0/troubleshooting.md
@@ -128,6 +128,22 @@ Your security groups are not blocking you from reaching your webhook.
 This is especially relevant if you have used `terraform-eks-module` version `>=18` since that version changed its security
 approach, and now it's much more restrictive.
 
+If this issue happens when installing karpenter for the first time and the provisionners are defined using the `extraObjects` key from the values file, ensure that :
+ * The helm install/upgrade command has the `--wait` flag (or `wait: true` when using helmfile)
+ * Your Provisioners and AWSNodeTemplates definitions have the proper [helm hooks annotations](https://helm.sh/docs/topics/charts_hooks/) to install them *after* the karpenter pods are running
+
+```yaml
+- apiVersion: karpenter.sh/v1alpha5
+  kind: Provisioner
+  metadata:
+    name: default
+    annotations:
+      "helm.sh/hook": "post-install, post-upgrade"
+      "helm.sh/hook-weight": "5"
+      "helm.sh/hook-delete-policy": before-hook-creation
+```
+
+
 ## Provisioning
 
 ### DaemonSets can result in deployment failures

--- a/website/content/en/v0.27.0/troubleshooting.md
+++ b/website/content/en/v0.27.0/troubleshooting.md
@@ -128,7 +128,7 @@ Your security groups are not blocking you from reaching your webhook.
 This is especially relevant if you have used `terraform-eks-module` version `>=18` since that version changed its security
 approach, and now it's much more restrictive.
 
-If this issue happens when installing karpenter for the first time and the provisionners are defined using the `extraObjects` key from the values file, ensure that :
+If you see this issue happens while using the`extraObjects` key from the values file, ensure that:
  * The helm install/upgrade command has the `--wait` flag (or `wait: true` when using helmfile)
  * Your Provisioners and AWSNodeTemplates definitions have the proper [helm hooks annotations](https://helm.sh/docs/topics/charts_hooks/) to install them *after* the karpenter pods are running
 

--- a/website/content/en/v0.27.0/troubleshooting.md
+++ b/website/content/en/v0.27.0/troubleshooting.md
@@ -128,22 +128,6 @@ Your security groups are not blocking you from reaching your webhook.
 This is especially relevant if you have used `terraform-eks-module` version `>=18` since that version changed its security
 approach, and now it's much more restrictive.
 
-If you see this issue happens while using the`extraObjects` key from the values file, ensure that:
- * The helm install/upgrade command has the `--wait` flag (or `wait: true` when using helmfile)
- * Your Provisioners and AWSNodeTemplates definitions have the proper [helm hooks annotations](https://helm.sh/docs/topics/charts_hooks/) to install them *after* the karpenter pods are running
-
-```yaml
-- apiVersion: karpenter.sh/v1alpha5
-  kind: Provisioner
-  metadata:
-    name: default
-    annotations:
-      "helm.sh/hook": "post-install, post-upgrade"
-      "helm.sh/hook-weight": "5"
-      "helm.sh/hook-delete-policy": before-hook-creation
-```
-
-
 ## Provisioning
 
 ### DaemonSets can result in deployment failures


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Managing the Provisioners and AWSNodeTemplate as extraObjects generate a race condition since the karpenter pods are not ready to handle calls.

`Error: Internal error occurred: failed calling webhook "defaulting.webhook.karpenter.k8s.aws": failed to call webhook: Post "[https://karpenter.karpenter.svc:443/?timeout=10s](https://karpenter.karpenter.svc/?timeout=10s)": no endpoints available for service "karpenter"`

Adding the helm hooks annotation has fixed this issue on 100% of the tests.
Not sure if you want to document this behavior elsewhere.

**How was this change tested?**

* Deployed on 2 production clusters

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
