### PR TITLE
test: Disable notify release to disable Tekton runs on Merge and Snapshot

### DIFF
--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -7,22 +7,12 @@ inputs:
   url:
     description: "Webhook URL to send the Slack notification to"
     required: true
-  event_name:
-    description: "Type of event that triggered this test run"
-    required: true
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
       with:
         path: actions
-    - shell: bash
-      run: |
-        if [[ ${{ inputs.event_name == "schedule" ]]; then
-          echo RUN_NAME="${{ inputs.suite }}-periodic" >> $GITHUB_ENV
-        else
-          echo RUN_NAME="${{ inputs.suite }}-${GITHUB_SHA::7}" >> $GITHUB_ENV
-        fi
     - uses: ./actions/.github/actions/e2e/slack/send-message
       if: ${{ job.status == 'success' }}
       with:

--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -7,12 +7,22 @@ inputs:
   url:
     description: "Webhook URL to send the Slack notification to"
     required: true
+  event_name:
+    description: "Type of event that triggered this test run"
+    required: true
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
       with:
         path: actions
+    - shell: bash
+      run: |
+        if [[ ${{ inputs.event_name == "schedule" ]]; then
+          echo RUN_NAME="${{ inputs.suite }}-periodic" >> $GITHUB_ENV
+        else
+          echo RUN_NAME="${{ inputs.suite }}-${GITHUB_SHA::7}" >> $GITHUB_ENV
+        fi
     - uses: ./actions/.github/actions/e2e/slack/send-message
       if: ${{ job.status == 'success' }}
       with:

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -47,7 +47,6 @@ Helm Chart Version $(helmChartVersion $RELEASE_VERSION)"
   cosignImages
   publishHelmChart "karpenter" "${RELEASE_VERSION}" "${RELEASE_REPO_ECR}"
   publishHelmChart "karpenter-crd" "${RELEASE_VERSION}" "${RELEASE_REPO_ECR}"
-  notifyRelease "$RELEASE_VERSION" $PR_NUMBER
   pullPrivateReplica "$RELEASE_VERSION"
 }
 
@@ -111,18 +110,6 @@ cosignImages() {
         -a GIT_VERSION="${RELEASE_VERSION}" \
         -a BUILD_DATE="$(buildDate)" \
         "${CONTROLLER_IMG}"
-}
-
-notifyRelease() {
-    RELEASE_VERSION=$1
-    PR_NUMBER=$2
-    RELEASE_TYPE=$(releaseType $RELEASE_VERSION)
-    LAST_STABLE_RELEASE_TAG=$(git describe --tags --abbrev=0)
-    MESSAGE="{\"releaseType\":\"${RELEASE_TYPE}\",\"releaseIdentifier\":\"${RELEASE_VERSION}\",\"prNumber\":\"${PR_NUMBER}\",\"githubAccount\":\"${GITHUB_ACCOUNT}\",\"lastStableReleaseTag\":\"${LAST_STABLE_RELEASE_TAG}\"}"
-    aws sns publish \
-        --topic-arn ${SNS_TOPIC_ARN} \
-        --message ${MESSAGE} \
-        --no-cli-pager
 }
 
 pullPrivateReplica(){


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Remove `notifyRelease` to disable Tekton runs on merge and on snapshot

**How was this change tested?**

* Manual validation

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
