### PR TITLE
fix: Stringify the kubeletExtraArgs values for AL2/Ubuntu

### DIFF
--- a/pkg/providers/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/eksbootstrap.go
@@ -27,7 +27,6 @@ import (
 	"net/textproto"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,86 +64,90 @@ func (e EKS) eksBootstrapScript() string {
 		caBundleArg = fmt.Sprintf("--b64-cluster-ca '%s'", *e.CABundle)
 	}
 	var userData bytes.Buffer
-	var kubeletExtraArgs strings.Builder
 	userData.WriteString("#!/bin/bash -xe\n")
 	userData.WriteString("exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1\n")
 	// Due to the way bootstrap.sh is written, parameters should not be passed to it with an equal sign
 	userData.WriteString(fmt.Sprintf("/etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' %s", e.ClusterName, e.ClusterEndpoint, caBundleArg))
 
-	kubeletExtraArgs.WriteString(strings.Join([]string{e.nodeLabelArg(), e.nodeTaintArg()}, " "))
-
 	if e.isIPv6() {
 		userData.WriteString(" \\\n--ip-family ipv6")
-	}
-	if e.KubeletConfig != nil && e.KubeletConfig.MaxPods != nil {
-		userData.WriteString(" \\\n--use-max-pods false")
-		kubeletExtraArgs.WriteString(fmt.Sprintf(" --max-pods=%d", ptr.Int32Value(e.KubeletConfig.MaxPods)))
-	} else if !e.AWSENILimitedPodDensity {
-		userData.WriteString(" \\\n--use-max-pods false")
-		kubeletExtraArgs.WriteString(" --max-pods=110")
-	}
-	if e.KubeletConfig != nil && e.KubeletConfig.PodsPerCore != nil {
-		kubeletExtraArgs.WriteString(fmt.Sprintf(" --pods-per-core=%d", ptr.Int32Value(e.KubeletConfig.PodsPerCore)))
-	}
-
-	if e.KubeletConfig != nil {
-		// We have to convert some of these maps so that their values return the correct string
-		kubeletExtraArgs.WriteString(joinParameterArgs("--system-reserved", resources.StringMap(e.KubeletConfig.SystemReserved), "="))
-		kubeletExtraArgs.WriteString(joinParameterArgs("--kube-reserved", resources.StringMap(e.KubeletConfig.KubeReserved), "="))
-		kubeletExtraArgs.WriteString(joinParameterArgs("--eviction-hard", e.KubeletConfig.EvictionHard, "<"))
-		kubeletExtraArgs.WriteString(joinParameterArgs("--eviction-soft", e.KubeletConfig.EvictionSoft, "<"))
-		kubeletExtraArgs.WriteString(joinParameterArgs("--eviction-soft-grace-period", lo.MapValues(e.KubeletConfig.EvictionSoftGracePeriod, func(v metav1.Duration, _ string) string { return v.Duration.String() }), "="))
-
-		if e.KubeletConfig.EvictionMaxPodGracePeriod != nil {
-			kubeletExtraArgs.WriteString(fmt.Sprintf(" --eviction-max-pod-grace-period=%d", ptr.Int32Value(e.KubeletConfig.EvictionMaxPodGracePeriod)))
-		}
-		if e.KubeletConfig.ImageGCHighThresholdPercent != nil {
-			kubeletExtraArgs.WriteString(fmt.Sprintf(" --image-gc-high-threshold=%d", ptr.Int32Value(e.KubeletConfig.ImageGCHighThresholdPercent)))
-		}
-		if e.KubeletConfig.ImageGCLowThresholdPercent != nil {
-			kubeletExtraArgs.WriteString(fmt.Sprintf(" --image-gc-low-threshold=%d", ptr.Int32Value(e.KubeletConfig.ImageGCLowThresholdPercent)))
-		}
-		if e.KubeletConfig.CPUCFSQuota != nil {
-			kubeletExtraArgs.WriteString(fmt.Sprintf(" --cpu-cfs-quota=%t", lo.FromPtr(e.KubeletConfig.CPUCFSQuota)))
-		}
 	}
 	if e.ContainerRuntime != "" {
 		userData.WriteString(fmt.Sprintf(" \\\n--container-runtime %s", e.ContainerRuntime))
 	}
-	if kubeletExtraArgsStr := strings.Trim(kubeletExtraArgs.String(), " "); len(kubeletExtraArgsStr) > 0 {
-		userData.WriteString(fmt.Sprintf(" \\\n--kubelet-extra-args '%s'", kubeletExtraArgsStr))
-	}
 	if e.KubeletConfig != nil && len(e.KubeletConfig.ClusterDNS) > 0 {
 		userData.WriteString(fmt.Sprintf(" \\\n--dns-cluster-ip '%s'", e.KubeletConfig.ClusterDNS[0]))
+	}
+	if e.KubeletConfig != nil && e.KubeletConfig.MaxPods != nil {
+		userData.WriteString(" \\\n--use-max-pods false")
+	} else if !e.AWSENILimitedPodDensity {
+		userData.WriteString(" \\\n--use-max-pods false")
+	}
+	if args := e.kubeletExtraArgs(); len(args) > 0 {
+		userData.WriteString(fmt.Sprintf(" \\\n--kubelet-extra-args '%s'", strings.Join(args, " ")))
 	}
 	return userData.String()
 }
 
+func (e EKS) kubeletExtraArgs() (args []string) {
+	args = append(args, e.nodeLabelArg(), e.nodeTaintArg())
+	if e.KubeletConfig != nil && e.KubeletConfig.MaxPods != nil {
+		args = append(args, fmt.Sprintf("--max-pods=%d", ptr.Int32Value(e.KubeletConfig.MaxPods)))
+	} else if !e.AWSENILimitedPodDensity {
+		args = append(args, "--max-pods=110")
+	}
+	if e.KubeletConfig != nil && e.KubeletConfig.PodsPerCore != nil {
+		args = append(args, fmt.Sprintf("--pods-per-core=%d", ptr.Int32Value(e.KubeletConfig.PodsPerCore)))
+	}
+	if e.KubeletConfig != nil {
+		// We have to convert some of these maps so that their values return the correct string
+		args = append(args, joinParameterArgs("--system-reserved", resources.StringMap(e.KubeletConfig.SystemReserved), "="))
+		args = append(args, joinParameterArgs("--kube-reserved", resources.StringMap(e.KubeletConfig.KubeReserved), "="))
+		args = append(args, joinParameterArgs("--eviction-hard", e.KubeletConfig.EvictionHard, "<"))
+		args = append(args, joinParameterArgs("--eviction-soft", e.KubeletConfig.EvictionSoft, "<"))
+		args = append(args, joinParameterArgs("--eviction-soft-grace-period", lo.MapValues(e.KubeletConfig.EvictionSoftGracePeriod, func(v metav1.Duration, _ string) string { return v.Duration.String() }), "="))
+
+		if e.KubeletConfig.EvictionMaxPodGracePeriod != nil {
+			args = append(args, fmt.Sprintf("--eviction-max-pod-grace-period=%d", ptr.Int32Value(e.KubeletConfig.EvictionMaxPodGracePeriod)))
+		}
+		if e.KubeletConfig.ImageGCHighThresholdPercent != nil {
+			args = append(args, fmt.Sprintf("--image-gc-high-threshold=%d", ptr.Int32Value(e.KubeletConfig.ImageGCHighThresholdPercent)))
+		}
+		if e.KubeletConfig.ImageGCLowThresholdPercent != nil {
+			args = append(args, fmt.Sprintf("--image-gc-low-threshold=%d", ptr.Int32Value(e.KubeletConfig.ImageGCLowThresholdPercent)))
+		}
+		if e.KubeletConfig.CPUCFSQuota != nil {
+			args = append(args, fmt.Sprintf("--cpu-cfs-quota=%t", lo.FromPtr(e.KubeletConfig.CPUCFSQuota)))
+		}
+	}
+	return lo.Filter(args, func(s string, _ int) bool { return s != "" })
+}
+
 func (e EKS) nodeTaintArg() string {
-	nodeTaintsArg := ""
-	taintStrings := []string{}
-	var once sync.Once
+	if len(e.Taints) == 0 {
+		return ""
+	}
+	var taintStrings []string
 	for _, taint := range e.Taints {
-		once.Do(func() { nodeTaintsArg = "--register-with-taints=" })
 		taintStrings = append(taintStrings, fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect))
 	}
-	return fmt.Sprintf("%s%s", nodeTaintsArg, strings.Join(taintStrings, ","))
+	return fmt.Sprintf("--register-with-taints=%q", strings.Join(taintStrings, ","))
 }
 
 func (e EKS) nodeLabelArg() string {
-	nodeLabelArg := ""
-	labelStrings := []string{}
-	var once sync.Once
+	if len(e.Labels) == 0 {
+		return ""
+	}
+	var labelStrings []string
 	keys := lo.Keys(e.Labels)
 	sort.Strings(keys) // ensures this list is deterministic, for easy testing.
 	for _, key := range keys {
 		if v1alpha5.LabelDomainExceptions.Has(key) {
 			continue
 		}
-		once.Do(func() { nodeLabelArg = "--node-labels=" })
 		labelStrings = append(labelStrings, fmt.Sprintf("%s=%v", key, e.Labels[key]))
 	}
-	return fmt.Sprintf("%s%s", nodeLabelArg, strings.Join(labelStrings, ","))
+	return fmt.Sprintf("--node-labels=%q", strings.Join(labelStrings, ","))
 }
 
 // joinParameterArgs joins a map of keys and values by their separator. The separator will sit between the
@@ -156,7 +159,7 @@ func joinParameterArgs[K comparable, V any](name string, m map[K]V, separator st
 		args = append(args, fmt.Sprintf("%v%s%v", k, separator, v))
 	}
 	if len(args) > 0 {
-		return fmt.Sprintf(" %s=%s", name, strings.Join(args, ","))
+		return fmt.Sprintf("%s=%q", name, strings.Join(args, ","))
 	}
 	return ""
 }

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
@@ -13,8 +13,8 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
---use-max-pods false \
 --container-runtime containerd \
---kubelet-extra-args '--node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/test-id=unspecified  --max-pods=110' \
---dns-cluster-ip '10.0.100.10'
+--dns-cluster-ip '10.0.100.10' \
+--use-max-pods false \
+--kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/test-id=unspecified" --max-pods=110'
 --//--

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
@@ -7,8 +7,8 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
---use-max-pods false \
 --container-runtime containerd \
---kubelet-extra-args '--node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/test-id=unspecified  --max-pods=110' \
---dns-cluster-ip '10.0.100.10'
+--dns-cluster-ip '10.0.100.10' \
+--use-max-pods false \
+--kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/test-id=unspecified" --max-pods=110'
 --//--

--- a/test/suites/integration/kubelet_config_test.go
+++ b/test/suites/integration/kubelet_config_test.go
@@ -38,125 +38,71 @@ import (
 )
 
 var _ = Describe("KubeletConfiguration Overrides", func() {
-	It("should startup successfully with all kubelet configuration set", func() {
-		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
-		}})
+	DescribeTable("should startup successfully with all kubelet configuration set",
+		func(amiFamily *string) {
+			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+				SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
+				AMIFamily:             amiFamily,
+			}})
 
-		// MaxPods needs to account for the daemonsets that will run on the nodes
-		provisioner := test.Provisioner(test.ProvisionerOptions{
-			ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
-			Kubelet: &v1alpha5.KubeletConfiguration{
-				ContainerRuntime: ptr.String("containerd"),
-				MaxPods:          ptr.Int32(110),
-				PodsPerCore:      ptr.Int32(10),
-				SystemReserved: v1.ResourceList{
-					v1.ResourceCPU:              resource.MustParse("200m"),
-					v1.ResourceMemory:           resource.MustParse("200Mi"),
-					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+			// MaxPods needs to account for the daemonsets that will run on the nodes
+			provisioner := test.Provisioner(test.ProvisionerOptions{
+				ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
+				Kubelet: &v1alpha5.KubeletConfiguration{
+					ContainerRuntime: ptr.String("containerd"),
+					MaxPods:          ptr.Int32(110),
+					PodsPerCore:      ptr.Int32(10),
+					SystemReserved: v1.ResourceList{
+						v1.ResourceCPU:              resource.MustParse("200m"),
+						v1.ResourceMemory:           resource.MustParse("200Mi"),
+						v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+					},
+					KubeReserved: v1.ResourceList{
+						v1.ResourceCPU:              resource.MustParse("200m"),
+						v1.ResourceMemory:           resource.MustParse("200Mi"),
+						v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+					},
+					EvictionHard: map[string]string{
+						"memory.available":   "5%",
+						"nodefs.available":   "5%",
+						"nodefs.inodesFree":  "5%",
+						"imagefs.available":  "5%",
+						"imagefs.inodesFree": "5%",
+						"pid.available":      "3%",
+					},
+					EvictionSoft: map[string]string{
+						"memory.available":   "10%",
+						"nodefs.available":   "10%",
+						"nodefs.inodesFree":  "10%",
+						"imagefs.available":  "10%",
+						"imagefs.inodesFree": "10%",
+						"pid.available":      "6%",
+					},
+					EvictionSoftGracePeriod: map[string]metav1.Duration{
+						"memory.available":   {Duration: time.Minute * 2},
+						"nodefs.available":   {Duration: time.Minute * 2},
+						"nodefs.inodesFree":  {Duration: time.Minute * 2},
+						"imagefs.available":  {Duration: time.Minute * 2},
+						"imagefs.inodesFree": {Duration: time.Minute * 2},
+						"pid.available":      {Duration: time.Minute * 2},
+					},
+					EvictionMaxPodGracePeriod:   ptr.Int32(120),
+					ImageGCHighThresholdPercent: ptr.Int32(50),
+					ImageGCLowThresholdPercent:  ptr.Int32(10),
+					CPUCFSQuota:                 ptr.Bool(false),
 				},
-				KubeReserved: v1.ResourceList{
-					v1.ResourceCPU:              resource.MustParse("200m"),
-					v1.ResourceMemory:           resource.MustParse("200Mi"),
-					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-				},
-				EvictionHard: map[string]string{
-					"memory.available":   "5%",
-					"nodefs.available":   "5%",
-					"nodefs.inodesFree":  "5%",
-					"imagefs.available":  "5%",
-					"imagefs.inodesFree": "5%",
-					"pid.available":      "3%",
-				},
-				EvictionSoft: map[string]string{
-					"memory.available":   "10%",
-					"nodefs.available":   "10%",
-					"nodefs.inodesFree":  "10%",
-					"imagefs.available":  "10%",
-					"imagefs.inodesFree": "10%",
-					"pid.available":      "6%",
-				},
-				EvictionSoftGracePeriod: map[string]metav1.Duration{
-					"memory.available":   {Duration: time.Minute * 2},
-					"nodefs.available":   {Duration: time.Minute * 2},
-					"nodefs.inodesFree":  {Duration: time.Minute * 2},
-					"imagefs.available":  {Duration: time.Minute * 2},
-					"imagefs.inodesFree": {Duration: time.Minute * 2},
-					"pid.available":      {Duration: time.Minute * 2},
-				},
-				EvictionMaxPodGracePeriod:   ptr.Int32(120),
-				ImageGCHighThresholdPercent: ptr.Int32(50),
-				ImageGCLowThresholdPercent:  ptr.Int32(10),
-				CPUCFSQuota:                 ptr.Bool(false),
-			},
-		})
+			})
 
-		pod := test.Pod()
-		env.ExpectCreated(provisioner, provider, pod)
-		env.EventuallyExpectHealthy(pod)
-		env.ExpectCreatedNodeCount("==", 1)
-	})
-	It("should startup successfully with all kubelet configuration set (Bottlerocket)", func() {
-		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
-			AMIFamily:             &v1alpha1.AMIFamilyBottlerocket,
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
-		}})
-
-		// MaxPods needs to account for the daemonsets that will run on the nodes
-		provisioner := test.Provisioner(test.ProvisionerOptions{
-			ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
-			Kubelet: &v1alpha5.KubeletConfiguration{
-				ContainerRuntime: ptr.String("containerd"),
-				MaxPods:          ptr.Int32(110),
-				PodsPerCore:      ptr.Int32(10),
-				SystemReserved: v1.ResourceList{
-					v1.ResourceCPU:              resource.MustParse("200m"),
-					v1.ResourceMemory:           resource.MustParse("200Mi"),
-					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-				},
-				KubeReserved: v1.ResourceList{
-					v1.ResourceCPU:              resource.MustParse("200m"),
-					v1.ResourceMemory:           resource.MustParse("200Mi"),
-					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-				},
-				EvictionHard: map[string]string{
-					"memory.available":   "5%",
-					"nodefs.available":   "5%",
-					"nodefs.inodesFree":  "5%",
-					"imagefs.available":  "5%",
-					"imagefs.inodesFree": "5%",
-					"pid.available":      "3%",
-				},
-				EvictionSoft: map[string]string{
-					"memory.available":   "10%",
-					"nodefs.available":   "10%",
-					"nodefs.inodesFree":  "10%",
-					"imagefs.available":  "10%",
-					"imagefs.inodesFree": "10%",
-					"pid.available":      "6%",
-				},
-				EvictionSoftGracePeriod: map[string]metav1.Duration{
-					"memory.available":   {Duration: time.Minute * 2},
-					"nodefs.available":   {Duration: time.Minute * 2},
-					"nodefs.inodesFree":  {Duration: time.Minute * 2},
-					"imagefs.available":  {Duration: time.Minute * 2},
-					"imagefs.inodesFree": {Duration: time.Minute * 2},
-					"pid.available":      {Duration: time.Minute * 2},
-				},
-				EvictionMaxPodGracePeriod:   ptr.Int32(120),
-				ImageGCHighThresholdPercent: ptr.Int32(50),
-				ImageGCLowThresholdPercent:  ptr.Int32(10),
-				CPUCFSQuota:                 ptr.Bool(false),
-			},
-		})
-
-		pod := test.Pod()
-		env.ExpectCreated(provisioner, provider, pod)
-		env.EventuallyExpectHealthy(pod)
-		env.ExpectCreatedNodeCount("==", 1)
-	})
+			pod := test.Pod()
+			env.ExpectCreated(provisioner, provider, pod)
+			env.EventuallyExpectHealthy(pod)
+			env.ExpectCreatedNodeCount("==", 1)
+		},
+		Entry("when the AMIFamily is AL2", &v1alpha1.AMIFamilyAL2),
+		Entry("when the AMIFamily is Ubuntu", &v1alpha1.AMIFamilyUbuntu),
+		Entry("when the AMIFamily is Bottlerocket", &v1alpha1.AMIFamilyBottlerocket),
+	)
 	It("should schedule pods onto separate nodes when maxPods is set", func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes #3818

**Description**

Fixes a bug in the Ubuntu AmiFamily where any `kubeletConfiguration` that generated kubelet arguments with the `<` symbol would not be properly parsed by the AMIFamily's bootstrap script, thus causing the Node never to join. This PR fixes this bug by wrapping all string values in the kubelet arguments with double-quotes so that these values will be treated as strings when parsed.

**How was this change tested?**

* `FOCUS=KubeletConfiguration make e2etests`
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
