### PR TITLE
test: adjust upgrade instance size

### DIFF
--- a/test/manifests/pre-upgrade-setup.yaml
+++ b/test/manifests/pre-upgrade-setup.yaml
@@ -24,9 +24,6 @@ spec:
       default: "https://github.com/aws/karpenter"
     - name: git-ref
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
-    - name: instance-size
-      description: Instance size used for the node group for cluster creation.
-      default: "c5.4xlarge"
   results:
     - name: account-id
     - name: region
@@ -81,7 +78,7 @@ spec:
         kubernetesNetworkConfig:
           ipFamily: $(params.ip-family)
         managedNodeGroups:
-          - instanceType: $(params.instance-size)
+          - instanceType: c5.4xlarge
             amiFamily: AmazonLinux2
             name: $(params.cluster-name)-system-pool
             disableIMDSv1: true

--- a/test/manifests/pre-upgrade-setup.yaml
+++ b/test/manifests/pre-upgrade-setup.yaml
@@ -127,8 +127,8 @@ spec:
           --set settings.aws.clusterEndpoint=$(cat /root/.kube/config | grep server | awk '{print $2}') \
           --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-$(params.cluster-name) \
           --set settings.aws.interruptionQueueName=$(params.cluster-name) \
-          --set controller.resources.requests.cpu=1 \
-          --set controller.resources.requests.memory=1Gi \
-          --set controller.resources.limits.cpu=1 \
-          --set controller.resources.limits.memory=1Gi \
+          --set controller.resources.requests.cpu=4 \
+          --set controller.resources.requests.memory=4Gi \
+          --set controller.resources.limits.cpu=4 \
+          --set controller.resources.limits.memory=4Gi \
           --wait

--- a/test/manifests/pre-upgrade-setup.yaml
+++ b/test/manifests/pre-upgrade-setup.yaml
@@ -24,6 +24,9 @@ spec:
       default: "https://github.com/aws/karpenter"
     - name: git-ref
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
+    - name: instance-size
+      description: Instance size used for the node group for cluster creation.
+      default: "c5.4xlarge"
   results:
     - name: account-id
     - name: region
@@ -78,7 +81,7 @@ spec:
         kubernetesNetworkConfig:
           ipFamily: $(params.ip-family)
         managedNodeGroups:
-          - instanceType: m5.large
+          - instanceType: $(params.instance-size)
             amiFamily: AmazonLinux2
             name: $(params.cluster-name)-system-pool
             disableIMDSv1: true
@@ -96,17 +99,17 @@ spec:
         - name: coredns
         - name: kube-proxy
         - name: aws-ebs-csi-driver
-          wellKnownPolicies: 
+          wellKnownPolicies:
             ebsCSIController: true
         EOF
-        
+
         eksctl create iamidentitymapping \
         --username system:node:{{EC2PrivateDNSName}} \
         --cluster "$(params.cluster-name)" \
         --arn "arn:aws:iam::$(cat $(results.account-id.path)):role/KarpenterNodeRole-$(params.cluster-name)" \
         --group system:bootstrappers \
         --group system:nodes
-        
+
         eksctl create iamserviceaccount \
           --cluster "$(params.cluster-name)" --name karpenter --namespace karpenter \
           --role-name "$(params.cluster-name)-karpenter" \

--- a/test/manifests/setup.yaml
+++ b/test/manifests/setup.yaml
@@ -58,7 +58,7 @@ spec:
   - name: create-cluster
     image: public.ecr.aws/karpenter/tools:latest
     script: |
-      cmd="create"  
+      cmd="create"
       eksctl get cluster --name $(params.cluster-name) && cmd="upgrade"
       eksctl ${cmd} cluster -f - <<EOF
       ---
@@ -73,7 +73,7 @@ spec:
       kubernetesNetworkConfig:
         ipFamily: $(params.ip-family)
       managedNodeGroups:
-        - instanceType: "c5.2xlarge"
+        - instanceType: "c5.4xlarge"
           amiFamily: AmazonLinux2
           name: $(params.cluster-name)-system-pool
           desiredCapacity: 2


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
Bumps up the instance size used for upgrade tests to fix resource requirement failures for having two Karpenter pods colocated on a node

**How was this change tested?**

* `make presubmit`
* Has to test through e2e triggered here

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
