### PR TITLE
test: Bump `from_git_ref` to fix e2e-upgrade

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -56,7 +56,7 @@ jobs:
     if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      from_git_ref: v0.27.5
+      from_git_ref: v0.28.0
       to_git_ref: ${{ needs.resolve-git-ref.outputs.GIT_REF }}
       pr_number: ${{ needs.resolve-git-ref.outputs.PR_NUM }}
       event_name: ${{ github.event_name }}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

The GHA action actions were not available until `v0.28.0`; therefore, we are temporarily bumping the `from_git_ref` for the upgrade test to that version to enable the Upgrade tests to start working

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
