### PR TITLE
test: Fix issue where `MockedFunction` results would leak into other calls

### DIFF
--- a/pkg/fake/eksapi.go
+++ b/pkg/fake/eksapi.go
@@ -39,5 +39,7 @@ func (s *EKSAPI) Reset() {
 }
 
 func (s *EKSAPI) DescribeCluster(input *eks.DescribeClusterInput) (*eks.DescribeClusterOutput, error) {
-	return s.DescribeClusterBehaviour.Invoke(input)
+	return s.DescribeClusterBehaviour.Invoke(input, func(*eks.DescribeClusterInput) (*eks.DescribeClusterOutput, error) {
+		return nil, nil
+	})
 }

--- a/pkg/fake/sqsapi.go
+++ b/pkg/fake/sqsapi.go
@@ -52,23 +52,21 @@ func (s *SQSAPI) Reset() {
 
 //nolint:revive,stylecheck
 func (s *SQSAPI) GetQueueUrlWithContext(_ context.Context, input *sqs.GetQueueUrlInput, _ ...request.Option) (*sqs.GetQueueUrlOutput, error) {
-	return s.GetQueueURLBehavior.WithDefault(&sqs.GetQueueUrlOutput{
-		QueueUrl: aws.String(dummyQueueURL),
-	}).Invoke(input)
-}
-
-func (s *SQSAPI) GetQueueAttributesWithContext(_ context.Context, input *sqs.GetQueueAttributesInput, _ ...request.Option) (*sqs.GetQueueAttributesOutput, error) {
-	return s.GetQueueAttributesBehavior.WithDefault(&sqs.GetQueueAttributesOutput{
-		Attributes: map[string]*string{
-			sqs.QueueAttributeNameQueueArn: aws.String("arn:aws:sqs:us-west-2:000000000000:Karpenter-Queue"),
-		},
-	}).Invoke(input)
+	return s.GetQueueURLBehavior.Invoke(input, func(_ *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
+		return &sqs.GetQueueUrlOutput{
+			QueueUrl: aws.String(dummyQueueURL),
+		}, nil
+	})
 }
 
 func (s *SQSAPI) ReceiveMessageWithContext(_ context.Context, input *sqs.ReceiveMessageInput, _ ...request.Option) (*sqs.ReceiveMessageOutput, error) {
-	return s.ReceiveMessageBehavior.Invoke(input)
+	return s.ReceiveMessageBehavior.Invoke(input, func(_ *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
+		return nil, nil
+	})
 }
 
 func (s *SQSAPI) DeleteMessageWithContext(_ context.Context, input *sqs.DeleteMessageInput, _ ...request.Option) (*sqs.DeleteMessageOutput, error) {
-	return s.DeleteMessageBehavior.Invoke(input)
+	return s.DeleteMessageBehavior.Invoke(input, func(_ *sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
+		return nil, nil
+	})
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Calling any `MockedFunction` with `WithDefault()` simultaneously could result in a race where the the `defaultOutput` value would be used for both calls to the function by the time Invoke was called. This is because using the result from the `WithDefault` function wasn't an atomic operation with the `Invoke` function. 

This PR removes the `WithDefault()` call and adjust `Invoke` so that it takes in the `input` value as well as a `defaultTransformer` which transforms the input into some expected output

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
