### PR TITLE
chore: Handle re-owned nodes linking

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -105,7 +105,7 @@ func (c *CloudProvider) Link(ctx context.Context, machine *v1alpha5.Machine) err
 		return fmt.Errorf("getting instance ID, %w", err)
 	}
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("id", id))
-	return c.instanceProvider.Link(ctx, id)
+	return c.instanceProvider.Link(ctx, id, machine.Labels[v1alpha5.ProvisionerNameLabelKey])
 }
 
 func (c *CloudProvider) List(ctx context.Context) ([]*v1alpha5.Machine, error) {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -100,13 +100,21 @@ func (p *Provider) Create(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 	return NewInstanceFromFleet(fleetInstance, tags), nil
 }
 
-func (p *Provider) Link(ctx context.Context, id string) error {
+func (p *Provider) Link(ctx context.Context, id, provisionerName string) error {
 	_, err := p.ec2api.CreateTagsWithContext(ctx, &ec2.CreateTagsInput{
 		Resources: aws.StringSlice([]string{id}),
 		Tags: []*ec2.Tag{
 			{
 				Key:   aws.String(v1alpha5.ManagedByLabelKey),
 				Value: aws.String(settings.FromContext(ctx).ClusterName),
+			},
+			{
+				Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", settings.FromContext(ctx).ClusterName)),
+				Value: aws.String("owned"),
+			},
+			{
+				Key:   aws.String(v1alpha5.ProvisionerNameLabelKey),
+				Value: aws.String(provisionerName),
 			},
 		},
 	})

--- a/test/suites/machine/link_test.go
+++ b/test/suites/machine/link_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -202,6 +203,75 @@ var _ = Describe("MachineLink", func() {
 			})
 			g.Expect(ok).To(BeTrue())
 			g.Expect(aws.StringValue(tag.Value)).To(Equal(settings.FromContext(env.Context).ClusterName))
+		}, time.Minute, time.Second).Should(Succeed())
+	})
+	It("should succeed to link a Machine for an existing instance re-owned by Karpenter", func() {
+		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+			AMIFamily:             &v1alpha1.AMIFamilyAL2,
+			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+		}})
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
+		})
+		env.ExpectCreated(provisioner, provider)
+
+		// Update the userData for the instance input with the correct provisionerName
+		rawContent, err := os.ReadFile("testdata/al2_userdata_input.sh")
+		Expect(err).ToNot(HaveOccurred())
+
+		// No tag specifications since we're mocking an instance not launched by Karpenter
+		instanceInput.UserData = lo.ToPtr(base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(string(rawContent), settings.FromContext(env.Context).ClusterName,
+			settings.FromContext(env.Context).ClusterEndpoint, env.ExpectCABundle(), provisioner.Name))))
+
+		// Create an instance manually to mock Karpenter launching an instance
+		out, err := env.EC2API.RunInstances(instanceInput)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.Instances).To(HaveLen(1))
+
+		// Always ensure that we cleanup the instance
+		DeferCleanup(func() {
+			_, err := env.EC2API.TerminateInstances(&ec2.TerminateInstancesInput{
+				InstanceIds: []*string{out.Instances[0].InstanceId},
+			})
+			if awserrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		// Wait for the node to register with the cluster
+		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
+
+		// Add the provisioner-name label to the node to re-own it
+		stored := node.DeepCopy()
+		node.Labels[v1alpha5.ProvisionerNameLabelKey] = provisioner.Name
+		Expect(env.Client.Patch(env.Context, node, client.MergeFrom(stored))).To(Succeed())
+
+		// Restart Karpenter to start the linking process
+		env.ExpectKarpenterPodsDeleted()
+
+		// Expect that the Machine is created when Karpenter starts up
+		machines := env.EventuallyExpectCreatedMachineCount("==", 1)
+		machine := machines[0]
+
+		// Expect the machine's fields are properly populated
+		Expect(machine.Spec.Requirements).To(Equal(provisioner.Spec.Requirements))
+		Expect(machine.Spec.MachineTemplateRef.Name).To(Equal(provider.Name))
+
+		// Expect the instance to have the karpenter.sh/managed-by tag and the karpenter.sh/provisioner-name tag
+		Eventually(func(g Gomega) {
+			instance := env.GetInstanceByID(aws.StringValue(out.Instances[0].InstanceId))
+			tag, ok := lo.Find(instance.Tags, func(t *ec2.Tag) bool {
+				return aws.StringValue(t.Key) == v1alpha5.ManagedByLabelKey
+			})
+			g.Expect(ok).To(BeTrue())
+			g.Expect(aws.StringValue(tag.Value)).To(Equal(settings.FromContext(env.Context).ClusterName))
+			tag, ok = lo.Find(instance.Tags, func(t *ec2.Tag) bool {
+				return aws.StringValue(t.Key) == v1alpha5.ProvisionerNameLabelKey
+			})
+			g.Expect(ok).To(BeTrue())
+			g.Expect(aws.StringValue(tag.Value)).To(Equal(provisioner.Name))
 		}, time.Minute, time.Second).Should(Succeed())
 	})
 })


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Handles linking nodes to machines that were linked to be managed by karpenter by just using the `karpenter.sh/provisioner-name` label on the nodes. These nodes would not have the `karpenter.sh/provisioner-name` tag attached to the instance so the only way to discover that they are managed by Karpenter is to look at the node labels.

**How was this change tested?**

* `make presubmit`
* `FOCUS=Machine make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
