### PR TITLE
feat: adds new karpenter_cloudprovider_instance_price_estimate prometheus metric

### DIFF
--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -268,6 +268,7 @@ func getIdentMapping(identName string) (string, error) {
 		"deprovisioningSubsystem": "deprovisioning",
 		"consistencySubsystem":    "consistency",
 		"batcherSubsystem":        "cloudprovider_batcher",
+		"cloudProviderSubsystem":  "cloudprovider",
 	}
 	if v, ok := identMapping[identName]; ok {
 		return v, nil

--- a/pkg/providers/pricing/metrics.go
+++ b/pkg/providers/pricing/metrics.go
@@ -1,0 +1,50 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pricing
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/aws/karpenter-core/pkg/metrics"
+)
+
+const (
+	cloudProviderSubsystem = "cloudprovider"
+)
+
+var (
+	InstanceTypeLabel     = "instance_type"
+	CapacityTypeLabel     = "capacity_type"
+	RegionLabel           = "region"
+	TopologyLabel         = "zone"
+	InstancePriceEstimate = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: cloudProviderSubsystem,
+			Name:      "instance_price_estimate",
+			Help:      "Estimated hourly price used when making informed decisions on node cost calculation. This is updated once on startup and then every 12 hours.",
+		},
+		[]string{
+			InstanceTypeLabel,
+			CapacityTypeLabel,
+			RegionLabel,
+			TopologyLabel,
+		})
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(InstancePriceEstimate)
+}

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/pricing"
 	"github.com/aws/aws-sdk-go/service/pricing/pricingiface"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	"knative.dev/pkg/logging"
@@ -209,6 +210,14 @@ func (p *Provider) UpdateOnDemandPricing(ctx context.Context) error {
 
 	p.onDemandPrices = lo.Assign(onDemandPrices, onDemandMetalPrices)
 	p.onDemandUpdateTime = time.Now()
+	for instanceType, price := range p.onDemandPrices {
+		InstancePriceEstimate.With(prometheus.Labels{
+			InstanceTypeLabel: instanceType,
+			CapacityTypeLabel: ec2.UsageClassTypeOnDemand,
+			RegionLabel:       p.region,
+			TopologyLabel:     "",
+		}).Set(price)
+	}
 	if p.cm.HasChanged("on-demand-prices", p.onDemandPrices) {
 		logging.FromContext(ctx).With("instance-type-count", len(p.onDemandPrices)).Infof("updated on-demand pricing")
 	}
@@ -338,6 +347,12 @@ func (p *Provider) UpdateSpotPricing(ctx context.Context) error {
 				prices[instanceType] = map[string]float64{}
 			}
 			prices[instanceType][az] = spotPrice
+			InstancePriceEstimate.With(prometheus.Labels{
+				InstanceTypeLabel: instanceType,
+				CapacityTypeLabel: ec2.UsageClassTypeSpot,
+				RegionLabel:       p.region,
+				TopologyLabel:     az,
+			}).Set(spotPrice)
 		}
 		return true
 	})

--- a/website/content/en/preview/concepts/metrics.md
+++ b/website/content/en/preview/concepts/metrics.md
@@ -94,6 +94,9 @@ Pod state is the current state of pods. This metric can be used several ways as 
 ### `karpenter_cloudprovider_duration_seconds`
 Duration of cloud provider method calls. Labeled by the controller, method name and provider.
 
+### `karpenter_cloudprovider_instance_price_estimate`
+Estimated hourly price used when making informed decisions on node cost calculation. This is updated once on startup and then every 12 hours.
+
 ## Cloudprovider Batcher Metrics
 
 ### `karpenter_cloudprovider_batcher_batch_size`


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3614

**Description**

Adds a new metric `karpenter_cloudprovider_instance_price_estimate` that reflects the currently known on-demand and spot prices for a given instance type in a given region and availability zone.

This metric is intended to be used when trying to calculate cost of an EC2 node.

Future improvements would be to add a `vcpu` and `memory` label to this metric which would reflect the CPU and memory of the given node to make it easier to calculate a CPU cost and memory cost per Pod.

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
