### PR TITLE
feat: Adds vcpu and memory metrics per instance type

### DIFF
--- a/pkg/providers/instancetype/metrics.go
+++ b/pkg/providers/instancetype/metrics.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pricing
+package instancetype
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,25 +26,31 @@ const (
 )
 
 var (
-	InstanceTypeLabel     = "instance_type"
-	CapacityTypeLabel     = "capacity_type"
-	RegionLabel           = "region"
-	TopologyLabel         = "zone"
-	InstancePriceEstimate = prometheus.NewGaugeVec(
+	InstanceTypeLabel = "instance_type"
+
+	InstanceTypeVCPU = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: cloudProviderSubsystem,
-			Name:      "instance_type_price_estimate",
-			Help:      "Estimated hourly price used when making informed decisions on node cost calculation. This is updated once on startup and then every 12 hours.",
+			Name:      "instance_type_cpu_cores",
+			Help:      "VCPUs cores for a given instance type.",
 		},
 		[]string{
 			InstanceTypeLabel,
-			CapacityTypeLabel,
-			RegionLabel,
-			TopologyLabel,
+		})
+
+	InstanceTypeMemory = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: cloudProviderSubsystem,
+			Name:      "instance_type_memory_bytes",
+			Help:      "Memory, in bytes, for a given instance type.",
+		},
+		[]string{
+			InstanceTypeLabel,
 		})
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(InstancePriceEstimate)
+	crmetrics.Registry.MustRegister(InstanceTypeVCPU, InstanceTypeMemory)
 }

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -616,6 +616,34 @@ var _ = Describe("Instance Types", func() {
 			Expect(it.Capacity.Pods().Value()).ToNot(BeNumerically("==", 110))
 		}
 	})
+	It("should expose vcpu metrics for instance types", func() {
+		instanceInfo, err := awsEnv.InstanceTypesProvider.List(ctx, provisioner.Spec.KubeletConfiguration, nodeTemplate)
+		Expect(err).To(BeNil())
+		Expect(len(instanceInfo)).To(BeNumerically(">", 0))
+		for _, info := range instanceInfo {
+			metric, ok := FindMetricWithLabelValues("karpenter_cloudprovider_instance_type_cpu_cores", map[string]string{
+				instancetype.InstanceTypeLabel: info.Name,
+			})
+			Expect(ok).To(BeTrue())
+			Expect(metric).To(Not(BeNil()))
+			value := metric.GetGauge().Value
+			Expect(aws.Float64Value(value)).To(BeNumerically(">", 0))
+		}
+	})
+	It("should expose memory metrics for instance types", func() {
+		instanceInfo, err := awsEnv.InstanceTypesProvider.List(ctx, provisioner.Spec.KubeletConfiguration, nodeTemplate)
+		Expect(err).To(BeNil())
+		Expect(len(instanceInfo)).To(BeNumerically(">", 0))
+		for _, info := range instanceInfo {
+			metric, ok := FindMetricWithLabelValues("karpenter_cloudprovider_instance_type_memory_bytes", map[string]string{
+				instancetype.InstanceTypeLabel: info.Name,
+			})
+			Expect(ok).To(BeTrue())
+			Expect(metric).To(Not(BeNil()))
+			value := metric.GetGauge().Value
+			Expect(aws.Float64Value(value)).To(BeNumerically(">", 0))
+		}
+	})
 
 	Context("Overhead", func() {
 		var info *ec2.InstanceTypeInfo

--- a/pkg/providers/pricing/suite_test.go
+++ b/pkg/providers/pricing/suite_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Pricing", func() {
 
 func getPricingEstimateMetricValue(instanceType string, capacityType string, zone string) float64 {
 	var value *float64
-	metric, ok := FindMetricWithLabelValues("karpenter_cloudprovider_instance_price_estimate", map[string]string{
+	metric, ok := FindMetricWithLabelValues("karpenter_cloudprovider_instance_type_price_estimate", map[string]string{
 		pricing.InstanceTypeLabel: instanceType,
 		pricing.CapacityTypeLabel: capacityType,
 		pricing.RegionLabel:       "",

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -33,6 +33,8 @@ import (
 	"github.com/aws/karpenter/pkg/providers/subnet"
 
 	coretest "github.com/aws/karpenter-core/pkg/test"
+
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 type Environment struct {
@@ -146,4 +148,15 @@ func (env *Environment) Reset() {
 	env.LaunchTemplateCache.Flush()
 	env.SubnetCache.Flush()
 	env.SecurityGroupCache.Flush()
+
+	mfs, err := crmetrics.Registry.Gather()
+	if err != nil {
+		for _, mf := range mfs {
+			for _, metric := range mf.GetMetric() {
+				if metric != nil {
+					metric.Reset()
+				}
+			}
+		}
+	}
 }

--- a/website/content/en/preview/concepts/metrics.md
+++ b/website/content/en/preview/concepts/metrics.md
@@ -94,7 +94,13 @@ Pod state is the current state of pods. This metric can be used several ways as 
 ### `karpenter_cloudprovider_duration_seconds`
 Duration of cloud provider method calls. Labeled by the controller, method name and provider.
 
-### `karpenter_cloudprovider_instance_price_estimate`
+### `karpenter_cloudprovider_instance_type_cpu_cores`
+VCPUs cores for a given instance type.
+
+### `karpenter_cloudprovider_instance_type_memory_bytes`
+Memory, in bytes, for a given instance type.
+
+### `karpenter_cloudprovider_instance_type_price_estimate`
 Estimated hourly price used when making informed decisions on node cost calculation. This is updated once on startup and then every 12 hours.
 
 ## Cloudprovider Batcher Metrics


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

**Description**

This adds `karpenter_cloudprovider_instance_type_cpu_cores` and `karpenter_cloudprovider_instance_type_memory_bytes` metrics for each instance type that Karpenter understands.

These new metrics can be combined with the `karpenter_cloudprovider_instance_price_estimate` metric to give you a price per VCPU and price per 1 GiB of memory to help calculate your hourly cost per Pod.

**How was this change tested?**

* `make test`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
