### PR TITLE
test: E2ETesting Delete launch templates in cleanup step

### DIFF
--- a/test/hack/cleanup/cleanup.sh
+++ b/test/hack/cleanup/cleanup.sh
@@ -13,10 +13,12 @@ aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE ROLLBACK_FA
 
 
 # Clean up old launch templates
-launch_templates=$(aws ec2 describe-launch-templates |  jq -r '.LaunchTemplates[].LaunchTemplateName' | grep Karpenter-karpenter-tests)
-n_lts=$(echo ${launch_templates} | wc -w)
+launch_templates=($(aws ec2 describe-launch-templates |  jq -r '.LaunchTemplates[].LaunchTemplateName' | grep "karpenter.k8s.aws"))
+n_lts="${#launch_templates[@]}"
 echo "Removing ${n_lts} launch templates"
-for lt in ${launch_templates}; do
+
+# Iterate through every line in the launch template describe response
+for lt in "${launch_templates[@]}"; do
   echo "Deleting LT ${lt}"
-  aws ec2 delete-launch-template --no-cli-pager --launch-template-name ${lt}
+  aws ec2 delete-launch-template --no-cli-pager --launch-template-name "${lt}"
 done

--- a/test/manifests/cleanup.yaml
+++ b/test/manifests/cleanup.yaml
@@ -24,3 +24,15 @@ spec:
     script: |
       aws cloudformation delete-stack --stack-name iam-$(params.cluster-name)
       aws cloudformation wait stack-delete-complete --stack-name iam-$(params.cluster-name)
+
+  - name: delete-launch-templates
+    image: public.ecr.aws/karpenter/tools:latest
+    script: |
+      aws ec2 describe-launch-templates \
+        --filter Name=tag:karpenter.k8s.aws/cluster,Values=$(params.cluster-name) \
+        --query "LaunchTemplates[*].LaunchTemplateId" \
+        --output text |
+      xargs \
+        -n 1 \
+        aws ec2 delete-launch-template \
+          --launch-template-id


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #

**Description**

Delete launch templates associated with the cluster during the cleanup step on the E2E test run. This ensures that we don't leak launch templates in our account when tearing down the cluster

**How was this change tested?**

* Running the command manually

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
