### PR TITLE
test: reduce scale test instance size

### DIFF
--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -94,9 +94,10 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			},
 			Requirements: []v1.NodeSelectorRequirement{
 				{
+					// With Prefix Delegation enabled, .large instances can have 434 pods.
 					Key:      v1alpha1.LabelInstanceSize,
 					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{"4xlarge"},
+					Values:   []string{"large"},
 				},
 				{
 					Key:      v1alpha5.LabelCapacityType,
@@ -118,8 +119,8 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			PodOptions: test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("100m"),
-						v1.ResourceMemory: resource.MustParse("100Mi"),
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 				},
 				TerminationGracePeriodSeconds: lo.ToPtr[int64](0),

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -94,12 +94,6 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 			},
 			Requirements: []v1.NodeSelectorRequirement{
 				{
-					// With Prefix Delegation enabled, .large instances can have 434 pods.
-					Key:      v1alpha1.LabelInstanceSize,
-					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{"large"},
-				},
-				{
 					Key:      v1alpha5.LabelCapacityType,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{v1alpha1.CapacityTypeOnDemand},

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -72,8 +72,8 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 			PodOptions: test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("100m"),
-						v1.ResourceMemory: resource.MustParse("100Mi"),
+						v1.ResourceCPU:    resource.MustParse("10m"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
 					},
 				},
 				TerminationGracePeriodSeconds: lo.ToPtr[int64](0),
@@ -126,9 +126,10 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 		}
 		provisioner.Spec.Requirements = append(provisioner.Spec.Requirements,
 			v1.NodeSelectorRequirement{
+				// With Prefix Delegation enabled, .large instances can have 434 pods.
 				Key:      v1alpha1.LabelInstanceSize,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"4xlarge"},
+				Values:   []string{"large"},
 			},
 		)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- reduce the instance size used for scale tests since prefix delegation is enabled. 

**How was this change tested?**

* `make presubmit`
* `TEST_SUITE=scale ENABLE_CLOUDWATCH=true FOCUS="Emptiness" make e2etests` and saw a successful test. Other tests use the same shared spec.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
