### PR TITLE
test: Add periodic trigger for scale testing

### DIFF
--- a/test/infrastructure/clusters/test-infra/karpenter-tests/kustomization.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/kustomization.yaml
@@ -2,14 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - pipeline-cleanup-cron.yaml
+  - pipeline-scale-trigger-cron.yaml
   - pipeline-trigger-cron.yaml
   - sweeper-cron.yaml
   - rbac.yaml
   - test-suites.yaml
+  - test-trigger-sa.yaml
 configMapGenerator:
   - name: scripts
     namespace: karpenter-tests
     files:
       - scripts/pipeline-cleanup.sh
+      - scripts/pipeline-scale-trigger.sh
       - scripts/pipeline-trigger.sh
       - scripts/cleanup.sh

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-scale-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-scale-trigger-cron.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pipelines-scale-trigger
+  namespace: karpenter-tests
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: scripts
+              configMap:
+                name: scripts
+                defaultMode: 0777
+          containers:
+            - command:
+                - /bin/sh
+                - -c
+                - /bin/pipeline-scale-trigger.sh
+              image: public.ecr.aws/bitnami/kubectl:1.22
+              imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: scripts
+                  mountPath: /bin/pipeline-scale-trigger.sh
+                  subPath: pipeline-scale-trigger.sh
+              name: pipeline-scale-trigger
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 256Mi
+                limits:
+                  memory: 256Mi
+          restartPolicy: OnFailure
+          serviceAccountName: karpenter-tests-trigger
+      ttlSecondsAfterFinished: 300
+  # every 24 hours on the 18th hour starting at the 7th minute
+  schedule: '7 18 * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/pipeline-trigger-cron.yaml
@@ -1,33 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: karpenter-tests-trigger
-  namespace: karpenter-tests
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: karpenter-tests-trigger-role
-  namespace: karpenter-tests
-rules:
-- apiGroups: ["tekton.dev"]
-  resources: ["pipelineruns"]
-  verbs: ["create"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: karpenter-tests-trigger-role-binding
-  namespace: karpenter-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: karpenter-tests-trigger-role
-subjects:
-- kind: ServiceAccount
-  name: karpenter-tests-trigger
-  namespace: karpenter-tests
----
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -49,14 +19,14 @@ spec:
           - command:
             - /bin/sh
             - -c
-            - /bin/pipelines-trigger.sh
+            - /bin/pipeline-trigger.sh
             image: public.ecr.aws/karpenter/tools:latest
             imagePullPolicy: IfNotPresent
             volumeMounts:
             - name: scripts
-              mountPath: /bin/pipelines-trigger.sh
-              subPath: pipelines-trigger.sh
-            name: pipelines-trigger
+              mountPath: /bin/pipeline-trigger.sh
+              subPath: pipeline-trigger.sh
+            name: pipeline-trigger
             resources:
               requests:
                 cpu: 250m

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/pipeline-scale-trigger.sh
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/pipeline-scale-trigger.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a pipeline run for the scale test suite
+cat <<EOF | kubectl create -f -
+ apiVersion: tekton.dev/v1beta1
+ kind: PipelineRun
+ metadata:
+   generateName: "scale-periodic-"
+   namespace: karpenter-tests
+ spec:
+   timeouts:
+    pipeline: "4h"
+   params:
+   - name: test-filter
+     value: "Scale"
+   pipelineRef:
+     name: suite
+   serviceAccountName: karpenter-tests
+EOF

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/test-trigger-sa.yaml
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/test-trigger-sa.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karpenter-tests-trigger
+  namespace: karpenter-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: karpenter-tests-trigger-role
+  namespace: karpenter-tests
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: karpenter-tests-trigger-role-binding
+  namespace: karpenter-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karpenter-tests-trigger-role
+subjects:
+  - kind: ServiceAccount
+    name: karpenter-tests-trigger
+    namespace: karpenter-tests


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Adds the periodic trigger for scale testing to trigger a run daily. This frequency can be reduced in the long-run once more metrics are created and the stability of scale testing is ensured.

Fixes a misspelling with the `pipeline-trigger` cron

**How was this change tested?**

* Manual Deployment to CI cluster

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
