### PR TITLE
test: Fix `k8s_version` value in create-cluster and Matching `"`

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -70,7 +70,7 @@ runs:
       metadata:
         name: ${{ inputs.cluster_name }}
         region: ${{ inputs.region }}
-        version: "${{ inputs.kubernetes_version }}"
+        version: "${{ inputs.k8s_version }}"
         tags:
           karpenter.sh/discovery: ${{ inputs.cluster_name }}
           github.com/run-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -55,7 +55,7 @@ runs:
         --template-file $CLOUDFORMATION_PATH \
         --capabilities CAPABILITY_NAMED_IAM \
         --parameter-overrides "ClusterName=${{ inputs.cluster_name }}" \
-        --tags "testing.karpenter.sh/type=e2e" github.com/run-url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        --tags "testing.karpenter.sh/type=e2e" "github.com/run-url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
   - name: create or upgrade cluster
     shell: bash
     run: |


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Fixes syntax error in `create-cluster` with missing `"` character
- Uses the `inputs.k8s_version` value instead of the old `kubernetes_version` value

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
