### PR TITLE
test: Add PR commit status reporting for `/karpenter snapshot` runs

### DIFF
--- a/.github/actions/e2e/commit-status/end/action.yaml
+++ b/.github/actions/e2e/commit-status/end/action.yaml
@@ -1,0 +1,36 @@
+name: CommitStatusEnd
+description: 'Adds a commit status at the end of the test run based on success, failure, or cancelled'
+inputs:
+  suite:
+    description: "Suite that's running"
+    required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      if: job.status == 'success'
+      with:
+        script: |
+          github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            context: "${{ github.workflow }} / e2e (${{ inputs.suite }}) / ${{ github.job }}",
+            sha: "${{ inputs.git_ref }}",
+            state: "success",
+            target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} (snapshot)",
+          });
+    - uses: actions/github-script@v6
+      if: job.status == 'failure' || job.status == 'cancelled'
+      with:
+        script: |
+          github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            context: "${{ github.workflow }} / e2e (${{ inputs.suite }}) / ${{ github.job }} (snapshot)",
+            sha: "${{ inputs.git_ref }}",
+            state: "failure",
+            target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          });

--- a/.github/actions/e2e/commit-status/start/action.yaml
+++ b/.github/actions/e2e/commit-status/start/action.yaml
@@ -1,0 +1,24 @@
+name: CommitStatusStart
+description: 'Adds a commit status at the start of the test run to set the status to pending'
+inputs:
+  suite:
+    description: "Suite that's running"
+    required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      if: always()
+      with:
+        script: |
+          github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            context: "${{ github.workflow }} / e2e (${{ inputs.suite }}) / ${{ github.job }} (snapshot)",
+            sha: "${{ inputs.git_ref }}",
+            state: "pending",
+            target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          });

--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -1,4 +1,4 @@
-name: NotifySlack
+name: SlackNotify
 description: 'Notifies slack of the success or failure of the suite'
 inputs:
   suite:

--- a/.github/actions/e2e/slack/send-message/action.yaml
+++ b/.github/actions/e2e/slack/send-message/action.yaml
@@ -1,4 +1,4 @@
-name: NotifySlack
+name: SlackSendMessage
 description: 'Notifies slack of the success or failure of the suite'
 inputs:
   message:

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -37,19 +37,29 @@ on:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout
+  statuses: write
 jobs:
   run-suite:
     runs-on: ubuntu-latest
     steps:
+      # This additional checkout can be removed when the commit status action is added to the from_git_ref version of Karpenter
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.to_git_ref }}
+      - if: always() && inputs.event_name == 'workflow_run'
+        uses: ./.github/actions/e2e/commit-status/start
+        with:
+          suite: Upgrade
+          git_ref: ${{ inputs.to_git_ref }}
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.from_git_ref }}
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ vars.ACCOUNT_ID }}:role/${{ vars.ROLE_NAME }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 21600
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.from_git_ref }}
       - name: generate cluster name
         run: |
           CLUSTER_NAME="upgrade-$RANDOM$RANDOM"
@@ -151,4 +161,9 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
+          git_ref: ${{ inputs.to_git_ref }}
+      - if: always() && inputs.event_name == 'workflow_run'
+        uses: ./.github/actions/e2e/commit-status/end
+        with:
+          suite: Upgrade
           git_ref: ${{ inputs.to_git_ref }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,19 +47,25 @@ on:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout
+  statuses: write
 jobs:
   run-suite:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git_ref }}
+      - if: always() && inputs.event_name == 'workflow_run'
+        uses: ./.github/actions/e2e/commit-status/start
+        with:
+          suite: ${{ inputs.suite }}
+          git_ref: ${{ inputs.git_ref }}
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ vars.ACCOUNT_ID }}:role/${{ vars.ROLE_NAME }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 21600
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.git_ref }}
       - name: generate cluster name
         run: |
           CLUSTER_NAME=$(echo ${{ inputs.suite }}-$RANDOM$RANDOM | awk '{print tolower($0)}')
@@ -122,4 +128,9 @@ jobs:
           role: ${{ vars.ROLE_NAME }}
           region: ${{ vars.AWS_REGION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
+          git_ref: ${{ inputs.git_ref }}
+      - if: always() && inputs.event_name == 'workflow_run'
+        uses: ./.github/actions/e2e/commit-status/end
+        with:
+          suite: ${{ inputs.suite }}
           git_ref: ${{ inputs.git_ref }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Adds commit status to a PR when running the `/karpenter snapshot` command

**How was this change tested?**

- Running the `e2e.yaml` and `e2e-upgrade.yaml` in my fork

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
