### PR TITLE
chore: Concatenate AMI IDs in logs

### DIFF
--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -219,9 +219,20 @@ func (p *Provider) fetchAMIsFromEC2(ctx context.Context, amiSelector map[string]
 	p.ec2Cache.SetDefault(fmt.Sprint(hash), output.Images)
 	amiIDs := lo.Map(output.Images, func(ami *ec2.Image, _ int) string { return *ami.ImageId })
 	if p.cm.HasChanged("amiIDs", amiIDs) {
-		logging.FromContext(ctx).With("ami-ids", amiIDs).Debugf("discovered images")
+		logging.FromContext(ctx).With("ids", concatenateAmiIDs(amiIDs), "count", len(amiIDs)).Debugf("discovered images")
 	}
 	return output.Images, nil
+}
+
+func concatenateAmiIDs(amisIds []string) string {
+	var amiString string
+	if len(amisIds) > 25 {
+		amiString = strings.Join(amisIds[:25], ", ")
+		amiString += fmt.Sprintf(" and %d other(s)", len(amisIds)-25)
+	} else {
+		amiString = strings.Join(amisIds, ", ")
+	}
+	return amiString
 }
 
 func getFiltersAndOwners(amiSelector map[string]string) ([]*ec2.Filter, []*string) {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- When user specify amiSelector to `aws::name: "*"` karpenter logs will become filled with all the AMI IDs that are discovered by ec2.

- `2023-04-14T16:56:32.980Z	DEBUG	controller.node	discovered images	{"commit": "b4f1d60-dirty", "node": "ip-192-168-112-220.us-west-2.compute.internal", "ids": "ami-0789036840ebc8c25, ami-0123d5874c000c92e, ami-01e2c4303a7750e9f, ami-0438e722aaf2037af, ami-0696f65e1894f23c1, ami-06d0b3b36f79ffd17, ami-0386da4fafcdb3286, ami-0f4af98dc9062fc55, ami-055613971ee89acd7, ami-06055064d6004521f, ami-065a7f1c72ec3164b, ami-05692094f77d6c828, ami-0fe99b168ad207a9e, ami-07d7dd2821eadc9b7, ami-093107ba06ec290c8, ami-019f57bd424d44fd3, ami-01fc410639698b4ca, ami-0ccdef9b637fc187c, ami-0e8c547337376a477, ami-0d44c92d6423bd06b, ami-01042020b7eb94eb7, ami-0fe0482fe8b6a011d, ami-05d00b2a498b88054, ami-0a86c6d5ab23eefa7, ami-0525d0d0a99a22dbb and 11778 other(s)", "count": 11803}`

**How was this change tested?**

* Manually Tested 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
