### PR TITLE
docs: updated cluster name case to capital case

### DIFF
--- a/website/content/en/v0.27.0/getting-started/migrating-from-cas/scripts/step04-instance-profile.sh
+++ b/website/content/en/v0.27.0/getting-started/migrating-from-cas/scripts/step04-instance-profile.sh
@@ -1,6 +1,6 @@
 aws iam create-instance-profile \
-    --instance-profile-name "KarpenterNodeInstanceProfile-${ClusterName}"
+    --instance-profile-name "KarpenterNodeInstanceProfile-${CLUSTER_NAME}"
 
 aws iam add-role-to-instance-profile \
-    --instance-profile-name "KarpenterNodeInstanceProfile-${ClusterName}" \
+    --instance-profile-name "KarpenterNodeInstanceProfile-${CLUSTER_NAME}" \
     --role-name "KarpenterNodeRole-${CLUSTER_NAME}"

--- a/website/content/en/v0.27.0/getting-started/migrating-from-cas/scripts/step09-generate-chart.sh
+++ b/website/content/en/v0.27.0/getting-started/migrating-from-cas/scripts/step09-generate-chart.sh
@@ -1,5 +1,5 @@
 helm template karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter \
-    --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${ClusterName} \
+    --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
     --set settings.aws.clusterName=${CLUSTER_NAME} \
     --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterControllerRole-${CLUSTER_NAME}" \
     --set controller.resources.requests.cpu=1 \


### PR DESCRIPTION
See this document with the clustername used as snake case in few places instead of capital case

Impact on code - None
Update in - Website/scripts in document

Release Note

> Website/scripts in document where the cluster name is in snake case instead of capital case which causes failed commands while running them from doc