### PR TITLE
fix: Fix missing preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm

### DIFF
--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -111,6 +111,7 @@ This works because Helm treats dictionaries as mutable objects and allows passin
 {{- end }}
 {{- if (hasKey ._podAffinity "preferredDuringSchedulingIgnoredDuringExecution") }}
 {{- range $weightedTerm := ._podAffinity.preferredDuringSchedulingIgnoredDuringExecution }}
+{{- $_ := set $weightedTerm "podAffinityTerm" (dict) }}
 {{- include "karpenter.patchLabelSelector" (merge (dict "_target" $weightedTerm.podAffinityTerm) $) }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Affinity configuration:

```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: karpenter.sh/provisioner-name
              operator: DoesNotExist
  podAntiAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
      - topologyKey: "kubernetes.io/hostname"
        weight: 100
```


Using the current chart, setting `preferredDuringSchedulingIgnoredDuringExecution` fails with the below error due to the templating expecting the key `podAffinityTerm` to be already present.

```
 $ helm template . --debug
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /home/alex/karpenter/charts/karpenter

walk.go:74: found symbolic link in path: /home/alex/karpenter/charts/karpenter/crds resolves to /home/alex/karpenter/pkg/apis/crds

Error: template: karpenter/templates/deployment.yaml:143:16: executing "karpenter/templates/deployment.yaml" at <include "karpenter.patchAffinity" $>: error calling include: template: karpenter/templates/_helpers.tpl:129:4: executing "karpenter.patchAffinity" at <include "karpenter.patchPodAffinity" (merge (dict "_podAffinity" .Values.affinity.podAntiAffinity) .)>: error calling include: template: karpenter/templates/_helpers.tpl:114:4: executing "karpenter.patchPodAffinity" at <include "karpenter.patchLabelSelector" (merge (dict "_target" $weightedTerm.podAffinityTerm) $)>: error calling include: template: karpenter/templates/_helpers.tpl:95:19: executing "karpenter.patchLabelSelector" at <._target>: wrong type for value; expected map[string]interface {}; got interface {}
helm.go:84: [debug] template: karpenter/templates/deployment.yaml:143:16: executing "karpenter/templates/deployment.yaml" at <include "karpenter.patchAffinity" $>: error calling include: template: karpenter/templates/_helpers.tpl:129:4: executing "karpenter.patchAffinity" at <include "karpenter.patchPodAffinity" (merge (dict "_podAffinity" .Values.affinity.podAntiAffinity) .)>: error calling include: template: karpenter/templates/_helpers.tpl:114:4: executing "karpenter.patchPodAffinity" at <include "karpenter.patchLabelSelector" (merge (dict "_target" $weightedTerm.podAffinityTerm) $)>: error calling include: template: karpenter/templates/_helpers.tpl:95:19: executing "karpenter.patchLabelSelector" at <._target>: wrong type for value; expected map[string]interface {}; got interface {}
```

With the commit attached, the affinity preference is correctly generated : 

```yaml
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: karpenter.sh/provisioner-name
                operator: DoesNotExist
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  app.kubernetes.io/instance: release-name
                  app.kubernetes.io/name: karpenter
            topologyKey: kubernetes.io/hostname
            weight: 100
```

**How was this change tested?**
Generated and deployed locally
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
