### PR TITLE
test: Disable Ubuntu testing on K8s version 1.27 or greater

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -554,6 +555,26 @@ func (env *Environment) ExpectCABundle() string {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	logging.FromContext(env.Context).Debugf("Discovered caBundle, length %d", len(transportConfig.TLS.CAData))
 	return base64.StdEncoding.EncodeToString(transportConfig.TLS.CAData)
+}
+
+type KubernetesVersionInfo struct {
+	Major int
+	Minor int
+}
+
+func (env *Environment) ExpectKubernetesVersionInfo() KubernetesVersionInfo {
+	GinkgoHelper()
+
+	version, err := env.KubeClient.Discovery().ServerVersion()
+	Expect(err).ToNot(HaveOccurred())
+	majorVersion, err := strconv.Atoi(version.Major)
+	Expect(err).ToNot(HaveOccurred())
+	minorVersion, err := strconv.Atoi(strings.TrimSuffix(version.Minor, "+"))
+	Expect(err).ToNot(HaveOccurred())
+	return KubernetesVersionInfo{
+		Major: majorVersion,
+		Minor: minorVersion,
+	}
 }
 
 func (env *Environment) GetDaemonSetCount(prov *v1alpha5.Provisioner) int {

--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -182,6 +182,12 @@ var _ = Describe("AMI", func() {
 			env.ExpectCreatedNodeCount("==", 1)
 		})
 		It("should provision a node using the Ubuntu family", func() {
+			// Ubuntu is currently not supported on K8s version 1.27
+			// This Skip can be removed once Ubuntu is supported by the newest version of Kubernetes
+			if env.ExpectKubernetesVersionInfo().Minor >= 27 {
+				Skip("Ubuntu is not currently supported on Kubernetes 1.27")
+			}
+
 			provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 				SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},

--- a/test/suites/integration/kubelet_config_test.go
+++ b/test/suites/integration/kubelet_config_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,6 +96,12 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 		})
 		DescribeTable("Linux AMIFamilies",
 			func(amiFamily *string) {
+				// Ubuntu is currently not supported on K8s version 1.27
+				// This Skip can be removed once Ubuntu is supported by the newest version of Kubernetes
+				if env.ExpectKubernetesVersionInfo().Minor >= 27 && lo.FromPtr(amiFamily) == v1alpha1.AMIFamilyUbuntu {
+					Skip("Ubuntu is not currently supported on Kubernetes 1.27")
+				}
+
 				nodeTemplate.Spec.AMIFamily = amiFamily
 				// Need to enable provisioner-level OS-scoping for now since DS evaluation is done off of the provisioner
 				// requirements, not off of the instance type options so scheduling can fail if provisioners aren't


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Disable Ubuntu testing on K8s version 1.27 or greater until Ubuntu releases an official AMI for Kubernetes 1.27 and the SSM alias is resolvable for K8s 1.27

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
