### PR TITLE
chore: Add SQS Server Side Encryption to interruption queue in getting started guide

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -82,6 +82,7 @@ Resources:
     Properties:
       QueueName: !Sub "${ClusterName}"
       MessageRetentionPeriod: 300
+      SqsManagedSseEnabled: true
   KarpenterInterruptionQueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:

--- a/website/content/en/v0.26.1/getting-started/getting-started-with-eksctl/cloudformation.yaml
+++ b/website/content/en/v0.26.1/getting-started/getting-started-with-eksctl/cloudformation.yaml
@@ -82,6 +82,7 @@ Resources:
     Properties:
       QueueName: !Sub "${ClusterName}"
       MessageRetentionPeriod: 300
+      SqsManagedSseEnabled: true
   KarpenterInterruptionQueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:

--- a/website/content/en/v0.27.3/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.27.3/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -82,6 +82,7 @@ Resources:
     Properties:
       QueueName: !Sub "${ClusterName}"
       MessageRetentionPeriod: 300
+      SqsManagedSseEnabled: true
   KarpenterInterruptionQueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:


### PR DESCRIPTION
**Description**

Enables best practice of serverside encryption for SQS queues

**How was this change tested?**
```
aws cloudformation deploy --stack-name "Karpenter-${CLUSTER_NAME}" --template-file /Users/etarn/go/src/github.com/aws/karpenter/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml --capabilities CAPABILITY_NAMED_IAM --parameter-overrides "ClusterName=${CLUSTER_NAME}"
```
Using AWS FIS to force an interruption.
```
karpenter-5f898d848c-vxhbr controller 2023-05-12T17:12:54.720Z	DEBUG	controller.interruption	removing offering from offerings	{"commit": "6ebe0b7", "queue": "dev", "messageKind": "SpotInterruptionKind", "machine": "default-gcvxv", "action": "CordonAndDrain", "node": "ip-192-168-104-43.us-west-2.compute.internal", "reason": "SpotInterruptionKind", "instance-type": "c6i.32xlarge", "zone": "us-west-2b", "capacity-type": "spot", "ttl": "3m0s"}
karpenter-5f898d848c-vxhbr controller 2023-05-12T17:12:54.731Z	INFO	controller.interruption	deleted machine from interruption message	{"commit": "6ebe0b7", "queue": "dev", "messageKind": "SpotInterruptionKind", "machine": "default-gcvxv", "action": "CordonAndDrain", "node": "ip-192-168-104-43.us-west-2.compute.internal"}
karpenter-5f898d848c-vxhbr controller 2023-05-12T17:12:54.776Z	INFO	controller.termination	cordoned node	{"commit": "6ebe0b7", "node": "ip-192-168-104-43.us-west-2.compute.internal"}
karpenter-5f898d848c-vxhbr controller 2023-05-12T17:12:57.440Z	INFO	controller.termination	deleted node	{"commit": "6ebe0b7", "node": "ip-192-168-104-43.us-west-2.compute.internal"}
karpenter-5f898d848c-vxhbr controller 2023-05-12T17:12:57.818Z	INFO	controller.machine_termination	deleted machine	{"commit": "6ebe0b7", "machine": "default-gcvxv", "node": "", "provisioner": "default", "provider-id": "aws:///us-west-2b/i-0bc8d30543be9a7b5"}
```

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
