### PR TITLE
test: Bump Tektoncli for e2etests

### DIFF
--- a/tools/release-notification-listener/Dockerfile
+++ b/tools/release-notification-listener/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /release-notification-listener
 RUN GOPROXY=direct go build .
 
 # Install tekton CLI
-RUN curl --silent --location "https://github.com/tektoncd/cli/releases/download/v0.28.0/tkn_0.28.0_$(uname -s)_x86_64.tar.gz" | tar xz -C /tmp
+RUN curl --silent --location "https://github.com/tektoncd/cli/releases/download/v0.31.0/tkn_0.31.0_$(uname -s)_x86_64.tar.gz" | tar xz -C /tmp
 RUN mv /tmp/tkn /usr/local/bin
 
 RUN go build -o release-notification-listener


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Bump `tektoncli` from v0.28.0 to v0.31.0, due to cluster update from 1.21 to 1.24, which required updates tekton crds.  

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
