### PR TITLE
test: Allow manual dispatch of individual workflows

### DIFF
--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -1,5 +1,15 @@
 name: E2EUpgrade
 on:
+  workflow_dispatch:
+    inputs:
+      git_repo:
+        type: string
+        default: "aws/karpenter"
+      from_git_ref:
+        type: string
+        required: true
+      to_git_ref:
+        type: string
   workflow_call:
     inputs:
       git_repo:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,25 @@
 name: E2E
 on:
+  workflow_dispatch:
+    inputs:
+      git_repo:
+        type: string
+        default: "aws/karpenter"
+      git_ref:
+        type: string
+      suite:
+        type: choice
+        required: true
+        options:
+          - Integration
+          - Machine
+          - Consolidation
+          - Utilization
+          - Interruption
+          - Drift
+          - Chaos
+          - IPv6
+          - Scale
   workflow_call:
     inputs:
       git_repo:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

Allow manual dispatch of re-usable workflows that are called by the `E2EMatrix` trigger

**How was this change tested?**

* Manual validation on fork

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
