### PR TITLE
fix: Correctly calculate max pods when multiple network cards are available

### DIFF
--- a/hack/code/instancetype_testdata_gen.go
+++ b/hack/code/instancetype_testdata_gen.go
@@ -157,6 +157,21 @@ func getInstanceTypeInfo(info *ec2.InstanceTypeInfo) string {
 	fmt.Fprintf(src, "MaximumNetworkInterfaces: aws.Int64(%d),\n", lo.FromPtr(info.NetworkInfo.MaximumNetworkInterfaces))
 	fmt.Fprintf(src, "Ipv4AddressesPerInterface: aws.Int64(%d),\n", lo.FromPtr(info.NetworkInfo.Ipv4AddressesPerInterface))
 	fmt.Fprintf(src, "EncryptionInTransitSupported: aws.Bool(%t),\n", lo.FromPtr(info.NetworkInfo.EncryptionInTransitSupported))
+	fmt.Fprintf(src, "DefaultNetworkCardIndex: aws.Int64(%d),\n", lo.FromPtr(info.NetworkInfo.DefaultNetworkCardIndex))
+	fmt.Fprintf(src, "NetworkCards: []*ec2.NetworkCardInfo{\n")
+	for _, networkCard := range info.NetworkInfo.NetworkCards {
+		fmt.Fprintf(src, getNetworkCardInfo(networkCard))
+	}
+	fmt.Fprintf(src, "},\n")
+	fmt.Fprintf(src, "},\n")
+	return src.String()
+}
+
+func getNetworkCardInfo(info *ec2.NetworkCardInfo) string {
+	src := &bytes.Buffer{}
+	fmt.Fprintf(src, "{\n")
+	fmt.Fprintf(src, "NetworkCardIndex: aws.Int64(%d),\n", lo.FromPtr(info.NetworkCardIndex))
+	fmt.Fprintf(src, "MaximumNetworkInterfaces: aws.Int64(%d),\n", lo.FromPtr(info.MaximumNetworkInterfaces))
 	fmt.Fprintf(src, "},\n")
 	return src.String()
 }

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -48,7 +48,7 @@ instanceTypeTestData() {
   SUBJECT="Instance Type Test Data"
 
   go run hack/code/instancetype_testdata_gen.go --out-file ${GENERATED_FILE} \
-    --instance-types t3.large,m5.large,m5.xlarge,p3.8xlarge,g4dn.8xlarge,c6g.large,inf1.2xlarge,inf1.6xlarge,m5.metal,dl1.24xlarge
+    --instance-types t3.large,m5.large,m5.xlarge,p3.8xlarge,g4dn.8xlarge,c6g.large,inf1.2xlarge,inf1.6xlarge,m5.metal,dl1.24xlarge,m6idn.32xlarge
 
   GIT_DIFF=$(git diff --stat "${GENERATED_FILE}")
   checkForUpdates "${GIT_DIFF}" "${NO_UPDATE}" "${SUBJECT}" "${GENERATED_FILE}"

--- a/pkg/fake/zz_generated.describe_instance_types.go
+++ b/pkg/fake/zz_generated.describe_instance_types.go
@@ -48,6 +48,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(3),
 				Ipv4AddressesPerInterface:    aws.Int64(10),
 				EncryptionInTransitSupported: aws.Bool(false),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(3),
+					},
+				},
 			},
 		},
 		{
@@ -86,6 +93,25 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(60),
 				Ipv4AddressesPerInterface:    aws.Int64(50),
 				EncryptionInTransitSupported: aws.Bool(true),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(15),
+					},
+					{
+						NetworkCardIndex:         aws.Int64(1),
+						MaximumNetworkInterfaces: aws.Int64(15),
+					},
+					{
+						NetworkCardIndex:         aws.Int64(2),
+						MaximumNetworkInterfaces: aws.Int64(15),
+					},
+					{
+						NetworkCardIndex:         aws.Int64(3),
+						MaximumNetworkInterfaces: aws.Int64(15),
+					},
+				},
 			},
 		},
 		{
@@ -124,6 +150,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(4),
 				Ipv4AddressesPerInterface:    aws.Int64(15),
 				EncryptionInTransitSupported: aws.Bool(true),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(4),
+					},
+				},
 			},
 		},
 		{
@@ -156,6 +189,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(4),
 				Ipv4AddressesPerInterface:    aws.Int64(10),
 				EncryptionInTransitSupported: aws.Bool(true),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(4),
+					},
+				},
 			},
 		},
 		{
@@ -188,6 +228,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(8),
 				Ipv4AddressesPerInterface:    aws.Int64(30),
 				EncryptionInTransitSupported: aws.Bool(true),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(8),
+					},
+				},
 			},
 		},
 		{
@@ -211,6 +258,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(3),
 				Ipv4AddressesPerInterface:    aws.Int64(10),
 				EncryptionInTransitSupported: aws.Bool(false),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(3),
+					},
+				},
 			},
 		},
 		{
@@ -234,6 +288,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(15),
 				Ipv4AddressesPerInterface:    aws.Int64(50),
 				EncryptionInTransitSupported: aws.Bool(false),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(15),
+					},
+				},
 			},
 		},
 		{
@@ -257,6 +318,50 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(4),
 				Ipv4AddressesPerInterface:    aws.Int64(15),
 				EncryptionInTransitSupported: aws.Bool(false),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(4),
+					},
+				},
+			},
+		},
+		{
+			InstanceType:                  aws.String("m6idn.32xlarge"),
+			SupportedUsageClasses:         aws.StringSlice([]string{"on-demand", "spot"}),
+			SupportedVirtualizationTypes:  aws.StringSlice([]string{"hvm"}),
+			BurstablePerformanceSupported: aws.Bool(false),
+			BareMetal:                     aws.Bool(false),
+			Hypervisor:                    aws.String("nitro"),
+			ProcessorInfo: &ec2.ProcessorInfo{
+				SupportedArchitectures: aws.StringSlice([]string{"x86_64"}),
+			},
+			VCpuInfo: &ec2.VCpuInfo{
+				DefaultCores: aws.Int64(64),
+				DefaultVCpus: aws.Int64(128),
+			},
+			MemoryInfo: &ec2.MemoryInfo{
+				SizeInMiB: aws.Int64(524288),
+			},
+			InstanceStorageInfo: &ec2.InstanceStorageInfo{NvmeSupport: aws.String("required"),
+				TotalSizeInGB: aws.Int64(7600),
+			},
+			NetworkInfo: &ec2.NetworkInfo{
+				MaximumNetworkInterfaces:     aws.Int64(14),
+				Ipv4AddressesPerInterface:    aws.Int64(50),
+				EncryptionInTransitSupported: aws.Bool(true),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(7),
+					},
+					{
+						NetworkCardIndex:         aws.Int64(1),
+						MaximumNetworkInterfaces: aws.Int64(7),
+					},
+				},
 			},
 		},
 		{
@@ -292,6 +397,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(8),
 				Ipv4AddressesPerInterface:    aws.Int64(30),
 				EncryptionInTransitSupported: aws.Bool(false),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(8),
+					},
+				},
 			},
 		},
 		{
@@ -315,6 +427,13 @@ var defaultDescribeInstanceTypesOutput = &ec2.DescribeInstanceTypesOutput{
 				MaximumNetworkInterfaces:     aws.Int64(3),
 				Ipv4AddressesPerInterface:    aws.Int64(12),
 				EncryptionInTransitSupported: aws.Bool(false),
+				DefaultNetworkCardIndex:      aws.Int64(0),
+				NetworkCards: []*ec2.NetworkCardInfo{
+					{
+						NetworkCardIndex:         aws.Int64(0),
+						MaximumNetworkInterfaces: aws.Int64(3),
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION


Fixes #3696

**Description**

Fixes a bug in max pods calculations

**How was this change tested?**

Unit + Manually. In flight checks no longer complain.

Before
```
karpenter-f79844559-xpxpd controller 2023-04-06T17:58:37.241Z	INFO	controller.provisioner.cloudprovider	launched new instance	{"commit": "982c35f", "provisioner": "default", "id": "i-0bd719348e7171937", "hostname": "ip-192-168-172-64.us-west-2.compute.internal", "instance-type": "m6idn.32xlarge", "zone": "us-west-2a", "capacity-type": "on-demand"}
karpenter-f79844559-xpxpd controller 2023-04-06T18:06:23.208Z	DEBUG	controller.aws	deleted launch template	{"commit": "982c35f"}
karpenter-f79844559-xpxpd controller 2023-04-06T18:08:37.249Z	INFO	controller.inflightchecks	Inflight check failed for node, Expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "982c35f", "node": "ip-192-168-172-64.us-west-2.compute.internal"}
karpenter-f79844559-xpxpd controller 2023-04-06T18:18:37.250Z	INFO	controller.inflightchecks	Inflight check failed for node, Expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "982c35f", "node": "ip-192-168-172-64.us-west-2.compute.internal"}
karpenter-f79844559-xpxpd controller 2023-04-06T18:28:37.251Z	INFO	controller.inflightchecks	Inflight check failed for node, Expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "982c35f", "node": "ip-192-168-172-64.us-west-2.compute.internal"}
karpenter-f79844559-xpxpd controller 2023-04-06T18:38:37.252Z	INFO	controller.inflightchecks	Inflight check failed for node, Expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "982c35f", "node": "ip-192-168-172-64.us-west-2.compute.internal"}
karpenter-f79844559-xpxpd controller 2023-04-06T18:48:37.252Z	INFO	controller.inflightchecks	Inflight check failed for node, Expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "982c35f", "node": "ip-192-168-172-64.us-west-2.compute.internal"}
karpenter-f79844559-xpxpd controller 2023-04-06T18:58:37.253Z	INFO	controller.inflightchecks	Inflight check failed for node, Expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "982c35f", "node": "ip-192-168-172-64.us-west-2.compute.internal"}
karpenter-f79844559-xpxpd controller 2023-04-06T19:08:37.253Z	INFO	controller.inflightchecks	Inflight check failed for node, Expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "982c35f", "node": "ip-192-168-172-64.us-west-2.compute.internal"}
```

After 
```
karpenter-5fbb6d9d99-6lrxk controller 2023-04-07T17:03:38.903Z	INFO	controller.provisioner.cloudprovider	launched new instance	{"commit": "43b4f4e-dirty", "provisioner": "default", "id": "i-06c30c52d602c8cc4", "hostname": "ip-192-168-98-227.us-west-2.compute.internal", "instance-type": "m6idn.32xlarge", "zone": "us-west-2b", "capacity-type": "on-demand", "capacity": {"cpu":"128","ephemeral-storage":"20Gi","memory":"484966Mi","pods":"345"}}
karpenter-5fbb6d9d99-6lrxk controller 2023-04-07T17:12:44.797Z	DEBUG	controller.aws	deleted launch template	{"commit": "43b4f4e-dirty", "launch-template": "karpenter.k8s.aws/14641531617515598163"}
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
