### PR TITLE
BREAKING CHANGE: Add tag key checking to `AWSNodeTemplate` validation

### DIFF
--- a/pkg/apis/v1alpha1/awsnodetemplate_validation.go
+++ b/pkg/apis/v1alpha1/awsnodetemplate_validation.go
@@ -54,6 +54,7 @@ func (a *AWSNodeTemplateSpec) validate(_ context.Context) (errs *apis.FieldError
 		a.validateUserData(),
 		a.validateAMISelector(),
 		a.validateAMIFamily(),
+		a.validateTags(),
 	)
 }
 
@@ -95,6 +96,17 @@ func (a *AWSNodeTemplateSpec) validateAMISelector() (errs *apis.FieldError) {
 					message := fmt.Sprintf("%s['%s'] must be a valid ami-id (regex: %s)", amiSelectorPath, key, amiRegex.String())
 					errs = errs.Also(apis.ErrInvalidValue(fieldValue, message))
 				}
+			}
+		}
+	}
+	return errs
+}
+
+func (a *AWSNodeTemplateSpec) validateTags() (errs *apis.FieldError) {
+	for k := range a.Tags {
+		for _, pattern := range RestrictedTagPatterns {
+			if pattern.MatchString(k) {
+				errs = errs.Also(apis.ErrInvalidKeyName(k, "tags", fmt.Sprintf("tag contains a restricted tag matching %q", pattern.String())))
 			}
 		}
 	}

--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -15,6 +15,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +40,13 @@ var (
 	}
 	RestrictedLabelDomains = []string{
 		LabelDomain,
+	}
+	RestrictedTagPatterns = []*regexp.Regexp{
+		// Adheres to cluster name pattern matching as specified in the API spec
+		// https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html
+		regexp.MustCompile(`^kubernetes.io/cluster/[0-9A-Za-z][A-Za-z0-9\-_]*$`),
+		regexp.MustCompile(fmt.Sprintf("^%s$", v1alpha5.ProvisionerNameLabelKey)),
+		regexp.MustCompile(fmt.Sprintf("^%s$", v1alpha5.ManagedByLabelKey)),
 	}
 	AMIFamilyBottlerocket = "Bottlerocket"
 	AMIFamilyAL2          = "AL2"

--- a/pkg/apis/v1alpha1/suite_test.go
+++ b/pkg/apis/v1alpha1/suite_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
 	"context"
@@ -26,6 +26,8 @@ import (
 	"knative.dev/pkg/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 )
 
 var ctx context.Context
@@ -37,25 +39,55 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = Describe("Validation", func() {
-	var ant *AWSNodeTemplate
+	var ant *v1alpha1.AWSNodeTemplate
 
 	BeforeEach(func() {
-		ant = &AWSNodeTemplate{
+		ant = &v1alpha1.AWSNodeTemplate{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
-			Spec:       AWSNodeTemplateSpec{},
-			Status:     AWSNodeTemplateStatus{},
+			Spec: v1alpha1.AWSNodeTemplateSpec{
+				AWS: v1alpha1.AWS{
+					SubnetSelector:        map[string]string{"foo": "bar"},
+					SecurityGroupSelector: map[string]string{"foo": "bar"},
+				},
+			},
 		}
 	})
 
 	Context("UserData", func() {
 		It("should succeed if user data is empty", func() {
-			ant.Spec.SubnetSelector = map[string]string{"foo": "bar"}
-			ant.Spec.SecurityGroupSelector = map[string]string{"foo": "bar"}
 			Expect(ant.Validate(ctx)).To(Succeed())
 		})
 		It("should fail if launch template is also specified", func() {
 			ant.Spec.LaunchTemplateName = ptr.String("someLaunchTemplate")
 			ant.Spec.UserData = ptr.String("someUserData")
+			Expect(ant.Validate(ctx)).To(Not(Succeed()))
+		})
+	})
+	Context("Tags", func() {
+		It("should succeed when tags are empty", func() {
+			ant.Spec.Tags = map[string]string{}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should succeed if tags aren't in restricted tag keys", func() {
+			ant.Spec.Tags = map[string]string{
+				"karpenter.sh/custom-key": "value",
+				"karpenter.sh/managed":    "true",
+				"kubernetes.io/role/key":  "value",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should fail if tags contain a restricted domain key", func() {
+			ant.Spec.Tags = map[string]string{
+				"karpenter.sh/provisioner-name": "value",
+			}
+			Expect(ant.Validate(ctx)).To(Not(Succeed()))
+			ant.Spec.Tags = map[string]string{
+				"kubernetes.io/cluster/test": "value",
+			}
+			Expect(ant.Validate(ctx)).To(Not(Succeed()))
+			ant.Spec.Tags = map[string]string{
+				"karpenter.sh/managed-by": "test",
+			}
 			Expect(ant.Validate(ctx)).To(Not(Succeed()))
 		})
 	})

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -381,8 +381,7 @@ var _ = Describe("LaunchTemplates", func() {
 		It("should override default tag names", func() {
 			// these tags are defaulted, so ensure users can override them
 			nodeTemplate.Spec.Tags = map[string]string{
-				v1alpha5.ProvisionerNameLabelKey: "myprovisioner",
-				"Name":                           "myname",
+				"Name": "myname",
 			}
 			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 			pod := coretest.UnschedulablePod()

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -247,7 +247,7 @@ karpenter.sh/provisioner-name: <provisioner-name>
 kubernetes.io/cluster/<cluster-name>: owned
 ```
 
-Additional tags can be added in the AWSNodeTemplate tags section which are merged with global tags in `aws.tags` (located in karpenter-global-settings ConfigMap) and can override the default tag values.
+Additional tags can be added in the AWSNodeTemplate tags section which are merged with global tags in `aws.tags` (located in karpenter-global-settings ConfigMap).
 ```yaml
 spec:
   tags:
@@ -255,6 +255,8 @@ spec:
     dev.corp.net/app: Calculator
     dev.corp.net/team: MyTeam
 ```
+
+Karpenter allows overrides of the default "Name" tag but does not allow overrides to restricted domains (such as "karpenter.sh", "karpenter.k8s.aws", and "kubernetes.io/cluster"). This ensures that Karpenter is able to correctly auto-discover machines that it owns.
 
 ## spec.metadataOptions
 

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -102,6 +102,12 @@ By adopting this practice we allow our users who are early adopters to test out 
 
 # Released Upgrade Notes
 
+## Upgrading to v0.28.0+
+* Karpenter now defines a set of "restricted tags" which can't be overridden with custom tagging in the AWSNodeTemplate or in the "karpenter-global-settings" ConfigMap. These tags include:
+  * karpenter.sh/provisioner-name
+  * kubernetes.io/cluster/<cluster-name>
+If you are currently using any of these tag overrides when tagging your instances, webhook validation will now fail.
+
 ## Upgrading to v0.27.0+
 * The Karpenter controller pods now deploy with `kubernetes.io/hostname` self anti-affinity by default. If you are running Karpenter in HA (high-availability) mode and you do not have enough nodes to match the number of pod replicas you are deploying with, you will need to scale-out your nodes for Karpenter.
 * The following controller metrics changed and moved under the `controller_runtime` metrics namespace:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Adds validation to the AWSNodeTemplate that keys provided in the `spec.tags` section are not within a "restricted set" of tags for Karpenter that Karpenter and other automation use for auto-discovery.

BREAKING CHANGE: Users who use the following restricted tag key set in either the AWSNodeTemplate `spec.tags` or the `karpenter-global-settings` `aws.tags` will experience validation errors 
1. `kubernetes.io/cluster/<cluster-name>`
2. `karpenter.sh/provisioner-name`
3. `karpenter.sh/managed-by`

**How was this change tested?**

* `make presubmit`
* `FOCUS=Webhooks make e2etests`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
