### PR TITLE
feat: add in finalizer removal for terminated instances

### DIFF
--- a/pkg/controllers/interruption/messages/noop/model.go
+++ b/pkg/controllers/interruption/messages/noop/model.go
@@ -27,5 +27,5 @@ func (Message) EC2InstanceIDs() []string {
 }
 
 func (Message) Kind() messages.Kind {
-	return messages.NoOpKind
+	return messages.Kind{Type: messages.NoOpKind}
 }

--- a/pkg/controllers/interruption/messages/rebalancerecommendation/model.go
+++ b/pkg/controllers/interruption/messages/rebalancerecommendation/model.go
@@ -35,5 +35,5 @@ func (m Message) EC2InstanceIDs() []string {
 }
 
 func (Message) Kind() messages.Kind {
-	return messages.RebalanceRecommendationKind
+	return messages.Kind{Type: messages.RebalanceRecommendationKind}
 }

--- a/pkg/controllers/interruption/messages/scheduledchange/model.go
+++ b/pkg/controllers/interruption/messages/scheduledchange/model.go
@@ -35,7 +35,7 @@ func (m Message) EC2InstanceIDs() []string {
 }
 
 func (Message) Kind() messages.Kind {
-	return messages.ScheduledChangeKind
+	return messages.Kind{Type: messages.ScheduledChangeKind}
 }
 
 type Detail struct {

--- a/pkg/controllers/interruption/messages/spotinterruption/model.go
+++ b/pkg/controllers/interruption/messages/spotinterruption/model.go
@@ -36,5 +36,5 @@ func (m Message) EC2InstanceIDs() []string {
 }
 
 func (Message) Kind() messages.Kind {
-	return messages.SpotInterruptionKind
+	return messages.Kind{Type: messages.SpotInterruptionKind}
 }

--- a/pkg/controllers/interruption/messages/statechange/model.go
+++ b/pkg/controllers/interruption/messages/statechange/model.go
@@ -35,6 +35,6 @@ func (m Message) EC2InstanceIDs() []string {
 	return []string{m.Detail.InstanceID}
 }
 
-func (Message) Kind() messages.Kind {
-	return messages.StateChangeKind
+func (m Message) Kind() messages.Kind {
+	return messages.Kind{Type: messages.StateChangeKind, ExtraDetail: m.Detail.State}
 }

--- a/pkg/controllers/interruption/messages/statechange/parser.go
+++ b/pkg/controllers/interruption/messages/statechange/parser.go
@@ -24,14 +24,16 @@ import (
 	"github.com/aws/karpenter/pkg/controllers/interruption/messages"
 )
 
-var acceptedStates = sets.NewString("stopping", "stopped", "shutting-down", "terminated")
+var TerminatedState = "terminated"
+
+var acceptedStates = sets.NewString("stopping", "stopped", "shutting-down", TerminatedState)
 
 type Parser struct{}
 
 func (p Parser) Parse(raw string) (messages.Message, error) {
 	msg := Message{}
 	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
-		return nil, fmt.Errorf("unmarhsalling the message as EC2InstanceStateChangeNotification, %w", err)
+		return nil, fmt.Errorf("unmarshalling the message as EC2InstanceStateChangeNotification, %w", err)
 	}
 
 	// We ignore states that are not in the set of states we can react to

--- a/pkg/controllers/interruption/messages/types.go
+++ b/pkg/controllers/interruption/messages/types.go
@@ -32,14 +32,19 @@ type Message interface {
 	StartTime() time.Time
 }
 
-type Kind string
+type Type string
+
+type Kind struct {
+	Type        Type
+	ExtraDetail string
+}
 
 const (
-	RebalanceRecommendationKind Kind = "RebalanceRecommendationKind"
-	ScheduledChangeKind         Kind = "ScheduledChangeKind"
-	SpotInterruptionKind        Kind = "SpotInterruptionKind"
-	StateChangeKind             Kind = "StateChangeKind"
-	NoOpKind                    Kind = "NoOpKind"
+	RebalanceRecommendationKind Type = "RebalanceRecommendationKind"
+	ScheduledChangeKind         Type = "ScheduledChangeKind"
+	SpotInterruptionKind        Type = "SpotInterruptionKind"
+	StateChangeKind             Type = "StateChangeKind"
+	NoOpKind                    Type = "NoOpKind"
 )
 
 type Metadata struct {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3562 

**Description**
This adds in a check to remove the finalizer and terminate the node with Interruption when the state changes to Terminated.

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
