### PR TITLE
test: Move test debugging to separate package

### DIFF
--- a/test/pkg/debug/events.go
+++ b/test/pkg/debug/events.go
@@ -1,0 +1,145 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type EventClient struct {
+	start      time.Time
+	kubeClient client.Client
+}
+
+func NewEventClient(kubeClient client.Client) *EventClient {
+	return &EventClient{
+		start:      time.Now(),
+		kubeClient: kubeClient,
+	}
+}
+
+func (c *EventClient) DumpEvents(ctx context.Context) error {
+	return multierr.Combine(
+		c.dumpKarpenterEvents(ctx),
+		c.dumpPodEvents(ctx),
+		c.dumpNodeEvents(ctx),
+	)
+
+}
+
+func (c *EventClient) dumpKarpenterEvents(ctx context.Context) error {
+	el := &v1.EventList{}
+	if err := c.kubeClient.List(ctx, el, client.InNamespace("karpenter")); err != nil {
+		return err
+	}
+	for k, v := range coallateEvents(filterTestEvents(el.Items, c.start)) {
+		fmt.Print(getEventInformation(k, v))
+	}
+	return nil
+}
+
+func (c *EventClient) dumpPodEvents(ctx context.Context) error {
+	el := &v1.EventList{}
+	if err := c.kubeClient.List(ctx, el, &client.ListOptions{
+		FieldSelector: fields.SelectorFromSet(map[string]string{"involvedObject.kind": "Pod"}),
+	}); err != nil {
+		return err
+	}
+	events := lo.Filter(filterTestEvents(el.Items, c.start), func(e v1.Event, _ int) bool {
+		return e.InvolvedObject.Namespace != "kube-system"
+	})
+	for k, v := range coallateEvents(events) {
+		fmt.Print(getEventInformation(k, v))
+	}
+	return nil
+}
+
+func (c *EventClient) dumpNodeEvents(ctx context.Context) error {
+	el := &v1.EventList{}
+	if err := c.kubeClient.List(ctx, el, &client.ListOptions{
+		FieldSelector: fields.SelectorFromSet(map[string]string{"involvedObject.kind": "Node"}),
+	}); err != nil {
+		return err
+	}
+	for k, v := range coallateEvents(el.Items) {
+		fmt.Print(getEventInformation(k, v))
+	}
+	return nil
+}
+
+func filterTestEvents(events []v1.Event, startTime time.Time) []v1.Event {
+	return lo.Filter(events, func(e v1.Event, _ int) bool {
+		if !e.EventTime.IsZero() {
+			if e.EventTime.BeforeTime(&metav1.Time{Time: startTime}) {
+				return false
+			}
+		} else if e.FirstTimestamp.Before(&metav1.Time{Time: startTime}) {
+			return false
+		}
+		return true
+	})
+}
+
+func coallateEvents(events []v1.Event) map[v1.ObjectReference]*v1.EventList {
+	eventMap := map[v1.ObjectReference]*v1.EventList{}
+	for i := range events {
+		elem := events[i]
+		objectKey := v1.ObjectReference{Kind: elem.InvolvedObject.Kind, Namespace: elem.InvolvedObject.Namespace, Name: elem.InvolvedObject.Name}
+		if _, ok := eventMap[objectKey]; !ok {
+			eventMap[objectKey] = &v1.EventList{}
+		}
+		eventMap[objectKey].Items = append(eventMap[objectKey].Items, elem)
+	}
+	return eventMap
+}
+
+// Partially copied from
+// https://github.com/kubernetes/kubernetes/blob/04ee339c7a4d36b4037ce3635993e2a9e395ebf3/staging/src/k8s.io/kubectl/pkg/describe/describe.go#L4232
+func getEventInformation(o v1.ObjectReference, el *v1.EventList) string {
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("------- %s/%s%s EVENTS -------\n",
+		strings.ToLower(o.Kind), lo.Ternary(o.Namespace != "", o.Namespace+"/", ""), o.Name))
+	if len(el.Items) == 0 {
+		return sb.String()
+	}
+	for _, e := range el.Items {
+		source := e.Source.Component
+		if source == "" {
+			source = e.ReportingController
+		}
+		eventTime := e.EventTime
+		if eventTime.IsZero() {
+			eventTime = metav1.NewMicroTime(e.FirstTimestamp.Time)
+		}
+		sb.WriteString(fmt.Sprintf("time=%s type=%s reason=%s from=%s message=%s\n",
+			eventTime.Format(time.RFC3339),
+			e.Type,
+			e.Reason,
+			source,
+			strings.TrimSpace(e.Message)),
+		)
+	}
+	return sb.String()
+}

--- a/test/pkg/debug/machine.go
+++ b/test/pkg/debug/machine.go
@@ -1,0 +1,82 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+)
+
+type MachineController struct {
+	kubeClient client.Client
+}
+
+func NewMachineController(kubeClient client.Client) *MachineController {
+	return &MachineController{
+		kubeClient: kubeClient,
+	}
+}
+
+func (c *MachineController) Name() string {
+	return "machine"
+}
+
+func (c *MachineController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	m := &v1alpha5.Machine{}
+	if err := c.kubeClient.Get(ctx, req.NamespacedName, m); err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Printf("[DELETED %s] MACHINE %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+		}
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	fmt.Printf("[CREATED/UPDATED %s] MACHINE %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.Name, c.GetInfo(m))
+	return reconcile.Result{}, nil
+}
+
+func (c *MachineController) GetInfo(m *v1alpha5.Machine) string {
+	return fmt.Sprintf("ready=%t launched=%t registered=%t initialized=%t",
+		m.StatusConditions().IsHappy(),
+		m.StatusConditions().GetCondition(v1alpha5.MachineLaunched).IsTrue(),
+		m.StatusConditions().GetCondition(v1alpha5.MachineRegistered).IsTrue(),
+		m.StatusConditions().GetCondition(v1alpha5.MachineInitialized).IsTrue(),
+	)
+}
+
+func (c *MachineController) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {
+	return corecontroller.Adapt(controllerruntime.
+		NewControllerManagedBy(m).
+		For(&v1alpha5.Machine{}).
+		WithEventFilter(predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				oldMachine := e.ObjectOld.(*v1alpha5.Machine)
+				newMachine := e.ObjectNew.(*v1alpha5.Machine)
+				return c.GetInfo(oldMachine) != c.GetInfo(newMachine)
+			},
+		}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}))
+}

--- a/test/pkg/debug/monitor.go
+++ b/test/pkg/debug/monitor.go
@@ -1,0 +1,81 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"sync"
+
+	"github.com/samber/lo"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/logging"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+)
+
+type Monitor struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	mgr    manager.Manager
+}
+
+func New(ctx context.Context, config *rest.Config, kubeClient client.Client) *Monitor {
+	logger := logging.FromContext(ctx)
+	mgr := lo.Must(controllerruntime.NewManager(config, controllerruntime.Options{
+		Scheme: scheme.Scheme,
+		BaseContext: func() context.Context {
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, logger)
+			logger.WithOptions()
+			return ctx
+		},
+	}))
+	for _, c := range newControllers(kubeClient) {
+		lo.Must0(c.Builder(ctx, mgr).Complete(c), "failed to register controller")
+	}
+	ctx, cancel := context.WithCancel(ctx) // this context is only meant for monitor start/stop
+	return &Monitor{
+		ctx:    ctx,
+		cancel: cancel,
+		mgr:    mgr,
+	}
+}
+
+// MustStart starts the debug monitor
+func (m *Monitor) MustStart() {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		lo.Must0(m.mgr.Start(m.ctx))
+	}()
+}
+
+// Stop stops the monitor
+func (m *Monitor) Stop() {
+	m.cancel()
+	m.wg.Wait()
+}
+
+func newControllers(kubeClient client.Client) []controller.Controller {
+	return []controller.Controller{
+		NewNodeController(kubeClient),
+		NewPodController(kubeClient),
+	}
+}

--- a/test/pkg/debug/node.go
+++ b/test/pkg/debug/node.go
@@ -1,0 +1,86 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+
+	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
+)
+
+type NodeController struct {
+	kubeClient client.Client
+}
+
+func NewNodeController(kubeClient client.Client) *NodeController {
+	return &NodeController{
+		kubeClient: kubeClient,
+	}
+}
+
+func (c *NodeController) Name() string {
+	return "node"
+}
+
+func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	n := &v1.Node{}
+	if err := c.kubeClient.Get(ctx, req.NamespacedName, n); err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Printf("[DELETED %s] NODE %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+		}
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	fmt.Printf("[CREATED/UPDATED %s] NODE %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.Name, c.GetInfo(ctx, n))
+	return reconcile.Result{}, nil
+}
+
+func (c *NodeController) GetInfo(ctx context.Context, n *v1.Node) string {
+	pods, _ := nodeutils.GetNodePods(ctx, c.kubeClient, n)
+	return fmt.Sprintf("ready=%s schedulable=%t initialized=%s pods=%d taints=%v", nodeutils.GetCondition(n, v1.NodeReady).Status, !n.Spec.Unschedulable, n.Labels[v1alpha5.LabelNodeInitialized], len(pods), n.Spec.Taints)
+}
+
+func (c *NodeController) Builder(ctx context.Context, m manager.Manager) corecontroller.Builder {
+	return corecontroller.Adapt(controllerruntime.
+		NewControllerManagedBy(m).
+		For(&v1.Node{}).
+		WithEventFilter(predicate.And(
+			predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldNode := e.ObjectOld.(*v1.Node)
+					newNode := e.ObjectNew.(*v1.Node)
+					return c.GetInfo(ctx, oldNode) != c.GetInfo(ctx, newNode)
+				},
+			},
+			predicate.NewPredicateFuncs(func(o client.Object) bool {
+				return o.GetLabels()[v1alpha5.ProvisionerNameLabelKey] != ""
+			}),
+		)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}))
+}

--- a/test/pkg/debug/pod.go
+++ b/test/pkg/debug/pod.go
@@ -1,0 +1,93 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/utils/pod"
+)
+
+type PodController struct {
+	kubeClient client.Client
+}
+
+func NewPodController(kubeClient client.Client) *PodController {
+	return &PodController{
+		kubeClient: kubeClient,
+	}
+}
+
+func (c *PodController) Name() string {
+	return "pod"
+}
+
+func (c *PodController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	p := &v1.Pod{}
+	if err := c.kubeClient.Get(ctx, req.NamespacedName, p); err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Printf("[DELETED %s] POD %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String())
+		}
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	fmt.Printf("[CREATED/UPDATED %s] POD %s %s\n", time.Now().Format(time.RFC3339), req.NamespacedName.String(), c.GetInfo(p))
+	return reconcile.Result{}, nil
+}
+
+func (c *PodController) GetInfo(p *v1.Pod) string {
+	var containerInfo strings.Builder
+	for _, c := range p.Status.ContainerStatuses {
+		if containerInfo.Len() > 0 {
+			_ = lo.Must(fmt.Fprintf(&containerInfo, ", "))
+		}
+		_ = lo.Must(fmt.Fprintf(&containerInfo, "%s restarts=%d", c.Name, c.RestartCount))
+	}
+	return fmt.Sprintf("provisionable=%v phase=%s nodename=%s owner=%#v [%s]",
+		pod.IsProvisionable(p), p.Status.Phase, p.Spec.NodeName, p.OwnerReferences, containerInfo.String())
+}
+
+func (c *PodController) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {
+	return corecontroller.Adapt(controllerruntime.
+		NewControllerManagedBy(m).
+		For(&v1.Pod{}).
+		WithEventFilter(predicate.And(
+			predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldPod := e.ObjectOld.(*v1.Pod)
+					newPod := e.ObjectNew.(*v1.Pod)
+					return c.GetInfo(oldPod) != c.GetInfo(newPod)
+				},
+			},
+			predicate.NewPredicateFuncs(func(o client.Object) bool {
+				return o.GetNamespace() != "kube-system" && o.GetNamespace() != "karpenter"
+			}),
+		)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}))
+}

--- a/test/pkg/debug/setup.go
+++ b/test/pkg/debug/setup.go
@@ -1,0 +1,55 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/samber/lo"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/gomega" //nolint:revive,stylecheck
+)
+
+const (
+	NoWatch  = "NoWatch"
+	NoEvents = "NoEvents"
+)
+
+var m *Monitor
+var e *EventClient
+
+func BeforeEach(ctx context.Context, config *rest.Config, kubeClient client.Client) {
+	// If the test is labeled as NoWatch, then the node/pod monitor will just list at the beginning
+	// of the test rather than perform a watch during it
+	if !lo.Contains(ginkgo.CurrentSpecReport().Labels(), NoWatch) {
+		m = New(ctx, config, kubeClient)
+		m.MustStart()
+	}
+	if !lo.Contains(ginkgo.CurrentSpecReport().Labels(), NoEvents) {
+		e = NewEventClient(kubeClient)
+	}
+}
+
+func AfterEach(ctx context.Context) {
+	if !lo.Contains(ginkgo.CurrentSpecReport().Labels(), NoWatch) {
+		m.Stop()
+	}
+	if !lo.Contains(ginkgo.CurrentSpecReport().Labels(), NoEvents) {
+		Expect(e.DumpEvents(ctx)).To(Succeed())
+	}
+}

--- a/test/pkg/environment/aws/environment.go
+++ b/test/pkg/environment/aws/environment.go
@@ -68,7 +68,3 @@ func NewEnvironment(t *testing.T) *Environment {
 		SQSProvider:     interruption.NewSQSProvider(sqs.New(session)),
 	}
 }
-
-func (env *Environment) Stop() {
-	env.Environment.Stop()
-}

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -41,18 +41,16 @@ import (
 type Environment struct {
 	context.Context
 
-	Client            client.Client
-	Config            *rest.Config
-	KubeClient        kubernetes.Interface
-	Monitor           *Monitor
-	StartingNodeCount int
+	Client     client.Client
+	Config     *rest.Config
+	KubeClient kubernetes.Interface
+	Monitor    *Monitor
 
-	cancel context.CancelFunc
+	StartingNodeCount int
 }
 
 func NewEnvironment(t *testing.T) *Environment {
 	ctx := loggingtesting.TestContextWithLogger(t)
-	ctx, cancel := context.WithCancel(ctx)
 	config := NewConfig()
 	client := lo.Must(NewClient(config))
 
@@ -68,13 +66,7 @@ func NewEnvironment(t *testing.T) *Environment {
 		Client:     client,
 		KubeClient: kubernetes.NewForConfigOrDie(config),
 		Monitor:    NewMonitor(ctx, client),
-
-		cancel: cancel,
 	}
-}
-
-func (env *Environment) Stop() {
-	env.cancel()
 }
 
 func NewConfig() *rest.Config {

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -16,13 +16,10 @@ package common
 
 import (
 	"fmt"
-	"strings"
 	"sync"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,stylecheck
 	. "github.com/onsi/gomega"    //nolint:revive,stylecheck
-	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -30,10 +27,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis"
@@ -41,8 +34,8 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter-core/pkg/utils/functional"
-	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
 	"github.com/aws/karpenter-core/pkg/utils/pod"
+	"github.com/aws/karpenter/test/pkg/debug"
 )
 
 var (
@@ -63,58 +56,21 @@ var (
 	}
 )
 
-const (
-	NoWatch  = "NoWatch"
-	NoEvents = "NoEvents"
-)
-
-var testStartTime time.Time
-var stop chan struct{}
-
 // nolint:gocyclo
 func (env *Environment) BeforeEach(opts ...Option) {
 	options := ResolveOptions(opts)
 	if !options.DisableDebug {
 		fmt.Println("------- START BEFORE -------")
 		defer fmt.Println("------- END BEFORE -------")
+
+		// Run the debug logger BeforeEach() methods
+		debug.BeforeEach(env.Context, env.Config, env.Client)
 	}
 	env.Context = injection.WithSettingsOrDie(env.Context, env.KubeClient, apis.Settings...)
 
-	stop = make(chan struct{})
-	testStartTime = time.Now()
+	// Expect this cluster to be clean for test runs to execute successfully
+	env.ExpectCleanCluster()
 
-	var nodes v1.NodeList
-	Expect(env.Client.List(env.Context, &nodes)).To(Succeed())
-	if !options.DisableDebug {
-		for i := range nodes.Items {
-			fmt.Println(env.getNodeInformation(&nodes.Items[i]))
-		}
-	}
-	for _, node := range nodes.Items {
-		if len(node.Spec.Taints) == 0 && !node.Spec.Unschedulable {
-			Fail(fmt.Sprintf("expected system pool node %s to be tainted", node.Name))
-		}
-	}
-
-	var pods v1.PodList
-	Expect(env.Client.List(env.Context, &pods)).To(Succeed())
-	if !options.DisableDebug {
-		for i := range pods.Items {
-			fmt.Println(getPodInformation(&pods.Items[i]))
-		}
-	}
-	for i := range pods.Items {
-		Expect(pod.IsProvisionable(&pods.Items[i])).To(BeFalse(),
-			fmt.Sprintf("expected to have no provisionable pods, found %s/%s", pods.Items[i].Namespace, pods.Items[i].Name))
-		Expect(pods.Items[i].Namespace).ToNot(Equal("default"),
-			fmt.Sprintf("expected no pods in the `default` namespace, found %s/%s", pods.Items[i].Namespace, pods.Items[i].Name))
-	}
-	// If the test is labeled as NoWatch, then the node/pod monitor will just list at the beginning
-	// of the test rather than perform a watch during it
-	if !options.DisableDebug && !lo.Contains(CurrentSpecReport().Labels(), NoWatch) {
-		env.startNodeMonitor(stop)
-		env.startPodMonitor(stop)
-	}
 	var provisioners v1alpha5.ProvisionerList
 	Expect(env.Client.List(env.Context, &provisioners)).To(Succeed())
 	Expect(provisioners.Items).To(HaveLen(0), "expected no provisioners to exist")
@@ -122,98 +78,22 @@ func (env *Environment) BeforeEach(opts ...Option) {
 	env.StartingNodeCount = env.Monitor.NodeCountAtReset()
 }
 
-func (env *Environment) getNodeInformation(n *v1.Node) string {
-	pods, _ := nodeutils.GetNodePods(env, env.Client, n)
-	return fmt.Sprintf("node %s ready=%s schedulable=%t initialized=%s pods=%d taints=%v", n.Name, nodeutils.GetCondition(n, v1.NodeReady).Status, !n.Spec.Unschedulable, n.Labels[v1alpha5.LabelNodeInitialized], len(pods), n.Spec.Taints)
-}
-
-func getPodInformation(p *v1.Pod) string {
-	var containerInfo strings.Builder
-	for _, c := range p.Status.ContainerStatuses {
-		if containerInfo.Len() > 0 {
-			fmt.Fprintf(&containerInfo, ", ")
+func (env *Environment) ExpectCleanCluster() {
+	var nodes v1.NodeList
+	Expect(env.Client.List(env.Context, &nodes)).To(Succeed())
+	for _, node := range nodes.Items {
+		if len(node.Spec.Taints) == 0 && !node.Spec.Unschedulable {
+			Fail(fmt.Sprintf("expected system pool node %s to be tainted", node.Name))
 		}
-		fmt.Fprintf(&containerInfo, "%s restarts=%d", c.Name, c.RestartCount)
 	}
-	return fmt.Sprintf("pods %s/%s provisionable=%v phase=%s nodename=%s owner=%#v [%s]", p.Namespace, p.Name,
-		pod.IsProvisionable(p), p.Status.Phase, p.Spec.NodeName, p.OwnerReferences, containerInfo.String())
-}
-
-// Partially copied from
-// https://github.com/kubernetes/kubernetes/blob/04ee339c7a4d36b4037ce3635993e2a9e395ebf3/staging/src/k8s.io/kubectl/pkg/describe/describe.go#L4232
-func getEventInformation(o v1.ObjectReference, el *v1.EventList) string {
-	sb := strings.Builder{}
-	sb.WriteString(fmt.Sprintf("------- %s/%s%s EVENTS -------\n",
-		strings.ToLower(o.Kind), lo.Ternary(o.Namespace != "", o.Namespace+"/", ""), o.Name))
-	if len(el.Items) == 0 {
-		return sb.String()
+	var pods v1.PodList
+	Expect(env.Client.List(env.Context, &pods)).To(Succeed())
+	for i := range pods.Items {
+		Expect(pod.IsProvisionable(&pods.Items[i])).To(BeFalse(),
+			fmt.Sprintf("expected to have no provisionable pods, found %s/%s", pods.Items[i].Namespace, pods.Items[i].Name))
+		Expect(pods.Items[i].Namespace).ToNot(Equal("default"),
+			fmt.Sprintf("expected no pods in the `default` namespace, found %s/%s", pods.Items[i].Namespace, pods.Items[i].Name))
 	}
-	for _, e := range el.Items {
-		source := e.Source.Component
-		if source == "" {
-			source = e.ReportingController
-		}
-		eventTime := e.EventTime
-		if eventTime.IsZero() {
-			eventTime = metav1.NewMicroTime(e.FirstTimestamp.Time)
-		}
-		sb.WriteString(fmt.Sprintf("time=%s type=%s reason=%s from=%s message=%s\n",
-			eventTime.Format(time.RFC3339),
-			e.Type,
-			e.Reason,
-			source,
-			strings.TrimSpace(e.Message)),
-		)
-	}
-	return sb.String()
-}
-
-// startPodMonitor monitors all pods that are provisioned in a namespace outside kube-system
-// and karpenter namespaces during a test
-func (env *Environment) startPodMonitor(stop <-chan struct{}) {
-	factory := informers.NewSharedInformerFactoryWithOptions(env.KubeClient, time.Second*30,
-		informers.WithTweakListOptions(func(l *metav1.ListOptions) {
-			l.FieldSelector = "metadata.namespace!=kube-system,metadata.namespace!=karpenter"
-		}))
-	podInformer := factory.Core().V1().Pods().Informer()
-	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			fmt.Printf("[CREATED %s] %s\n", time.Now().Format(time.RFC3339), getPodInformation(obj.(*v1.Pod)))
-		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
-			if getPodInformation(oldObj.(*v1.Pod)) != getPodInformation(newObj.(*v1.Pod)) {
-				fmt.Printf("[UPDATED %s] %s\n", time.Now().Format(time.RFC3339), getPodInformation(newObj.(*v1.Pod)))
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			fmt.Printf("[DELETED %s] %s\n", time.Now().Format(time.RFC3339), getPodInformation(obj.(*v1.Pod)))
-		},
-	})
-	factory.Start(stop)
-}
-
-// startNodeMonitor monitors all nodes that are provisioned by any provisioners during a test
-func (env *Environment) startNodeMonitor(stop <-chan struct{}) {
-	factory := informers.NewSharedInformerFactoryWithOptions(env.KubeClient, time.Second*30,
-		informers.WithTweakListOptions(func(l *metav1.ListOptions) { l.LabelSelector = v1alpha5.ProvisionerNameLabelKey }))
-	nodeInformer := factory.Core().V1().Nodes().Informer()
-	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			node := obj.(*v1.Node)
-			if _, ok := node.Labels[test.DiscoveryLabel]; ok {
-				fmt.Printf("[CREATED %s] %s\n", time.Now().Format(time.RFC3339), env.getNodeInformation(obj.(*v1.Node)))
-			}
-		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
-			if env.getNodeInformation(oldObj.(*v1.Node)) != env.getNodeInformation(newObj.(*v1.Node)) {
-				fmt.Printf("[UPDATED %s] %s\n", time.Now().Format(time.RFC3339), env.getNodeInformation(newObj.(*v1.Node)))
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			fmt.Printf("[DELETED %s] %s\n", time.Now().Format(time.RFC3339), env.getNodeInformation(obj.(*v1.Node)))
-		},
-	})
-	factory.Start(stop)
 }
 
 func (env *Environment) Cleanup(opts ...Option) {
@@ -221,6 +101,9 @@ func (env *Environment) Cleanup(opts ...Option) {
 	if !options.DisableDebug {
 		fmt.Println("------- START CLEANUP -------")
 		defer fmt.Println("------- END CLEANUP -------")
+
+		// Run the debug logger AfterEach() methods
+		debug.AfterEach(env.Context)
 	}
 	env.CleanupObjects(CleanableObjects)
 	env.eventuallyExpectScaleDown()
@@ -243,12 +126,6 @@ func (env *Environment) AfterEach(opts ...Option) {
 	if !options.DisableDebug {
 		fmt.Println("------- START AFTER -------")
 		defer fmt.Println("------- END AFTER -------")
-	}
-	close(stop) // close the pod/node monitor watch channel
-	if !options.DisableDebug && !lo.Contains(CurrentSpecReport().Labels(), NoEvents) {
-		env.dumpKarpenterEvents(testStartTime)
-		env.dumpPodEvents(testStartTime)
-		env.dumpNodeEvents(testStartTime)
 	}
 	env.printControllerLogs(&v1.PodLogOptions{Container: "controller"})
 }
@@ -281,67 +158,4 @@ func (env *Environment) CleanupObjects(cleanableObjects []functional.Pair[client
 		}
 	}
 	wg.Wait()
-}
-
-func (env *Environment) dumpKarpenterEvents(testStartTime time.Time) {
-	el := &v1.EventList{}
-	ExpectWithOffset(1, env.Client.List(env, el, client.InNamespace("karpenter"))).To(Succeed())
-
-	for k, v := range coallateEvents(filterTestEvents(el.Items, testStartTime)) {
-		fmt.Print(getEventInformation(k, v))
-	}
-}
-
-func (env *Environment) dumpPodEvents(testStartTime time.Time) {
-	el := &v1.EventList{}
-	ExpectWithOffset(1, env.Client.List(env, el, &client.ListOptions{
-		FieldSelector: fields.SelectorFromSet(map[string]string{"involvedObject.kind": "Pod"}),
-	})).To(Succeed())
-	events := lo.Filter(filterTestEvents(el.Items, testStartTime), func(e v1.Event, _ int) bool {
-		return e.InvolvedObject.Namespace != "kube-system"
-	})
-	for k, v := range coallateEvents(events) {
-		fmt.Print(getEventInformation(k, v))
-	}
-}
-
-func (env *Environment) dumpNodeEvents(testStartTime time.Time) {
-	nodeNames := sets.NewString(lo.Map(env.Monitor.CreatedNodes(), func(n *v1.Node, _ int) string { return n.Name })...)
-	el := &v1.EventList{}
-	ExpectWithOffset(1, env.Client.List(env, el, &client.ListOptions{
-		FieldSelector: fields.SelectorFromSet(map[string]string{"involvedObject.kind": "Node"}),
-	})).To(Succeed())
-
-	events := lo.Filter(filterTestEvents(el.Items, testStartTime), func(e v1.Event, _ int) bool {
-		return nodeNames.Has(e.InvolvedObject.Name)
-	})
-	for k, v := range coallateEvents(events) {
-		fmt.Print(getEventInformation(k, v))
-	}
-}
-
-func filterTestEvents(events []v1.Event, startTime time.Time) []v1.Event {
-	return lo.Filter(events, func(e v1.Event, _ int) bool {
-		if !e.EventTime.IsZero() {
-			if e.EventTime.BeforeTime(&metav1.Time{Time: startTime}) {
-				return false
-			}
-		} else if e.FirstTimestamp.Before(&metav1.Time{Time: startTime}) {
-			return false
-		}
-		return true
-	})
-}
-
-func coallateEvents(events []v1.Event) map[v1.ObjectReference]*v1.EventList {
-	eventMap := map[v1.ObjectReference]*v1.EventList{}
-	for i := range events {
-		elem := events[i]
-		objectKey := v1.ObjectReference{Kind: elem.InvolvedObject.Kind, Namespace: elem.InvolvedObject.Namespace, Name: elem.InvolvedObject.Name}
-		if _, ok := eventMap[objectKey]; !ok {
-			eventMap[objectKey] = &v1.EventList{}
-		}
-		eventMap[objectKey].Items = append(eventMap[objectKey].Items, elem)
-	}
-	return eventMap
 }

--- a/test/suites/chaos/suite_test.go
+++ b/test/suites/chaos/suite_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	awstest "github.com/aws/karpenter/pkg/test"
+	"github.com/aws/karpenter/test/pkg/debug"
 	"github.com/aws/karpenter/test/pkg/environment/common"
 )
 
@@ -50,9 +51,6 @@ func TestChaos(t *testing.T) {
 	RegisterFailHandler(Fail)
 	BeforeSuite(func() {
 		env = common.NewEnvironment(t)
-	})
-	AfterSuite(func() {
-		env.Stop()
 	})
 	RunSpecs(t, "Chaos")
 }
@@ -64,7 +62,7 @@ var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("Chaos", func() {
 	Describe("Runaway Scale-Up", func() {
-		It("should not produce a runaway scale-up when consolidation is enabled", Label(common.NoWatch), Label(common.NoEvents), func() {
+		It("should not produce a runaway scale-up when consolidation is enabled", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 			ctx, cancel := context.WithCancel(env.Context)
 			defer cancel()
 
@@ -109,7 +107,7 @@ var _ = Describe("Chaos", func() {
 				g.Expect(len(list.Items)).To(BeNumerically("<", 35))
 			}, time.Minute*5).Should(Succeed())
 		})
-		It("should not produce a runaway scale-up when ttlSecondsAfterEmpty is enabled", Label(common.NoWatch), Label(common.NoEvents), func() {
+		It("should not produce a runaway scale-up when ttlSecondsAfterEmpty is enabled", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 			ctx, cancel := context.WithCancel(env.Context)
 			defer cancel()
 

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/test/pkg/debug"
 
 	awstest "github.com/aws/karpenter/pkg/test"
 	environmentaws "github.com/aws/karpenter/test/pkg/environment/aws"
@@ -46,9 +47,6 @@ func TestConsolidation(t *testing.T) {
 	BeforeSuite(func() {
 		env = environmentaws.NewEnvironment(t)
 	})
-	AfterSuite(func() {
-		env.Stop()
-	})
 	RunSpecs(t, "Consolidation")
 }
 
@@ -58,7 +56,7 @@ var _ = AfterEach(func() { env.ForceCleanup() })
 var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("Consolidation", func() {
-	It("should consolidate nodes (delete)", Label(common.NoWatch), Label(common.NoEvents), func() {
+	It("should consolidate nodes (delete)", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -46,9 +46,6 @@ func TestDrift(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
-	AfterSuite(func() {
-		env.Stop()
-	})
 	RunSpecs(t, "Drift")
 }
 

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/test/pkg/debug"
 
 	awstest "github.com/aws/karpenter/pkg/test"
-	"github.com/aws/karpenter/test/pkg/environment/common"
 )
 
 var _ = Describe("Scheduling", func() {
@@ -150,7 +150,7 @@ var _ = Describe("Scheduling", func() {
 		env.EventuallyExpectHealthy(pod)
 		env.ExpectCreatedNodeCount("==", 1)
 	})
-	It("should provision a node for a deployment", Label(common.NoWatch), Label(common.NoEvents), func() {
+	It("should provision a node for a deployment", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -30,9 +30,6 @@ func TestIntegration(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
-	AfterSuite(func() {
-		env.Stop()
-	})
 	RunSpecs(t, "Integration")
 }
 

--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -48,9 +48,6 @@ func TestInterruption(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
-	AfterSuite(func() {
-		env.Stop()
-	})
 	RunSpecs(t, "Interruption")
 }
 

--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -38,9 +38,6 @@ func TestIPv6(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
-	AfterSuite(func() {
-		env.Stop()
-	})
 	RunSpecs(t, "IPv6")
 }
 

--- a/test/suites/utilization/suite_test.go
+++ b/test/suites/utilization/suite_test.go
@@ -27,10 +27,10 @@ import (
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/test/pkg/debug"
 
 	awstest "github.com/aws/karpenter/pkg/test"
 	"github.com/aws/karpenter/test/pkg/environment/aws"
-	"github.com/aws/karpenter/test/pkg/environment/common"
 )
 
 var env *aws.Environment
@@ -40,9 +40,6 @@ func TestUtilization(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
-	AfterSuite(func() {
-		env.Stop()
-	})
 	RunSpecs(t, "Utilization")
 }
 
@@ -51,7 +48,7 @@ var _ = AfterEach(func() { env.Cleanup() })
 var _ = AfterEach(func() { env.ForceCleanup() })
 var _ = AfterEach(func() { env.AfterEach() })
 
-var _ = Describe("Utilization", Label(common.NoWatch), Label(common.NoEvents), func() {
+var _ = Describe("Utilization", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 	It("should provision one pod per node", func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Debugging logging is moved out of the main `environment` package to create separation between the debug logging portion of the package code and the expectation portion of the code. node/pod watchers were transferred to controller-runtime due to increased complexity in adding a machine watcher. Adding a machine watcher using the informer pattern would have required using a dynamic informer factory. Instead, controller-runtime patterns are familiar and support the code quality in the future.

1. Moves test debugging to a separate package
2. Migrates node/pod watchers to use controller-runtime
3. Adds the machine watcher to stage out the Machine testing 

**How was this change tested?**

* `FOCUS=KubeletConfiguration make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
