### PR TITLE
fix: Don't Delete Instances if Orphaned

### DIFF
--- a/pkg/controllers/machine/link/controller.go
+++ b/pkg/controllers/machine/link/controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
@@ -34,13 +33,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/aws/karpenter-core/pkg/metrics"
-	"github.com/aws/karpenter/pkg/cloudprovider"
-
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/metrics"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
+	"github.com/aws/karpenter/pkg/cloudprovider"
 )
 
 const creationReasonLabel = "linking"
@@ -90,7 +88,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// Filter out any machines that shouldn't be linked
 	retrieved = lo.Filter(retrieved, func(m *v1alpha5.Machine, _ int) bool {
 		_, ok := m.Labels[v1alpha5.ManagedByLabelKey]
-		return !ok && m.DeletionTimestamp.IsZero()
+		return !ok && m.DeletionTimestamp.IsZero() && m.Labels[v1alpha5.ProvisionerNameLabelKey] != ""
 	})
 	errs := make([]error, len(retrieved))
 	workqueue.ParallelizeUntil(ctx, 100, len(retrieved), func(i int) {
@@ -101,17 +99,10 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 }
 
 func (c *Controller) link(ctx context.Context, retrieved *v1alpha5.Machine, existingMachines []v1alpha5.Machine) error {
-	provisionerName, ok := retrieved.Labels[v1alpha5.ProvisionerNameLabelKey]
-	if !ok {
-		return corecloudprovider.IgnoreMachineNotFoundError(c.cloudProvider.Delete(ctx, retrieved))
-	}
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", retrieved.Status.ProviderID, "provisioner", provisionerName))
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", retrieved.Status.ProviderID, "provisioner", retrieved.Labels[v1alpha5.ProvisionerNameLabelKey]))
 	provisioner := &v1alpha5.Provisioner{}
-	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: provisionerName}, provisioner); err != nil {
-		if errors.IsNotFound(err) {
-			return corecloudprovider.IgnoreMachineNotFoundError(c.cloudProvider.Delete(ctx, retrieved))
-		}
-		return err
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: retrieved.Labels[v1alpha5.ProvisionerNameLabelKey]}, provisioner); err != nil {
+		return client.IgnoreNotFound(err)
 	}
 	if c.shouldCreateLinkedMachine(retrieved, existingMachines) {
 		machine := machineutil.New(&v1.Node{}, provisioner)

--- a/pkg/controllers/machine/link/suite_test.go
+++ b/pkg/controllers/machine/link/suite_test.go
@@ -393,6 +393,9 @@ var _ = Describe("MachineLink", func() {
 		machineList := &v1alpha5.MachineList{}
 		Expect(env.Client.List(ctx, machineList)).To(Succeed())
 		Expect(machineList.Items).To(HaveLen(0))
+
+		// Expect that the instance was left alone if the provisioner wasn't found
+		ExpectInstanceExists(awsEnv.EC2API, instanceID)
 	})
 	It("should not link an instance for an instance that is already linked", func() {
 		m := coretest.Machine(v1alpha5.Machine{


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

The Machine Linker Controller shouldn't delete instances that have the `v1alpha5.ProvisionerName` label but do not have Provisioners present on the cluster. These instances should either be assumed to be actively deleting (in which case a delete is unnecessary) or be assumed to have been orphaned when the provisioner is deleted. If the Node/Instance was orphaned when the Provisioner was deleted, we shouldn't take any action on the instance.

**How was this change tested?**

* `make presubmit`
* `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
