### PR TITLE
chore: Reduce garbage collection eventual consistency timeout

### DIFF
--- a/pkg/controllers/machine/garbagecollect/suite_test.go
+++ b/pkg/controllers/machine/garbagecollect/suite_test.go
@@ -132,7 +132,7 @@ var _ = Describe("MachineGarbageCollect", func() {
 
 	It("should delete an instance if there is no machine owner", func() {
 		// Launch time was 10m ago
-		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute))
 		awsEnv.EC2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
 
 		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
@@ -142,7 +142,7 @@ var _ = Describe("MachineGarbageCollect", func() {
 	})
 	It("should delete an instance along with the node if there is no machine owner (to quicken scheduling)", func() {
 		// Launch time was 10m ago
-		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute))
 		awsEnv.EC2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
 
 		node := coretest.Node(coretest.NodeOptions{
@@ -186,8 +186,8 @@ var _ = Describe("MachineGarbageCollect", func() {
 					Placement: &ec2.Placement{
 						AvailabilityZone: aws.String("test-zone-1a"),
 					},
-					// Launch time was 10m ago
-					LaunchTime:   aws.Time(time.Now().Add(-time.Minute * 10)),
+					// Launch time was 1m ago
+					LaunchTime:   aws.Time(time.Now().Add(-time.Minute)),
 					InstanceId:   aws.String(instanceID),
 					InstanceType: aws.String("m5.large"),
 				},
@@ -241,7 +241,7 @@ var _ = Describe("MachineGarbageCollect", func() {
 						AvailabilityZone: aws.String("test-zone-1a"),
 					},
 					// Launch time was 10m ago
-					LaunchTime:   aws.Time(time.Now().Add(-time.Minute * 10)),
+					LaunchTime:   aws.Time(time.Now().Add(-time.Minute)),
 					InstanceId:   aws.String(instanceID),
 					InstanceType: aws.String("m5.large"),
 				},
@@ -290,7 +290,7 @@ var _ = Describe("MachineGarbageCollect", func() {
 		})
 
 		// Launch time was 10m ago
-		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute))
 		awsEnv.EC2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
 
 		ExpectReconcileSucceeded(ctx, garbageCollectController, client.ObjectKey{})
@@ -299,7 +299,7 @@ var _ = Describe("MachineGarbageCollect", func() {
 	})
 	It("should not delete the instance or node if it already has a machine that matches it", func() {
 		// Launch time was 10m ago
-		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute))
 		awsEnv.EC2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
 
 		machine := coretest.Machine(v1alpha5.Machine{
@@ -319,7 +319,7 @@ var _ = Describe("MachineGarbageCollect", func() {
 	})
 	It("should not delete an instance if it is linked", func() {
 		// Launch time was 10m ago
-		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute))
 		awsEnv.EC2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
 
 		// Create a machine that is actively linking
@@ -338,7 +338,7 @@ var _ = Describe("MachineGarbageCollect", func() {
 	})
 	It("should not delete an instance if it is recently linked but the machine doesn't exist", func() {
 		// Launch time was 10m ago
-		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute * 10))
+		instance.LaunchTime = aws.Time(time.Now().Add(-time.Minute))
 		awsEnv.EC2API.Instances.Store(aws.StringValue(instance.InstanceId), instance)
 
 		// Add a provider id to the recently linked cache

--- a/pkg/controllers/machine/link/controller.go
+++ b/pkg/controllers/machine/link/controller.go
@@ -59,7 +59,7 @@ func NewController(kubeClient client.Client, cloudProvider *cloudprovider.CloudP
 }
 
 func (c *Controller) Name() string {
-	return "machine.link"
+	return "machine_link"
 }
 
 func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Reduce garbage collection eventual consistency timeout. This is meant to make the controllers quicker to react to overlaunching that might occur during the time that we are performing an upgrade or when we the Karpenter controllers crash. When this is the case, the garbage collection mechanism should ensure that it cleans up the Machines that it creates relatively quickly while the new capacity is launched.

**How was this change tested?**

* `make presubmit`
* Manual testing

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
