### PR TITLE
fix: Ensure that our cluster Machine list is more updated than our CloudProvider Machine list

### DIFF
--- a/pkg/controllers/machine/garbagecollection/controller.go
+++ b/pkg/controllers/machine/garbagecollection/controller.go
@@ -58,6 +58,16 @@ func (c *Controller) Name() string {
 }
 
 func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	// We LIST machines on the CloudProvider BEFORE we grab Machines/Nodes on the cluster so that we make sure that, if
+	// LISTing instances takes a long time, our information is more updated by the time we get to Machine and Node LIST
+	// This works since our CloudProvider instances are deleted based on whether the Machine exists or not, not vise-versa
+	retrieved, err := c.cloudProvider.List(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("listing cloudprovider machines, %w", err)
+	}
+	managedRetrieved := lo.Filter(retrieved, func(m *v1alpha5.Machine, _ int) bool {
+		return m.Labels[v1alpha5.ManagedByLabelKey] != "" && m.DeletionTimestamp.IsZero()
+	})
 	machineList := &v1alpha5.MachineList{}
 	if err := c.kubeClient.List(ctx, machineList); err != nil {
 		return reconcile.Result{}, err
@@ -75,13 +85,6 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		}
 		return m.Annotations[v1alpha5.MachineLinkedAnnotationKey]
 	})...)
-	retrieved, err := c.cloudProvider.List(ctx)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("listing cloudprovider machines, %w", err)
-	}
-	managedRetrieved := lo.Filter(retrieved, func(m *v1alpha5.Machine, _ int) bool {
-		return m.Labels[v1alpha5.ManagedByLabelKey] != "" && m.DeletionTimestamp.IsZero()
-	})
 	errs := make([]error, len(retrieved))
 	workqueue.ParallelizeUntil(ctx, 100, len(managedRetrieved), func(i int) {
 		_, recentlyLinked := c.linkController.Cache.Get(managedRetrieved[i].Status.ProviderID)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Prior to this change, it was possible for a call to `ec2.DescribeInstances` to take a long time. Machines were listed prior to this API call, which meant that if this `DescribeInstances` call took a long time, that the instances returned from the EC2 API would be more updated than the Machines that were retrieved from the List. To solve this, we should reverse the order of execution. This way, if the `DescribeInstances` takes longer, we will still get the Machines at the end of the call.

With this new order of execution, even if the Machine LIST takes a lot longer and the EC2 data is old, Machines should be a superset of the instances data, meaning that we will only ever delete _less_ instances than we should, not _more_.

**How was this change tested?**

* `make presubmit`
* `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
