### PR TITLE
test: Cleanup Subnet tests

### DIFF
--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -103,124 +103,136 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			subnetIDs := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) string {
-				return *ec2subnet.SubnetId
-			})
-			sort.Strings(subnetIDs)
-			subnetIDsInStatus := lo.Map(nodeTemplate.Status.Subnets, func(subnet v1alpha1.Subnet, _ int) string {
-				return subnet.ID
-			})
-			sort.Strings(subnetIDsInStatus)
-			Expect(subnetIDsInStatus).To(Equal(subnetIDs))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+				{
+					ID:   "subnet-test2",
+					Zone: "test-zone-1b",
+				},
+				{
+					ID:   "subnet-test3",
+					Zone: "test-zone-1c",
+				},
+			}))
 		})
 		It("Should have the correct ordering for the Subnets", func() {
+			awsEnv.EC2API.DescribeSubnetsOutput.Set(&ec2.DescribeSubnetsOutput{Subnets: []*ec2.Subnet{
+				{SubnetId: aws.String("subnet-test1"), AvailabilityZone: aws.String("test-zone-1a"), AvailableIpAddressCount: aws.Int64(20)},
+				{SubnetId: aws.String("subnet-test2"), AvailabilityZone: aws.String("test-zone-1b"), AvailableIpAddressCount: aws.Int64(100)},
+				{SubnetId: aws.String("subnet-test3"), AvailabilityZone: aws.String("test-zone-1c"), AvailableIpAddressCount: aws.Int64(50)},
+			}})
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			sort.Slice(subnet, func(i, j int) bool {
-				return int(*subnet[i].AvailableIpAddressCount) > int(*subnet[j].AvailableIpAddressCount)
-			})
-			correctSubnetIDs := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) string {
-				return *ec2subnet.SubnetId
-			})
-			subnetIDsInStatus := lo.Map(nodeTemplate.Status.Subnets, func(subnet v1alpha1.Subnet, _ int) string {
-				return subnet.ID
-			})
-			Expect(subnetIDsInStatus).To(Equal(correctSubnetIDs))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test2",
+					Zone: "test-zone-1b",
+				},
+				{
+					ID:   "subnet-test3",
+					Zone: "test-zone-1c",
+				},
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+			}))
 		})
 		It("Should resolve a valid selectors for Subnet by tags", func() {
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`Name`: `test-subnet-1,test-subnet-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			sort.Slice(subnet, func(i, j int) bool {
-				return int(*subnet[i].AvailableIpAddressCount) > int(*subnet[j].AvailableIpAddressCount)
-			})
-			correctSubnets := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) v1alpha1.Subnet {
-				return v1alpha1.Subnet{
-					ID:   *ec2subnet.SubnetId,
-					Zone: *ec2subnet.AvailabilityZone,
-				}
-			})
-			Expect(nodeTemplate.Status.Subnets).To(Equal(correctSubnets))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+				{
+					ID:   "subnet-test2",
+					Zone: "test-zone-1b",
+				},
+			}))
 		})
 		It("Should resolve a valid selectors for Subnet by ids", func() {
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`aws-ids`: `subnet-test1`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			correctSubnetIDs := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) v1alpha1.Subnet {
-				return v1alpha1.Subnet{
-					ID:   *ec2subnet.SubnetId,
-					Zone: *ec2subnet.AvailabilityZone,
-				}
-			})
-			// Only one subnet will be resolved
-			Expect(nodeTemplate.Status.Subnets).To(Equal(correctSubnetIDs))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+			}))
 		})
 		It("Should update Subnet status when the Subnet selector gets updated by tags", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			subnetIDs := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) string {
-				return *ec2subnet.SubnetId
-			})
-			sort.Strings(subnetIDs)
-			subnetIDsInStatus := lo.Map(nodeTemplate.Status.Subnets, func(subnet v1alpha1.Subnet, _ int) string {
-				return subnet.ID
-			})
-			sort.Strings(subnetIDsInStatus)
-			Expect(subnetIDsInStatus).To(Equal(subnetIDs))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+				{
+					ID:   "subnet-test2",
+					Zone: "test-zone-1b",
+				},
+				{
+					ID:   "subnet-test3",
+					Zone: "test-zone-1c",
+				},
+			}))
 
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`Name`: `test-subnet-1,test-subnet-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ = awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			sort.Slice(subnet, func(i, j int) bool {
-				return int(*subnet[i].AvailableIpAddressCount) > int(*subnet[j].AvailableIpAddressCount)
-			})
-			correctSubnets := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) v1alpha1.Subnet {
-				return v1alpha1.Subnet{
-					ID:   *ec2subnet.SubnetId,
-					Zone: *ec2subnet.AvailabilityZone,
-				}
-			})
-			Expect(nodeTemplate.Status.Subnets).To(Equal(correctSubnets))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+				{
+					ID:   "subnet-test2",
+					Zone: "test-zone-1b",
+				},
+			}))
 		})
 		It("Should update Subnet status when the Subnet selector gets updated by ids", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			subnetIDs := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) string {
-				return *ec2subnet.SubnetId
-			})
-			sort.Strings(subnetIDs)
-			subnetIDsInStatus := lo.Map(nodeTemplate.Status.Subnets, func(subnet v1alpha1.Subnet, _ int) string {
-				return subnet.ID
-			})
-			sort.Strings(subnetIDsInStatus)
-			Expect(subnetIDsInStatus).To(Equal(subnetIDs))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+				{
+					ID:   "subnet-test2",
+					Zone: "test-zone-1b",
+				},
+				{
+					ID:   "subnet-test3",
+					Zone: "test-zone-1c",
+				},
+			}))
 
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`aws-ids`: `subnet-test1`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ = awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			correctSubnetIDs := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) v1alpha1.Subnet {
-				return v1alpha1.Subnet{
-					ID:   *ec2subnet.SubnetId,
-					Zone: *ec2subnet.AvailabilityZone,
-				}
-			})
-			// Only one subnet will be resolved
-			Expect(nodeTemplate.Status.Subnets).To(Equal(correctSubnetIDs))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+			}))
 		})
 		It("Should not resolve a invalid selectors for Subnet", func() {
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`foo`: `invalid`}
@@ -233,16 +245,20 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			subnet, _ := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-			subnetIDs := lo.Map(subnet, func(ec2subnet *ec2.Subnet, _ int) string {
-				return *ec2subnet.SubnetId
-			})
-			sort.Strings(subnetIDs)
-			subnetIDsInStatus := lo.Map(nodeTemplate.Status.Subnets, func(subnet v1alpha1.Subnet, _ int) string {
-				return subnet.ID
-			})
-			sort.Strings(subnetIDsInStatus)
-			Expect(subnetIDsInStatus).To(Equal(subnetIDs))
+			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
+				{
+					ID:   "subnet-test1",
+					Zone: "test-zone-1a",
+				},
+				{
+					ID:   "subnet-test2",
+					Zone: "test-zone-1b",
+				},
+				{
+					ID:   "subnet-test3",
+					Zone: "test-zone-1c",
+				},
+			}))
 
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`foo`: `invalid`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Subnet Provider", func() {
 		Expect(subnets).To(HaveLen(1))
 		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
 		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 	})
 	It("should discover subnets by IDs", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test1,subnet-test2"}
@@ -128,8 +129,10 @@ var _ = Describe("Subnet Provider", func() {
 		Expect(subnets).To(HaveLen(2))
 		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
 		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 		Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
 		Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
+		Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 	})
 	It("should discover subnets by IDs and tags", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test1,subnet-test2", "foo": "bar"}
@@ -140,8 +143,10 @@ var _ = Describe("Subnet Provider", func() {
 		Expect(subnets).To(HaveLen(2))
 		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
 		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 		Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
 		Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
+		Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 	})
 	It("should discover subnets by a single tag", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1"}
@@ -152,6 +157,7 @@ var _ = Describe("Subnet Provider", func() {
 		Expect(subnets).To(HaveLen(1))
 		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
 		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 	})
 	It("should discover subnets by multiple tag values", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1,test-subnet-2"}
@@ -162,8 +168,10 @@ var _ = Describe("Subnet Provider", func() {
 		Expect(subnets).To(HaveLen(2))
 		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
 		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 		Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
 		Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
+		Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 	})
 	It("should discover subnets by IDs intersected with tags", func() {
 		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test2", "foo": "bar"}
@@ -174,5 +182,6 @@ var _ = Describe("Subnet Provider", func() {
 		Expect(subnets).To(HaveLen(1))
 		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test2"))
 		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1b"))
+		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
 	})
 })


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- Improving the `nodetempate.status` testing for subnets by validating the whole API surface 

**How was this change tested?**

* Unite tests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
