### PR TITLE
docs: root volume is incorrect size in bottlerocket example manifest

### DIFF
--- a/examples/provisioner/bottlerocket.yaml
+++ b/examples/provisioner/bottlerocket.yaml
@@ -23,7 +23,7 @@ spec:
     - deviceName: /dev/xvda
       ebs:
         volumeType: gp3
-        volumeSize: 4Gi
+        volumeSize: 2Gi
         deleteOnTermination: true
     - deviceName: /dev/xvdb
       ebs:


### PR DESCRIPTION
See https://github.com/bottlerocket-os/bottlerocket/issues/2915 for why this is needed

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->


**Description**

In bottlerocket 1.13 it is important the root volume size is not modified from the default 2gb size. See https://github.com/bottlerocket-os/bottlerocket/issues/2915

**Release Note**

```release-note
Updated example bottlerocket node template to use 2gb root volume. See https://github.com/bottlerocket-os/bottlerocket/issues/2915
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
