### PR TITLE
feat: Support AL2 instance storage RAID-0 for node ephemeral storage

### DIFF
--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -576,6 +576,18 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 				InstanceType: aws.String("m5.metal"),
 				Location:     aws.String("test-zone-1c"),
 			},
+			{
+				InstanceType: aws.String("m6idn.32xlarge"),
+				Location:     aws.String("test-zone-1a"),
+			},
+			{
+				InstanceType: aws.String("m6idn.32xlarge"),
+				Location:     aws.String("test-zone-1b"),
+			},
+			{
+				InstanceType: aws.String("m6idn.32xlarge"),
+				Location:     aws.String("test-zone-1c"),
+			},
 		},
 	}, false)
 	return nil

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -18,10 +18,13 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/scheduling"
+	"github.com/aws/karpenter-core/pkg/utils/resources"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -103,4 +106,11 @@ func (a AL2) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
 
 func (a AL2) EphemeralBlockDevice() *string {
 	return aws.String("/dev/xvda")
+}
+
+func (a AL2) InstanceStorage(instanceType *ec2.InstanceTypeInfo) *resource.Quantity {
+	if instanceType.InstanceStorageInfo == nil {
+		return nil
+	}
+	return resources.Quantity(fmt.Sprintf("%dG", *instanceType.InstanceStorageInfo.TotalSizeInGB))
 }

--- a/pkg/providers/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/eksbootstrap.go
@@ -68,6 +68,9 @@ func (e EKS) eksBootstrapScript() string {
 	userData.WriteString("exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1\n")
 	// Due to the way bootstrap.sh is written, parameters should not be passed to it with an equal sign
 	userData.WriteString(fmt.Sprintf("/etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' %s", e.ClusterName, e.ClusterEndpoint, caBundleArg))
+	// Setup instance storage disks in a RAID-0 for kubelet and containerd
+	// This only runs if there are instance storage disks for the instance type
+	userData.WriteString(" --local-disks raid0")
 
 	if e.isIPv6() {
 		userData.WriteString(" \\\n--ip-family ipv6")

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -78,6 +78,7 @@ type AMIFamily interface {
 	DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping
 	DefaultMetadataOptions() *v1alpha1.MetadataOptions
 	EphemeralBlockDevice() *string
+	InstanceStorage(*ec2.InstanceTypeInfo) *resource.Quantity
 	FeatureFlags() FeatureFlags
 }
 
@@ -192,6 +193,10 @@ func (o Options) DefaultMetadataOptions() *v1alpha1.MetadataOptions {
 		HTTPPutResponseHopLimit: aws.Int64(2),
 		HTTPTokens:              aws.String(ec2.LaunchTemplateHttpTokensStateRequired),
 	}
+}
+
+func (o Options) InstanceStorage(_ *ec2.InstanceTypeInfo) *resource.Quantity {
+	return nil
 }
 
 func (r Resolver) defaultClusterDNS(opts *Options, kubeletConfig *v1alpha5.KubeletConfiguration) *v1alpha5.KubeletConfiguration {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -597,6 +597,50 @@ var _ = Describe("Instance Types", func() {
 		}
 		Expect(nodeNames.Len()).To(Equal(2))
 	})
+	It("should launch instances w/ instance storage for ephemeral storage resource requests when exceeding blockDeviceMapping on AL2 AMI Family", func() {
+		nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
+		pod := coretest.UnschedulablePod(coretest.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("5000Gi")},
+			},
+		})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		ExpectScheduled(ctx, env.Client, pod)
+	})
+	It("should not launch instances w/ instance storage for ephemeral storage resource requests when exceeding blockDeviceMapping on Bottlerocket AMI Family", func() {
+		nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
+		pod := coretest.UnschedulablePod(coretest.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("5000Gi")},
+			},
+		})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		ExpectNotScheduled(ctx, env.Client, pod)
+	})
+	It("should not launch instances w/ instance storage for ephemeral storage resource requests when exceeding blockDeviceMapping on Ubuntu AMI Family", func() {
+		nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyUbuntu
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
+		pod := coretest.UnschedulablePod(coretest.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("5000Gi")},
+			},
+		})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		ExpectNotScheduled(ctx, env.Client, pod)
+	})
+	It("should not launch instances w/ instance storage for ephemeral storage resource requests when exceeding blockDeviceMapping on Custom AMI Family", func() {
+		nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyCustom
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
+		pod := coretest.UnschedulablePod(coretest.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("5000Gi")},
+			},
+		})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		ExpectNotScheduled(ctx, env.Client, pod)
+	})
 	It("should set pods to 110 if not using ENI-based pod density", func() {
 		ctx = settings.ToContext(ctx, test.Settings(test.SettingOptions{
 			EnableENILimitedPodDensity: lo.ToPtr(false),

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -630,6 +630,10 @@ var _ = Describe("LaunchTemplates", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 		})
 		It("should not pack pods if the sum of pod ephemeral-storage and overhead exceeds node capacity", func() {
+			provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{
+				Key:      v1alpha1.LabelInstanceLocalNVME,
+				Operator: v1.NodeSelectorOpDoesNotExist,
+			})
 			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 			pod := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
@@ -662,6 +666,10 @@ var _ = Describe("LaunchTemplates", func() {
 			Expect(nodes).To(HaveLen(2))
 		})
 		It("should only pack pods with ephemeral-storage requests that will fit on an available node", func() {
+			provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{
+				Key:      v1alpha1.LabelInstanceLocalNVME,
+				Operator: v1.NodeSelectorOpDoesNotExist,
+			})
 			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
 			pods := []*v1.Pod{
 				coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: v1.ResourceRequirements{

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
@@ -12,7 +12,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
+/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' --local-disks raid0 \
 --container-runtime containerd \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
+/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' --local-disks raid0 \
 --container-runtime containerd \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->
https://github.com/aws/karpenter/issues/3111
https://github.com/aws/karpenter/issues/2723
https://github.com/aws/karpenter/issues/2394

**Description**
 - Uses the EKS Optimized AMI for AL2's new local-disk setup in RAID-0 mode (https://github.com/awslabs/amazon-eks-ami/pull/1171). On instance types with local instance storage, the EKS Optimized AMI's bootstrap will now setup the local disks in a RAID-0 and then move /var/lib/kubelet, /var/lib/containerd, and /var/log/pods to the RAID-0 array.  Karpenter assumes this setup during binpacking so that ephemeral storage requests can be fulfilled. 

**How was this change tested?**

* manually tested ephemeral-storage requests on pods and observed instances provisioned that had local instance storage to fulfill the pod requests.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
