### PR TITLE
BREAKING CHANGE: Remove `.Values.extraObjects`

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -50,7 +50,6 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
 | dnsPolicy | string | `"Default"` | Configure the DNS Policy for the pod |
-| extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | extraVolumes | list | `[]` | Additional volumes for the pod. |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname. |
 | hostNetwork | bool | `false` | Bind the pod to the host network. This is required when using a custom CNI. |

--- a/charts/karpenter/templates/extra-manifests.yaml
+++ b/charts/karpenter/templates/extra-manifests.yaml
@@ -1,4 +1,0 @@
-{{ range .Values.extraObjects }}
----
-{{ tpl (toYaml .) $ }}
-{{ end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -94,26 +94,6 @@ extraVolumes: []
 #         audience: sts.amazonaws.com
 #         expirationSeconds: 86400
 #         path: token
-
-# -- Array of extra K8s manifests to deploy
-extraObjects: []
-#- apiVersion: karpenter.k8s.aws/v1alpha1
-#  kind: AWSNodeTemplate
-#  metadata:
-#    name: default
-#  spec:
-#    subnetSelector:
-#      karpenter.sh/discovery: {CLUSTER_NAME}
-#    securityGroupSelector:
-#      karpenter.sh/discovery: {CLUSTER_NAME}
-#- apiVersion: karpenter.sh/v1alpha5
-#  kind: Provisioner
-#  metadata:
-#    name: default
-#  spec:
-#    providerRef:
-#      name: default
-
 controller:
   image:
     # -- Repository path to the controller image.

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -101,9 +101,6 @@ extraObjects: []
 #  kind: AWSNodeTemplate
 #  metadata:
 #    name: default
-#    annotations:
-#      "helm.sh/hook": "post-install,post-upgrade"
-#      "helm.sh/hook-delete-policy": before-hook-creation
 #  spec:
 #    subnetSelector:
 #      karpenter.sh/discovery: {CLUSTER_NAME}
@@ -113,9 +110,6 @@ extraObjects: []
 #  kind: Provisioner
 #  metadata:
 #    name: default
-#    annotations:
-#      "helm.sh/hook": "post-install,post-upgrade"
-#      "helm.sh/hook-delete-policy": before-hook-creation
 #  spec:
 #    providerRef:
 #      name: default

--- a/website/content/en/preview/concepts/metrics.md
+++ b/website/content/en/preview/concepts/metrics.md
@@ -21,8 +21,8 @@ Number of deprovisioning actions performed. Labeled by action.
 ### `karpenter_deprovisioning_evaluation_duration_seconds`
 Duration of the deprovisioning evaluation process in seconds.
 
-### `karpenter_deprovisioning_replacement_node_initialized_seconds`
-Amount of time required for a replacement node to become initialized.
+### `karpenter_deprovisioning_replacement_machine_initialized_seconds`
+Amount of time required for a replacement machine to become initialized.
 
 ## Interruption Metrics
 
@@ -58,13 +58,13 @@ The Provisioner Usage Percentage is the percentage of each resource used based o
 Node allocatable are the resources allocatable by nodes.
 
 ### `karpenter_nodes_created`
-Number of nodes created in total by Karpenter. Labeled by reason the node was created and the owning provisioner.
+Number of nodes created in total by Karpenter. Labeled by owning provisioner.
 
 ### `karpenter_nodes_system_overhead`
 Node system daemon overhead are the resources reserved for system overhead, the difference between the node's capacity and allocatable values are reported by the status.
 
 ### `karpenter_nodes_terminated`
-Number of nodes terminated in total by Karpenter. Labeled by reason the node was terminated and the owning provisioner.
+Number of nodes terminated in total by Karpenter. Labeled by owning provisioner.
 
 ### `karpenter_nodes_termination_time_seconds`
 The time taken between a node's deletion request and the removal of its finalizer

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -171,21 +171,6 @@ Your security groups are not blocking you from reaching your webhook.
 This is especially relevant if you have used `terraform-eks-module` version `>=18` since that version changed its security
 approach, and now it's much more restrictive.
 
-If you see this issue happens while using the`extraObjects` key from the values file, ensure that:
-
-- The helm install/upgrade command has the `--wait` flag (or `wait: true` when using helmfile)
-- Your Provisioners and AWSNodeTemplates definitions have the proper [helm hooks annotations](https://helm.sh/docs/topics/charts_hooks/) to install them *after* the karpenter pods are running
-
-```yaml
-- apiVersion: karpenter.sh/v1alpha5
-  kind: Provisioner
-  metadata:
-    name: default
-    annotations:
-      "helm.sh/hook": "post-install,post-upgrade"
-      "helm.sh/hook-delete-policy": before-hook-creation
-```
-
 ## Provisioning
 
 ### DaemonSets can result in deployment failures

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -103,6 +103,7 @@ By adopting this practice we allow our users who are early adopters to test out 
 # Released Upgrade Notes
 
 ## Upgrading to v0.28.0+
+* The `extraObjects` value is now removed from the Helm chart. Having this value in the chart proved to not work in the majority of Karpenter installs and often led to anti-patterns, where the Karpenter resources installed to manage Karpenter's capacity were directly tied to the install of the Karpenter controller deployments. The Karpenter team recommends that, if you want to install Karpenter manifests alongside the Karpenter helm chart, to do so by creating a separate chart for the manifests, creating a dependency on the controller chart.
 * Karpenter now defines a set of "restricted tags" which can't be overridden with custom tagging in the AWSNodeTemplate or in the "karpenter-global-settings" ConfigMap. These tags include:
   * karpenter.sh/provisioner-name
   * kubernetes.io/cluster/<cluster-name>


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Reverts #3370 which allowed the ability to add extra manifests into the helm chart. This is being removed from the Karpenter project for a few reasons:
1. It couples the install of Karpenter with the layer that manages and controls the nodes. Since Provisioners own Machines, Karpenter cannot be uninstalled without carefully tearing down the Provisioners before uninstalling the Provisioners and the Karpenter deployment
2. The `extraObjects` field did not work for new installs since the webhooks were not up before the objects were applied. This meant that `helm installs` would often fail for users that were installing their manifests in this way.

Since Helm offers no in-chart dependency mechanisms (beyond hooks, which do not work in this case), the Karpenter maintainer team recommends that, if you want to install Karpenter manifests as a helm chart (alongside Karpenter), it should be done using a separate chart that can take the `aws/karpenter` chart as a dependency so there is a strict ordering for install.

**How was this change tested?**

* `make apply`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
