### PR TITLE
docs: Simplify large-instances example using `Gt` operator

### DIFF
--- a/examples/provisioner/large-instances.yaml
+++ b/examples/provisioner/large-instances.yaml
@@ -6,75 +6,13 @@ metadata:
   name: default
 spec:
   requirements:
-    - key: "node.kubernetes.io/instance-type"
-      operator: NotIn
-      values:
-      # exclude instances with < 4 cores and < 8gb memory
-      # got list from
-      # ec2-instance-selector --vcpus-max 4 --memory-max 8 --service eks --max-results 100
-      - a1.large
-      - a1.medium
-      - a1.xlarge
-      - c3.large
-      - c3.xlarge
-      - c4.large
-      - c4.xlarge
-      - c5.large
-      - c5.xlarge
-      - c5a.large
-      - c5a.xlarge
-      - c5ad.large
-      - c5ad.xlarge
-      - c5d.large
-      - c5d.xlarge
-      - c5n.large
-      - c6g.large
-      - c6g.medium
-      - c6g.xlarge
-      - c6gd.large
-      - c6gd.medium
-      - c6gd.xlarge
-      - c6gn.large
-      - c6gn.medium
-      - c6gn.xlarge
-      - inf1.xlarge
-      - m3.large
-      - m3.medium
-      - m4.large
-      - m5.large
-      - m5a.large
-      - m5ad.large
-      - m5d.large
-      - m5dn.large
-      - m5n.large
-      - m5zn.large
-      - m6g.large
-      - m6g.medium
-      - m6gd.large
-      - m6gd.medium
-      - m6i.large
-      - r6g.medium
-      - r6gd.medium
-      - t2.large
-      - t2.medium
-      - t2.micro
-      - t2.nano
-      - t2.small
-      - t3.large
-      - t3.medium
-      - t3.micro
-      - t3.nano
-      - t3.small
-      - t3a.large
-      - t3a.medium
-      - t3a.micro
-      - t3a.nano
-      - t3a.small
-      - t4g.large
-      - t4g.medium
-      - t4g.micro
-      - t4g.nano
-      - t4g.small
+      # exclude instances with < 4 cores and < 8GiB memory (8192 mebibytes)
+    - key: "karpenter.k8s.aws/instance-cpu"
+      operator: Gt
+      values: ["3"]
+    - key: "karpenter.k8s.aws/instance-memory"
+      operator: Gt
+      values: ["8191"]
   providerRef:
     name: my-provider
 ---


### PR DESCRIPTION
Fixes # <!-- issue number -->

**Description**

Looks like this example was added before https://github.com/aws/karpenter/pull/2051 got implemented so, unless I'm missing something else that the example wishes to demonstrate, the requirements can be simplified so they don't require hard-coding the instance types. 

**How was this change tested?**

* Currently using a provisioner with similar requirements.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
