### PR TITLE
feat: Add windows support (single amifamily)

### DIFF
--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -38,26 +38,45 @@ var (
 	RestrictedLabelDomains = []string{
 		LabelDomain,
 	}
-	AMIFamilyBottlerocket = "Bottlerocket"
-	AMIFamilyAL2          = "AL2"
-	AMIFamilyUbuntu       = "Ubuntu"
-	AMIFamilyCustom       = "Custom"
-	SupportedAMIFamilies  = []string{
+	AMIFamilyBottlerocket  = "Bottlerocket"
+	AMIFamilyAL2           = "AL2"
+	AMIFamilyUbuntu        = "Ubuntu"
+	AMIFamilyWindowsServer = "WindowsServer"
+	AMIFamilyCustom        = "Custom"
+	SupportedAMIFamilies   = []string{
 		AMIFamilyBottlerocket,
 		AMIFamilyAL2,
 		AMIFamilyUbuntu,
+		AMIFamilyWindowsServer,
 		AMIFamilyCustom,
 	}
 	SupportedContainerRuntimesByAMIFamily = map[string]sets.String{
-		AMIFamilyBottlerocket: sets.NewString("containerd"),
-		AMIFamilyAL2:          sets.NewString("dockerd", "containerd"),
-		AMIFamilyUbuntu:       sets.NewString("dockerd", "containerd"),
+		AMIFamilyBottlerocket:  sets.NewString("containerd"),
+		AMIFamilyAL2:           sets.NewString("dockerd", "containerd"),
+		AMIFamilyUbuntu:        sets.NewString("dockerd", "containerd"),
+		AMIFamilyWindowsServer: sets.NewString("containerd"),
 	}
-	ResourceNVIDIAGPU             v1.ResourceName         = "nvidia.com/gpu"
-	ResourceAMDGPU                v1.ResourceName         = "amd.com/gpu"
-	ResourceAWSNeuron             v1.ResourceName         = "aws.amazon.com/neuron"
-	ResourceHabanaGaudi           v1.ResourceName         = "habana.ai/gaudi"
-	ResourceAWSPodENI             v1.ResourceName         = "vpc.amazonaws.com/pod-eni"
+
+	Windows2019              = "2019"
+	Windows2022              = "2022"
+	WindowsCore              = "Core"
+	WindowsFull              = "Full"
+	SupportedWindowsVersions = []string{
+		Windows2019,
+		Windows2022,
+	}
+	SupportedWindowsVariants = []string{
+		WindowsCore,
+		WindowsFull,
+	}
+
+	ResourceNVIDIAGPU          v1.ResourceName = "nvidia.com/gpu"
+	ResourceAMDGPU             v1.ResourceName = "amd.com/gpu"
+	ResourceAWSNeuron          v1.ResourceName = "aws.amazon.com/neuron"
+	ResourceHabanaGaudi        v1.ResourceName = "habana.ai/gaudi"
+	ResourceAWSPodENI          v1.ResourceName = "vpc.amazonaws.com/pod-eni"
+	ResourcePrivateIPv4Address v1.ResourceName = "vpc.amazonaws.com/PrivateIPv4Address"
+
 	NVIDIAacceleratorManufacturer AcceleratorManufacturer = "nvidia"
 	AWSAcceleratorManufacturer    AcceleratorManufacturer = "aws"
 
@@ -85,6 +104,9 @@ var (
 	LabelInstanceAcceleratorManufacturer = LabelDomain + "/instance-accelerator-manufacturer"
 	LabelInstanceAcceleratorCount        = LabelDomain + "/instance-accelerator-count"
 	LabelInstanceAcceleratorMemory       = LabelDomain + "/instance-accelerator-memory"
+
+	LabelWindowsVersion = LabelDomain + "/windows-version"
+	LabelWindowsVariant = LabelDomain + "/windows-variant"
 
 	InterruptionInfrastructureFinalizer = Group + "/interruption-infrastructure"
 )
@@ -127,6 +149,8 @@ func init() {
 		LabelInstanceAcceleratorManufacturer,
 		LabelInstanceAcceleratorCount,
 		LabelInstanceAcceleratorMemory,
+		LabelWindowsVersion,
+		LabelWindowsVariant,
 	)
 }
 

--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -38,23 +38,23 @@ var (
 	RestrictedLabelDomains = []string{
 		LabelDomain,
 	}
-	AMIFamilyBottlerocket  = "Bottlerocket"
-	AMIFamilyAL2           = "AL2"
-	AMIFamilyUbuntu        = "Ubuntu"
-	AMIFamilyWindowsServer = "WindowsServer"
-	AMIFamilyCustom        = "Custom"
-	SupportedAMIFamilies   = []string{
+	AMIFamilyBottlerocket = "Bottlerocket"
+	AMIFamilyAL2          = "AL2"
+	AMIFamilyUbuntu       = "Ubuntu"
+	AMIFamilyWindows      = "Windows"
+	AMIFamilyCustom       = "Custom"
+	SupportedAMIFamilies  = []string{
 		AMIFamilyBottlerocket,
 		AMIFamilyAL2,
 		AMIFamilyUbuntu,
-		AMIFamilyWindowsServer,
+		AMIFamilyWindows,
 		AMIFamilyCustom,
 	}
 	SupportedContainerRuntimesByAMIFamily = map[string]sets.String{
-		AMIFamilyBottlerocket:  sets.NewString("containerd"),
-		AMIFamilyAL2:           sets.NewString("dockerd", "containerd"),
-		AMIFamilyUbuntu:        sets.NewString("dockerd", "containerd"),
-		AMIFamilyWindowsServer: sets.NewString("containerd"),
+		AMIFamilyBottlerocket: sets.NewString("containerd"),
+		AMIFamilyAL2:          sets.NewString("dockerd", "containerd"),
+		AMIFamilyUbuntu:       sets.NewString("dockerd", "containerd"),
+		AMIFamilyWindows:      sets.NewString("containerd"),
 	}
 
 	Windows2019              = "2019"

--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -57,13 +57,15 @@ var (
 		AMIFamilyWindows:      sets.NewString("containerd"),
 	}
 
-	Windows2019              = "2019"
-	Windows2022              = "2022"
-	WindowsCore              = "Core"
-	WindowsFull              = "Full"
-	SupportedWindowsVersions = []string{
-		Windows2019,
-		Windows2022,
+	Windows2019                            = "2019"
+	Windows2019Build                       = "10.0.17763"
+	Windows2022                            = "2022"
+	Windows2022Build                       = "10.0.20348"
+	WindowsCore                            = "Core"
+	WindowsFull                            = "Full"
+	SupportedWindowsVersionAndBuildMapping = map[string]string{
+		Windows2019: Windows2019Build,
+		Windows2022: Windows2022Build,
 	}
 	SupportedWindowsVariants = []string{
 		WindowsCore,
@@ -105,7 +107,6 @@ var (
 	LabelInstanceAcceleratorCount        = LabelDomain + "/instance-accelerator-count"
 	LabelInstanceAcceleratorMemory       = LabelDomain + "/instance-accelerator-memory"
 
-	LabelWindowsVersion = LabelDomain + "/windows-version"
 	LabelWindowsVariant = LabelDomain + "/windows-variant"
 
 	InterruptionInfrastructureFinalizer = Group + "/interruption-infrastructure"
@@ -149,7 +150,7 @@ func init() {
 		LabelInstanceAcceleratorManufacturer,
 		LabelInstanceAcceleratorCount,
 		LabelInstanceAcceleratorMemory,
-		LabelWindowsVersion,
+		v1.LabelWindowsBuild, //Todo: Move this to core
 		LabelWindowsVariant,
 	)
 }

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -330,8 +330,8 @@ func (c *CloudProvider) instanceToMachine(ctx context.Context, ec2instance *ec2.
 	if tag, ok := lo.Find(ec2instance.Tags, func(t *ec2.Tag) bool { return aws.StringValue(t.Key) == v1alpha5.ManagedByLabelKey }); ok {
 		labels[v1alpha5.ManagedByLabelKey] = aws.StringValue(tag.Value)
 	}
-	if tag, ok := lo.Find(ec2instance.Tags, func(t *ec2.Tag) bool { return aws.StringValue(t.Key) == v1alpha1.LabelWindowsVersion }); ok {
-		labels[v1alpha1.LabelWindowsVersion] = aws.StringValue(tag.Value)
+	if tag, ok := lo.Find(ec2instance.Tags, func(t *ec2.Tag) bool { return aws.StringValue(t.Key) == v1.LabelWindowsBuild }); ok {
+		labels[v1.LabelWindowsBuild] = aws.StringValue(tag.Value)
 	}
 	if tag, ok := lo.Find(ec2instance.Tags, func(t *ec2.Tag) bool { return aws.StringValue(t.Key) == v1alpha1.LabelWindowsVariant }); ok {
 		labels[v1alpha1.LabelWindowsVariant] = aws.StringValue(tag.Value)

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -17,10 +17,11 @@ package amifamily
 import (
 	"context"
 	"fmt"
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/providers/amifamily/bootstrap/windows.go
+++ b/pkg/providers/amifamily/bootstrap/windows.go
@@ -1,0 +1,79 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+
+	"github.com/samber/lo"
+)
+
+type Windows struct {
+	Options
+}
+
+// nolint:gocyclo
+func (w Windows) Script() (string, error) {
+	var userData bytes.Buffer
+	userData.WriteString("<powershell>\n")
+	userData.WriteString("[string]$EKSBootstrapScriptFile = \"$env:ProgramFiles\\Amazon\\EKS\\Start-EKSBootstrap.ps1\"\n")
+	userData.WriteString(fmt.Sprintf(`& $EKSBootstrapScriptFile -EKSClusterName "%s" -APIServerEndpoint "%s"`, w.ClusterName, w.ClusterEndpoint))
+	if w.CABundle != nil {
+		userData.WriteString(fmt.Sprintf(" -Base64ClusterCA \"%s\"", *w.CABundle))
+	}
+	kubeletExtraArgs := strings.Join([]string{w.nodeLabelArg(), w.nodeTaintArg()}, " ")
+	if kubeletExtraArgs = strings.Trim(kubeletExtraArgs, " "); len(kubeletExtraArgs) > 0 {
+		userData.WriteString(fmt.Sprintf(` -KubeletExtraArgs "%s"`, kubeletExtraArgs))
+	}
+	if w.KubeletConfig != nil && len(w.KubeletConfig.ClusterDNS) > 0 {
+		userData.WriteString(fmt.Sprintf(` -DNSClusterIP "%s"`, w.KubeletConfig.ClusterDNS[0]))
+	}
+	userData.WriteString("\n</powershell>")
+	return base64.StdEncoding.EncodeToString(userData.Bytes()), nil
+}
+
+func (w Windows) nodeTaintArg() string {
+	nodeTaintsArg := ""
+	var taintStrings []string
+	var once sync.Once
+	for _, taint := range w.Taints {
+		once.Do(func() { nodeTaintsArg = "--register-with-taints=" })
+		taintStrings = append(taintStrings, fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect))
+	}
+	return fmt.Sprintf("%s%s", nodeTaintsArg, strings.Join(taintStrings, ","))
+}
+
+func (w Windows) nodeLabelArg() string {
+	nodeLabelArg := ""
+	var labelStrings []string
+	var once sync.Once
+	keys := lo.Keys(w.Labels)
+	sort.Strings(keys) // ensures this list is deterministic, for easy testing.
+	for _, key := range keys {
+		if v1alpha5.LabelDomainExceptions.Has(key) {
+			continue
+		}
+		once.Do(func() { nodeLabelArg = "--node-labels=" })
+		labelStrings = append(labelStrings, fmt.Sprintf("%s=%v", key, w.Labels[key]))
+	}
+	return fmt.Sprintf("%s%s", nodeLabelArg, strings.Join(labelStrings, ","))
+}

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -78,7 +78,6 @@ type AMIFamily interface {
 	DefaultMetadataOptions() *v1alpha1.MetadataOptions
 	EphemeralBlockDevice() *string
 	FeatureFlags() FeatureFlags
-	IsWindows() bool
 }
 
 type DefaultAMIOutput struct {
@@ -103,10 +102,6 @@ func (d DefaultFamily) FeatureFlags() FeatureFlags {
 		PodsPerCoreEnabled:           true,
 		EvictionSoftEnabled:          true,
 	}
-}
-
-func (d DefaultFamily) IsWindows() bool {
-	return false
 }
 
 // New constructs a new launch template Resolver
@@ -167,7 +162,7 @@ func GetAMIFamily(amiFamily *string, options *Options) AMIFamily {
 		return &Bottlerocket{Options: options}
 	case v1alpha1.AMIFamilyUbuntu:
 		return &Ubuntu{Options: options}
-	case v1alpha1.AMIFamilyWindowsServer:
+	case v1alpha1.AMIFamilyWindows:
 		return &Windows{Options: options}
 	case v1alpha1.AMIFamilyCustom:
 		return &Custom{Options: options}

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -40,14 +40,14 @@ type Windows struct {
 }
 
 func (w Windows) DefaultAMIs(version string) (results []DefaultAMIOutput) {
-	for _, windowsVersion := range v1alpha1.SupportedWindowsVersions {
+	for windowsVersion, windowsBuild := range v1alpha1.SupportedWindowsVersionAndBuildMapping {
 		for _, windowsVariant := range v1alpha1.SupportedWindowsVariants {
 			results = append(results, DefaultAMIOutput{Name: fmt.Sprintf("windows-server-%s-%s-%s", windowsVersion, windowsVariant, version),
 				Query: fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-%s-English-%s-EKS_Optimized-%s/image_id", windowsVersion, windowsVariant, version),
 				Requirements: scheduling.NewRequirements(
 					scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
 					scheduling.NewRequirement(v1.LabelOSStable, v1.NodeSelectorOpIn, string(v1.Windows)),
-					scheduling.NewRequirement(v1alpha1.LabelWindowsVersion, v1.NodeSelectorOpIn, windowsVersion),
+					scheduling.NewRequirement(v1.LabelWindowsBuild, v1.NodeSelectorOpIn, windowsBuild),
 					scheduling.NewRequirement(v1alpha1.LabelWindowsVariant, v1.NodeSelectorOpIn, windowsVariant),
 				)})
 		}

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -83,7 +83,3 @@ func (w Windows) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
 func (w Windows) EphemeralBlockDevice() *string {
 	return aws.String("/dev/sda1")
 }
-
-func (w Windows) IsWindows() bool {
-	return true
-}

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -1,0 +1,89 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amifamily
+
+import (
+	"fmt"
+
+	"github.com/aws/karpenter-core/pkg/scheduling"
+
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+
+	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+)
+
+type Windows struct {
+	DefaultFamily
+	*Options
+}
+
+func (w Windows) DefaultAMIs(version string) (results []DefaultAMIOutput) {
+	for _, windowsVersion := range v1alpha1.SupportedWindowsVersions {
+		for _, windowsVariant := range v1alpha1.SupportedWindowsVariants {
+			results = append(results, DefaultAMIOutput{Name: fmt.Sprintf("windows-server-%s-%s-%s", windowsVersion, windowsVariant, version),
+				Query: fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-%s-English-%s-EKS_Optimized-%s/image_id", windowsVersion, windowsVariant, version),
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
+					scheduling.NewRequirement(v1.LabelOSStable, v1.NodeSelectorOpIn, string(v1.Windows)),
+					scheduling.NewRequirement(v1alpha1.LabelWindowsVersion, v1.NodeSelectorOpIn, windowsVersion),
+					scheduling.NewRequirement(v1alpha1.LabelWindowsVariant, v1.NodeSelectorOpIn, windowsVariant),
+				)})
+		}
+	}
+	return results
+}
+
+// UserData returns the default userdata script for the AMI Family
+func (w Windows) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+	return bootstrap.Windows{
+		Options: bootstrap.Options{
+			ClusterName:     w.Options.ClusterName,
+			ClusterEndpoint: w.Options.ClusterEndpoint,
+			KubeletConfig:   kubeletConfig,
+			Taints:          taints,
+			Labels:          labels,
+			CABundle:        caBundle,
+			CustomUserData:  customUserData,
+		},
+	}
+}
+
+// DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
+func (w Windows) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
+	sda1EBS := DefaultEBS
+	sda1EBS.VolumeSize = lo.ToPtr(resource.MustParse("50Gi"))
+	return []*v1alpha1.BlockDeviceMapping{{
+		DeviceName: w.EphemeralBlockDevice(),
+		EBS:        &sda1EBS,
+	}}
+}
+
+func (w Windows) EphemeralBlockDevice() *string {
+	return aws.String("/dev/sda1")
+}
+
+func (w Windows) IsWindows() bool {
+	return true
+}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -582,4 +583,11 @@ func GetCapacityType(instance *ec2.Instance) string {
 		return v1alpha5.CapacityTypeSpot
 	}
 	return v1alpha5.CapacityTypeOnDemand
+}
+
+func GetOS(instance *ec2.Instance) string {
+	if strings.ToLower(aws.StringValue(instance.Platform)) == strings.ToLower(ec2.PlatformValuesWindows) {
+		return string(v1.Windows)
+	}
+	return string(v1.Linux)
 }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -586,7 +586,7 @@ func GetCapacityType(instance *ec2.Instance) string {
 }
 
 func GetOS(instance *ec2.Instance) string {
-	if strings.ToLower(aws.StringValue(instance.Platform)) == strings.ToLower(ec2.PlatformValuesWindows) {
+	if strings.EqualFold(aws.StringValue(instance.Platform), ec2.PlatformValuesWindows) {
 		return string(v1.Windows)
 	}
 	return string(v1.Linux)

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -153,6 +153,7 @@ var _ = Describe("Instance Types", func() {
 			v1.LabelOSStable:                 "linux",
 			v1.LabelArchStable:               "amd64",
 			v1alpha5.LabelCapacityType:       "on-demand",
+			v1.LabelWindowsBuild:             "10.0.17763",
 			// Well Known to AWS
 			v1alpha1.LabelInstanceHypervisor:                   "nitro",
 			v1alpha1.LabelInstanceEncryptionInTransitSupported: "true",
@@ -180,7 +181,6 @@ var _ = Describe("Instance Types", func() {
 			"beta.kubernetes.io/os":         "linux",
 			v1.LabelInstanceType:            "g4dn.8xlarge",
 			"topology.ebs.csi.aws.com/zone": "test-zone-1a",
-			v1alpha1.LabelWindowsVersion:    "2019",
 			v1alpha1.LabelWindowsVariant:    "Core",
 		}
 

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/karpenter/pkg/providers/amifamily"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo/v2"
@@ -873,7 +875,8 @@ var _ = Describe("Instance Types", func() {
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(1)}})
 			for _, info := range instanceInfo {
 				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
-				limitedPods := instancetype.ENILimitedPods(info)
+				amiFamily := amifamily.GetAMIFamily(nodeTemplate.Spec.AMIFamily, &amifamily.Options{})
+				limitedPods := instancetype.ENILimitedPods(info, amiFamily)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", limitedPods.Value()))
 			}
 		})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -178,6 +178,8 @@ var _ = Describe("Instance Types", func() {
 			"beta.kubernetes.io/os":         "linux",
 			v1.LabelInstanceType:            "g4dn.8xlarge",
 			"topology.ebs.csi.aws.com/zone": "test-zone-1a",
+			v1alpha1.LabelWindowsVersion:    "2019",
+			v1alpha1.LabelWindowsVariant:    "Core",
 		}
 
 		// Ensure that we're exercising all well known labels

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -215,7 +215,7 @@ func (p *Provider) createLaunchTemplate(ctx context.Context, options *amifamily.
 			},
 			SecurityGroupIds: aws.StringSlice(options.SecurityGroupsIDs),
 			UserData:         aws.String(userData),
-			ImageId:          aws.String(options.AMIID),
+			ImageId:          aws.String(options.Ami.AmiID),
 			MetadataOptions: &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
 				HttpEndpoint:            options.MetadataOptions.HTTPEndpoint,
 				HttpProtocolIpv6:        options.MetadataOptions.HTTPProtocolIPv6,
@@ -223,7 +223,7 @@ func (p *Provider) createLaunchTemplate(ctx context.Context, options *amifamily.
 				HttpTokens:              options.MetadataOptions.HTTPTokens,
 			},
 			TagSpecifications: []*ec2.LaunchTemplateTagSpecificationRequest{
-				{ResourceType: aws.String(ec2.ResourceTypeNetworkInterface), Tags: utils.MergeTags(options.Tags)},
+				{ResourceType: aws.String(ec2.ResourceTypeInstance), Tags: utils.MergeTags(options.Tags, options.Ami.GetLabelsFromRequirements())},
 			},
 		},
 		TagSpecifications: []*ec2.TagSpecification{


### PR DESCRIPTION
This change integrates with the latest EKS window support.

Add a new Windows AMI Family.
Windows relevant code, "kubernetes.io/os" and "vpc.amazonaws.com/PrivateIPv4Address" is only active when Windows AMI Family defined in the AwsNodeTemplate

Add two new provisioner requirement well-known labels karpenter.k8s.aws/windows-version and karpenter.k8s.aws/windows-variant

Test on a Linux and Windows mixed system for provision and de-provision.

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
