### PR TITLE
test: Add `TEST_TIMEOUT` for scale test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ KARPENTER_CORE_DIR = $(shell go list -m -f '{{ .Dir }}' github.com/aws/karpenter
 
 # TEST_SUITE enables you to select a specific test suite directory to run "make e2etests" or "make test" against
 TEST_SUITE ?= "..."
+TEST_TIMEOUT ?= "3h"
 
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -82,11 +83,11 @@ e2etests: ## Run the e2e suite against your local cluster
 	cd test && CLUSTER_NAME=${CLUSTER_NAME} go test \
 		-p 1 \
 		-count 1 \
-		-timeout 180m \
+		-timeout ${TEST_TIMEOUT} \
 		-v \
 		./suites/$(shell echo $(TEST_SUITE) | tr A-Z a-z)/... \
 		--ginkgo.focus="${FOCUS}" \
-		--ginkgo.timeout=180m \
+		--ginkgo.timeout=${TEST_TIMEOUT} \
 		--ginkgo.grace-period=3m \
 		--ginkgo.vv
 

--- a/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/pipeline-scale-trigger.sh
+++ b/test/infrastructure/clusters/test-infra/karpenter-tests/scripts/pipeline-scale-trigger.sh
@@ -14,6 +14,8 @@ cat <<EOF | kubectl create -f -
    params:
    - name: test-filter
      value: "Scale"
+   - name: test-timeout
+     value: "6h"
    pipelineRef:
      name: suite
    serviceAccountName: karpenter-tests

--- a/test/manifests/ipv6-suite.yaml
+++ b/test/manifests/ipv6-suite.yaml
@@ -23,6 +23,9 @@ spec:
     - name: test-filter
       description: Test filter passed to `go test -run`
       default: "IPv6"
+    - name: test-timeout
+      description: Test timeout passed to `go test -run`
+      default: "3h"
     - name: cleanup
       default: "true"
       description: If true, clean up resources
@@ -55,6 +58,8 @@ spec:
       value: $(params.git-ref)
     - name: test-filter
       value: $(params.test-filter)
+    - name: test-timeout
+      value: $(params.test-timeout)
     runAfter:
     - setup
 

--- a/test/manifests/run-test.yaml
+++ b/test/manifests/run-test.yaml
@@ -11,6 +11,8 @@ spec:
       description: Name of the cluster under test.
     - name: test-filter
       description: Test filter passed to `go test -run`
+    - name: test-timeout
+      description: Test timeout passed to `go test -run`
     - name: git-repo-url
       description: the git repo url can be used to run tests on a fork
       default: "https://github.com/aws/karpenter"
@@ -39,4 +41,4 @@ spec:
     workingDir: $(workspaces.ws.path)
     script: |
       aws eks update-kubeconfig --name $(params.cluster-name)
-      KUBECONFIG=/root/.kube/config ENABLE_CLOUDWATCH=true TEST_SUITE="$(params.test-filter)" GIT_REF="$(git rev-parse HEAD)" make e2etests
+      KUBECONFIG=/root/.kube/config ENABLE_CLOUDWATCH=true TEST_SUITE="$(params.test-filter)" TEST_TIMEOUT="$(params.test-timeout)" GIT_REF="$(git rev-parse HEAD)" make e2etests

--- a/test/manifests/suite.yaml
+++ b/test/manifests/suite.yaml
@@ -19,6 +19,9 @@ spec:
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
     - name: test-filter
       description: Test filter passed to `go test -run`
+    - name: test-timeout
+      description: Test timeout passed to `go test -run`
+      default: "3h"
     - name: cleanup
       default: "true"
       description: If true, clean up resources
@@ -49,6 +52,8 @@ spec:
       value: $(params.git-ref)
     - name: test-filter
       value: $(params.test-filter)
+    - name: test-timeout
+      value: $(params.test-timeout)
     runAfter:
     - setup
 

--- a/test/manifests/upgrade-suite.yaml
+++ b/test/manifests/upgrade-suite.yaml
@@ -19,6 +19,9 @@ spec:
     - name: to-git-ref
       default: HEAD
       description: Git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release.
+    - name: test-timeout
+      description: Test timeout passed to `go test -run`
+      default: "3h"
     - name: cleanup
       default: "true"
       description: If true, clean up resources
@@ -75,6 +78,8 @@ spec:
       value: $(params.to-git-ref)
     - name: test-filter
       value: Integration
+    - name: test-timeout
+      value: $(params.test-timeout)
     runAfter:
     - upgrade-chart
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Add `TEST_TIMEOUT` to `Makefile` so that we can pass through test timeouts for E2E tests that need longer timeouts in "go test"

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
