### PR TITLE
test: Fix settings override logic in AfterEach

### DIFF
--- a/test/pkg/environment/aws/setup.go
+++ b/test/pkg/environment/aws/setup.go
@@ -52,5 +52,5 @@ func (env *Environment) Cleanup(opts ...common.Option) {
 func (env *Environment) AfterEach(opts ...common.Option) {
 	env.Environment.AfterEach(opts...)
 	// Ensure we reset settings after collecting the controller logs
-	env.ExpectSettingsOverridden(persistedSettings.Data)
+	env.ExpectSettingsReplaced(persistedSettings.Data)
 }

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -35,7 +35,7 @@ import (
 	awstest "github.com/aws/karpenter/pkg/test"
 )
 
-var _ = Describe("Scheduling", Ordered, func() {
+var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 	var provider *v1alpha1.AWSNodeTemplate
 	var provisioner *v1alpha5.Provisioner
 	var selectors sets.String
@@ -46,8 +46,11 @@ var _ = Describe("Scheduling", Ordered, func() {
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 		}})
 		provisioner = test.Provisioner(test.ProvisionerOptions{
-			ProviderRef:  &v1alpha5.MachineTemplateRef{Name: provider.Name},
-			Requirements: []v1.NodeSelectorRequirement{{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists}},
+			ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
+			Requirements: []v1.NodeSelectorRequirement{
+				{Key: v1alpha1.LabelInstanceCategory, Operator: v1.NodeSelectorOpExists},
+				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpExists},
+			},
 		})
 	})
 	BeforeAll(func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Create a `ExpectSettingsReplaced` function that will completely replace all of the data in the `karpenter-global-settings`. This is used to retain the settings from before the test run due to settings that might be updated throughout the testing.

**How was this change tested?**

* `make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
