### PR TITLE
test: add in more scale test dimensions

### DIFF
--- a/test/manifests/run-test.yaml
+++ b/test/manifests/run-test.yaml
@@ -39,4 +39,4 @@ spec:
     workingDir: $(workspaces.ws.path)
     script: |
       aws eks update-kubeconfig --name $(params.cluster-name)
-      KUBECONFIG=/root/.kube/config ENABLE_CLOUDWATCH=true TEST_SUITE="$(params.test-filter)" GIT_REF="$(params.git-ref)" make e2etests
+      KUBECONFIG=/root/.kube/config ENABLE_CLOUDWATCH=true TEST_SUITE="$(params.test-filter)" GIT_REF="$(git rev-parse HEAD)" make e2etests

--- a/test/pkg/environment/aws/metrics.go
+++ b/test/pkg/environment/aws/metrics.go
@@ -48,15 +48,15 @@ const (
 )
 
 const (
-	scaleTestingMetricNamespace = v1alpha5.TestingGroup + "/scale"
-	TestEventTypeDimension      = "eventType"
-	TestSubEventTypeDimension   = "subEventType"
-	TestGroupDimension          = "group"
-	TestNameDimension           = "name"
-	GitRefDimension             = "gitRef"
-	DeprovisionedNodeCountDimension          = "deprovisionedNodeCount"
-	ProvisionedNodeCountDimension          = "provisionedNodeCount"
-	PodDensityDimension         = "podDensity"
+	scaleTestingMetricNamespace     = v1alpha5.TestingGroup + "/scale"
+	TestEventTypeDimension          = "eventType"
+	TestSubEventTypeDimension       = "subEventType"
+	TestGroupDimension              = "group"
+	TestNameDimension               = "name"
+	GitRefDimension                 = "gitRef"
+	DeprovisionedNodeCountDimension = "deprovisionedNodeCount"
+	ProvisionedNodeCountDimension   = "provisionedNodeCount"
+	PodDensityDimension             = "podDensity"
 )
 
 // MeasureDurationFor observes the duration between the beginning of the function f() and the end of the function f()
@@ -101,8 +101,8 @@ func (env *Environment) ExpectMetric(name string, unit string, value float64, la
 
 func GenerateTestDimensions(provisionedNodeCount, deprovisionedNodeCount, podDensity int) map[string]string {
 	return map[string]string{
-		DeprovisionedNodeCountDimension:  strconv.Itoa(deprovisionedNodeCount),
-		ProvisionedNodeCountDimension: strconv.Itoa(provisionedNodeCount),
-		PodDensityDimension: strconv.Itoa(podDensity),
+		DeprovisionedNodeCountDimension: strconv.Itoa(deprovisionedNodeCount),
+		ProvisionedNodeCountDimension:   strconv.Itoa(provisionedNodeCount),
+		PodDensityDimension:             strconv.Itoa(podDensity),
 	}
 }

--- a/test/pkg/environment/aws/metrics.go
+++ b/test/pkg/environment/aws/metrics.go
@@ -54,7 +54,8 @@ const (
 	TestGroupDimension          = "group"
 	TestNameDimension           = "name"
 	GitRefDimension             = "gitRef"
-	NodeCountDimension          = "nodeCount"
+	DeprovisionedNodeCountDimension          = "deprovisionedNodeCount"
+	ProvisionedNodeCountDimension          = "provisionedNodeCount"
 	PodDensityDimension         = "podDensity"
 )
 
@@ -98,9 +99,10 @@ func (env *Environment) ExpectMetric(name string, unit string, value float64, la
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func GenerateTestDimensions(nodeCount, podDensity int) map[string]string {
+func GenerateTestDimensions(provisionedNodeCount, deprovisionedNodeCount, podDensity int) map[string]string {
 	return map[string]string{
-		NodeCountDimension:  strconv.Itoa(nodeCount),
+		DeprovisionedNodeCountDimension:  strconv.Itoa(deprovisionedNodeCount),
+		ProvisionedNodeCountDimension: strconv.Itoa(provisionedNodeCount),
 		PodDensityDimension: strconv.Itoa(podDensity),
 	}
 }

--- a/test/pkg/environment/aws/metrics.go
+++ b/test/pkg/environment/aws/metrics.go
@@ -15,6 +15,7 @@ limitations under the License.
 package aws
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -53,6 +54,8 @@ const (
 	TestGroupDimension          = "group"
 	TestNameDimension           = "name"
 	GitRefDimension             = "gitRef"
+	NodeCountDimension          = "nodeCount"
+	PodDensityDimension         = "podDensity"
 )
 
 // MeasureDurationFor observes the duration between the beginning of the function f() and the end of the function f()
@@ -93,4 +96,11 @@ func (env *Environment) ExpectMetric(name string, unit string, value float64, la
 		},
 	})
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func GenerateTestDimensions(nodeCount, podDensity int) map[string]string {
+	return map[string]string{
+		NodeCountDimension:  strconv.Itoa(nodeCount),
+		PodDensityDimension: strconv.Itoa(podDensity),
+	}
 }

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 					deletedNodeCountSelector labels.Selector
 					nodeCount                int
 					nodeCountSelector        labels.Selector
-					createdCount 			 int
+					createdCount             int
 				}
 				assertionMap := map[string]testAssertions{
 					consolidationValue: {

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -466,7 +466,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 		}, SpecTimeout(time.Hour))
 	})
 	Context("Emptiness", func() {
-		FIt("should deprovision all nodes when empty", func(_ context.Context) {
+		It("should deprovision all nodes when empty", func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 200

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 			env.EventuallyExpectCreatedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectInitializedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
-		}, aws.ProvisioningEventType, testGroup, "pod-dense", aws.GenerateTestDimensions(expectedNodeCount, replicasPerNode))
+		}, aws.ProvisioningEventType, testGroup, "pod-dense", aws.GenerateTestDimensions(expectedNodeCount, 0, replicasPerNode))
 	}, SpecTimeout(time.Minute*30))
 	It("should scale successfully on a pod-dense scale-up", func(_ context.Context) {
 		replicasPerNode := 110
@@ -144,6 +144,6 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 			env.EventuallyExpectCreatedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectInitializedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
-		}, aws.ProvisioningEventType, testGroup, "node-dense", aws.GenerateTestDimensions(expectedNodeCount, replicasPerNode))
+		}, aws.ProvisioningEventType, testGroup, "node-dense", aws.GenerateTestDimensions(expectedNodeCount, 0, replicasPerNode))
 	}, SpecTimeout(time.Minute*30))
 })

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 			env.EventuallyExpectCreatedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectInitializedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
-		}, aws.ProvisioningEventType, testGroup, "pod-dense")
+		}, aws.ProvisioningEventType, testGroup, "pod-dense", aws.GenerateTestDimensions(expectedNodeCount, replicasPerNode))
 	}, SpecTimeout(time.Minute*30))
 	It("should scale successfully on a pod-dense scale-up", func(_ context.Context) {
 		replicasPerNode := 110
@@ -144,6 +144,6 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 			env.EventuallyExpectCreatedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectInitializedNodeCount("==", expectedNodeCount)
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
-		}, aws.ProvisioningEventType, testGroup, "node-dense")
+		}, aws.ProvisioningEventType, testGroup, "node-dense", aws.GenerateTestDimensions(expectedNodeCount, replicasPerNode))
 	}, SpecTimeout(time.Minute*30))
 })


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- adds in more test dimensions 
- reduces the git-ref that's used to only be commits

**How was this change tested?**

* `TEST_SUITE=scale ENABLE_CLOUDWATCH=true make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
