### PR TITLE
feat: Add SecurityGroup Name to AWSNodeTemplate Status

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
@@ -268,7 +268,6 @@ spec:
                       type: array
                   required:
                   - id
-                  - name
                   - requirements
                   type: object
                 type: array
@@ -281,6 +280,9 @@ spec:
                   properties:
                     id:
                       description: ID of the security group
+                      type: string
+                    name:
+                      description: Name of the security group
                       type: string
                   required:
                   - id

--- a/pkg/apis/v1alpha1/awsnodetemplate.go
+++ b/pkg/apis/v1alpha1/awsnodetemplate.go
@@ -34,6 +34,9 @@ type SecurityGroup struct {
 	// ID of the security group
 	// +required
 	ID string `json:"id"`
+	// Name of the security group
+	// +optional
+	Name string `json:"name,omitempty"`
 }
 
 // AMI contains resolved AMI selector values utilized for node launch
@@ -42,8 +45,8 @@ type AMI struct {
 	// +required
 	ID string `json:"id"`
 	// Name of the AMI
-	// +required
-	Name string `json:"name"`
+	// +optional
+	Name string `json:"name,omitempty"`
 	// Requirements of the AMI to be utilized on an instance type
 	// +required
 	Requirements []v1.NodeSelectorRequirement `json:"requirements"`

--- a/pkg/controllers/nodetemplate/controller.go
+++ b/pkg/controllers/nodetemplate/controller.go
@@ -118,18 +118,19 @@ func (c *Controller) resolveSubnets(ctx context.Context, nodeTemplate *v1alpha1.
 }
 
 func (c *Controller) resolveSecurityGroups(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) error {
-	securityGroupIds, err := c.securityGroupProvider.List(ctx, nodeTemplate)
+	securityGroups, err := c.securityGroupProvider.List(ctx, nodeTemplate)
 	if err != nil {
 		return err
 	}
-	if len(securityGroupIds) == 0 && nodeTemplate.Spec.SecurityGroupSelector != nil {
+	if len(securityGroups) == 0 && nodeTemplate.Spec.SecurityGroupSelector != nil {
 		nodeTemplate.Status.SecurityGroups = nil
 		return fmt.Errorf("no security groups exist given constraints")
 	}
 
-	nodeTemplate.Status.SecurityGroups = lo.Map(securityGroupIds, func(id string, _ int) v1alpha1.SecurityGroup {
+	nodeTemplate.Status.SecurityGroups = lo.Map(securityGroups, func(securityGroup *ec2.SecurityGroup, _ int) v1alpha1.SecurityGroup {
 		return v1alpha1.SecurityGroup{
-			ID: id,
+			ID:   *securityGroup.GroupId,
+			Name: *securityGroup.GroupName,
 		}
 	})
 

--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -257,92 +257,118 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			nodeTemplate.Spec.SecurityGroupSelector = nil
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
-			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			securityGroupsIDInStatus := lo.Map(nodeTemplate.Status.SecurityGroups, func(securitygroup v1alpha1.SecurityGroup, _ int) string {
-				return securitygroup.ID
-			})
-			Expect(securityGroupsIDInStatus).To(Equal(securityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(BeNil())
 		})
 		It("Should update AWSNodeTemplate status for Security Groups", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			securityGroupsIDInStatus := lo.Map(nodeTemplate.Status.SecurityGroups, func(securitygroup v1alpha1.SecurityGroup, _ int) string {
-				return securitygroup.ID
-			})
-			Expect(securityGroupsIDInStatus).To(Equal(securityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+				{
+					ID:   "sg-test2",
+					Name: "securityGroup-test2",
+				},
+				{
+					ID:   "sg-test3",
+					Name: "securityGroup-test3",
+				},
+			}))
 		})
 		It("Should resolve a valid selectors for Security Groups by tags", func() {
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`Name`: `test-security-group-1,test-security-group-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			correctSecurityGroupsIDs := lo.Map(securityGroupsIDs, func(securitygroup string, _ int) v1alpha1.SecurityGroup {
-				return v1alpha1.SecurityGroup{
-					ID: securitygroup,
-				}
-			})
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal(correctSecurityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+				{
+					ID:   "sg-test2",
+					Name: "securityGroup-test2",
+				},
+			}))
 		})
 		It("Should resolve a valid selectors for Security Groups by ids", func() {
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`aws-ids`: `sg-test1`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			correctSecurityGroupsIDs := lo.Map(securityGroupsIDs, func(securitygroup string, _ int) v1alpha1.SecurityGroup {
-				return v1alpha1.SecurityGroup{
-					ID: securitygroup,
-				}
-			})
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal(correctSecurityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+			}))
 		})
 		It("Should update Security Groups status when the Security Groups selector gets updated by tags", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			securityGroupsIDInStatus := lo.Map(nodeTemplate.Status.SecurityGroups, func(securitygroup v1alpha1.SecurityGroup, _ int) string {
-				return securitygroup.ID
-			})
-			Expect(securityGroupsIDInStatus).To(Equal(securityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+				{
+					ID:   "sg-test2",
+					Name: "securityGroup-test2",
+				},
+				{
+					ID:   "sg-test3",
+					Name: "securityGroup-test3",
+				},
+			}))
 
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`Name`: `test-security-group-1,test-security-group-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ = awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			correctSecurityGroupsIDs := lo.Map(securityGroupsIDs, func(securitygroup string, _ int) v1alpha1.SecurityGroup {
-				return v1alpha1.SecurityGroup{
-					ID: securitygroup,
-				}
-			})
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal(correctSecurityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+				{
+					ID:   "sg-test2",
+					Name: "securityGroup-test2",
+				},
+			}))
 		})
 		It("Should update Security Groups status when the Security Groups selector gets updated by ids", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			securityGroupsIDInStatus := lo.Map(nodeTemplate.Status.SecurityGroups, func(securitygroup v1alpha1.SecurityGroup, _ int) string {
-				return securitygroup.ID
-			})
-			Expect(securityGroupsIDInStatus).To(Equal(securityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+				{
+					ID:   "sg-test2",
+					Name: "securityGroup-test2",
+				},
+				{
+					ID:   "sg-test3",
+					Name: "securityGroup-test3",
+				},
+			}))
 
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`aws-ids`: `sg-test1`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ = awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			correctSecurityGroupsIDs := lo.Map(securityGroupsIDs, func(securitygroup string, _ int) v1alpha1.SecurityGroup {
-				return v1alpha1.SecurityGroup{
-					ID: securitygroup,
-				}
-			})
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal(correctSecurityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+			}))
 		})
 		It("Should not resolve a invalid selectors for Security Groups", func() {
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`foo`: `invalid`}
@@ -355,11 +381,20 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			securityGroupsIDs, _ := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
-			securityGroupsIDInStatus := lo.Map(nodeTemplate.Status.SecurityGroups, func(securitygroup v1alpha1.SecurityGroup, _ int) string {
-				return securitygroup.ID
-			})
-			Expect(securityGroupsIDInStatus).To(Equal(securityGroupsIDs))
+			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
+				{
+					ID:   "sg-test1",
+					Name: "securityGroup-test1",
+				},
+				{
+					ID:   "sg-test2",
+					Name: "securityGroup-test2",
+				},
+				{
+					ID:   "sg-test3",
+					Name: "securityGroup-test3",
+				},
+			}))
 
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`foo`: `invalid`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -421,21 +421,24 @@ func (e *EC2API) DescribeSecurityGroupsWithContext(ctx context.Context, input *e
 	}
 	sgs := []*ec2.SecurityGroup{
 		{
-			GroupId: aws.String("sg-test1"),
+			GroupId:   aws.String("sg-test1"),
+			GroupName: aws.String("securityGroup-test1"),
 			Tags: []*ec2.Tag{
 				{Key: aws.String("Name"), Value: aws.String("test-security-group-1")},
 				{Key: aws.String("foo"), Value: aws.String("bar")},
 			},
 		},
 		{
-			GroupId: aws.String("sg-test2"),
+			GroupId:   aws.String("sg-test2"),
+			GroupName: aws.String("securityGroup-test2"),
 			Tags: []*ec2.Tag{
 				{Key: aws.String("Name"), Value: aws.String("test-security-group-2")},
 				{Key: aws.String("foo"), Value: aws.String("bar")},
 			},
 		},
 		{
-			GroupId: aws.String("sg-test3"),
+			GroupId:   aws.String("sg-test3"),
+			GroupName: aws.String("securityGroup-test3"),
 			Tags: []*ec2.Tag{
 				{Key: aws.String("Name"), Value: aws.String("test-security-group-3")},
 				{Key: aws.String("TestTag")},

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -54,10 +54,10 @@ type Options struct {
 	InstanceProfile         string
 	CABundle                *string `hash:"ignore"`
 	// Level-triggered fields that may change out of sync.
-	SecurityGroupsIDs []string
-	Tags              map[string]string
-	Labels            map[string]string `hash:"ignore"`
-	KubeDNSIP         net.IP
+	SecurityGroups []v1alpha1.SecurityGroup
+	Tags           map[string]string
+	Labels         map[string]string `hash:"ignore"`
+	KubeDNSIP      net.IP
 }
 
 // LaunchTemplate holds the dynamically generated launch template parameters

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -141,11 +141,11 @@ func (p *Provider) createAMIOptions(ctx context.Context, nodeTemplate *v1alpha1.
 		return nil, err
 	}
 	// Get constrained security groups
-	securityGroupsIDs, err := p.securityGroupProvider.List(ctx, nodeTemplate)
+	securityGroups, err := p.securityGroupProvider.List(ctx, nodeTemplate)
 	if err != nil {
 		return nil, err
 	}
-	if len(securityGroupsIDs) == 0 {
+	if len(securityGroups) == 0 {
 		return nil, fmt.Errorf("no security groups exist given constraints")
 	}
 	return &amifamily.Options{
@@ -153,11 +153,13 @@ func (p *Provider) createAMIOptions(ctx context.Context, nodeTemplate *v1alpha1.
 		ClusterEndpoint:         p.ClusterEndpoint,
 		AWSENILimitedPodDensity: settings.FromContext(ctx).EnableENILimitedPodDensity,
 		InstanceProfile:         instanceProfile,
-		SecurityGroupsIDs:       securityGroupsIDs,
-		Tags:                    tags,
-		Labels:                  labels,
-		CABundle:                p.caBundle,
-		KubeDNSIP:               p.KubeDNSIP,
+		SecurityGroups: lo.Map(securityGroups, func(s *ec2.SecurityGroup, _ int) v1alpha1.SecurityGroup {
+			return v1alpha1.SecurityGroup{ID: aws.StringValue(s.GroupId), Name: aws.StringValue(s.GroupName)}
+		}),
+		Tags:      tags,
+		Labels:    labels,
+		CABundle:  p.caBundle,
+		KubeDNSIP: p.KubeDNSIP,
 	}, nil
 }
 
@@ -209,7 +211,7 @@ func (p *Provider) createLaunchTemplate(ctx context.Context, options *amifamily.
 			Monitoring: &ec2.LaunchTemplatesMonitoringRequest{
 				Enabled: aws.Bool(options.DetailedMonitoring),
 			},
-			SecurityGroupIds: aws.StringSlice(options.SecurityGroupsIDs),
+			SecurityGroupIds: lo.Map(options.SecurityGroups, func(s v1alpha1.SecurityGroup, _ int) *string { return aws.String(s.ID) }),
 			UserData:         aws.String(userData),
 			ImageId:          aws.String(options.AMIID),
 			MetadataOptions: &ec2.LaunchTemplateInstanceMetadataOptionsRequest{

--- a/pkg/providers/securitygroup/securitygroup.go
+++ b/pkg/providers/securitygroup/securitygroup.go
@@ -51,7 +51,7 @@ func NewProvider(ec2api ec2iface.EC2API, cache *cache.Cache) *Provider {
 	}
 }
 
-func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]string, error) {
+func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*ec2.SecurityGroup, error) {
 	p.Lock()
 	defer p.Unlock()
 	// Get SecurityGroups
@@ -59,7 +59,7 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 	// The check will not be necessary
 	filters := p.getFilters(nodeTemplate)
 	if len(filters) == 0 {
-		return []string{}, nil
+		return []*ec2.SecurityGroup{}, nil
 	}
 	securityGroups, err := p.getSecurityGroups(ctx, filters)
 	if err != nil {
@@ -72,7 +72,7 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 			})).
 			Debugf("discovered security groups")
 	}
-	return lo.Map(securityGroups, func(s *ec2.SecurityGroup, _ int) string { return aws.StringValue(s.GroupId) }), nil
+	return securityGroups, nil
 }
 
 func (p *Provider) getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {

--- a/pkg/providers/securitygroup/suite_test.go
+++ b/pkg/providers/securitygroup/suite_test.go
@@ -113,80 +113,199 @@ var _ = AfterEach(func() {
 var _ = Describe("Security Group Provider", func() {
 	It("should default to the clusters security groups", func() {
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		resolvedSecurityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
 		Expect(err).To(BeNil())
-		Expect(len(resolvedSecurityGroups)).To(Equal(3))
-		Expect(resolvedSecurityGroups).To(ConsistOf(
-			"sg-test1",
-			"sg-test2",
-			"sg-test3",
-		))
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test1"),
+				GroupName: aws.String("securityGroup-test1"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-1"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+			{
+				GroupId:   aws.String("sg-test2"),
+				GroupName: aws.String("securityGroup-test2"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-2"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+			{
+				GroupId:   aws.String("sg-test3"),
+				GroupName: aws.String("securityGroup-test3"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-3"),
+				}, {
+					Key: aws.String("TestTag"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
 	})
 	It("should discover security groups by tag", func() {
 		awsEnv.EC2API.DescribeSecurityGroupsOutput.Set(&ec2.DescribeSecurityGroupsOutput{SecurityGroups: []*ec2.SecurityGroup{
-			{GroupId: aws.String("test-sg-1"), Tags: []*ec2.Tag{{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("test-sg-1")}}},
-			{GroupId: aws.String("test-sg-2"), Tags: []*ec2.Tag{{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("test-sg-2")}}},
+			{GroupName: aws.String("test-sgName-1"), GroupId: aws.String("test-sg-1"), Tags: []*ec2.Tag{{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("test-sg-1")}}},
+			{GroupName: aws.String("test-sgName-2"), GroupId: aws.String("test-sg-2"), Tags: []*ec2.Tag{{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("test-sg-2")}}},
 		}})
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		resolvedSecurityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
 		Expect(err).To(BeNil())
-		Expect(len(resolvedSecurityGroups)).To(Equal(2))
-		Expect(resolvedSecurityGroups).To(ConsistOf(
-			"test-sg-1",
-			"test-sg-2",
-		))
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupName: aws.String("test-sgName-1"),
+				GroupId:   aws.String("test-sg-1"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+					Value: aws.String("test-sg-1"),
+				}},
+			},
+			{
+				GroupName: aws.String("test-sgName-2"),
+				GroupId:   aws.String("test-sg-2"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("kubernetes.io/cluster/test-cluster"),
+					Value: aws.String("test-sg-2"),
+				}},
+			},
+		}))
 	})
 	It("should discover security groups by multiple tag values", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"Name": "test-security-group-1,test-security-group-2"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		resolvedSecurityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
 		Expect(err).To(BeNil())
-		Expect(len(resolvedSecurityGroups)).To(Equal(2))
-		Expect(resolvedSecurityGroups).To(ConsistOf(
-			"sg-test1",
-			"sg-test2",
-		))
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test1"),
+				GroupName: aws.String("securityGroup-test1"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-1"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+			{
+				GroupId:   aws.String("sg-test2"),
+				GroupName: aws.String("securityGroup-test2"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-2"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
 	})
 	It("should discover security groups by ID", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		resolvedSecurityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
 		Expect(err).To(BeNil())
-		Expect(len(resolvedSecurityGroups)).To(Equal(1))
-		Expect(resolvedSecurityGroups).To(ConsistOf(
-			"sg-test1",
-		))
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test1"),
+				GroupName: aws.String("securityGroup-test1"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-1"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
 	})
 	It("should discover security groups by IDs", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1,sg-test2"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		resolvedSecurityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
 		Expect(err).To(BeNil())
-		Expect(len(resolvedSecurityGroups)).To(Equal(2))
-		Expect(resolvedSecurityGroups).To(ConsistOf(
-			"sg-test1",
-			"sg-test2",
-		))
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test1"),
+				GroupName: aws.String("securityGroup-test1"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-1"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+			{
+				GroupId:   aws.String("sg-test2"),
+				GroupName: aws.String("securityGroup-test2"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-2"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
 	})
 	It("should discover security groups by IDs and tags", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1,sg-test2", "foo": "bar"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		resolvedSecurityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
 		Expect(err).To(BeNil())
-		Expect(len(resolvedSecurityGroups)).To(Equal(2))
-		Expect(resolvedSecurityGroups).To(ConsistOf(
-			"sg-test1",
-			"sg-test2",
-		))
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test1"),
+				GroupName: aws.String("securityGroup-test1"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-1"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+			{
+				GroupId:   aws.String("sg-test2"),
+				GroupName: aws.String("securityGroup-test2"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-2"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
 	})
 	It("should discover security groups by IDs intersected with tags", func() {
 		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test2", "foo": "bar"}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		resolvedSecurityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
 		Expect(err).To(BeNil())
-		Expect(len(resolvedSecurityGroups)).To(Equal(1))
-		Expect(resolvedSecurityGroups).To(ConsistOf(
-			"sg-test2",
-		))
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test2"),
+				GroupName: aws.String("securityGroup-test2"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-2"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
 	})
 })

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -567,7 +567,7 @@ status:
 ```
 
 ## status.securityGroups
-`status.securityGroups` contains the `id` of the security groups utilized during node launch.
+`status.securityGroups` contains the `id` and `name` of the security groups utilized during node launch.
 
 **Examples**
 
@@ -575,7 +575,9 @@ status:
   status:
     securityGroups:
     - id: sg-041513b454818610b
+      name: ClusterSharedNodeSecurityGroup
     - id: sg-0286715698b894bca
+      name: ControlPlaneSecurityGroup-1AQ073TSAAPW
 ```
 
 ## status.amis


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- Added to name for SecurityGroups in the `AWSNodeTemplate.status `

**How was this change tested?**
* Manually tested

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
