### PR TITLE
test: Fix missed Eventually() checks in happiness check

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -286,6 +286,16 @@ func (env *Environment) EventuallyExpectCreatedMachineCount(comparator string, c
 	})
 }
 
+func (env *Environment) EventuallyExpectMachinesReady(machines ...*v1alpha5.Machine) {
+	Eventually(func(g Gomega) {
+		for _, machine := range machines {
+			temp := &v1alpha5.Machine{}
+			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(machine), temp)).Should(Succeed())
+			g.Expect(temp.StatusConditions().IsHappy()).To(BeTrue())
+		}
+	}).Should(Succeed())
+}
+
 func (env *Environment) GetNode(nodeName string) v1.Node {
 	var node v1.Node
 	ExpectWithOffset(1, env.Client.Get(env.Context, types.NamespacedName{Name: nodeName}, &node)).To(Succeed())

--- a/test/suites/machine/machine_test.go
+++ b/test/suites/machine/machine_test.go
@@ -68,9 +68,7 @@ var _ = Describe("StandaloneMachine", func() {
 		node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
 		machine = env.EventuallyExpectCreatedMachineCount("==", 1)[0]
 		Expect(node.Labels).To(HaveKeyWithValue(v1alpha1.LabelInstanceCategory, "c"))
-		Eventually(func(g Gomega) {
-			g.Expect(machine.StatusConditions().IsHappy()).To(BeTrue())
-		}, time.Second*5).Should(Succeed())
+		env.EventuallyExpectMachinesReady(machine)
 	})
 	It("should create a standard machine based on resource requests", func() {
 		machine := test.Machine(v1alpha5.Machine{
@@ -90,9 +88,7 @@ var _ = Describe("StandaloneMachine", func() {
 		node := env.EventuallyExpectInitializedNodeCount("==", 1)[0]
 		machine = env.EventuallyExpectCreatedMachineCount("==", 1)[0]
 		Expect(resources.Fits(machine.Spec.Resources.Requests, node.Status.Allocatable))
-		Eventually(func(g Gomega) {
-			g.Expect(machine.StatusConditions().IsHappy()).To(BeTrue())
-		}, time.Second*5).Should(Succeed())
+		env.EventuallyExpectMachinesReady(machine)
 	})
 	It("should create a machine propagating all the machine spec details", func() {
 		machine := test.Machine(v1alpha5.Machine{
@@ -196,11 +192,7 @@ var _ = Describe("StandaloneMachine", func() {
 			},
 		))
 		env.EventuallyExpectCreatedMachineCount("==", 1)
-		Eventually(func(g Gomega) {
-			temp := &v1alpha5.Machine{}
-			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(machine), temp)).Should(Succeed())
-			g.Expect(temp.StatusConditions().IsHappy()).To(BeTrue())
-		}, time.Second*5).Should(Succeed())
+		env.EventuallyExpectMachinesReady(machine)
 	})
 	It("should remove the cloudProvider machine when the cluster machine is deleted", func() {
 		machine := test.Machine(v1alpha5.Machine{
@@ -299,11 +291,7 @@ var _ = Describe("StandaloneMachine", func() {
 		Expect(node.Labels).To(HaveKeyWithValue("custom-label2", "custom-value2"))
 
 		env.EventuallyExpectCreatedMachineCount("==", 1)
-		Eventually(func(g Gomega) {
-			temp := &v1alpha5.Machine{}
-			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(machine), temp)).Should(Succeed())
-			g.Expect(temp.StatusConditions().IsHappy()).To(BeTrue())
-		}, time.Second*5).Should(Succeed())
+		env.EventuallyExpectMachinesReady(machine)
 	})
 	It("should delete a machine after the registration timeout when the node doesn't register", func() {
 		customAMI := env.GetCustomAMI("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", 1)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Fix re-getting the StatusConditions when checking whether the Machine is Ready at the end of some E2E tests

**How was this change tested?**

* `FOCUS=Machine make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
