### PR TITLE
fix bottlerocket node-labels merge in user-data

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -21,6 +21,7 @@ import (
 
 	"knative.dev/pkg/ptr"
 
+	"github.com/imdario/mergo"
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-core/pkg/utils/resources"
@@ -43,7 +44,9 @@ func (b Bottlerocket) Script() (string, error) {
 	s.Settings.Kubernetes.ClusterName = &b.ClusterName
 	s.Settings.Kubernetes.APIServer = &b.ClusterEndpoint
 	s.Settings.Kubernetes.ClusterCertificate = b.CABundle
-	s.Settings.Kubernetes.NodeLabels = b.Labels
+	if err := mergo.MergeWithOverwrite(&s.Settings.Kubernetes.NodeLabels, b.Labels); err != nil {
+		return "", err
+	}
 
 	// Backwards compatibility for AWSENILimitedPodDensity flag
 	if b.KubeletConfig != nil && b.KubeletConfig.MaxPods != nil {

--- a/pkg/providers/launchtemplate/testdata/br_userdata_input.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_input.golden
@@ -10,6 +10,11 @@ max-pods = 9999999999 # replaceme
 
 [settings.kubernetes.labels]
 "replace" = "me"
+
+[settings.kubernetes.node-labels]
+"custom-node-label" = "custom"
+"karpenter.sh/provisioner-name" = "should-be-overridden"
+
 [settings.kubernetes.node-taints]
 "replace" = ["me:Schedule"]
 

--- a/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
@@ -7,6 +7,7 @@ cluster-dns-ip = '10.0.100.10'
 max-pods = 110
 
 [settings.kubernetes.node-labels]
+custom-node-label = 'custom'
 'karpenter.sh/capacity-type' = 'on-demand'
 'karpenter.sh/provisioner-name' = '%s'
 'testing.karpenter.sh/test-id' = 'unspecified'

--- a/website/content/en/docs/concepts/node-templates.md
+++ b/website/content/en/docs/concepts/node-templates.md
@@ -441,7 +441,7 @@ Your UserData -
 [settings.kubernetes]
 "unknown-setting" = "unknown"
 [settings.kubernetes.node-labels]
-'field.controlled.by/karpenter': 'will-be-overridden'
+'field.controlled.by/karpenter' = 'will-be-overridden'
 ```
 
 Final merged UserData -

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -443,7 +443,7 @@ Your UserData -
 [settings.kubernetes]
 "unknown-setting" = "unknown"
 [settings.kubernetes.node-labels]
-'field.controlled.by/karpenter': 'will-be-overridden'
+'field.controlled.by/karpenter' = 'will-be-overridden'
 ```
 
 Final merged UserData -

--- a/website/content/en/v0.27/concepts/node-templates.md
+++ b/website/content/en/v0.27/concepts/node-templates.md
@@ -441,7 +441,7 @@ Your UserData -
 [settings.kubernetes]
 "unknown-setting" = "unknown"
 [settings.kubernetes.node-labels]
-'field.controlled.by/karpenter': 'will-be-overridden'
+'field.controlled.by/karpenter' = 'will-be-overridden'
 ```
 
 Final merged UserData -


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->
https://github.com/aws/karpenter/issues/4013

**Description**
 - Fixes Node Labels merging in Bottlerocket's user-data.
 - Fixes invalid toml in docs

**How was this change tested?**
* tested manually by:
   * adding labels that should be overridden like `karpenter.sh/capacity-type` and observed it being properly overridden. 
   * adding labels that should not be overridden and observing them properly merged
* make test

**Does this change impact docs?**
- [ x Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
