### PR TITLE
test: fix node created count

### DIFF
--- a/test/pkg/environment/common/monitor.go
+++ b/test/pkg/environment/common/monitor.go
@@ -101,7 +101,7 @@ func (m *Monitor) NodeCountAtReset() int {
 
 // CreatedNodeCount returns the number of nodes created since the last reset
 func (m *Monitor) CreatedNodeCount() int {
-	return m.NodeCount() - m.NodeCountAtReset()
+	return len(m.CreatedNodes())
 }
 
 // NodesAtReset returns a slice of nodes that the monitor saw at the last reset

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -467,6 +467,7 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				})
 				env.ExpectUpdated(provisioner)
 
+				env.EventuallyExpectCreatedNodeCount("==", expectedNodeCount)
 				env.EventuallyExpectDeletedNodeCount("==", expectedNodeCount) // every node should delete due to replacement
 				env.EventuallyExpectNodeCount("==", expectedNodeCount)
 				env.EventuallyExpectHealthyPodCount(selector, replicas)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**
When a test would create and delete nodes at the same time, this would just check the difference, rather than actually returning how many nodes were created. 

**How was this change tested?**

* `TEST_SUITE=scale ENABLE_CLOUDWATCH=true FOCUS="single consolidation replace" make e2etests`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
