### PR TITLE
chore: Log selected instance capacity on launch

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -30,9 +30,11 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
 
+	"github.com/aws/karpenter-core/pkg/utils/functional"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/batcher"
@@ -110,12 +112,19 @@ func (p *Provider) Create(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 	); err != nil {
 		return nil, fmt.Errorf("retrieving node name for instance %s, %w", aws.StringValue(id), err)
 	}
+	var capacity v1.ResourceList
+	if instanceType, ok := lo.Find(instanceTypes, func(i *cloudprovider.InstanceType) bool {
+		return i.Name == aws.StringValue(instance.InstanceType)
+	}); ok {
+		capacity = functional.FilterMap(instanceType.Capacity, func(_ v1.ResourceName, v resource.Quantity) bool { return !resources.IsZero(v) })
+	}
 	logging.FromContext(ctx).With(
 		"id", aws.StringValue(instance.InstanceId),
 		"hostname", aws.StringValue(instance.PrivateDnsName),
 		"instance-type", aws.StringValue(instance.InstanceType),
 		"zone", aws.StringValue(instance.Placement.AvailabilityZone),
-		"capacity-type", GetCapacityType(instance)).Infof("launched new instance")
+		"capacity-type", GetCapacityType(instance),
+		"capacity", capacity).Infof("launched new instance")
 
 	return instance, nil
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
 
Log the selected instance type capacity based on the GetInstanceTypes() cloudprovider API. This helps users to discover the capacity that Karpenter expected to launch through the logs which should ease some of the issues with expected ephemeral-storage like mentioned in #3676

Logs for launched capacity now look like

```console
2023-04-04T16:28:07.644Z        INFO    controller.provisioner.cloudprovider    launched new instance   {"commit": "ef5c076", "provisioner": "default", "id": "i-0e9db85152cbdb3bd", "hostname": "ip-192-168-27-76.us-west-2.compute.internal", "instance-type": "c6a.4xlarge", "zone": "us-west-2b", "capacity-type": "on-demand", "capacity": {"cpu":"16","ephemeral-storage":"20Gi","memory":"30310Mi","pods":"234"}}
2023-04-04T16:44:43.324Z        INFO    controller.provisioner.cloudprovider    launched new instance   {"commit": "ef5c076", "provisioner": "default", "id": "i-0ca9d6b277ac34ebd", "hostname": "ip-192-168-142-170.us-west-2.compute.internal", "instance-type": "inf1.24xlarge", "zone": "us-west-2a", "capacity-type": "on-demand", "capacity": {"aws.amazon.com/neuron":"16","cpu":"96","ephemeral-storage":"20Gi","memory":"181862Mi","pods":"321"}}
2023-04-04T16:44:43.324Z        INFO    controller.provisioner.cloudprovider    launched new instance   {"commit": "ef5c076", "provisioner": "default", "id": "i-013fc0f69b9e7c2fe", "hostname": "ip-192-168-179-231.us-west-2.compute.internal", "instance-type": "c5.metal", "zone": "us-west-2d", "capacity-type": "spot", "capacity": {"cpu":"96","ephemeral-storage":"20Gi","memory":"181862Mi","pods":"737"}}
```

**How was this change tested?**

* `make apply`
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
