### PR TITLE
test: Run the tests scoped to the test suite with `TEST_SUITE`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ GETTING_STARTED_SCRIPT_DIR = website/content/en/preview/getting-started/getting-
 MOD_DIRS = $(shell find . -name go.mod -type f | xargs dirname)
 KARPENTER_CORE_DIR = $(shell go list -m -f '{{ .Dir }}' github.com/aws/karpenter-core)
 
+# TEST_SUITE enables you to select a specific test suite directory to run "make e2etests" or "make test" against
+TEST_SUITE ?= "..."
+
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
@@ -64,7 +67,7 @@ clean-run: ## Clean resources deployed by the run target
 	kubectl delete configmap -n ${SYSTEM_NAMESPACE} karpenter-global-settings --ignore-not-found
 
 test: ## Run tests
-	go test -v ./pkg/... --ginkgo.focus="${FOCUS}" --ginkgo.vv
+	go test -v ./pkg/$(shell echo $(TEST_SUITE) | tr A-Z a-z)/... --ginkgo.focus="${FOCUS}" --ginkgo.vv
 
 battletest: ## Run randomized, racing, code-covered tests
 	go test -v ./pkg/... \
@@ -81,7 +84,7 @@ e2etests: ## Run the e2e suite against your local cluster
 		-count 1 \
 		-timeout 180m \
 		-v \
-		./suites/... \
+		./suites/$(shell echo $(TEST_SUITE) | tr A-Z a-z)/... \
 		--ginkgo.focus="${FOCUS}" \
 		--ginkgo.timeout=180m \
 		--ginkgo.vv

--- a/test/manifests/run-test.yaml
+++ b/test/manifests/run-test.yaml
@@ -39,4 +39,4 @@ spec:
     workingDir: $(workspaces.ws.path)
     script: |
       aws eks update-kubeconfig --name $(params.cluster-name)
-      KUBECONFIG=/root/.kube/config FOCUS=$(params.test-filter) make e2etests
+      KUBECONFIG=/root/.kube/config ENABLE_CLOUDWATCH=true TEST_SUITE="$(params.test-filter)" make e2etests


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Currently, our tests run scoped based off of the `--ginkgo.focus` parameter. This works across test suites and uses regex to determine which suites to select. While this works for _most_ suites, we should scope the suite to a particularly directory so that we make sure that Regex doesn't leak between test suites

**How was this change tested?**

* `make e2etests` with `FOCUS=Integretion`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
