### PR TITLE
test: Fix `cleanup.sh` script failures from empty responses

### DIFF
--- a/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/cleanup.sh
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/cleanup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+KARPENTER_METRIC_NAMESPACE="testing.karpenter.sh/cleanup"
+
 # Clean up the CI account from failed CF stacks or failed test runs
 # The script assumes the aws CLI command is authenticated AWS_REGION is set
 
@@ -9,16 +11,17 @@ EXPIRATION_TIME=$(date -d 'now-12 hours' +%Y-%m-%dT%H:%M --utc)
 echo "Expiration time for all resources is: $EXPIRATION_TIME"
 
 # Grab all instances that are older than the EXPIRATION_TIME and then filter out the KITInfrastructure instances
-old_instances=($(aws ec2 describe-instances --filters Name=instance-state-name,Values=running --query "Reservations[].Instances[?LaunchTime <= '$EXPIRATION_TIME'][]" | grep -v "kubernetes.io/cluster/KITInfrastructure" | jq -r '.[].InstanceId'))
+old_instances=($(aws ec2 describe-instances --filters Name=instance-state-name,Values=running Name=tag-key,Values=karpenter.sh/provisioner-name --query "Reservations[].Instances[?LaunchTime <= '$EXPIRATION_TIME'][]" | { grep -v "kubernetes.io/cluster/KITInfrastructure" || true; } | jq -r '.[].InstanceId'))
 n_old_instances="${#old_instances[@]}"
 echo "Removing ${n_old_instances} old instances"
 
 if (( n_old_instances > 0 )); then
-  aws ec2 terminate-instances --instance-ids "${old_instances[*]}"
+  aws ec2 terminate-instances --instance-ids ${old_instances}
 fi
+aws cloudwatch put-metric-data --namespace $KARPENTER_METRIC_NAMESPACE --metric-name InstancesDeleted --value "$n_old_instances"
 
 # Delete old stacks from the account
-stacks=($(aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE ROLLBACK_FAILED ROLLBACK_COMPLETE DELETE_FAILED UPDATE_COMPLETE UPDATE_FAILED UPDATE_ROLLBACK_FAILED UPDATE_ROLLBACK_COMPLETE IMPORT_COMPLETE IMPORT_ROLLBACK_FAILED IMPORT_ROLLBACK_COMPLETE --query "StackSummaries[?CreationTime <= '$EXPIRATION_TIME']" | jq -r '.[].StackName' | grep 'karpenter-tests-*-*'))
+stacks=($(aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE ROLLBACK_FAILED ROLLBACK_COMPLETE DELETE_FAILED UPDATE_COMPLETE UPDATE_FAILED UPDATE_ROLLBACK_FAILED UPDATE_ROLLBACK_COMPLETE IMPORT_COMPLETE IMPORT_ROLLBACK_FAILED IMPORT_ROLLBACK_COMPLETE --query "StackSummaries[?CreationTime <= '$EXPIRATION_TIME']" | jq -r '.[].StackName' | { grep 'karpenter-tests-*-*' || true; }))
 n_stacks="${#stacks[@]}"
 echo "Removing ${n_stacks} cloudformation stacks"
 
@@ -27,9 +30,10 @@ for stack in "${stacks[@]}"; do
   echo "Deleting Stack ${stack}"
   aws cloudformation delete-stack --no-cli-pager --stack-name "${stack}"
 done
+aws cloudwatch put-metric-data --namespace $KARPENTER_METRIC_NAMESPACE --metric-name CloudFormationStacksDeleted --value "$n_stacks"
 
 # Clean up old launch templates
-launch_templates=($(aws ec2 describe-launch-templates --query "LaunchTemplates[?CreateTime <= '$EXPIRATION_TIME']" |  jq -r '.[].LaunchTemplateName' | grep "karpenter.k8s.aws"))
+launch_templates=($(aws ec2 describe-launch-templates --query "LaunchTemplates[?CreateTime <= '$EXPIRATION_TIME']" |  jq -r '.[].LaunchTemplateName' | { grep "karpenter.k8s.aws" || true; }))
 n_lts="${#launch_templates[@]}"
 echo "Removing ${n_lts} launch templates"
 
@@ -38,3 +42,4 @@ for lt in "${launch_templates[@]}"; do
   echo "Deleting LT ${lt}"
   aws ec2 delete-launch-template --no-cli-pager --launch-template-name "${lt}"
 done
+aws cloudwatch put-metric-data --namespace $KARPENTER_METRIC_NAMESPACE --metric-name LaunchTemplatesDeleted --value "$n_lts"

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/cleanup.sh
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/cleanup.sh
@@ -14,7 +14,7 @@ n_old_instances="${#old_instances[@]}"
 echo "Removing ${n_old_instances} old instances"
 
 if (( n_old_instances > 0 )); then
-  aws ec2 terminate-instances --instance-ids ${old_instances}
+  aws ec2 terminate-instances --instance-ids "${old_instances[*]}"
 fi
 
 # Delete old stacks from the account

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/sweeper-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/sweeper-cron.yaml
@@ -37,7 +37,7 @@ spec:
           # This serviceAccountName has permission to make calls against EC2 in the account
           serviceAccountName: karpenter-tests
       ttlSecondsAfterFinished: 300
-  # every day on the 12th hour
-  schedule: '* 12 * * *'
+  # every day, every 12th hour
+  schedule: '* */12 * * *'
   successfulJobsHistoryLimit: 3
   suspend: false


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Fixes the `cleanup.sh` failures occurring from empty responses

`grep` will return an exit code `1` if there are no lines matching the search filter. In this case, we should not cause an exit code `1`; else, this will cause the entire script to fail due to `set -o pipefail` and `set -e`

Adds metrics to the sweeper so that we know how many objects are cleaned up on each run

**How was this change tested?**

* Script run on the CI test cluster

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
