### PR TITLE
Bump karpenter-core to latest for `v0.28.0-rc.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.267
-	github.com/aws/karpenter-core v0.28.0-rc.1.0.20230524172501-4418ff4eef78
+	github.com/aws/karpenter-core v0.28.0-rc.2
 	github.com/go-playground/validator/v10 v10.13.0
 	github.com/imdario/mergo v0.3.15
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.267 h1:Asrp6EMqqRxZvjK0NjzkWcrOk15RnWtupuUrUuZMabk=
 github.com/aws/aws-sdk-go v1.44.267/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.28.0-rc.1.0.20230524172501-4418ff4eef78 h1:N0dBJ3QAsAtNO7z9f4HadaDw/1/g2NYU3T1vjEYVr88=
-github.com/aws/karpenter-core v0.28.0-rc.1.0.20230524172501-4418ff4eef78/go.mod h1:IBZCqvVupygJriJDDTCI3hscT4H9NnrApX45YBYY5Og=
+github.com/aws/karpenter-core v0.28.0-rc.2 h1:WmlvsRtckcWaKwqEtGRvImtpPlYn3uT5g0CHlviOiPo=
+github.com/aws/karpenter-core v0.28.0-rc.2/go.mod h1:IBZCqvVupygJriJDDTCI3hscT4H9NnrApX45YBYY5Og=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/aws/aws-sdk-go v1.44.267
 	github.com/aws/karpenter v0.22.0
-	github.com/aws/karpenter-core v0.28.0-rc.1.0.20230524172501-4418ff4eef78
+	github.com/aws/karpenter-core v0.28.0-rc.2
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/samber/lo v1.38.1

--- a/test/go.sum
+++ b/test/go.sum
@@ -10,8 +10,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.267 h1:Asrp6EMqqRxZvjK0NjzkWcrOk15RnWtupuUrUuZMabk=
 github.com/aws/aws-sdk-go v1.44.267/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.28.0-rc.1.0.20230524172501-4418ff4eef78 h1:N0dBJ3QAsAtNO7z9f4HadaDw/1/g2NYU3T1vjEYVr88=
-github.com/aws/karpenter-core v0.28.0-rc.1.0.20230524172501-4418ff4eef78/go.mod h1:IBZCqvVupygJriJDDTCI3hscT4H9NnrApX45YBYY5Og=
+github.com/aws/karpenter-core v0.28.0-rc.2 h1:WmlvsRtckcWaKwqEtGRvImtpPlYn3uT5g0CHlviOiPo=
+github.com/aws/karpenter-core v0.28.0-rc.2/go.mod h1:IBZCqvVupygJriJDDTCI3hscT4H9NnrApX45YBYY5Og=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Bumps the version of `karpenter-core` to the latest to be up-to-date with the released version of `karpenter-core` `v0.28.0-rc.2`

**How was this change tested?**

* `/karpenter snapshot`
* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
