### PR TITLE
Adding custom multiplier and injected through config

### DIFF
--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -60,8 +60,8 @@ type Settings struct {
 	InterruptionQueueName      string
 	Tags                       map[string]string
 	ReservedENIs               int     `validate:"min=0"`
-	SpotDiscount               float64 `validate:"min=0"`
-	OnDemandDiscount           float64 `validate:"min=0"`
+	SpotPriceMultiplier        float64 `validate:"min=0"`
+	OnDemandPriceMultiplier    float64 `validate:"min=0"`
 }
 
 func (*Settings) ConfigMap() string {

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -84,7 +84,7 @@ func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context,
 		AsStringMap("aws.tags", &s.Tags),
 		configmap.AsInt("aws.reservedENIs", &s.ReservedENIs),
 		configmap.AsFloat64("aws.spotPriceMultiplier", &s.SpotPriceMultiplier),
-		configmap.AsFloat64("aws.onDemandPriceMultiplier", &s.OnDemandPriceMultiplier)
+		configmap.AsFloat64("aws.onDemandPriceMultiplier", &s.OnDemandPriceMultiplier),
 	); err != nil {
 		return ctx, fmt.Errorf("parsing settings, %w", err)
 	}

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -44,8 +44,8 @@ var defaultSettings = &Settings{
 	InterruptionQueueName:      "",
 	Tags:                       map[string]string{},
 	ReservedENIs:               0,
-	SpotDiscount:               1,
-	OnDemandDiscount:           1,
+	SpotPriceMultiplier:        1,
+	OnDemandPriceMultiplier:    1,
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -83,6 +83,8 @@ func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context,
 		configmap.AsString("aws.interruptionQueueName", &s.InterruptionQueueName),
 		AsStringMap("aws.tags", &s.Tags),
 		configmap.AsInt("aws.reservedENIs", &s.ReservedENIs),
+		configmap.AsFloat64("aws.spotPriceMultiplier", &s.SpotPriceMultiplier),
+		configmap.AsFloat64("aws.onDemandPriceMultiplier", &s.OnDemandPriceMultiplier)
 	); err != nil {
 		return ctx, fmt.Errorf("parsing settings, %w", err)
 	}

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -44,6 +44,8 @@ var defaultSettings = &Settings{
 	InterruptionQueueName:      "",
 	Tags:                       map[string]string{},
 	ReservedENIs:               0,
+	SpotDiscount:               1,
+	OnDemandDiscount:           1,
 }
 
 // +k8s:deepcopy-gen=true
@@ -57,7 +59,9 @@ type Settings struct {
 	VMMemoryOverheadPercent    float64 `validate:"min=0"`
 	InterruptionQueueName      string
 	Tags                       map[string]string
-	ReservedENIs               int `validate:"min=0"`
+	ReservedENIs               int     `validate:"min=0"`
+	SpotDiscount               float64 `validate:"min=0"`
+	OnDemandDiscount           float64 `validate:"min=0"`
 }
 
 func (*Settings) ConfigMap() string {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -435,6 +435,7 @@ func (p *Provider) isMixedCapacityLaunch(machine *v1alpha5.Machine, instanceType
 
 // filterUnwantedSpot is used to filter out spot types that are more expensive than the cheapest on-demand type that we
 // could launch during mixed capacity-type launches
+// Discount as a percentage are passed in and applied to ondemand and spot pricing
 func filterUnwantedSpot(instanceTypes []*cloudprovider.InstanceType, onDemandDiscount float64, spotDiscount float64) []*cloudprovider.InstanceType {
 	cheapestOnDemand := math.MaxFloat64
 	// first, find the price of our cheapest available on-demand instance type that could support this node

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -442,9 +442,9 @@ func filterUnwantedSpot(instanceTypes []*cloudprovider.InstanceType, onDemandPri
 	// first, find the price of our cheapest available on-demand instance type that could support this node
 	for _, it := range instanceTypes {
 		for _, o := range it.Offerings.Available() {
-			currentPrice := o.Price * onDemandPriceMultiplier
-			if o.CapacityType == v1alpha5.CapacityTypeOnDemand && currentPrice < cheapestOnDemand {
-				cheapestOnDemand = currentPrice
+			currentOnDemandPrice := o.Price * onDemandPriceMultiplier
+			if o.CapacityType == v1alpha5.CapacityTypeOnDemand && currentOnDemandPrice < cheapestOnDemand {
+				cheapestOnDemand = currentOnDemandPrice
 			}
 		}
 	}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -442,8 +442,9 @@ func filterUnwantedSpot(instanceTypes []*cloudprovider.InstanceType, onDemandPri
 	// first, find the price of our cheapest available on-demand instance type that could support this node
 	for _, it := range instanceTypes {
 		for _, o := range it.Offerings.Available() {
-			if o.CapacityType == v1alpha5.CapacityTypeOnDemand && o.Price < cheapestOnDemand {
-				cheapestOnDemand = o.Price * onDemandPriceMultiplier
+			currentPrice := o.Price * onDemandPriceMultiplier
+			if o.CapacityType == v1alpha5.CapacityTypeOnDemand && currentPrice < cheapestOnDemand {
+				cheapestOnDemand = currentPrice
 			}
 		}
 	}

--- a/website/content/en/preview/concepts/settings.md
+++ b/website/content/en/preview/concepts/settings.md
@@ -69,6 +69,10 @@ data:
   # Reserved ENIs are not included in the calculations for max-pods or kube-reserved
   # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
   aws.reservedENIs: "1"
+  # Spot Price Multiplier for including volume discounts etc. for spot prices. The spot price will be multiplied with the spotPriceMultiplier to determine the real cost
+  aws.spotPriceMultiplier: "0.95"
+  # On Demand Multiplier for including volume discounts etc. to ensure choosing the cheapest available instance. The ondemand price will be multiplied with the onDemandPriceMultiplier to determine the real cost
+  aws.onDemandPriceMultiplier: "0.60"
 ```
 
 ### Feature Gates


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
Added code to allow a custom multiplier onto ondemand and spot pricing. This allows you to add a multiplier to prices that will be taken into consideration on which instance to use. This take's the same approach as autospotting (https://github.com/LeanerCloud/AutoSpotting/blob/master/START.md#configuration-of-autospotting). Prices can come from the Payer account of enterprise customers this leads to a problem as we cannot get the price data.
**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
