### PR TITLE
test: Reference `git_ref` in action calls to allow testing updates to actions

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -13,6 +13,8 @@ inputs:
   cluster_name:
     description: 'Name of the cluster to be launched by eksctl'
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
 runs:
   using: "composite"
   steps:
@@ -25,6 +27,7 @@ runs:
     - uses: actions/checkout@v3
       with:
         path: "actions"
+        ref: ${{ inputs.git_ref }}
     - uses: ./actions/.github/actions/e2e/install-eksctl
     - name: delete-cluster
       shell: bash

--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -28,7 +28,7 @@ runs:
       with:
         path: "actions"
         ref: ${{ inputs.git_ref }}
-    - uses: ./actions/.github/actions/e2e/install-eksctl
+    - uses: ./.github/actions/e2e/install-eksctl
     - name: delete-cluster
       shell: bash
       run: |

--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -26,7 +26,6 @@ runs:
         role-duration-seconds: 21600
     - uses: actions/checkout@v3
       with:
-        path: "actions"
         ref: ${{ inputs.git_ref }}
     - uses: ./.github/actions/e2e/install-eksctl
     - name: delete-cluster

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -55,10 +55,14 @@ runs:
         --template-file $CLOUDFORMATION_PATH \
         --capabilities CAPABILITY_NAMED_IAM \
         --parameter-overrides "ClusterName=${{ inputs.cluster_name }}"
-  - name: create cluster
+  - name: create or upgrade cluster
     shell: bash
     run: |
-      eksctl create cluster -f - <<EOF
+      # Create or Upgrade the cluster based on whether the cluster already exists
+      cmd="create"
+      eksctl get cluster --name $(params.cluster-name) && cmd="upgrade"
+      
+      eksctl ${cmd} cluster -f - <<EOF
       ---
       apiVersion: eksctl.io/v1alpha5
       kind: ClusterConfig

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -21,10 +21,6 @@ inputs:
     description: "IP Family of the cluster. Valid values are IPv4 or IPv6"
     required: false
     default: "IPv4"
-  git_repo:
-    description: "The git repo can be used to run tests on a fork"
-    required: false
-    default: "aws/karpenter"
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
     required: false
@@ -39,11 +35,11 @@ runs:
       role-duration-seconds: 21600
   - uses: actions/checkout@v3
     with:
-      repository: ${{ inputs.git_repo }}
       ref: ${{ inputs.git_ref }}
   - uses: actions/checkout@v3
     with:
       path: "actions"
+      ref: ${{ inputs.git_ref }}
   - uses: ./actions/.github/actions/e2e/install-eksctl
   - name: create iam policies
     shell: bash

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -40,7 +40,7 @@ runs:
     with:
       path: "actions"
       ref: ${{ inputs.git_ref }}
-  - uses: ./actions/.github/actions/e2e/install-eksctl
+  - uses: ./.github/actions/e2e/install-eksctl
   - name: create iam policies
     shell: bash
     run: |

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -36,10 +36,6 @@ runs:
   - uses: actions/checkout@v3
     with:
       ref: ${{ inputs.git_ref }}
-  - uses: actions/checkout@v3
-    with:
-      path: "actions"
-      ref: ${{ inputs.git_ref }}
   - uses: ./.github/actions/e2e/install-eksctl
   - name: create iam policies
     shell: bash

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -13,9 +13,6 @@ inputs:
   cluster_name:
     description: 'Name of the cluster to be launched by eksctl'
     required: true
-  git_repo:
-    description: "The git repo can be used to run tests on a fork"
-    default: "aws/karpenter"
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
 runs:
@@ -29,11 +26,11 @@ runs:
       role-duration-seconds: 21600
   - uses: actions/checkout@v3
     with:
-      repository: ${{ inputs.git_repo }}
       ref: ${{ inputs.git_ref }}
   - uses: actions/checkout@v3
     with:
       path: "actions"
+      ref: ${{ inputs.git_ref }}
   - uses: ./actions/.github/actions/e2e/install-helm
   - name: install-karpenter
     shell: bash

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -27,10 +27,6 @@ runs:
   - uses: actions/checkout@v3
     with:
       ref: ${{ inputs.git_ref }}
-  - uses: actions/checkout@v3
-    with:
-      path: "actions"
-      ref: ${{ inputs.git_ref }}
   - uses: ./.github/actions/e2e/install-helm
   - name: install-karpenter
     shell: bash

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -31,7 +31,7 @@ runs:
     with:
       path: "actions"
       ref: ${{ inputs.git_ref }}
-  - uses: ./actions/.github/actions/e2e/install-helm
+  - uses: ./.github/actions/e2e/install-helm
   - name: install-karpenter
     shell: bash
     run: |

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -16,12 +16,15 @@ inputs:
   workspace_id:
     description: "Id of the prometheus remote_write workspace"
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
       with:
         path: "actions"
+        ref: ${{ inputs.git_ref }}
     - uses: ./actions/.github/actions/e2e/install-helm
     - name: add prometheus repo
       shell: bash

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -23,7 +23,6 @@ runs:
   steps:
     - uses: actions/checkout@v3
       with:
-        path: "actions"
         ref: ${{ inputs.git_ref }}
     - uses: ./.github/actions/e2e/install-helm
     - name: add prometheus repo

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -25,7 +25,7 @@ runs:
       with:
         path: "actions"
         ref: ${{ inputs.git_ref }}
-    - uses: ./actions/.github/actions/e2e/install-helm
+    - uses: ./.github/actions/e2e/install-helm
     - name: add prometheus repo
       shell: bash
       run: |
@@ -40,7 +40,7 @@ runs:
       run: |
         helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
           -n prometheus --create-namespace \
-          -f ./actions/.github/actions/e2e/install-prometheus/values.yaml \
+          -f ./.github/actions/e2e/install-prometheus/values.yaml \
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}"

--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -9,6 +9,8 @@ inputs:
   url:
     description: "Webhook URL to send the Slack notification to"
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
   event_name:
     description: "Type of event that triggered this test run"
     required: true
@@ -18,6 +20,7 @@ runs:
     - uses: actions/checkout@v3
       with:
         path: actions
+        ref: ${{ inputs.git_ref }}
     - shell: bash
       run: |
         if [[ ! -z "${{ inputs.pr_number }}" ]]; then

--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -33,12 +33,12 @@ runs:
         
         # Convert the RUN_NAME to all lowercase
         echo RUN_NAME=${RUN_NAME,,} >> $GITHUB_ENV
-    - uses: ./actions/.github/actions/e2e/slack/send-message
+    - uses: ./.github/actions/e2e/slack/send-message
       if: ${{ job.status == 'success' }}
       with:
         url: ${{ inputs.url }}
         message: ":white_check_mark: ${{ env.RUN_NAME }} tests succeeded (#${{ github.run_number }})"
-    - uses: ./actions/.github/actions/e2e/slack/send-message
+    - uses: ./.github/actions/e2e/slack/send-message
       if: ${{ job.status == 'failure' }}
       with:
         url: ${{ inputs.url }}

--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -19,7 +19,6 @@ runs:
   steps:
     - uses: actions/checkout@v3
       with:
-        path: actions
         ref: ${{ inputs.git_ref }}
     - shell: bash
       run: |

--- a/.github/actions/e2e/upgrade-crds/action.yaml
+++ b/.github/actions/e2e/upgrade-crds/action.yaml
@@ -27,10 +27,6 @@ runs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.git_ref }}
-    - uses: actions/checkout@v3
-      with:
-        path: "actions"
-        ref: ${{ inputs.git_ref }}
     - name: install-karpenter
       shell: bash
       run: |

--- a/.github/actions/e2e/upgrade-crds/action.yaml
+++ b/.github/actions/e2e/upgrade-crds/action.yaml
@@ -13,9 +13,6 @@ inputs:
   cluster_name:
     description: 'Name of the cluster to be launched by eksctl'
     required: true
-  git_repo:
-    description: "The git repo can be used to run tests on a fork"
-    default: "aws/karpenter"
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
 runs:
@@ -29,11 +26,11 @@ runs:
         role-duration-seconds: 21600
     - uses: actions/checkout@v3
       with:
-        repository: ${{ inputs.git_repo }}
         ref: ${{ inputs.git_ref }}
     - uses: actions/checkout@v3
       with:
         path: "actions"
+        ref: ${{ inputs.git_ref }}
     - name: install-karpenter
       shell: bash
       run: |

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -56,7 +56,7 @@ jobs:
     if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      from_git_ref: v0.26.1
+      from_git_ref: v0.27.5
       to_git_ref: ${{ needs.resolve-git-ref.outputs.GIT_REF }}
       pr_number: ${{ needs.resolve-git-ref.outputs.PR_NUM }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -23,6 +23,8 @@ jobs:
       # Download the artifact and resolve the commit if initiated by PR snapshot
       # Otherwise, use the currently checked-out branch to run the E2E tests against
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git_ref }}
       - if: github.event_name == 'workflow_run'
         uses: ./.github/actions/download-artifact
       - id: resolve-step
@@ -44,7 +46,6 @@ jobs:
     uses: ./.github/workflows/e2e.yaml
     with:
       suite: ${{ matrix.suite }}
-      git_repo: aws/karpenter
       git_ref: ${{ needs.resolve-git-ref.outputs.GIT_REF }}
       pr_number: ${{ needs.resolve-git-ref.outputs.PR_NUM }}
       event_name: ${{ github.event_name }}
@@ -55,7 +56,6 @@ jobs:
     if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      git_repo: aws/karpenter
       from_git_ref: v0.26.1
       to_git_ref: ${{ needs.resolve-git-ref.outputs.GIT_REF }}
       pr_number: ${{ needs.resolve-git-ref.outputs.PR_NUM }}

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -9,7 +9,6 @@ jobs:
     uses: ./.github/workflows/e2e.yaml
     with:
       suite: Scale
-      git_repo: aws/karpenter
       event_name: ${{ github.event_name }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -37,7 +37,6 @@ jobs:
           role-duration-seconds: 21600
       - uses: actions/checkout@v3
         with:
-          path: actions
           ref: ${{ inputs.to_git_ref }}
       - name: generate cluster name
         run: |

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -52,7 +52,7 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           kubernetes_version: ${{ vars.K8S_VERSION }}
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
-          git_ref: ${{ inputs.to_git_ref }}
+          git_ref: ${{ inputs.from_git_ref }}
       - name: install prometheus
         uses: ./.github/actions/e2e/install-prometheus
         with:
@@ -61,7 +61,7 @@ jobs:
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           workspace_id: ${{ vars.WORKSPACE_ID }}
-          git_ref: ${{ inputs.to_git_ref }}
+          git_ref: ${{ inputs.from_git_ref }}
       - name: install karpenter
         uses: ./.github/actions/e2e/install-karpenter
         with:
@@ -70,6 +70,25 @@ jobs:
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           git_ref: ${{ inputs.from_git_ref }}
+      - name: upgrade eks cluster '${{ env.CLUSTER_NAME }}'
+        uses: ./.github/actions/e2e/create-cluster
+        with:
+          account_id: ${{ vars.ACCOUNT_ID }}
+          role: ${{ vars.ROLE_NAME }}
+          region: ${{ vars.AWS_REGION }}
+          cluster_name: ${{ env.CLUSTER_NAME }}
+          kubernetes_version: ${{ vars.K8S_VERSION }}
+          ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
+          git_ref: ${{ inputs.to_git_ref }}
+      - name: upgrade prometheus
+        uses: ./.github/actions/e2e/install-prometheus
+        with:
+          account_id: ${{ vars.ACCOUNT_ID }}
+          role: ${{ vars.ROLE_NAME }}
+          region: ${{ vars.AWS_REGION }}
+          cluster_name: ${{ env.CLUSTER_NAME }}
+          workspace_id: ${{ vars.WORKSPACE_ID }}
+          git_ref: ${{ inputs.to_git_ref }}
       - name: upgrade crds
         uses: ./.github/actions/e2e/upgrade-crds
         with:

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -45,7 +45,7 @@ jobs:
           echo "Using cluster name \"$CLUSTER_NAME\""
           echo CLUSTER_NAME=$CLUSTER_NAME >> $GITHUB_ENV
       - name: create eks cluster '${{ env.CLUSTER_NAME }}'
-        uses: ./actions/.github/actions/e2e/create-cluster
+        uses: ./.github/actions/e2e/create-cluster
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -55,7 +55,7 @@ jobs:
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.to_git_ref }}
       - name: install prometheus
-        uses: ./actions/.github/actions/e2e/install-prometheus
+        uses: ./.github/actions/e2e/install-prometheus
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -64,7 +64,7 @@ jobs:
           workspace_id: ${{ vars.WORKSPACE_ID }}
           git_ref: ${{ inputs.to_git_ref }}
       - name: install karpenter
-        uses: ./actions/.github/actions/e2e/install-karpenter
+        uses: ./.github/actions/e2e/install-karpenter
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -72,7 +72,7 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           git_ref: ${{ inputs.from_git_ref }}
       - name: upgrade crds
-        uses: ./actions/.github/actions/e2e/upgrade-crds
+        uses: ./.github/actions/e2e/upgrade-crds
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -80,7 +80,7 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           git_ref: ${{ inputs.to_git_ref }}
       - name: upgrade karpenter
-        uses: ./actions/.github/actions/e2e/install-karpenter
+        uses: ./.github/actions/e2e/install-karpenter
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -92,7 +92,7 @@ jobs:
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }}
           TEST_SUITE="Integration" make e2etests
       - name: notify slack of success or failure
-        uses: ./actions/.github/actions/e2e/slack/notify
+        uses: ./.github/actions/e2e/slack/notify
         if: success() || failure()
         with:
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -101,7 +101,7 @@ jobs:
           event_name: ${{ inputs.event_name }}
           git_ref: ${{ inputs.to_git_ref }}
       - name: dump logs on failure
-        uses: ./actions/.github/actions/e2e/dump-logs
+        uses: ./.github/actions/e2e/dump-logs
         if: failure() || cancelled()
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
@@ -109,7 +109,7 @@ jobs:
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
       - name: cleanup karpenter and cluster '${{ env.CLUSTER_NAME }}' resources
-        uses: ./actions/.github/actions/e2e/cleanup
+        uses: ./.github/actions/e2e/cleanup
         if: always()
         with:
           account_id: ${{ vars.ACCOUNT_ID }}

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -2,9 +2,6 @@ name: E2EUpgrade
 on:
   workflow_dispatch:
     inputs:
-      git_repo:
-        type: string
-        default: "aws/karpenter"
       from_git_ref:
         type: string
         required: true
@@ -12,9 +9,6 @@ on:
         type: string
   workflow_call:
     inputs:
-      git_repo:
-        type: string
-        default: "aws/karpenter"
       from_git_ref:
         type: string
         required: true
@@ -44,6 +38,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: actions
+          ref: ${{ inputs.to_git_ref }}
       - name: generate cluster name
         run: |
           CLUSTER_NAME="upgrade-$RANDOM$RANDOM"
@@ -58,7 +53,7 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           kubernetes_version: ${{ vars.K8S_VERSION }}
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
-          git_repo: ${{ inputs.git_repo }}
+          git_ref: ${{ inputs.to_git_ref }}
       - name: install prometheus
         uses: ./actions/.github/actions/e2e/install-prometheus
         with:
@@ -67,6 +62,7 @@ jobs:
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           workspace_id: ${{ vars.WORKSPACE_ID }}
+          git_ref: ${{ inputs.to_git_ref }}
       - name: install karpenter
         uses: ./actions/.github/actions/e2e/install-karpenter
         with:
@@ -74,7 +70,6 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
-          git_repo: ${{ inputs.git_repo }}
           git_ref: ${{ inputs.from_git_ref }}
       - name: upgrade crds
         uses: ./actions/.github/actions/e2e/upgrade-crds
@@ -83,7 +78,6 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
-          git_repo: ${{ inputs.git_repo }}
           git_ref: ${{ inputs.to_git_ref }}
       - name: upgrade karpenter
         uses: ./actions/.github/actions/e2e/install-karpenter
@@ -92,7 +86,6 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
-          git_repo: ${{ inputs.git_repo }}
           git_ref: ${{ inputs.to_git_ref }}
       - name: run the Upgrade test suite
         run: |
@@ -106,6 +99,7 @@ jobs:
           suite: Upgrade
           pr_number: ${{ inputs.pr_number }}
           event_name: ${{ inputs.event_name }}
+          git_ref: ${{ inputs.to_git_ref }}
       - name: dump logs on failure
         uses: ./actions/.github/actions/e2e/dump-logs
         if: failure() || cancelled()
@@ -122,3 +116,4 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
+          git_ref: ${{ inputs.to_git_ref }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,7 +55,7 @@ jobs:
           echo "Using cluster name \"$CLUSTER_NAME\""
           echo CLUSTER_NAME=$CLUSTER_NAME >> $GITHUB_ENV
       - name: create eks cluster '${{ env.CLUSTER_NAME }}'
-        uses: ./actions/.github/actions/e2e/create-cluster
+        uses: ./.github/actions/e2e/create-cluster
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -65,7 +65,7 @@ jobs:
           ip_family: ${{ inputs.suite == 'IPv6' && 'IPv6' || 'IPv4' }} # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.git_ref }}
       - name: install prometheus
-        uses: ./actions/.github/actions/e2e/install-prometheus
+        uses: ./.github/actions/e2e/install-prometheus
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -74,7 +74,7 @@ jobs:
           workspace_id: ${{ vars.WORKSPACE_ID }}
           git_ref: ${{ inputs.git_ref }}
       - name: install karpenter
-        uses: ./actions/.github/actions/e2e/install-karpenter
+        uses: ./.github/actions/e2e/install-karpenter
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}
@@ -86,7 +86,7 @@ jobs:
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }}
           TEST_SUITE="${{ inputs.suite }}" make e2etests
       - name: notify slack of success or failure
-        uses: ./actions/.github/actions/e2e/slack/notify
+        uses: ./.github/actions/e2e/slack/notify
         if: success() || failure()
         with:
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -95,7 +95,7 @@ jobs:
           event_name: ${{ inputs.event_name }}
           git_ref: ${{ inputs.git_ref }}
       - name: dump logs on failure
-        uses: ./actions/.github/actions/e2e/dump-logs
+        uses: ./.github/actions/e2e/dump-logs
         if: failure() || cancelled()
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
@@ -103,7 +103,7 @@ jobs:
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
       - name: cleanup karpenter and cluster '${{ env.CLUSTER_NAME }}' resources
-        uses: ./actions/.github/actions/e2e/cleanup
+        uses: ./.github/actions/e2e/cleanup
         if: always()
         with:
           account_id: ${{ vars.ACCOUNT_ID }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,6 @@ jobs:
           role-duration-seconds: 21600
       - uses: actions/checkout@v3
         with:
-          path: actions
           ref: ${{ inputs.git_ref }}
       - name: generate cluster name
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,9 +2,6 @@ name: E2E
 on:
   workflow_dispatch:
     inputs:
-      git_repo:
-        type: string
-        default: "aws/karpenter"
       git_ref:
         type: string
       suite:
@@ -22,9 +19,6 @@ on:
           - Scale
   workflow_call:
     inputs:
-      git_repo:
-        type: string
-        default: "aws/karpenter"
       git_ref:
         type: string
       pr_number:
@@ -54,6 +48,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: actions
+          ref: ${{ inputs.git_ref }}
       - name: generate cluster name
         run: |
           CLUSTER_NAME=$(echo ${{ inputs.suite }}-$RANDOM$RANDOM | awk '{print tolower($0)}')
@@ -68,7 +63,6 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           kubernetes_version: ${{ vars.K8S_VERSION }}
           ip_family: ${{ inputs.suite == 'IPv6' && 'IPv6' || 'IPv4' }} # Set the value to IPv6 if IPv6 suite, else IPv4
-          git_repo: ${{ inputs.git_repo }}
           git_ref: ${{ inputs.git_ref }}
       - name: install prometheus
         uses: ./actions/.github/actions/e2e/install-prometheus
@@ -78,6 +72,7 @@ jobs:
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           workspace_id: ${{ vars.WORKSPACE_ID }}
+          git_ref: ${{ inputs.git_ref }}
       - name: install karpenter
         uses: ./actions/.github/actions/e2e/install-karpenter
         with:
@@ -85,7 +80,6 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
-          git_repo: ${{ inputs.git_repo }}
           git_ref: ${{ inputs.git_ref }}
       - name: run the ${{ inputs.suite }} test suite
         run: |
@@ -99,6 +93,7 @@ jobs:
           suite: ${{ inputs.suite }}
           pr_number: ${{ inputs.pr_number }}
           event_name: ${{ inputs.event_name }}
+          git_ref: ${{ inputs.git_ref }}
       - name: dump logs on failure
         uses: ./actions/.github/actions/e2e/dump-logs
         if: failure() || cancelled()
@@ -115,3 +110,4 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
+          git_ref: ${{ inputs.git_ref }}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

- Removes separate `actions/checkout` calls for the Action and the Repo and favors checking out the `inputs.git_ref` a single time
- Remove the `git_repo` parameter since that parameter will reference whichever repository that the action context is running inside of

**How was this change tested?**

* Manual runs on fork

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
