### PR TITLE
test: separate cleanup objects for finalizable and non finalizable objects

### DIFF
--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -51,6 +51,10 @@ var (
 		{First: &v1.LimitRange{}, Second: &v1.LimitRangeList{}},
 		{First: &schedulingv1.PriorityClass{}, Second: &schedulingv1.PriorityClassList{}},
 	}
+	// Delete objects with Karpenter finalizers separately. Executing delete calls on all of these objects at once
+	// may be grouped as DeleteCollection requests, which have a lower timeout than individual delete calls (before k8s 1.27).
+	// Separating them out diminishes the chance of running into timeouts when doing cleanup for tests of high scale.
+	// https://github.com/kubernetes/kubernetes/pull/115341
 	FinalizableObjects = []functional.Pair[client.Object, client.ObjectList]{
 		{First: &v1.Node{}, Second: &v1.NodeList{}},
 		{First: &v1alpha5.Machine{}, Second: &v1alpha5.MachineList{}},

--- a/test/pkg/environment/common/setup.go
+++ b/test/pkg/environment/common/setup.go
@@ -50,6 +50,8 @@ var (
 		{First: &v1alpha5.Provisioner{}, Second: &v1alpha5.ProvisionerList{}},
 		{First: &v1.LimitRange{}, Second: &v1.LimitRangeList{}},
 		{First: &schedulingv1.PriorityClass{}, Second: &schedulingv1.PriorityClassList{}},
+	}
+	FinalizableObjects = []functional.Pair[client.Object, client.ObjectList]{
 		{First: &v1.Node{}, Second: &v1.NodeList{}},
 		{First: &v1alpha5.Machine{}, Second: &v1alpha5.MachineList{}},
 	}
@@ -90,6 +92,7 @@ func (env *Environment) ExpectCleanCluster() {
 
 func (env *Environment) Cleanup() {
 	env.CleanupObjects(CleanableObjects...)
+	env.CleanupObjects(FinalizableObjects...)
 	env.eventuallyExpectScaleDown()
 	env.ExpectNoCrashes()
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
- Getting 504s on deletecollection calls for the finalizable objects. Separating them out to reduce the chance of throttling since these are called in rapid succession. 

**How was this change tested?**

* `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
