### PR TITLE
fix: Enable IMDSv2

### DIFF
--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -214,3 +214,17 @@ func (env *Environment) GetCustomAMI(amiPath string, versionOffset int) string {
 	Expect(err).To(BeNil())
 	return *parameter.Parameter.Value
 }
+
+func (env *Environment) ExpectRunInstances(instanceInput *ec2.RunInstancesInput) *ec2.Reservation {
+	GinkgoHelper()
+	// implement IMDSv2
+	instanceInput.MetadataOptions = &ec2.InstanceMetadataOptionsRequest{
+		HttpEndpoint: aws.String("enabled"),
+		HttpTokens:   aws.String("required"),
+	}
+
+	out, err := env.EC2API.RunInstances(instanceInput)
+	Expect(err).ToNot(HaveOccurred())
+
+	return out
+}

--- a/test/suites/machine/garbage_collection_test.go
+++ b/test/suites/machine/garbage_collection_test.go
@@ -97,8 +97,7 @@ var _ = Describe("MachineGarbageCollection", func() {
 			settings.FromContext(env.Context).ClusterEndpoint, env.ExpectCABundle(), provisioner.Name))))
 
 		// Create an instance manually to mock Karpenter launching an instance
-		out, err := env.EC2API.RunInstances(instanceInput)
-		Expect(err).ToNot(HaveOccurred())
+		out := env.ExpectRunInstances(instanceInput)
 		Expect(out.Instances).To(HaveLen(1))
 
 		// Always ensure that we cleanup the instance

--- a/test/suites/machine/link_test.go
+++ b/test/suites/machine/link_test.go
@@ -106,8 +106,7 @@ var _ = Describe("MachineLink", func() {
 			settings.FromContext(env.Context).ClusterEndpoint, env.ExpectCABundle(), provisioner.Name))))
 
 		// Create an instance manually to mock Karpenter launching an instance
-		out, err := env.EC2API.RunInstances(instanceInput)
-		Expect(err).ToNot(HaveOccurred())
+		out := env.ExpectRunInstances(instanceInput)
 		Expect(out.Instances).To(HaveLen(1))
 
 		// Always ensure that we cleanup the instance
@@ -166,8 +165,7 @@ var _ = Describe("MachineLink", func() {
 			settings.FromContext(env.Context).ClusterEndpoint, env.ExpectCABundle(), provisioner.Name))))
 
 		// Create an instance manually to mock Karpenter launching an instance
-		out, err := env.EC2API.RunInstances(instanceInput)
-		Expect(err).ToNot(HaveOccurred())
+		out := env.ExpectRunInstances(instanceInput)
 		Expect(out.Instances).To(HaveLen(1))
 
 		// Always ensure that we cleanup the instance
@@ -225,8 +223,7 @@ var _ = Describe("MachineLink", func() {
 			settings.FromContext(env.Context).ClusterEndpoint, env.ExpectCABundle(), provisioner.Name))))
 
 		// Create an instance manually to mock Karpenter launching an instance
-		out, err := env.EC2API.RunInstances(instanceInput)
-		Expect(err).ToNot(HaveOccurred())
+		out := env.ExpectRunInstances(instanceInput)
 		Expect(out.Instances).To(HaveLen(1))
 
 		// Always ensure that we cleanup the instance


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- For better security posture, our e2etests need to enable IMDSv2 on all instance that are launched

**How was this change tested?**

* Ran e2etests 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
