### PR TITLE
chore: Fix `make docgen` by using a fake manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-kit/log v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,7 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=

--- a/website/content/en/preview/concepts/instance-types.md
+++ b/website/content/en/preview/concepts/instance-types.md
@@ -3202,29 +3202,6 @@ below are the resources available with some assumptions and after the instance o
  |memory|238333Mi|
  |pods|345|
  |vpc.amazonaws.com/pod-eni|108|
-### `c6in.metal`
-#### Labels
- | Label | Value |
- |--|--|
- |karpenter.k8s.aws/instance-category|c|
- |karpenter.k8s.aws/instance-cpu|128|
- |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
- |karpenter.k8s.aws/instance-family|c6in|
- |karpenter.k8s.aws/instance-generation|6|
- |karpenter.k8s.aws/instance-hypervisor||
- |karpenter.k8s.aws/instance-memory|262144|
- |karpenter.k8s.aws/instance-pods|688|
- |karpenter.k8s.aws/instance-size|metal|
- |kubernetes.io/arch|amd64|
- |kubernetes.io/os|linux|
- |node.kubernetes.io/instance-type|c6in.metal|
-#### Resources
- | Resource | Quantity |
- |--|--|
- |cpu|127610m|
- |ephemeral-storage|17Gi|
- |memory|234560Mi|
- |pods|688|
 ## c7g Family
 ### `c7g.medium`
 #### Labels
@@ -9539,30 +9516,6 @@ below are the resources available with some assumptions and after the instance o
  |memory|480816Mi|
  |pods|345|
  |vpc.amazonaws.com/pod-eni|108|
-### `m6idn.metal`
-#### Labels
- | Label | Value |
- |--|--|
- |karpenter.k8s.aws/instance-category|m|
- |karpenter.k8s.aws/instance-cpu|128|
- |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
- |karpenter.k8s.aws/instance-family|m6idn|
- |karpenter.k8s.aws/instance-generation|6|
- |karpenter.k8s.aws/instance-hypervisor||
- |karpenter.k8s.aws/instance-local-nvme|7600|
- |karpenter.k8s.aws/instance-memory|524288|
- |karpenter.k8s.aws/instance-pods|688|
- |karpenter.k8s.aws/instance-size|metal|
- |kubernetes.io/arch|amd64|
- |kubernetes.io/os|linux|
- |node.kubernetes.io/instance-type|m6idn.metal|
-#### Resources
- | Resource | Quantity |
- |--|--|
- |cpu|127610m|
- |ephemeral-storage|17Gi|
- |memory|477043Mi|
- |pods|688|
 ## m6in Family
 ### `m6in.large`
 #### Labels
@@ -9814,29 +9767,6 @@ below are the resources available with some assumptions and after the instance o
  |memory|480816Mi|
  |pods|345|
  |vpc.amazonaws.com/pod-eni|108|
-### `m6in.metal`
-#### Labels
- | Label | Value |
- |--|--|
- |karpenter.k8s.aws/instance-category|m|
- |karpenter.k8s.aws/instance-cpu|128|
- |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
- |karpenter.k8s.aws/instance-family|m6in|
- |karpenter.k8s.aws/instance-generation|6|
- |karpenter.k8s.aws/instance-hypervisor||
- |karpenter.k8s.aws/instance-memory|524288|
- |karpenter.k8s.aws/instance-pods|688|
- |karpenter.k8s.aws/instance-size|metal|
- |kubernetes.io/arch|amd64|
- |kubernetes.io/os|linux|
- |node.kubernetes.io/instance-type|m6in.metal|
-#### Resources
- | Resource | Quantity |
- |--|--|
- |cpu|127610m|
- |ephemeral-storage|17Gi|
- |memory|477043Mi|
- |pods|688|
 ## m7g Family
 ### `m7g.medium`
 #### Labels
@@ -13634,30 +13564,6 @@ below are the resources available with some assumptions and after the instance o
  |memory|965782Mi|
  |pods|345|
  |vpc.amazonaws.com/pod-eni|108|
-### `r6idn.metal`
-#### Labels
- | Label | Value |
- |--|--|
- |karpenter.k8s.aws/instance-category|r|
- |karpenter.k8s.aws/instance-cpu|128|
- |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
- |karpenter.k8s.aws/instance-family|r6idn|
- |karpenter.k8s.aws/instance-generation|6|
- |karpenter.k8s.aws/instance-hypervisor||
- |karpenter.k8s.aws/instance-local-nvme|7600|
- |karpenter.k8s.aws/instance-memory|1048576|
- |karpenter.k8s.aws/instance-pods|688|
- |karpenter.k8s.aws/instance-size|metal|
- |kubernetes.io/arch|amd64|
- |kubernetes.io/os|linux|
- |node.kubernetes.io/instance-type|r6idn.metal|
-#### Resources
- | Resource | Quantity |
- |--|--|
- |cpu|127610m|
- |ephemeral-storage|17Gi|
- |memory|962009Mi|
- |pods|688|
 ## r6in Family
 ### `r6in.large`
 #### Labels
@@ -13909,29 +13815,6 @@ below are the resources available with some assumptions and after the instance o
  |memory|965782Mi|
  |pods|345|
  |vpc.amazonaws.com/pod-eni|108|
-### `r6in.metal`
-#### Labels
- | Label | Value |
- |--|--|
- |karpenter.k8s.aws/instance-category|r|
- |karpenter.k8s.aws/instance-cpu|128|
- |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
- |karpenter.k8s.aws/instance-family|r6in|
- |karpenter.k8s.aws/instance-generation|6|
- |karpenter.k8s.aws/instance-hypervisor||
- |karpenter.k8s.aws/instance-memory|1048576|
- |karpenter.k8s.aws/instance-pods|688|
- |karpenter.k8s.aws/instance-size|metal|
- |kubernetes.io/arch|amd64|
- |kubernetes.io/os|linux|
- |node.kubernetes.io/instance-type|r6in.metal|
-#### Resources
- | Resource | Quantity |
- |--|--|
- |cpu|127610m|
- |ephemeral-storage|17Gi|
- |memory|962009Mi|
- |pods|688|
 ## r7g Family
 ### `r7g.medium`
 #### Labels


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Fix `make docgen` by using a fake manager
- Dedupes entries in the instance_types_gen doc

**How was this change tested?**

* `make presubmit`
* `make docgen` with no KUBECONFIG
* Validated that no duplicates were coming from instance types generation script

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
