### PR TITLE
test: Fix pre-upgrade release tag pinning

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -18,6 +18,17 @@ config(){
   RELEASE_TYPE_SNAPSHOT="snapshot"
 }
 
+# versionData sets all the version properties for the passed release version. It sets the values
+# RELEASE_VERSION_MAJOR, RELEASE_VERSION_MINOR, and RELEASE_VERSION_PATCH to be used by other scripts
+versionData(){
+  local VERSION="$1"
+  local VERSION="${VERSION#[vV]}"
+  RELEASE_VERSION_MAJOR="${VERSION%%\.*}"
+  RELEASE_VERSION_MINOR="${VERSION#*.}"
+  RELEASE_VERSION_MINOR="${RELEASE_VERSION_MINOR%.*}"
+  RELEASE_VERSION_PATCH="${VERSION##*.}"
+}
+
 release() {
   RELEASE_VERSION=$1
   echo "Release Type: $(releaseType "${RELEASE_VERSION}")
@@ -137,19 +148,6 @@ publishHelmChart() {
     helm push "${HELM_CHART_FILE_NAME}" "oci://${RELEASE_REPO}"
     rm "${HELM_CHART_FILE_NAME}"
     cd ..
-}
-
-updateKarpenterCoreGoMod(){
-  RELEASE_VERSION=$1
-  if [[ $GITHUB_ACCOUNT != $MAIN_GITHUB_ACCOUNT ]]; then
-    echo "not updating go mod for a repo other than the main repo"
-    return
-  fi
-  go get -u "github.com/aws/karpenter-core@${RELEASE_VERSION}"
-  cd test
-  go get -u "github.com/aws/karpenter-core@${RELEASE_VERSION}"
-  cd ..
-  make tidy
 }
 
 createNewWebsiteDirectory() {

--- a/hack/release/release.sh
+++ b/hack/release/release.sh
@@ -16,3 +16,4 @@ git reset --hard
 if [[ $(releaseType $GIT_TAG) == $RELEASE_TYPE_STABLE ]]; then
   release $GIT_TAG
 fi
+

--- a/test/manifests/upgrade-suite.yaml
+++ b/test/manifests/upgrade-suite.yaml
@@ -12,7 +12,6 @@ spec:
       description: Kubernetes version to deploy
       default: "1.23"
     - name: from-git-ref
-      default: v0.23.0
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
     - name: git-repo-url
       description: the git repo url can be used to run tests on a fork

--- a/tools/release-notification-listener/listener/message.go
+++ b/tools/release-notification-listener/listener/message.go
@@ -32,7 +32,6 @@ const (
 	delayBetweenMessageReads          = time.Minute * 3
 	maxNotificationMessageParamLength = 40 // Length of a git SHA
 	visibilityTimeOutS                = 60
-	defaultKnownLastStableRelease     = "v0.22.1"
 
 	releaseTypeStable   = "stable"
 	releaseTypeSnapshot = "snapshot"
@@ -40,11 +39,10 @@ const (
 )
 
 type notificationMessage struct {
-	ReleaseType          string `json:"releaseType"`
-	ReleaseIdentifier    string `json:"releaseIdentifier"`
-	PrNumber             string `json:"prNumber"`
-	GithubAccount        string `json:"githubAccount"`
-	LastStableReleaseTag string `json:"lastStableReleaseTag"`
+	ReleaseType       string `json:"releaseType"`
+	ReleaseIdentifier string `json:"releaseIdentifier"`
+	PrNumber          string `json:"prNumber"`
+	GithubAccount     string `json:"githubAccount"`
 }
 
 var (
@@ -55,7 +53,6 @@ var (
 		releaseTypeSnapshot: {},
 		releaseTypePeriodic: {},
 	}
-	lastKnownLastStableRelease string
 )
 
 func processMessage(queueMessage *sqs.Message, config *config) {
@@ -106,17 +103,6 @@ func newNotificationMessage(msg *sqs.Message) (*notificationMessage, error) {
 		queueMessage.PrNumber = noPrNumber
 	}
 	return queueMessage, nil
-}
-
-func (n *notificationMessage) lastStableReleaseTagOrDefault() string {
-	if n.LastStableReleaseTag != "" {
-		lastKnownLastStableRelease = n.LastStableReleaseTag
-		return n.LastStableReleaseTag
-	}
-	if lastKnownLastStableRelease != "" {
-		return lastKnownLastStableRelease
-	}
-	return defaultKnownLastStableRelease
 }
 
 func (n *notificationMessage) validate() error {

--- a/tools/release-notification-listener/listener/tekton.go
+++ b/tools/release-notification-listener/listener/tekton.go
@@ -46,6 +46,7 @@ var (
 		},
 		pipelineUpgrade: {},
 	}
+	preUpgradeVersion = "v0.26.1"
 )
 
 func runTests(message *notificationMessage, args ...string) error {
@@ -111,7 +112,7 @@ func tknArgs(message *notificationMessage, pipelineName, testFilter string) []st
 		pipelineParams = append(pipelineParams, "ip-family=IPv6")
 		pipelineParams = append(pipelineParams, "git-ref="+gitRef)
 	case pipelineUpgrade:
-		pipelineParams = append(pipelineParams, "from-git-ref="+message.lastStableReleaseTagOrDefault())
+		pipelineParams = append(pipelineParams, "from-git-ref="+preUpgradeVersion)
 		pipelineParams = append(pipelineParams, "to-git-ref="+message.ReleaseIdentifier)
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Sets a static preUpgradeVersion for the release-listener and updates this static version any time there is a new release through the `stable-pr.sh`

**How was this change tested?**

* Manual testing of script changes in local environment

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
