### PR TITLE
fix: replace DS_PROMETHEUS with datasource variable

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-controllers-allocation.json
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-controllers-allocation.json
@@ -1,45 +1,12 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "8.1.6"
-    },
-    {
-      "type": "panel",
-      "id": "heatmap",
-      "name": "Heatmap",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -77,6 +44,7 @@
       "pluginVersion": "8.1.6",
       "targets": [
         {
+          "datasource": {},
           "queryType": "randomWalk",
           "refId": "A"
         }
@@ -100,7 +68,9 @@
         "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "description": "Aggregates the duration of all bind operations of the Allocation controller.\n\nThe color of each \"bucket\" is a visual clue to the number of bind operations that completed within that duration range.\n\nMouse-over a bucket to display exact values.",
       "gridPos": {
         "h": 8,
@@ -120,6 +90,9 @@
       "reverseYBuckets": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "exemplar": true,
           "expr": "sum(increase(karpenter_allocation_controller_bind_duration_seconds_bucket[$__interval])) by (le)",
           "format": "heatmap",
@@ -167,7 +140,9 @@
         "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "description": "Aggregates the duration of all binpack operations of the Allocation controller.\n\nThe color of each \"bucket\" is a visual clue to the number of binpack operations that completed within that duration range.\n\nMouse-over a bucket to display exact values.",
       "gridPos": {
         "h": 8,
@@ -187,6 +162,9 @@
       "reverseYBuckets": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "exemplar": true,
           "expr": "sum(increase(karpenter_allocation_controller_binpacking_duration_seconds_bucket[$__interval])) by (le)",
           "format": "heatmap",
@@ -233,7 +211,9 @@
         "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "description": "Aggregates the duration of all scheduling operations of the Allocation controller for provisioner $provisioner.\n\nThe color of each \"bucket\" is a visual clue to the number of scheduling operations that completed within that duration range.\n\nMouse-over a bucket to display exact values.",
       "gridPos": {
         "h": 8,
@@ -253,6 +233,9 @@
       "reverseYBuckets": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "exemplar": true,
           "expr": "sum(increase(karpenter_allocation_controller_scheduling_duration_seconds_bucket{provisioner=\"$provisioner\"}[$__interval])) by (le)",
           "format": "heatmap",
@@ -296,7 +279,9 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": {
+          "uid": "${datasource}"
+        },
         "definition": "label_values(karpenter_allocation_controller_scheduling_duration_seconds_bucket, provisioner)",
         "description": "Karpenter provisioner",
         "error": null,
@@ -315,6 +300,24 @@
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
       }
     ]
   },

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-controllers.json
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/karpenter-controllers.json
@@ -1,51 +1,12 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "8.1.6"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph (old)",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "heatmap",
-      "name": "Heatmap",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -92,7 +53,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "description": "",
       "fill": 1,
       "fillGradient": 2,
@@ -130,6 +93,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "exemplar": true,
           "expr": "workqueue_depth{name=\"$controller\"}",
           "interval": "",
@@ -190,7 +156,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "description": "The rate of completed reconciliations per minute broken out by result status.",
       "fill": 1,
       "fillGradient": 1,
@@ -228,6 +196,9 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "exemplar": true,
           "expr": "rate(controller_runtime_reconcile_total{controller=\"$controller\"}[$trailing]) * 60",
           "interval": "",
@@ -292,7 +263,9 @@
         "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "uid": "${datasource}"
+      },
       "description": "Aggregates the duration of the reconciliation process.\n\nThe color of each \"bucket\" is a visual clue to the number of reconciliations that completed within that time range.\n\nMouse-over a bucket to display exact values.",
       "gridPos": {
         "h": 8,
@@ -312,6 +285,9 @@
       "reverseYBuckets": false,
       "targets": [
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
           "exemplar": true,
           "expr": "sum(increase(controller_runtime_reconcile_time_seconds_bucket{controller=\"$controller\"}[$__interval])) by (le)",
           "format": "heatmap",
@@ -350,7 +326,7 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 30,
+  "schemaVersion": 31,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -358,7 +334,9 @@
       {
         "allValue": "",
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": {
+          "uid": "${datasource}"
+        },
         "definition": "label_values(controller_runtime_reconcile_errors_total, controller)",
         "description": "Kubernetes controller",
         "error": null,
@@ -431,6 +409,20 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
       }
     ]
   },


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4094

**Description**

The `DS_PROMETHEUS` variable is not available in more recent Grafana versions. Therefore, it was replaced with a variable based on a data source query that resolves the local default Prometheus data source.
I changed the files in the `preview` directory, I'm not sure whether we want to port the changes back to the latest releases (`v0,27`, `v0..28`).

**How was this change tested?**

Tested on Grafana `9.5.3`. 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
