### PR TITLE
chore: Fix escaping regex special characters

### DIFF
--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -44,9 +44,9 @@ var (
 	RestrictedTagPatterns = []*regexp.Regexp{
 		// Adheres to cluster name pattern matching as specified in the API spec
 		// https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html
-		regexp.MustCompile(`^kubernetes.io/cluster/[0-9A-Za-z][A-Za-z0-9\-_]*$`),
-		regexp.MustCompile(fmt.Sprintf("^%s$", v1alpha5.ProvisionerNameLabelKey)),
-		regexp.MustCompile(fmt.Sprintf("^%s$", v1alpha5.ManagedByLabelKey)),
+		regexp.MustCompile(`^kubernetes\.io/cluster/[0-9A-Za-z][A-Za-z0-9\-_]*$`),
+		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(v1alpha5.ProvisionerNameLabelKey))),
+		regexp.MustCompile(fmt.Sprintf("^%s$", regexp.QuoteMeta(v1alpha5.ManagedByLabelKey))),
 	}
 	AMIFamilyBottlerocket = "Bottlerocket"
 	AMIFamilyAL2          = "AL2"

--- a/pkg/apis/v1alpha1/suite_test.go
+++ b/pkg/apis/v1alpha1/suite_test.go
@@ -76,6 +76,20 @@ var _ = Describe("Validation", func() {
 			}
 			Expect(ant.Validate(ctx)).To(Succeed())
 		})
+		It("should succeed by validating that regex is properly escaped", func() {
+			ant.Spec.Tags = map[string]string{
+				"karpenterzsh/provisioner-name": "value",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+			ant.Spec.Tags = map[string]string{
+				"kubernetesbio/cluster/test": "value",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+			ant.Spec.Tags = map[string]string{
+				"karpenterzsh/managed-by": "test",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
 		It("should fail if tags contain a restricted domain key", func() {
 			ant.Spec.Tags = map[string]string{
 				"karpenter.sh/provisioner-name": "value",


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

The PR that validates the tags on the `v1alpha1.AWSNodeTemplate` (https://github.com/aws/karpenter/pull/3784) contains checking against tags based on regex. This regex needs all the special characters escaped. The current state will match more tags than it should.

**How was this change tested?**

* `FOCUS=Webhooks make e2etests`
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
