### PR TITLE
fix: Fix Duplicate InstanceID Batching Bug

### DIFF
--- a/pkg/batcher/terminateinstances_test.go
+++ b/pkg/batcher/terminateinstances_test.go
@@ -65,6 +65,34 @@ var _ = Describe("TerminateInstances Batcher", func() {
 		call := fakeEC2API.TerminateInstancesBehavior.CalledWithInput.Pop()
 		Expect(len(call.InstanceIds)).To(BeNumerically("==", len(instanceIDs)))
 	})
+	It("should batch input correctly when receiving multiple calls with the same instance id", func() {
+		instanceIDs := []string{"i-1", "i-1", "i-1", "i-2", "i-2"}
+		for _, id := range instanceIDs {
+			fakeEC2API.Instances.Store(id, &ec2.Instance{})
+		}
+
+		var wg sync.WaitGroup
+		var receivedInstance int64
+		for _, instanceID := range instanceIDs {
+			wg.Add(1)
+			go func(instanceID string) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				rsp, err := cfb.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+					InstanceIds: []*string{aws.String(instanceID)},
+				})
+				Expect(err).To(BeNil())
+				atomic.AddInt64(&receivedInstance, 1)
+				Expect(rsp.TerminatingInstances).To(HaveLen(1))
+			}(instanceID)
+		}
+		wg.Wait()
+
+		Expect(receivedInstance).To(BeNumerically("==", len(instanceIDs)))
+		Expect(fakeEC2API.TerminateInstancesBehavior.CalledWithInput.Len()).To(BeNumerically("==", 1))
+		call := fakeEC2API.TerminateInstancesBehavior.CalledWithInput.Pop()
+		Expect(len(call.InstanceIds)).To(BeNumerically("==", len(instanceIDs)))
+	})
 	It("should handle partial terminations on batched call and recover with individual requests", func() {
 		instanceIDs := []string{"i-1", "i-2", "i-3"}
 		// Output with only the first Terminating Instance


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Fixes a bug where passing the same instance ID in two separate calls in the same batch would result in an empty output which would throw off the callers to the EC2 API and result in panics. This occurred because we were only looking at the last index that represented an instance ID rather than looking at ALL the indexes that request that instance ID

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
