### PR TITLE
docs: Update AWSNodeTemplate docs for ami selectors

### DIFF
--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -222,7 +222,14 @@ Select all AMIs with a specified tag:
 Select AMIs by name:
 ```yaml
   amiSelector:
-    Name: my-ami
+    aws::name: my-ami
+```
+
+Select AMIs by name and a specific owner:
+```yaml
+  amiSelector:
+    aws::name: my-ami
+    owners: self/ownerAccountID
 ```
 
 Select AMIs by an arbitrary AWS tag key/value pair:
@@ -234,7 +241,7 @@ Select AMIs by an arbitrary AWS tag key/value pair:
 Specify AMIs explicitly by ID:
 ```yaml
   amiSelector:
-    aws-ids: "ami-123,ami-456"
+    aws::ids: "ami-123,ami-456"
 ```
 
 ## spec.tags

--- a/website/content/en/v0.26.1/concepts/node-templates.md
+++ b/website/content/en/v0.26.1/concepts/node-templates.md
@@ -222,7 +222,14 @@ Select all AMIs with a specified tag:
 Select AMIs by name:
 ```yaml
   amiSelector:
-    Name: my-ami
+    aws::name: my-ami
+```
+
+Select AMIs by name and a specific owner:
+```yaml
+  amiSelector:
+    aws::name: my-ami
+    owners: self/ownerAccountID
 ```
 
 Select AMIs by an arbitrary AWS tag key/value pair:
@@ -234,7 +241,7 @@ Select AMIs by an arbitrary AWS tag key/value pair:
 Specify AMIs explicitly by ID:
 ```yaml
   amiSelector:
-    aws-ids: "ami-123,ami-456"
+    aws::ids: "ami-123,ami-456"
 ```
 
 ## spec.tags

--- a/website/content/en/v0.27.3/concepts/node-templates.md
+++ b/website/content/en/v0.27.3/concepts/node-templates.md
@@ -222,7 +222,14 @@ Select all AMIs with a specified tag:
 Select AMIs by name:
 ```yaml
   amiSelector:
-    Name: my-ami
+    aws::name: my-ami
+```
+
+Select AMIs by name and a specific owner:
+```yaml
+  amiSelector:
+    aws::name: my-ami
+    owners: self/ownerAccountID
 ```
 
 Select AMIs by an arbitrary AWS tag key/value pair:
@@ -234,7 +241,7 @@ Select AMIs by an arbitrary AWS tag key/value pair:
 Specify AMIs explicitly by ID:
 ```yaml
   amiSelector:
-    aws-ids: "ami-123,ami-456"
+    aws::ids: "ami-123,ami-456"
 ```
 
 ## spec.tags


### PR DESCRIPTION



**Description**

The AMI Selector as shown on the [merged pr](https://github.com/aws/karpenter/pull/3204) uses the `aws::` prefixes on the tags. 

**How was this change tested?**
We tested using the AMISelector without the `aws::` prefix and it breaks. So thought of updating the docs to reflect this.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates

**Release Note**

Update AWSNodeTemplate docs for ami selectors to reflect the `aws::` prefix requirements.
