### PR TITLE
docs: Add Karpenter support for Windows docs

### DIFF
--- a/examples/provisioner/windows2019.yaml
+++ b/examples/provisioner/windows2019.yaml
@@ -1,0 +1,29 @@
+# This example provisioner will provision instances running Windows Server 2019
+
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: windows2019
+spec:
+  requirements:
+    - key: kubernetes.io/os
+      operator: In
+      values: ["windows"]
+  providerRef:
+    name: windows2019
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: windows2019
+  annotations:
+    kubernetes.io/description: "Nodes running Windows Server 2019"
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelector:
+    karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  amiFamily: Windows2019
+  metadataOptions:
+    httpProtocolIPv6: disabled
+    httpTokens: required

--- a/examples/provisioner/windows2022.yaml
+++ b/examples/provisioner/windows2022.yaml
@@ -1,0 +1,29 @@
+# This example provisioner will provision instances running Windows Server 2022
+
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: windows2022
+spec:
+  requirements:
+    - key: kubernetes.io/os
+      operator: In
+      values: ["windows"]
+  providerRef:
+    name: windows2022
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: windows2022
+  annotations:
+    kubernetes.io/description: "Nodes running Windows Server 2022"
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelector:
+    karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  amiFamily: Windows2022
+  metadataOptions:
+    httpProtocolIPv6: disabled
+    httpTokens: required

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -39,7 +39,8 @@ status:
   securityGroups: { ... }        # resolved security groups
   amis: { ... }                  # resolved AMIs 
 ```
-Refer to the [Provisioner docs]({{<ref "./provisioners" >}}) for settings applicable to all providers.
+Refer to the [Provisioner docs]({{<ref "./provisioners" >}}) for settings applicable to all providers. To explore various `AWSNodeTemplate` configurations, refer to the examples provided [in the Karpenter Github repository](https://github.com/aws/karpenter/blob/main/examples/provisioner/).
+
 See below for other AWS provider-specific parameters.
 
 ## spec.subnetSelector
@@ -161,12 +162,16 @@ spec:
 
 The AMI used when provisioning nodes can be controlled by the `amiFamily` field. Based on the value set for `amiFamily`, Karpenter will automatically query for the appropriate [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-amis.html) via AWS Systems Manager (SSM). When an `amiFamily` of `Custom` is chosen, then an `amiSelector` must be specified that informs Karpenter on which custom AMIs are to be used.
 
-Currently, Karpenter supports `amiFamily` values `AL2`, `Bottlerocket`, `Ubuntu` and `Custom`. GPUs are only supported with `AL2` and `Bottlerocket`. The `AL2` amiFamily does not support ARM64 GPU instance types unless you specify a custom amiSelector.
+Currently, Karpenter supports `amiFamily` values `AL2`, `Bottlerocket`, `Ubuntu`, `Windows2019`, `Windows2022` and `Custom`. GPUs are only supported with `AL2` and `Bottlerocket`. The `AL2` amiFamily does not support ARM64 GPU instance types unless you specify a custom amiSelector.
+
+{{% alert title="Defaults" color="secondary" %}}
+If no `amiFamily` is defined, Karpenter will set the default `amiFamily` to AL2
 
 ```yaml
 spec:
-  amiFamily: Bottlerocket
+  amiFamily: AL2
 ```
+{{% /alert %}}
 
 ## spec.amiSelector
 
@@ -313,10 +318,10 @@ spec:
         snapshotID: snap-0123456789
 ```
 
-### Defaults
+{{% alert title="Defaults" color="secondary" %}}
+If no `blockDeviceMappings` is defined, Karpenter will set the default `blockDeviceMappings` to the following for the given AMI family.
 
 #### AL2
-
 ```yaml
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate
@@ -330,7 +335,6 @@ spec:
 ```
 
 #### Bottlerocket
-
 ```yaml
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate
@@ -351,7 +355,6 @@ spec:
 ```
 
 #### Ubuntu
-
 ```yaml
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate
@@ -363,6 +366,20 @@ spec:
         volumeType: gp3
         encrypted: true
 ```
+
+#### Windows2019, Windows2022
+```yaml
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+spec:
+  blockDeviceMappings:
+    - deviceName: /dev/sda1
+      ebs:
+        volumeSize: 50Gi
+        volumeType: gp3
+        encrypted: true
+```
+{{% /alert %}}
 
 ## spec.userData
 
@@ -420,6 +437,10 @@ spec:
 ```
 
 For more examples on configuring these fields for different AMI families, see the [examples here](https://github.com/aws/karpenter/blob/main/examples/provisioner/launchtemplates).
+
+{{% alert title="Windows Support Notice" color="warning" %}}
+Specifying `spec.userData` is not currently supported for Windows nodes, but support is expected in the future.
+{{% /alert %}}
 
 ### Merge Semantics
 

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -439,7 +439,7 @@ spec:
 For more examples on configuring these fields for different AMI families, see the [examples here](https://github.com/aws/karpenter/blob/main/examples/provisioner/launchtemplates).
 
 {{% alert title="Windows Support Notice" color="warning" %}}
-Specifying `spec.userData` is not currently supported for Windows nodes, but support is expected in the future.
+Specifying `spec.userData` is not currently supported for Windows nodes. Support for this feature is tracked through [this Github issue](https://github.com/aws/karpenter/issues/4081).
 {{% /alert %}}
 
 ### Merge Semantics

--- a/website/content/en/preview/concepts/pod-density.md
+++ b/website/content/en/preview/concepts/pod-density.md
@@ -25,7 +25,7 @@ When using small instance types, it may be necessary to enable [prefix assignmen
 {{% /alert %}}
 
 {{% alert title="Windows Support Notice" color="warning" %}}
-Presently, only a single ENI per Windows worker node is supported.
+Presently, Windows worker nodes do not support using more than one ENI.
 As a consequence, the number of IP addresses, and subsequently, the number of pods that a Windows worker node can support is limited by the number of IPv4 addresses available on the primary ENI.
 At the moment, Karpenter will only consider individual secondary IP addresses when calculating the pod density limit.
 {{% /alert %}}

--- a/website/content/en/preview/concepts/pod-density.md
+++ b/website/content/en/preview/concepts/pod-density.md
@@ -24,6 +24,12 @@ Karpenter can be configured to disable nodes' ENI-based pod density.  This is es
 When using small instance types, it may be necessary to enable [prefix assignment mode](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) in the AWS VPC CNI plugin to more pods per node.  Prefix assignment mode was introduced in AWS VPC CNI v1.9 and allows ENIs to manage a broader set of IP addresses.  Much higher pod densities are supported as a result.
 {{% /alert %}}
 
+{{% alert title="Windows Support Notice" color="warning" %}}
+Presently, only a single ENI per Windows worker node is supported.
+As a consequence, the number of IP addresses, and subsequently, the number of pods that a Windows worker node can support is limited by the number of IPv4 addresses available on the primary ENI.
+At the moment, Karpenter will only consider individual secondary IP addresses when calculating the pod density limit.
+{{% /alert %}}
+
 ### Provisioner-Specific Pod Density
 
 #### Static Pod Density
@@ -51,6 +57,10 @@ Environment variables for the Karpenter controller may be specified as [helm cha
 ### VPC CNI Custom Networking
 
 By default, the VPC CNI allocates IPs for a node and pods from the same subnet. With [VPC CNI Custom Networking](https://aws.github.io/aws-eks-best-practices/networking/custom-networking), the pods will receive IP addresses from another subnet dedicated to pod IPs. This approach makes it easier to manage IP addresses and allows for separate Network Access Control Lists (NACLs) applied to your pods. VPC CNI Custom Networking reduces the pod density of a node since one of the ENI attachments will be used for the node and cannot share the allocated IPs on the interface to pods. Karpenter supports VPC CNI Custom Networking and similar CNI setups where the primary node interface is separated from the pods interfaces through a global [setting](./settings.md#configmap) within the karpenter-global-settings configmap: `aws.reservedENIs`. In the common case, `aws.reservedENIs` should be set to `"1"` if using Custom Networking.
+
+{{% alert title="Windows Support Notice" color="warning" %}}
+It's currently not possible to specify custom networking with Windows nodes.
+{{% /alert %}}
 
 ## Limit Pod Density
 

--- a/website/content/en/preview/concepts/provisioners.md
+++ b/website/content/en/preview/concepts/provisioners.md
@@ -24,6 +24,8 @@ Here are things you should know about Provisioners:
 * If Karpenter encounters a startup taint in the Provisioner it will be applied to nodes that are provisioned, but pods do not need to tolerate the taint.  Karpenter assumes that the taint is temporary and some other system will remove the taint.
 * It is recommended to create Provisioners that are mutually exclusive. So no Pod should match multiple Provisioners. If multiple Provisioners are matched, Karpenter will use the Provisioner with the highest [weight](#specweight).
 
+For some example `Provisioner` configurations, see the [examples in the Karpenter GitHub repository](https://github.com/aws/karpenter/blob/main/examples/provisioner/).
+
 ```yaml
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
@@ -211,8 +213,9 @@ requirements:
  - key: `kubernetes.io/os`
  - values
    - `linux`
+   - `windows`
 
-Karpenter supports only `linux` nodes at this time.
+Karpenter supports `linux` and `windows` operating systems.
 
 {{% alert title="Defaults" color="secondary" %}}
 If no operating system constraint is defined, Karpenter will set the default operating system constraint on your Provisioner that supports most common user workloads:
@@ -294,11 +297,9 @@ spec:
     maxPods: 20
 ```
 
-☁️ **AWS**
-
 You can specify the container runtime to be either `dockerd` or `containerd`. By default, `containerd` is used.
 
-* `containerd` is the only valid container runtime when using the Bottlerocket AMI Family or when using the AL2 AMI Family and K8s version 1.24+
+* `containerd` is the only valid container runtime when using the `Bottlerocket` AMIFamily or when using Kubernetes version 1.24+ and the `AL2`, `Windows2019`, or `Windows2022` AMIFamilies.
 
 ### Reserved Resources
 
@@ -465,7 +466,7 @@ In order for a pod to run on a node defined in this provisioner, it must tolerat
 
 ### Cilium Startup Taint
 
-Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects), it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5

--- a/website/content/en/preview/concepts/scheduling.md
+++ b/website/content/en/preview/concepts/scheduling.md
@@ -117,6 +117,10 @@ spec:
             vpc.amazonaws.com/pod-eni: "1"
 ```
 
+{{% alert title="Windows Support Notice" color="warning" %}}
+Security groups for pods are [currently unsupported for Windows nodes](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html)
+{{% /alert %}}
+
 ## Selecting nodes
 
 With `nodeSelector` you can ask for a node that matches selected key-value pairs.
@@ -137,6 +141,7 @@ Take care to ensure the label domains are correct. A well known label like `karp
 | -------------------------------------------------------------- | ----------  | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | topology.kubernetes.io/zone                                    | us-east-2a  | Zones are defined by your cloud provider ([aws](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html))                     |
 | node.kubernetes.io/instance-type                               | g4dn.8xlarge| Instance types are defined by your cloud provider ([aws](https://aws.amazon.com/ec2/instance-types/))                                                           |
+| node.kubernetes.io/windows-build                               | 10.0.17763  | Windows OS build in the format "MajorVersion.MinorVersion.BuildNumber". Can be `10.0.17763` for WS2019, or `10.0.20348` for WS2022. ([k8s](https://kubernetes.io/docs/reference/labels-annotations-taints/#nodekubernetesiowindows-build)) |
 | kubernetes.io/os                                               | linux       | Operating systems are defined by [GOOS values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L10) on the instance                            |
 | kubernetes.io/arch                                             | amd64       | Architectures are defined by [GOARCH values](https://github.com/golang/go/blob/master/src/go/build/syslist.go#L50) on the instance                              |
 | karpenter.sh/capacity-type                                     | spot        | Capacity types include `spot`, `on-demand`                                                                                                                      |

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -155,6 +155,10 @@ spec:
 
 For more documentation on enabling IPv6 with the Amazon VPC CNI, see the [docs](https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html).
 
+{{% alert title="Windows Support Notice" color="warning" %}}
+Windows nodes do not support IPv6.
+{{% /alert %}}
+
 ## Scheduling
 
 ### When using preferred scheduling constraints, Karpenter launches the correct number of nodes at first.  Why do they then sometimes get consolidated immediately?
@@ -174,6 +178,16 @@ Yes.  See [Persistent Volume Topology]({{< ref "./concepts/scheduling#persistent
 
 ### Can I set `--max-pods` on my nodes?
 Not yet.
+
+### Why do the Windows2019 and Windows2022 AMI families only support Windows Server Core?
+The difference between the Core and Full variants is that Core is a minimal OS with less components and no graphic user interface (GUI) or desktop experience.
+`Windows2019` and `Windows2022` AMI families use the Windows Server Core option for simplicity, but if required, you can specify a custom AMI to run Windows Server Full.
+
+You can specify the [Amazon EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-windows-ami.html) with Windows Server 2022 Full for Kubernetes 1.27 by configuring an `amiSelector` that references the AMI name.
+```
+amiSelector:
+    aws::name: Windows_Server-2022-English-Full-EKS_Optimized-1.27*
+```
 
 ## Deprovisioning
 ### How does Karpenter deprovision nodes?

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -79,6 +79,11 @@ The following cluster configuration will:
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step06-add-spot-role.sh" language="bash"%}}
 
+{{% alert title="Windows Support Notice" color="warning" %}}
+In order to run Windows workloads, Windows support should be enabled in your EKS Cluster.
+See [Enabling Windows support](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support) to learn more.
+{{% /alert %}}
+
 ### 4. Install Karpenter
 
 {{% script file="./content/en/{VERSION}/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh" language="bash"%}}

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -314,6 +314,32 @@ When a node is launched by Karpenter, it is assigned to a subnet within your VPC
 
 For more troubleshooting information on why your pod may have a `FailedCreateSandbox` error, view the [EKS CreatePodSandbox Knowledge Center Post](https://repost.aws/knowledge-center/eks-failed-create-pod-sandbox).
 
+### Windows pods are failing with `FailedCreatedPodSandbox`
+
+The following solution(s) may resolve your issue if you are seeing an error similar to the following when attempting to launch Windows pods. This error typically occurs if you have not enabled Windows support.
+
+```
+Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": plugin type="vpc-bridge" name="vpc" failed (add): failed to parse Kubernetes args: pod does not have label vpc.amazonaws.com/PrivateIPv4Address
+```
+
+#### Solutions
+1. See [Enabling Windows support](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support) for instructions on how to enable Windows support.
+
+### Windows pods fail to launch with image pull error
+
+The following solution(s) may resolve your issue if you are seeing an error similar to the following when attempting to launch Windows pods.
+
+```
+Failed to pull image "mcr.microsoft.com/windows/servercore:xxx": rpc error: code = NotFound desc = failed to pull and unpack image "mcr.microsoft.com/windows/servercore:xxx": no match for platform in manifest: not found
+```
+
+This error typically occurs in a scenario whereby a pod with a given container OS version attempts to be scheduled on an incompatible Windows host OS version.
+Windows requires the host OS version to match the container OS version.
+
+#### Solutions
+
+1. Define your pod's `nodeSelector` to ensure that your containers are scheduled on a compatible OS host version. To learn more, see [Windows container version compatibility](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned


### PR DESCRIPTION
Fixes #1131 

**Description**
Karpenter will be adding Windows support in an upcoming change and this pull request contains documentation updates related to Karpenter Windows support.

**How was this change tested?**

Doc changes have been verified by checking the [Netlify deploy preview 4074](https://deploy-preview-4074--karpenter-docs-prod.netlify.app).

**Does this change impact docs?**

- [x] Yes, PR includes docs updates

**Release Note**

No release notes required for this PR. Release notes regarding Windows support will be included in PR #3698 with the following text.

```release-note
Add Windows support by introducing new Windows AMI Families.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.