### PR TITLE
test: Fix upgrading CRDS from older version

### DIFF
--- a/test/manifests/upgrade-crds.yaml
+++ b/test/manifests/upgrade-crds.yaml
@@ -9,15 +9,29 @@ spec:
   params:
     - name: cluster-name
       description: Name of the cluster under test.
+    - name: git-repo-url
+      description: the git repo url can be used to run tests on a fork
+      default: "https://github.com/aws/karpenter"
     - name: git-ref
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
   workspaces:
     - name: ws
   steps:
+  - name: checkout-repository
+    image: alpine/git
+    workingDir: $(workspaces.ws.path)
+    script: |
+      echo "Cloning $(params.git-repo-url)"
+      git clone $(params.git-repo-url).git .
+      
+      echo "Fetching: $(params.git-ref)"
+      git fetch origin $(params.git-ref)
+      
+      echo "Checking out git ref: $(echo $(params.git-ref) | cut -d":" -f2)"
+      git checkout $(echo $(params.git-ref)| cut -d":" -f2)
   - name: upgrade-crds
     image: public.ecr.aws/karpenter/tools:latest
+    workingDir: $(workspaces.ws.path)
     script: |
       aws eks update-kubeconfig --name $(params.cluster-name)
-      kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/$(params.git-ref)/pkg/apis/crds/karpenter.sh_provisioners.yaml
-      kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/$(params.git-ref)/pkg/apis/crds/karpenter.sh_machines.yaml
-      kubectl replace -f https://raw.githubusercontent.com/aws/karpenter/$(params.git-ref)/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+      kubectl apply -f pkg/apis/crds/

--- a/test/manifests/upgrade-suite.yaml
+++ b/test/manifests/upgrade-suite.yaml
@@ -43,6 +43,8 @@ spec:
     params:
     - name: cluster-name
       value: $(params.cluster-name)
+    - name: git-repo-url
+      value: $(params.git-repo-url)
     - name: git-ref
       value: $(params.to-git-ref)
     runAfter:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

The `kubectl replace` directive does not work when the object doesn't already exist. Anyways, we should not have to specify new CRDs when we add them. This change applies _every_ CRD from the pkg/apis/crds directory

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
