### PR TITLE
test: fix cloudwatch importing with missing env variable

### DIFF
--- a/test/pkg/environment/aws/metrics.go
+++ b/test/pkg/environment/aws/metrics.go
@@ -73,7 +73,10 @@ func (env *Environment) MeasureDurationFor(f func(), eventType EventType, group,
 
 func (env *Environment) ExpectEventDurationMetric(d time.Duration, labels map[string]string) {
 	GinkgoHelper()
-	gitRef := lo.Ternary(env.Context.Value(common.GitRefContextKey) != nil, env.Value(common.GitRefContextKey).(string), "n/a")
+	gitRef := "n/a"
+	if env.Context.Value(common.GitRefContextKey) != nil {
+		gitRef = env.Value(common.GitRefContextKey).(string)
+	}
 	env.ExpectMetric("eventDuration", cloudwatch.StandardUnitSeconds, d.Seconds(), lo.Assign(labels, map[string]string{GitRefDimension: gitRef}))
 }
 

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -62,7 +62,10 @@ func NewEnvironment(t *testing.T) *Environment {
 
 	lo.Must0(os.Setenv(system.NamespaceEnvKey, "karpenter"))
 	kubernetesInterface := kubernetes.NewForConfigOrDie(config)
-	ctx = context.WithValue(injection.WithSettingsOrDie(ctx, kubernetesInterface, apis.Settings...), GitRefContextKey, os.Getenv("GIT_REF"))
+	ctx = injection.WithSettingsOrDie(ctx, kubernetesInterface, apis.Settings...)
+	if val, ok := os.LookupEnv("GIT_REF"); ok {
+		ctx = context.WithValue(ctx, GitRefContextKey, val)
+	}
 
 	gomega.SetDefaultEventuallyTimeout(5 * time.Minute)
 	gomega.SetDefaultEventuallyPollingInterval(1 * time.Second)

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -71,7 +71,7 @@ var disableProvisioningLimits = &v1alpha5.Limits{
 	},
 }
 
-var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
+var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 	var provisioner *v1alpha5.Provisioner
 	var provisionerOptions test.ProvisionerOptions
 	var nodeTemplate *v1alpha1.AWSNodeTemplate
@@ -135,7 +135,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 	})
 
 	Context("Multiple Deprovisioners", func() {
-		It("should run consolidation, emptiness, expiration, and drift simultaneously", Label(debug.NoEvents), func(_ context.Context) {
+		It("should run consolidation, emptiness, expiration, and drift simultaneously", func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			nodeCountPerProvisioner := 10
@@ -333,7 +333,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 		}, SpecTimeout(time.Hour))
 	})
 	Context("Consolidation", func() {
-		It("should delete all empty nodes with consolidation", Label(debug.NoEvents), func(_ context.Context) {
+		It("should delete all empty nodes with consolidation", func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 200
@@ -373,7 +373,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 				env.EventuallyExpectNodeCount("==", 0)
 			}, aws.DeprovisioningEventType, consolidationTestGroup, "empty/delete", aws.GenerateTestDimensions(0, expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Minute*30))
-		It("should consolidate nodes to get a higher utilization (multi-consolidation delete)", Label(debug.NoEvents), func(_ context.Context) {
+		It("should consolidate nodes to get a higher utilization (multi-consolidation delete)", func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 200
@@ -415,7 +415,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 				env.EventuallyExpectHealthyPodCount(selector, replicas)
 			}, aws.DeprovisioningEventType, consolidationTestGroup, "delete", aws.GenerateTestDimensions(env.Monitor.CreatedNodeCount(), int(float64(expectedNodeCount)*0.8), replicasPerNode))
 		}, SpecTimeout(time.Minute*30))
-		It("should consolidate nodes to get a higher utilization (single consolidation replace)", Label(debug.NoEvents), func(_ context.Context) {
+		It("should consolidate nodes to get a higher utilization (single consolidation replace)", func(_ context.Context) {
 			replicasPerNode := 1
 			expectedNodeCount := 20 // we're currently doing around 1 node/2 mins so this test should run deprovisioning in about 45m
 			replicas := replicasPerNode * expectedNodeCount
@@ -465,8 +465,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 			}, aws.DeprovisioningEventType, consolidationTestGroup, "replace", aws.GenerateTestDimensions(env.Monitor.CreatedNodeCount(), expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Hour))
 	})
-	Context("Emptiness", Label(debug.NoEvents), func() {
-		It("should deprovision all nodes when empty", Label(debug.NoEvents), func(_ context.Context) {
+	Context("Emptiness", func() {
+		It("should deprovision all nodes when empty", func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 200
@@ -508,8 +508,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 			}, aws.DeprovisioningEventType, emptinessTestGroup, defaultTestName, aws.GenerateTestDimensions(0, expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Minute*30))
 	})
-	Context("Expiration", Label(debug.NoEvents), func() {
-		It("should expire all nodes", Label(debug.NoEvents), func(_ context.Context) {
+	Context("Expiration", func() {
+		It("should expire all nodes", func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 20 // we're currently doing around 1 node/2 mins so this test should run deprovisioning in about 45m
@@ -556,7 +556,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 		}, SpecTimeout(time.Hour))
 	})
 	Context("Drift", func() {
-		It("should drift all nodes", Label(debug.NoEvents), func(_ context.Context) {
+		It("should drift all nodes", func(_ context.Context) {
 			// Before Deprovisioning, we need to Provision the cluster to the state that we need.
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
@@ -595,8 +595,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 			}, aws.DeprovisioningEventType, driftTestGroup, defaultTestName, aws.GenerateTestDimensions(expectedNodeCount, expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Hour))
 	})
-	Context("Interruption", Label(debug.NoEvents), func() {
-		It("should interrupt all nodes due to scheduledChange", Label(debug.NoEvents), func(_ context.Context) {
+	Context("Interruption", func() {
+		It("should interrupt all nodes due to scheduledChange", func(_ context.Context) {
 			env.ExpectQueueExists() // Ensure the queue exists before sending messages
 
 			replicasPerNode := 20

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 	})
 
 	Context("Multiple Deprovisioners", func() {
-		It("should run consolidation, emptiness, expiration, and drift simultaneously", func(_ context.Context) {
+		It("should run consolidation, emptiness, expiration, and drift simultaneously", Label(debug.NoEvents), func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			nodeCountPerProvisioner := 10
@@ -333,7 +333,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 		}, SpecTimeout(time.Hour))
 	})
 	Context("Consolidation", func() {
-		It("should delete all empty nodes with consolidation", func(_ context.Context) {
+		It("should delete all empty nodes with consolidation", Label(debug.NoEvents), func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 200
@@ -373,7 +373,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 				env.EventuallyExpectNodeCount("==", 0)
 			}, aws.DeprovisioningEventType, consolidationTestGroup, "empty/delete", aws.GenerateTestDimensions(0, expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Minute*30))
-		It("should consolidate nodes to get a higher utilization (multi-consolidation delete)", func(_ context.Context) {
+		It("should consolidate nodes to get a higher utilization (multi-consolidation delete)", Label(debug.NoEvents), func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 200
@@ -415,7 +415,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 				env.EventuallyExpectHealthyPodCount(selector, replicas)
 			}, aws.DeprovisioningEventType, consolidationTestGroup, "delete", aws.GenerateTestDimensions(env.Monitor.CreatedNodeCount(), int(float64(expectedNodeCount)*0.8), replicasPerNode))
 		}, SpecTimeout(time.Minute*30))
-		It("should consolidate nodes to get a higher utilization (single consolidation replace)", func(_ context.Context) {
+		It("should consolidate nodes to get a higher utilization (single consolidation replace)", Label(debug.NoEvents), func(_ context.Context) {
 			replicasPerNode := 1
 			expectedNodeCount := 20 // we're currently doing around 1 node/2 mins so this test should run deprovisioning in about 45m
 			replicas := replicasPerNode * expectedNodeCount
@@ -465,8 +465,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 			}, aws.DeprovisioningEventType, consolidationTestGroup, "replace", aws.GenerateTestDimensions(env.Monitor.CreatedNodeCount(), expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Hour))
 	})
-	Context("Emptiness", func() {
-		It("should deprovision all nodes when empty", func(_ context.Context) {
+	Context("Emptiness", Label(debug.NoEvents), func() {
+		It("should deprovision all nodes when empty", Label(debug.NoEvents), func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 200
@@ -508,8 +508,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 			}, aws.DeprovisioningEventType, emptinessTestGroup, defaultTestName, aws.GenerateTestDimensions(0, expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Minute*30))
 	})
-	Context("Expiration", func() {
-		It("should expire all nodes", func(_ context.Context) {
+	Context("Expiration", Label(debug.NoEvents), func() {
+		It("should expire all nodes", Label(debug.NoEvents), func(_ context.Context) {
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
 			expectedNodeCount := 20 // we're currently doing around 1 node/2 mins so this test should run deprovisioning in about 45m
@@ -556,7 +556,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 		}, SpecTimeout(time.Hour))
 	})
 	Context("Drift", func() {
-		It("should drift all nodes", func(_ context.Context) {
+		It("should drift all nodes", Label(debug.NoEvents), func(_ context.Context) {
 			// Before Deprovisioning, we need to Provision the cluster to the state that we need.
 			replicasPerNode := 20
 			maxPodDensity := replicasPerNode + dsCount
@@ -595,8 +595,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), func() {
 			}, aws.DeprovisioningEventType, driftTestGroup, defaultTestName, aws.GenerateTestDimensions(expectedNodeCount, expectedNodeCount, replicasPerNode))
 		}, SpecTimeout(time.Hour))
 	})
-	Context("Interruption", func() {
-		It("should interrupt all nodes due to scheduledChange", func(_ context.Context) {
+	Context("Interruption", Label(debug.NoEvents), func() {
+		It("should interrupt all nodes due to scheduledChange", Label(debug.NoEvents), func(_ context.Context) {
 			env.ExpectQueueExists() // Ensure the queue exists before sending messages
 
 			replicasPerNode := 20

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 			env.EventuallyExpectHealthyPodCount(selector, replicas)
 		}, aws.ProvisioningEventType, testGroup, "pod-dense", aws.GenerateTestDimensions(expectedNodeCount, 0, replicasPerNode))
 	}, SpecTimeout(time.Minute*30))
-	It("should scale successfully on a pod-dense scale-up", func(_ context.Context) {
+	It("should scale successfully on a pod-dense scale-up", Label(debug.NoEvents), func(_ context.Context) {
 		replicasPerNode := 110
 		maxPodDensity := replicasPerNode + dsCount
 		expectedNodeCount := 60


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- With a missing environment variable, the context value would get inputted as an empty string, which isn't a valid cloudwatch dimension string.

**How was this change tested?**

* `unset GIT_REF`
* `TEST_SUITE=scale ENABLE_CLOUDWATCH=true FOCUS="Emptiness" make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [X] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
