### PR TITLE
test: Add PR number back to notify call

### DIFF
--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -27,7 +27,7 @@ runs:
         if [[ ${{ inputs.event_name }} == "conformance" ]]; then
           RUN_NAME="conformance-periodic-${{ inputs.k8s_version }}"
         elif [[ ! -z "${{ inputs.pr_number }}" ]]; then
-          RUN_NAME="${{ inputs.suite }}-pr"
+          RUN_NAME="${{ inputs.suite }}-pr-${{ inputs.pr_number }}"
         elif [[ ${{ inputs.event_name }} == "schedule" ]]; then
           RUN_NAME="${{ inputs.suite }}-periodic"
         else


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

PR number was removed erroneously by #4099. This adds the PR number used to trigger the call back to the Slack notification

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
