### PR TITLE
docs: update supported versions from FAQ

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with Kubernetes v1.20-v1.24.
+Karpenter is tested with Kubernetes v1.21-v1.25. Support for Kubernetes v1.20 was dropped in Karpenter v0.22.0+ as described in the [Upgrade Guide]({{< ref "./upgrade-guide/" >}}).
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh install of the latest AWS Elastic Kubernetes Service (EKS).


### PR DESCRIPTION
Update the supported kubernetes versions from FAQ notes

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
FAQ notes still mention the supported kubernetes versions are 1.20-1.24, while upgrade notes mention 1.20 support was dropped from 0.22.

**How was this change tested?**

* n/a

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
