### PR TITLE
test: Fix failures in Scale Testing Suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ e2etests: ## Run the e2e suite against your local cluster
 		./suites/$(shell echo $(TEST_SUITE) | tr A-Z a-z)/... \
 		--ginkgo.focus="${FOCUS}" \
 		--ginkgo.timeout=180m \
+		--ginkgo.grace-period=3m \
 		--ginkgo.vv
 
 benchmark:

--- a/test/manifests/setup.yaml
+++ b/test/manifests/setup.yaml
@@ -32,7 +32,6 @@ spec:
       TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
       curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/identity-credentials/ec2/info | jq -r ".AccountId" | tr -d '\n' > $(results.account-id.path)
       curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/placement/region > $(results.region.path)
-
   - name: checkout-repository
     image: alpine/git
     workingDir: $(workspaces.ws.path)
@@ -59,7 +58,7 @@ spec:
   - name: create-cluster
     image: public.ecr.aws/karpenter/tools:latest
     script: |
-      cmd="create"
+      cmd="create"  
       eksctl get cluster --name $(params.cluster-name) && cmd="upgrade"
       eksctl ${cmd} cluster -f - <<EOF
       ---
@@ -74,7 +73,7 @@ spec:
       kubernetesNetworkConfig:
         ipFamily: $(params.ip-family)
       managedNodeGroups:
-        - instanceType: m5.large
+        - instanceType: "c5.2xlarge"
           amiFamily: AmazonLinux2
           name: $(params.cluster-name)-system-pool
           desiredCapacity: 2
@@ -123,10 +122,10 @@ spec:
         --set settings.aws.clusterEndpoint=$(cat /root/.kube/config | grep server | awk '{print $2}') \
         --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-$(params.cluster-name) \
         --set settings.aws.interruptionQueueName=$(params.cluster-name) \
-        --set controller.resources.requests.cpu=1 \
-        --set controller.resources.requests.memory=1Gi \
-        --set controller.resources.limits.cpu=1 \
-        --set controller.resources.limits.memory=1Gi \
+        --set controller.resources.requests.cpu=4 \
+        --set controller.resources.requests.memory=4Gi \
+        --set controller.resources.limits.cpu=4 \
+        --set controller.resources.limits.memory=4Gi \
         --wait
 
   - name: diff-karpenter

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -71,7 +71,7 @@ var disableProvisioningLimits = &v1alpha5.Limits{
 	},
 }
 
-var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), func() {
+var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 	var provisioner *v1alpha5.Provisioner
 	var provisionerOptions test.ProvisionerOptions
 	var nodeTemplate *v1alpha1.AWSNodeTemplate

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				env.EventuallyExpectNodeCount("==", int(float64(expectedNodeCount)*0.2))
 				env.EventuallyExpectHealthyPodCount(selector, replicas)
 			}, aws.DeprovisioningEventType, consolidationTestGroup, "delete")
-		}, SpecTimeout(10*time.Minute))
+		}, SpecTimeout(time.Minute*30))
 		It("should consolidate nodes to get a higher utilization (single consolidation replace)", func(_ context.Context) {
 			replicasPerNode := 1
 			expectedNodeCount := 20 // we're currently doing around 1 node/2 mins so this test should run deprovisioning in about 45m
@@ -450,9 +450,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 
 				env.EventuallyExpectDeletedNodeCount("==", expectedNodeCount)
 				env.EventuallyExpectNodeCount("==", 0)
-				env.EventuallyExpectHealthyPodCount(selector, replicas)
 			}, aws.DeprovisioningEventType, emptinessTestGroup, defaultTestName)
-		}, SpecTimeout(10*time.Minute))
+		}, SpecTimeout(time.Minute*30))
 	})
 	Context("Expiration", func() {
 		It("should expire all nodes", func(_ context.Context) {
@@ -490,6 +489,9 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				provisioner.Spec.TTLSecondsUntilExpired = lo.ToPtr[int64](0)
 
 				noExpireProvisioner := test.Provisioner(provisionerOptions)
+				noExpireProvisioner.Spec.KubeletConfiguration = &v1alpha5.KubeletConfiguration{
+					MaxPods: lo.ToPtr[int32](int32(maxPodDensity)),
+				}
 				env.ExpectCreatedOrUpdated(provisioner, noExpireProvisioner)
 
 				env.EventuallyExpectDeletedNodeCount("==", expectedNodeCount)
@@ -583,7 +585,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				env.EventuallyExpectNodeCount("==", expectedNodeCount)
 				env.EventuallyExpectHealthyPodCount(selector, replicas)
 			}, aws.DeprovisioningEventType, interruptionTestGroup, defaultTestName)
-		}, SpecTimeout(time.Minute*10))
+		}, SpecTimeout(time.Minute*30))
 	})
 })
 

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), fu
 			env.EventuallyExpectInitializedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
 		}, aws.ProvisioningEventType, testGroup, "pod-dense")
-	}, SpecTimeout(10*time.Minute))
+	}, SpecTimeout(time.Minute*30))
 	It("should scale successfully on a pod-dense scale-up", func(_ context.Context) {
 		replicasPerNode := 110
 		maxPodDensity := replicasPerNode + dsCount
@@ -145,5 +145,5 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), fu
 			env.EventuallyExpectInitializedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
 		}, aws.ProvisioningEventType, testGroup, "node-dense")
-	}, SpecTimeout(10*time.Minute))
+	}, SpecTimeout(time.Minute*30))
 })

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -36,7 +36,7 @@ import (
 
 const testGroup = "provisioning"
 
-var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), func() {
+var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 	var provisioner *v1alpha5.Provisioner
 	var nodeTemplate *v1alpha1.AWSNodeTemplate
 	var deployment *appsv1.Deployment


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

1. Updates the `SpecTimeouts` for each of the shorter tests since the current `SpecTimeouts` were too constrained
2. Updates the `--grace-period` for Ginkgo so that clean-ups on `SpecTimeouts` have enough time to clean-up after a failure
3. Updates the E2E test suite manifests to use a different instance type when running scale testing

**How was this change tested?**

* Tekton runs of Scale Testing

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
