### PR TITLE
docs: Change AWS IAM permissions example

### DIFF
--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step05-controller-iam.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step05-controller-iam.sh
@@ -50,7 +50,7 @@ echo '{
             "Action": "ec2:TerminateInstances",
             "Condition": {
                 "StringLike": {
-                    "ec2:ResourceTag/Name": "*karpenter*"
+                    "ec2:ResourceTag/karpenter.sh/provisioner-name": "*"
                 }
             },
             "Effect": "Allow",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3712

**Description**
Permissions from the documentation do not work if instances use some value of the `Name` tag that does not contain the word `karpenter`. At the same time, Karpenter adds to all nodes a tag with the name of the provisioner. It seems quite logical to use this tag.

**How was this change tested?**
We use this permissions and it works well in production

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [x] Yes, issue opened: #3712
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
