### PR TITLE
docs: Update docs to switch ttlSecondsAfterEmpty to consolidation

### DIFF
--- a/examples/provisioner/launchtemplates/al2-custom-ami.yaml
+++ b/examples/provisioner/launchtemplates/al2-custom-ami.yaml
@@ -12,7 +12,8 @@ spec:
       cpu: 20
   providerRef:
     name: al2
-  ttlSecondsAfterEmpty: 30
+  consolidation: 
+    enabled: true
 ---
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate

--- a/examples/provisioner/launchtemplates/al2-custom-userdata.yaml
+++ b/examples/provisioner/launchtemplates/al2-custom-userdata.yaml
@@ -12,7 +12,8 @@ spec:
       cpu: 20
   providerRef:
     name: al2
-  ttlSecondsAfterEmpty: 30
+  consolidation: 
+    enabled: true
 ---
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate

--- a/examples/provisioner/launchtemplates/br-custom-userdata.yaml
+++ b/examples/provisioner/launchtemplates/br-custom-userdata.yaml
@@ -12,7 +12,8 @@ spec:
       cpu: 20
   providerRef:
     name: default
-  ttlSecondsAfterEmpty: 30
+  consolidation: 
+    enabled: true
 ---
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate

--- a/examples/provisioner/launchtemplates/custom-family.yaml
+++ b/examples/provisioner/launchtemplates/custom-family.yaml
@@ -11,7 +11,8 @@ spec:
       cpu: 20
   providerRef:
     name: custom-family
-  ttlSecondsAfterEmpty: 30
+  consolidation: 
+    enabled: true
 ---
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate

--- a/website/content/en/preview/concepts/provisioners.md
+++ b/website/content/en/preview/concepts/provisioners.md
@@ -450,7 +450,8 @@ kind: Provisioner
 metadata:
   name: gpu
 spec:
-  ttlSecondsAfterEmpty: 60
+  consolidation: 
+    enabled: true
   requirements:
   - key: node.kubernetes.io/instance-type
     operator: In
@@ -472,7 +473,8 @@ kind: Provisioner
 metadata:
   name: cilium-startup
 spec:
-  ttlSecondsAfterEmpty: 60
+  consolidation: 
+    enabled: true
   startupTaints:
   - key: node.cilium.io/agent-not-ready
     value: "true"

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -105,8 +105,7 @@ This provisioner uses `securityGroupSelector` and `subnetSelector` to discover r
 We applied the tag `karpenter.sh/discovery` in the `eksctl` command above.
 Depending how these resources are shared between clusters, you may need to use different tagging schemes.
 
-The `ttlSecondsAfterEmpty` value configures Karpenter to terminate empty nodes.
-This behavior can be disabled by leaving the value undefined.
+The `consolidation` value configures Karpenter to reduce cluster cost by removing and replacing nodes. As a result, consolidation will terminate any empty nodes on the cluster. This behavior can be disabled by leaving the value undefined or setting `consolidation.enabled` to `false`. Review the [provisioner CRD]({{<ref "../../concepts/provisioners" >}}) for more information.
 
 Review the [provisioner CRD]({{<ref "../../concepts/provisioners" >}}) for more information. For example,
 `ttlSecondsUntilExpired` configures Karpenter to terminate nodes when a maximum age is reached.
@@ -129,8 +128,7 @@ This deployment uses the [pause image](https://www.ianlewis.org/en/almighty-paus
 
 ### Scale down deployment
 
-Now, delete the deployment. After 30 seconds (`ttlSecondsAfterEmpty`),
-Karpenter should terminate the now empty nodes.
+Now, delete the deployment. After a short amount of time, Karpenter should terminate the empty nodes due to consolidation.
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step14-deprovisioning.sh" language="bash"%}}
 

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-provisioner.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step12-add-provisioner.sh
@@ -13,7 +13,8 @@ spec:
       cpu: 1000
   providerRef:
     name: default
-  ttlSecondsAfterEmpty: 30
+  consolidation: 
+    enabled: true
 ---
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- Update docs to introduce consolidation on the getting started guide for new users

**How was this change tested?**

* Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
