### PR TITLE
chore: Restore GPU labels and use DoesNotExist

### DIFF
--- a/hack/docs/instancetypes_gen_docs.go
+++ b/hack/docs/instancetypes_gen_docs.go
@@ -147,12 +147,7 @@ below are the resources available with some assumptions and after the instance o
 		familyName := strings.Split(it.Name, ".")[0]
 		families[familyName] = append(families[familyName], it)
 		for labelName := range it.Requirements {
-			// TODO: This is to remove the gpu labels from the docs
-			// GPU labels were removed from docs in favor of Accelerator labels
-			// this should be removed after v1 once gpu label has been removed.
-			if !strings.Contains(labelName, "gpu") {
-				labelNameMap.Insert(labelName)
-			}
+			labelNameMap.Insert(labelName)
 		}
 		for resourceName := range it.Capacity {
 			resourceNameMap.Insert(string(resourceName))

--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -38,6 +38,10 @@ var (
 		"x86_64":                   v1alpha5.ArchitectureAmd64,
 		v1alpha5.ArchitectureArm64: v1alpha5.ArchitectureArm64,
 	}
+	WellKnownArchitectures = sets.NewString(
+		v1alpha5.ArchitectureAmd64,
+		v1alpha5.ArchitectureArm64,
+	)
 	RestrictedLabelDomains = []string{
 		LabelDomain,
 	}
@@ -82,21 +86,14 @@ var (
 	LabelInstanceMemory                       = LabelDomain + "/instance-memory"
 	LabelInstanceNetworkBandwidth             = LabelDomain + "/instance-network-bandwidth"
 	LabelInstancePods                         = LabelDomain + "/instance-pods"
-	// TODO: will deprecate at v1beta1, remove at v1
-	LabelInstanceGPUName = LabelDomain + "/instance-gpu-name"
-	// TODO: will deprecate at v1beta1, remove at v1
-	LabelInstanceGPUManufacturer = LabelDomain + "/instance-gpu-manufacturer"
-	// TODO: will deprecate at v1beta1, remove at v1
-	LabelInstanceGPUCount = LabelDomain + "/instance-gpu-count"
-	// TODO: will deprecate at v1beta1, remove at v1
-	LabelInstanceGPUMemory               = LabelDomain + "/instance-gpu-memory"
-	LabelInstanceAMIID                   = LabelDomain + "/instance-ami-id"
-	LabelInstanceAcceleratorName         = LabelDomain + "/instance-accelerator-name"
-	LabelInstanceAcceleratorManufacturer = LabelDomain + "/instance-accelerator-manufacturer"
-	LabelInstanceAcceleratorCount        = LabelDomain + "/instance-accelerator-count"
-	LabelInstanceAcceleratorMemory       = LabelDomain + "/instance-accelerator-memory"
-
-	InterruptionInfrastructureFinalizer = Group + "/interruption-infrastructure"
+	LabelInstanceGPUName                      = LabelDomain + "/instance-gpu-name"
+	LabelInstanceGPUManufacturer              = LabelDomain + "/instance-gpu-manufacturer"
+	LabelInstanceGPUCount                     = LabelDomain + "/instance-gpu-count"
+	LabelInstanceGPUMemory                    = LabelDomain + "/instance-gpu-memory"
+	LabelInstanceAMIID                        = LabelDomain + "/instance-ami-id"
+	LabelInstanceAcceleratorName              = LabelDomain + "/instance-accelerator-name"
+	LabelInstanceAcceleratorManufacturer      = LabelDomain + "/instance-accelerator-manufacturer"
+	LabelInstanceAcceleratorCount             = LabelDomain + "/instance-accelerator-count"
 )
 
 var (
@@ -136,7 +133,6 @@ func init() {
 		LabelInstanceAcceleratorName,
 		LabelInstanceAcceleratorManufacturer,
 		LabelInstanceAcceleratorCount,
-		LabelInstanceAcceleratorMemory,
 	)
 }
 

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -190,7 +190,6 @@ var _ = Describe("Provisioner", func() {
 					v1alpha1.LabelInstanceAcceleratorName,
 					v1alpha1.LabelInstanceAcceleratorManufacturer,
 					v1alpha1.LabelInstanceAcceleratorCount,
-					v1alpha1.LabelInstanceAcceleratorMemory,
 				} {
 					provisioner.Spec.Labels = map[string]string{label: randomdata.SillyName()}
 					Expect(provisioner.Validate(ctx)).To(Succeed())

--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -464,9 +464,12 @@ var _ = Describe("AWSNodeTemplateController", func() {
 							Values:   []string{v1alpha5.ArchitectureAmd64},
 						},
 						{
-							Key:      v1alpha1.LabelInstanceAcceleratorManufacturer,
-							Operator: v1.NodeSelectorOpNotIn,
-							Values:   []string{string(v1alpha1.AWSAcceleratorManufacturer), string(v1alpha1.NVIDIAacceleratorManufacturer)},
+							Key:      v1alpha1.LabelInstanceGPUCount,
+							Operator: v1.NodeSelectorOpDoesNotExist,
+						},
+						{
+							Key:      v1alpha1.LabelInstanceAcceleratorCount,
+							Operator: v1.NodeSelectorOpDoesNotExist,
 						},
 					},
 				},
@@ -480,9 +483,12 @@ var _ = Describe("AWSNodeTemplateController", func() {
 							Values:   []string{v1alpha5.ArchitectureArm64},
 						},
 						{
-							Key:      v1alpha1.LabelInstanceAcceleratorManufacturer,
-							Operator: v1.NodeSelectorOpNotIn,
-							Values:   []string{string(v1alpha1.AWSAcceleratorManufacturer), string(v1alpha1.NVIDIAacceleratorManufacturer)},
+							Key:      v1alpha1.LabelInstanceGPUCount,
+							Operator: v1.NodeSelectorOpDoesNotExist,
+						},
+						{
+							Key:      v1alpha1.LabelInstanceAcceleratorCount,
+							Operator: v1.NodeSelectorOpDoesNotExist,
 						},
 					},
 				},
@@ -496,9 +502,23 @@ var _ = Describe("AWSNodeTemplateController", func() {
 							Values:   []string{v1alpha5.ArchitectureAmd64},
 						},
 						{
-							Key:      v1alpha1.LabelInstanceAcceleratorManufacturer,
+							Key:      v1alpha1.LabelInstanceGPUCount,
+							Operator: v1.NodeSelectorOpExists,
+						},
+					},
+				},
+				{
+					Name: "test-ami-2",
+					ID:   "ami-id-456",
+					Requirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1.LabelArchStable,
 							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{string(v1alpha1.AWSAcceleratorManufacturer), string(v1alpha1.NVIDIAacceleratorManufacturer)},
+							Values:   []string{v1alpha5.ArchitectureAmd64},
+						},
+						{
+							Key:      v1alpha1.LabelInstanceAcceleratorCount,
+							Operator: v1.NodeSelectorOpExists,
 						},
 					},
 				},

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -40,21 +40,30 @@ func (a AL2) DefaultAMIs(version string) []DefaultAMIOutput {
 			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version),
 			Requirements: scheduling.NewRequirements(
 				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpNotIn, string(v1alpha1.NVIDIAacceleratorManufacturer), string(v1alpha1.AWSAcceleratorManufacturer)),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version),
 			Requirements: scheduling.NewRequirements(
 				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpIn, string(v1alpha1.NVIDIAacceleratorManufacturer), string(v1alpha1.AWSAcceleratorManufacturer)),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpExists),
+			),
+		},
+		{
+			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version),
+			Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpExists),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-%s/recommended/image_id", version, v1alpha5.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
 				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpNotIn, string(v1alpha1.NVIDIAacceleratorManufacturer), string(v1alpha1.AWSAcceleratorManufacturer)),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 	}

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -45,28 +45,44 @@ func (b Bottlerocket) DefaultAMIs(version string) []DefaultAMIOutput {
 			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version),
 			Requirements: scheduling.NewRequirements(
 				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpNotIn, string(v1alpha1.NVIDIAacceleratorManufacturer)),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version),
 			Requirements: scheduling.NewRequirements(
 				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpIn, string(v1alpha1.NVIDIAacceleratorManufacturer)),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpExists),
+			),
+		},
+		{
+			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version),
+			Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpExists),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/image_id", version, v1alpha5.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
 				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpNotIn, string(v1alpha1.NVIDIAacceleratorManufacturer)),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/%s/latest/image_id", version, v1alpha5.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
 				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpIn, string(v1alpha1.NVIDIAacceleratorManufacturer)),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpExists),
+			),
+		},
+		{
+			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/%s/latest/image_id", version, v1alpha5.ArchitectureArm64),
+			Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
+				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpExists),
 			),
 		},
 	}

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -93,7 +93,6 @@ func computeRequirements(ctx context.Context, info *ec2.InstanceTypeInfo, offeri
 		scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorName, v1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorMemory, v1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(v1alpha1.LabelInstanceHypervisor, v1.NodeSelectorOpIn, aws.StringValue(info.Hypervisor)),
 		scheduling.NewRequirement(v1alpha1.LabelInstanceEncryptionInTransitSupported, v1.NodeSelectorOpIn, fmt.Sprint(aws.BoolValue(info.NetworkInfo.EncryptionInTransitSupported))),
 	)
@@ -118,10 +117,6 @@ func computeRequirements(ctx context.Context, info *ec2.InstanceTypeInfo, offeri
 	// GPU Labels
 	if info.GpuInfo != nil && len(info.GpuInfo.Gpus) == 1 {
 		gpu := info.GpuInfo.Gpus[0]
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorName).Insert(lowerKabobCase(aws.StringValue(gpu.Name)))
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorManufacturer).Insert(lowerKabobCase(aws.StringValue(gpu.Manufacturer)))
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorCount).Insert(fmt.Sprint(aws.Int64Value(gpu.Count)))
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorMemory).Insert(fmt.Sprint(aws.Int64Value(gpu.MemoryInfo.SizeInMiB)))
 		requirements.Get(v1alpha1.LabelInstanceGPUName).Insert(lowerKabobCase(aws.StringValue(gpu.Name)))
 		requirements.Get(v1alpha1.LabelInstanceGPUManufacturer).Insert(lowerKabobCase(aws.StringValue(gpu.Manufacturer)))
 		requirements.Get(v1alpha1.LabelInstanceGPUCount).Insert(fmt.Sprint(aws.Int64Value(gpu.Count)))

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -189,16 +189,12 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
 		env.ExpectCreatedNodeCount("==", 1)
 	})
-	It("should support well-known labels for an accelerator (nvidia)", func() {
+	It("should support well-known labels for a gpu (nvidia)", func() {
 		nodeSelector := map[string]string{
-			v1alpha1.LabelInstanceGPUName:                 "t4",
-			v1alpha1.LabelInstanceGPUMemory:               "16384",
-			v1alpha1.LabelInstanceGPUManufacturer:         "nvidia",
-			v1alpha1.LabelInstanceGPUCount:                "1",
-			v1alpha1.LabelInstanceAcceleratorName:         "t4",
-			v1alpha1.LabelInstanceAcceleratorMemory:       "16384",
-			v1alpha1.LabelInstanceAcceleratorManufacturer: "nvidia",
-			v1alpha1.LabelInstanceAcceleratorCount:        "1",
+			v1alpha1.LabelInstanceGPUName:         "t4",
+			v1alpha1.LabelInstanceGPUMemory:       "16384",
+			v1alpha1.LabelInstanceGPUManufacturer: "nvidia",
+			v1alpha1.LabelInstanceGPUCount:        "1",
 		}
 		selectors.Insert(lo.Keys(nodeSelector)...) // Add node selector keys to selectors used in testing to ensure we test all labels
 		requirements := lo.MapToSlice(nodeSelector, func(key string, value string) v1.NodeSelectorRequirement {

--- a/website/content/en/preview/concepts/instance-types.md
+++ b/website/content/en/preview/concepts/instance-types.md
@@ -3792,15 +3792,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|8|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|habana|
- |karpenter.k8s.aws/instance-accelerator-memory|32768|
- |karpenter.k8s.aws/instance-accelerator-name|gaudi-hl-205|
  |karpenter.k8s.aws/instance-category|dl|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|dl1|
  |karpenter.k8s.aws/instance-generation|1|
+ |karpenter.k8s.aws/instance-gpu-count|8|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|habana|
+ |karpenter.k8s.aws/instance-gpu-memory|32768|
+ |karpenter.k8s.aws/instance-gpu-name|gaudi-hl-205|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|4000|
  |karpenter.k8s.aws/instance-memory|786432|
@@ -3897,15 +3897,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|4096|
- |karpenter.k8s.aws/instance-accelerator-name|k520|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g2|
  |karpenter.k8s.aws/instance-generation|2|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|4096|
+ |karpenter.k8s.aws/instance-gpu-name|k520|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|15360|
  |karpenter.k8s.aws/instance-pods|58|
@@ -3925,15 +3925,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|4|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|4096|
- |karpenter.k8s.aws/instance-accelerator-name|k520|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g2|
  |karpenter.k8s.aws/instance-generation|2|
+ |karpenter.k8s.aws/instance-gpu-count|4|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|4096|
+ |karpenter.k8s.aws/instance-gpu-name|k520|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|61440|
  |karpenter.k8s.aws/instance-pods|234|
@@ -3954,15 +3954,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|m60|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g3|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|m60|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|124928|
  |karpenter.k8s.aws/instance-pods|234|
@@ -3982,15 +3982,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|2|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|m60|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g3|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|2|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|m60|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-pods|234|
@@ -4010,15 +4010,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|4|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|m60|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g3|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|4|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|m60|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-pods|737|
@@ -4039,15 +4039,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|m60|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g3s|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|m60|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|31232|
  |karpenter.k8s.aws/instance-pods|58|
@@ -4068,15 +4068,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|amd|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4ad|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|150|
  |karpenter.k8s.aws/instance-memory|16384|
@@ -4099,15 +4099,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|amd|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4ad|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|300|
  |karpenter.k8s.aws/instance-memory|32768|
@@ -4130,15 +4130,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|amd|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4ad|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|600|
  |karpenter.k8s.aws/instance-memory|65536|
@@ -4161,15 +4161,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|2|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|amd|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4ad|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|2|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|1200|
  |karpenter.k8s.aws/instance-memory|131072|
@@ -4192,15 +4192,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|4|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|amd|
- |karpenter.k8s.aws/instance-accelerator-memory|8192|
- |karpenter.k8s.aws/instance-accelerator-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4ad|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|4|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|amd|
+ |karpenter.k8s.aws/instance-gpu-memory|8192|
+ |karpenter.k8s.aws/instance-gpu-name|radeon-pro-v520|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|2400|
  |karpenter.k8s.aws/instance-memory|262144|
@@ -4224,15 +4224,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4dn|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|125|
  |karpenter.k8s.aws/instance-memory|16384|
@@ -4255,15 +4255,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4dn|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|225|
  |karpenter.k8s.aws/instance-memory|32768|
@@ -4286,15 +4286,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4dn|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|225|
  |karpenter.k8s.aws/instance-memory|65536|
@@ -4317,15 +4317,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4dn|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|900|
  |karpenter.k8s.aws/instance-memory|131072|
@@ -4348,15 +4348,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|4|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4dn|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|4|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|900|
  |karpenter.k8s.aws/instance-memory|196608|
@@ -4379,15 +4379,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4dn|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|900|
  |karpenter.k8s.aws/instance-memory|262144|
@@ -4410,15 +4410,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|8|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g4dn|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|8|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4|
  |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-local-nvme|1800|
  |karpenter.k8s.aws/instance-memory|393216|
@@ -4442,15 +4442,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|250|
  |karpenter.k8s.aws/instance-memory|16384|
@@ -4473,15 +4473,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|450|
  |karpenter.k8s.aws/instance-memory|32768|
@@ -4504,15 +4504,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|600|
  |karpenter.k8s.aws/instance-memory|65536|
@@ -4535,15 +4535,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|900|
  |karpenter.k8s.aws/instance-memory|131072|
@@ -4566,15 +4566,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|4|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|48|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|4|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|3800|
  |karpenter.k8s.aws/instance-memory|196608|
@@ -4597,15 +4597,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|1900|
  |karpenter.k8s.aws/instance-memory|262144|
@@ -4628,15 +4628,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|4|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|4|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|3800|
  |karpenter.k8s.aws/instance-memory|393216|
@@ -4659,15 +4659,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|8|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|24576|
- |karpenter.k8s.aws/instance-accelerator-name|a10g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|192|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|g5|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|8|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|24576|
+ |karpenter.k8s.aws/instance-gpu-name|a10g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|7600|
  |karpenter.k8s.aws/instance-memory|786432|
@@ -4691,15 +4691,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g5g|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|8192|
  |karpenter.k8s.aws/instance-network-bandwidth|1250|
@@ -4721,15 +4721,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g5g|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|16384|
  |karpenter.k8s.aws/instance-network-bandwidth|2500|
@@ -4751,15 +4751,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|16|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g5g|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|32768|
  |karpenter.k8s.aws/instance-network-bandwidth|5000|
@@ -4781,15 +4781,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g5g|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|65536|
  |karpenter.k8s.aws/instance-network-bandwidth|12000|
@@ -4811,15 +4811,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|2|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g5g|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|2|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4g|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-network-bandwidth|25000|
@@ -4841,15 +4841,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|2|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|t4g|
  |karpenter.k8s.aws/instance-category|g|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|g5g|
  |karpenter.k8s.aws/instance-generation|5|
+ |karpenter.k8s.aws/instance-gpu-count|2|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|t4g|
  |karpenter.k8s.aws/instance-hypervisor||
  |karpenter.k8s.aws/instance-memory|131072|
  |karpenter.k8s.aws/instance-network-bandwidth|25000|
@@ -10111,15 +10111,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|12288|
- |karpenter.k8s.aws/instance-accelerator-name|k80|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|4|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|p2|
  |karpenter.k8s.aws/instance-generation|2|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|12288|
+ |karpenter.k8s.aws/instance-gpu-name|k80|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-pods|58|
@@ -10139,15 +10139,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|8|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|12288|
- |karpenter.k8s.aws/instance-accelerator-name|k80|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|p2|
  |karpenter.k8s.aws/instance-generation|2|
+ |karpenter.k8s.aws/instance-gpu-count|8|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|12288|
+ |karpenter.k8s.aws/instance-gpu-name|k80|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-pods|234|
@@ -10167,15 +10167,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|16|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|12288|
- |karpenter.k8s.aws/instance-accelerator-name|k80|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|p2|
  |karpenter.k8s.aws/instance-generation|2|
+ |karpenter.k8s.aws/instance-gpu-count|16|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|12288|
+ |karpenter.k8s.aws/instance-gpu-name|k80|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|749568|
  |karpenter.k8s.aws/instance-pods|234|
@@ -10196,15 +10196,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|1|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|v100|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|8|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|p3|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|1|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|v100|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|62464|
  |karpenter.k8s.aws/instance-pods|58|
@@ -10225,15 +10225,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|4|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|v100|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|32|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|p3|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|4|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|v100|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|249856|
  |karpenter.k8s.aws/instance-pods|234|
@@ -10254,15 +10254,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|8|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|16384|
- |karpenter.k8s.aws/instance-accelerator-name|v100|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|64|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|false|
  |karpenter.k8s.aws/instance-family|p3|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|8|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|16384|
+ |karpenter.k8s.aws/instance-gpu-name|v100|
  |karpenter.k8s.aws/instance-hypervisor|xen|
  |karpenter.k8s.aws/instance-memory|499712|
  |karpenter.k8s.aws/instance-pods|234|
@@ -10284,15 +10284,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|8|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|32768|
- |karpenter.k8s.aws/instance-accelerator-name|v100|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|p3dn|
  |karpenter.k8s.aws/instance-generation|3|
+ |karpenter.k8s.aws/instance-gpu-count|8|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|32768|
+ |karpenter.k8s.aws/instance-gpu-name|v100|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|1800|
  |karpenter.k8s.aws/instance-memory|786432|
@@ -10316,15 +10316,15 @@ below are the resources available with some assumptions and after the instance o
 #### Labels
  | Label | Value |
  |--|--|
- |karpenter.k8s.aws/instance-accelerator-count|8|
- |karpenter.k8s.aws/instance-accelerator-manufacturer|nvidia|
- |karpenter.k8s.aws/instance-accelerator-memory|40960|
- |karpenter.k8s.aws/instance-accelerator-name|a100|
  |karpenter.k8s.aws/instance-category|p|
  |karpenter.k8s.aws/instance-cpu|96|
  |karpenter.k8s.aws/instance-encryption-in-transit-supported|true|
  |karpenter.k8s.aws/instance-family|p4d|
  |karpenter.k8s.aws/instance-generation|4|
+ |karpenter.k8s.aws/instance-gpu-count|8|
+ |karpenter.k8s.aws/instance-gpu-manufacturer|nvidia|
+ |karpenter.k8s.aws/instance-gpu-memory|40960|
+ |karpenter.k8s.aws/instance-gpu-name|a100|
  |karpenter.k8s.aws/instance-hypervisor|nitro|
  |karpenter.k8s.aws/instance-local-nvme|8000|
  |karpenter.k8s.aws/instance-memory|1179648|


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Changes the instance type labels to more closely align with the `describe-instance-types` API response for EC2. It also changes the AMI selection logic to use the `DoesNotExist` and `Exist` requirement rather than selecting AMIs on very specific labels by manufacturer name

**How was this change tested?**

* `make presubmit`
* `FOCUS=Scheduling make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
