### PR TITLE
chore: Fix change monitor changing on different node templates

### DIFF
--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -92,7 +92,7 @@ func (p *Provider) KubeServerVersion(ctx context.Context) (string, error) {
 	version := fmt.Sprintf("%s.%s", serverVersion.Major, strings.TrimSuffix(serverVersion.Minor, "+"))
 	p.kubernetesVersionCache.SetDefault(kubernetesVersionCacheKey, version)
 	if p.cm.HasChanged("kubernetes-version", version) {
-		logging.FromContext(ctx).With("kubernetes-version", version).Debugf("discovered kubernetes version")
+		logging.FromContext(ctx).With("version", version).Debugf("discovered kubernetes version")
 	}
 	return version, nil
 }
@@ -127,8 +127,10 @@ func (p *Provider) Get(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempla
 			return nil, err
 		}
 	}
-	amis = sortAMIsByCreationDate(amis)
-	amis = groupAMIsByRequirements(amis)
+	amis = groupAMIsByRequirements(sortAMIsByCreationDate(amis))
+	if p.cm.HasChanged(fmt.Sprintf("amis/%s", nodeTemplate.Name), amis) {
+		logging.FromContext(ctx).With("ids", amiList(amis), "count", len(amis)).Debugf("discovered amis")
+	}
 	return amis, nil
 }
 
@@ -162,7 +164,6 @@ func (p *Provider) getDefaultAMIFromSSM(ctx context.Context, nodeTemplate *v1alp
 		}
 		amis = append(amis, AMI{AmiID: amiID, Requirements: ssmOutput.Requirements})
 	}
-
 	amis, err = p.findAMINames(ctx, amis)
 	if err != nil {
 		return nil, err
@@ -209,9 +210,6 @@ func (p *Provider) fetchAMIsFromSSM(ctx context.Context, ssmQuery string) (strin
 	}
 	ami := aws.StringValue(output.Parameter.Value)
 	p.ssmCache.SetDefault(ssmQuery, ami)
-	if p.cm.HasChanged("ssmquery-"+ssmQuery, ami) {
-		logging.FromContext(ctx).With("ami", ami, "query", ssmQuery).Debugf("discovered ami")
-	}
 	return ami, nil
 }
 
@@ -246,24 +244,20 @@ func (p *Provider) fetchAMIsFromEC2(ctx context.Context, amiSelector map[string]
 	if err != nil {
 		return nil, fmt.Errorf("describing images %+v, %w", filters, err)
 	}
-
 	p.ec2Cache.SetDefault(fmt.Sprint(hash), output.Images)
-	amiIDs := lo.Map(output.Images, func(ami *ec2.Image, _ int) string { return *ami.ImageId })
-	if p.cm.HasChanged("amiIDs", amiIDs) {
-		logging.FromContext(ctx).With("ids", concatenateAmiIDs(amiIDs), "count", len(amiIDs)).Debugf("discovered images")
-	}
 	return output.Images, nil
 }
 
-func concatenateAmiIDs(amisIds []string) string {
-	var amiString string
-	if len(amisIds) > 25 {
-		amiString = strings.Join(amisIds[:25], ", ")
-		amiString += fmt.Sprintf(" and %d other(s)", len(amisIds)-25)
+func amiList(amis []AMI) string {
+	var sb strings.Builder
+	ids := lo.Map(amis, func(a AMI, _ int) string { return a.AmiID })
+	if len(amis) > 25 {
+		sb.WriteString(strings.Join(ids[:25], ", "))
+		sb.WriteString(fmt.Sprintf(" and %d other(s)", len(amis)-25))
 	} else {
-		amiString = strings.Join(amisIds, ", ")
+		sb.WriteString(strings.Join(ids, ", "))
 	}
-	return amiString
+	return sb.String()
 }
 
 func getFiltersAndOwners(amiSelector map[string]string) ([]*ec2.Filter, []*string) {

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -79,9 +79,12 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 	for _, subnet := range output.Subnets {
 		delete(p.inflightIPs, *subnet.SubnetId)
 	}
-	subnetLog := Pretty(output.Subnets)
-	if p.cm.HasChanged("subnets", subnetLog) {
-		logging.FromContext(ctx).With("subnets", subnetLog).Debugf("discovered subnets")
+	if p.cm.HasChanged(fmt.Sprintf("subnets/%s", nodeTemplate.Name), output.Subnets) {
+		logging.FromContext(ctx).
+			With("subnets", lo.Map(output.Subnets, func(s *ec2.Subnet, _ int) string {
+				return fmt.Sprintf("%s (%s)", aws.StringValue(s.SubnetId), aws.StringValue(s.AvailabilityZone))
+			})).
+			Debugf("discovered subnets")
 	}
 	return output.Subnets, nil
 }
@@ -232,12 +235,4 @@ func getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {
 		}
 	}
 	return filters
-}
-
-func Pretty(subnets []*ec2.Subnet) []string {
-	names := []string{}
-	for _, subnet := range subnets {
-		names = append(names, fmt.Sprintf("%s (%s)", aws.StringValue(subnet.SubnetId), aws.StringValue(subnet.AvailabilityZone)))
-	}
-	return names
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

The current `ChangeMonitor` for subnets, security groups, and images only considers __one set__ of selectors to get the resolved values. This means that, if there are multiple `AWSNodeTemplates`, this ChangeMonitor value will be continually changing and will continue to print the logs message "discovered..." so long as the value associated with the key keeps changing. 

Rather than using a singleton key value, the value should be keyed based on the `AWSNodeTemplate` name. This will allow us to print different values once (every 24h) and then scope that value to its associated `AWSNodeTemplate`

### Old Logs (You can see duplicate lines printed after 5m)

```console
2023-04-25T16:35:37.670Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ce030bd", "awsnodetemplate": "default", "subnets": ["subnet-0a89ab2e50dfe40d6 (us-west-2b)", "subnet-01ac1560ed61b3ea5 (us-west-2d)", "subnet-0d2e48c60b6f70689 (us-west-2d)", "subnet-007aafdece10d1105 (us-west-2b)", "subnet-065d2bd943d9549a6 (us-west-2a)", "subnet-004e4cd40a2953909 (us-west-2a)"]}
2023-04-25T16:35:37.723Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ce030bd", "awsnodetemplate": "default", "security-groups": ["sg-09222dc5dd763565e", "sg-01dd189962807c84d"]}
2023-04-25T16:35:37.724Z        DEBUG   controller.awsnodetemplate      discovered kubernetes version   {"commit": "ce030bd", "awsnodetemplate": "default", "kubernetes-version": "1.25"}
2023-04-25T16:35:37.740Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ce030bd", "awsnodetemplate": "default2", "subnets": ["subnet-0d2e48c60b6f70689 (us-west-2d)", "subnet-007aafdece10d1105 (us-west-2b)", "subnet-004e4cd40a2953909 (us-west-2a)"]}
2023-04-25T16:35:37.746Z        INFO    controller.pricing      updated spot pricing with instance types and offerings  {"commit": "ce030bd", "instance-type-count": 636, "offering-count": 2178}
2023-04-25T16:35:37.748Z        DEBUG   controller.awsnodetemplate      discovered ami  {"commit": "ce030bd", "awsnodetemplate": "default", "ami": "ami-0e1597f2056965cab", "query": "/aws/service/eks/optimized-ami/1.25/amazon-linux-2/recommended/image_id"}
2023-04-25T16:35:37.765Z        DEBUG   controller.awsnodetemplate      discovered ami  {"commit": "ce030bd", "awsnodetemplate": "default", "ami": "ami-0fdfd7d20fb74aef9", "query": "/aws/service/eks/optimized-ami/1.25/amazon-linux-2-gpu/recommended/image_id"}
2023-04-25T16:35:37.790Z        DEBUG   controller.awsnodetemplate      discovered ami  {"commit": "ce030bd", "awsnodetemplate": "default", "ami": "ami-021e98c1789275883", "query": "/aws/service/eks/optimized-ami/1.25/amazon-linux-2-arm64/recommended/image_id"}
2023-04-25T16:35:37.793Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ce030bd", "awsnodetemplate": "default2", "security-groups": ["sg-09222dc5dd763565e"]}
2023-04-25T16:35:37.796Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ce030bd", "awsnodetemplate": "default3", "subnets": ["subnet-065d2bd943d9549a6 (us-west-2a)"]}
2023-04-25T16:35:37.847Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ce030bd", "awsnodetemplate": "default3", "security-groups": ["sg-01dd189962807c84d"]}
2023-04-25T16:35:38.256Z        DEBUG   controller.awsnodetemplate      discovered images       {"commit": "ce030bd", "awsnodetemplate": "default2", "ids": "ami-0e1597f2056965cab, ami-021e98c1789275883, ami-0fdfd7d20fb74aef9", "count": 3}
2023-04-25T16:35:39.419Z        DEBUG   controller.deprovisioning       discovered instance types       {"commit": "ce030bd", "count": 627}
2023-04-25T16:35:39.644Z        DEBUG   controller.deprovisioning       discovered offerings for instance types {"commit": "ce030bd", "zones": ["us-west-2a", "us-west-2b", "us-west-2d"], "instance-type-count": 629, "node-template": "default"}
2023-04-25T16:35:40.096Z        INFO    controller.pricing      updated on-demand pricing       {"commit": "ce030bd", "instance-type-count": 631}
2023-04-25T16:40:38.433Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ce030bd", "awsnodetemplate": "default2", "subnets": ["subnet-0d2e48c60b6f70689 (us-west-2d)", "subnet-007aafdece10d1105 (us-west-2b)", "subnet-004e4cd40a2953909 (us-west-2a)"]}
2023-04-25T16:40:38.502Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ce030bd", "awsnodetemplate": "default3", "subnets": ["subnet-065d2bd943d9549a6 (us-west-2a)"]}
2023-04-25T16:40:38.551Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ce030bd", "awsnodetemplate": "default", "subnets": ["subnet-0a89ab2e50dfe40d6 (us-west-2b)", "subnet-01ac1560ed61b3ea5 (us-west-2d)", "subnet-0d2e48c60b6f70689 (us-west-2d)", "subnet-007aafdece10d1105 (us-west-2b)", "subnet-065d2bd943d9549a6 (us-west-2a)", "subnet-004e4cd40a2953909 (us-west-2a)"]}
2023-04-25T16:40:38.566Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ce030bd", "awsnodetemplate": "default2", "security-groups": ["sg-09222dc5dd763565e"]}
2023-04-25T16:40:38.620Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ce030bd", "awsnodetemplate": "default3", "security-groups": ["sg-01dd189962807c84d"]}
2023-04-25T16:40:38.673Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ce030bd", "awsnodetemplate": "default", "security-groups": ["sg-09222dc5dd763565e", "sg-01dd189962807c84d"]}
```

### New Logs (No duplicates after 5m)

```console
2023-04-25T16:21:17.392Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ba69bae", "awsnodetemplate": "default", "security-groups": ["sg-09222dc5dd763565e", "sg-01dd189962807c84d"]}
2023-04-25T16:21:17.394Z        DEBUG   controller.awsnodetemplate      discovered kubernetes version   {"commit": "ba69bae", "awsnodetemplate": "default", "kubernetes-version": "1.25"}
2023-04-25T16:21:17.397Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ba69bae", "awsnodetemplate": "default2", "subnets": ["subnet-0d2e48c60b6f70689 (us-west-2d)", "subnet-007aafdece10d1105 (us-west-2b)", "subnet-004e4cd40a2953909 (us-west-2a)"]}
2023-04-25T16:21:17.441Z        DEBUG   controller.awsnodetemplate      discovered subnets      {"commit": "ba69bae", "awsnodetemplate": "default3", "subnets": ["subnet-065d2bd943d9549a6 (us-west-2a)"]}
2023-04-25T16:21:17.446Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ba69bae", "awsnodetemplate": "default2", "security-groups": ["sg-09222dc5dd763565e"]}
2023-04-25T16:21:17.487Z        DEBUG   controller.awsnodetemplate      discovered security groups      {"commit": "ba69bae", "awsnodetemplate": "default3", "security-groups": ["sg-01dd189962807c84d"]}
2023-04-25T16:21:17.525Z        INFO    controller.pricing      updated spot pricing with instance types and offerings  {"commit": "ba69bae", "instance-type-count": 636, "offering-count": 2178}
2023-04-25T16:21:17.893Z        DEBUG   controller.awsnodetemplate      discovered amis {"commit": "ba69bae", "awsnodetemplate": "default", "ids": "ami-0e1597f2056965cab, ami-0fdfd7d20fb74aef9, ami-021e98c1789275883", "count": 3}
2023-04-25T16:21:17.915Z        DEBUG   controller.awsnodetemplate      discovered amis {"commit": "ba69bae", "awsnodetemplate": "default3", "ids": "ami-0e1597f2056965cab, ami-0fdfd7d20fb74aef9, ami-021e98c1789275883", "count": 3}
2023-04-25T16:21:17.936Z        DEBUG   controller.awsnodetemplate      discovered amis {"commit": "ba69bae", "awsnodetemplate": "default2", "ids": "ami-0e1597f2056965cab, ami-0fdfd7d20fb74aef9, ami-021e98c1789275883", "count": 3}
2023-04-25T16:21:19.121Z        DEBUG   controller.deprovisioning       discovered instance types       {"commit": "ba69bae", "count": 627}
2023-04-25T16:21:19.284Z        DEBUG   controller.deprovisioning       discovered offerings for instance types {"commit": "ba69bae", "zones": ["us-west-2a", "us-west-2b", "us-west-2d"], "instance-type-count": 629, "node-template": "default"}
2023-04-25T16:21:19.515Z        INFO    controller.pricing      updated on-demand pricing       {"commit": "ba69bae", "instance-type-count": 631}
```

**How was this change tested?**

* `make presubmit`
* Manually viewing the logs

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
