### PR TITLE
chore!: Remove container loglevel from config-logging

### DIFF
--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -35,9 +35,3 @@ data:
         "timeEncoder": "iso8601"
       }
     }
-{{- with .Values.controller.logLevel }}
-  loglevel.controller: {{ . | quote }}
-{{- end }}
-{{- with .Values.webhook.logLevel }}
-  loglevel.webhook: {{ . | quote }}
-{{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -154,10 +154,6 @@ controller:
   # -- Controller errorOutputPaths - default to stderr only
   errorOutputPaths:
     - stderr
-  # -- Controller log level, defaults to the global log level
-  logLevel: ""
-  # -- Controller log encoding, defaults to the global log encoding
-  logEncoding: ""
   # -- Additional volumeMounts for the controller pod.
   extraVolumeMounts: []
   # - name: aws-iam-token
@@ -174,7 +170,6 @@ controller:
     # -- The container port to use for http health probe.
     port: 8081
 webhook:
-  logLevel: error
   # -- The container port to use for the webhook.
   port: 8443
 # -- Global log level

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.195
-	github.com/aws/karpenter-core v0.27.2-0.20230407175913-394c11ceb55a
+	github.com/aws/karpenter-core v0.27.2-0.20230410194800-58087aec96e6
 	github.com/go-playground/validator/v10 v10.11.2
 	github.com/imdario/mergo v0.3.15
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/aws/aws-sdk-go v1.44.195 h1:d5xFL0N83Fpsq2LFiHgtBUHknCRUPGHdOlCWt/jtO
 github.com/aws/aws-sdk-go v1.44.195/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/karpenter-core v0.27.2-0.20230407175913-394c11ceb55a h1:t8sVxSVAnLwNbc+K0uAhE9EPNq7NBoDZTuI/zlLvt4U=
 github.com/aws/karpenter-core v0.27.2-0.20230407175913-394c11ceb55a/go.mod h1:NQOEY9xxhPi6xUTknEA0KaY9pPbXzS5N4EKkZ5f85d8=
+github.com/aws/karpenter-core v0.27.2-0.20230410194800-58087aec96e6 h1:/JWFbAeYxQxz99ISImy4y/1LuW4KnUBJH1gvTgQGFJI=
+github.com/aws/karpenter-core v0.27.2-0.20230410194800-58087aec96e6/go.mod h1:NQOEY9xxhPi6xUTknEA0KaY9pPbXzS5N4EKkZ5f85d8=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -102,6 +102,9 @@ By adopting this practice we allow our users who are early adopters to test out 
 
 # Released Upgrade Notes
 
+## Upgrading to v0.28.0+
+* Container log level values `controller.logLevel` and `webhook.logLevel` are now removed from the Karpenter helm chart. Configure the container through the global value `logLevel`.
+
 ## Upgrading to v0.27.0+
 * The Karpenter controller pods now deploy with `kubernetes.io/hostname` self anti-affinity by default. If you are running Karpenter in HA (high-availability) mode and you do not have enough nodes to match the number of pod replicas you are deploying with, you will need to scale-out your nodes for Karpenter.
 * The following controller metrics changed and moved under the `controller_runtime` metrics namespace:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Container-based log level should not be supported since the separate containers for the controller and the webhook were removed in https://github.com/aws/karpenter-core/pull/29. These values should be removed from the values.yaml file in the helm chart

BREAKING: A user who would normally set the logLevel through --set controller.logLevel will now have to set it globally; otherwise, the log level will default to the global level.

**How was this change tested?**

* `make presubmit`
* `make apply`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
