### PR TITLE
chore: link to testrun

### DIFF
--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -40,9 +40,9 @@ runs:
       if: ${{ job.status == 'success' }}
       with:
         url: ${{ inputs.url }}
-        message: ":white_check_mark: ${{ env.RUN_NAME }} tests succeeded (#${{ github.run_number }})"
+        message: ":white_check_mark: ${{ env.RUN_NAME }} (https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
     - uses: ./.github/actions/e2e/slack/send-message
       if: ${{ job.status == 'failure' }}
       with:
         url: ${{ inputs.url }}
-        message: ":x: ${{ env.RUN_NAME }} tests failed (#${{ github.run_number }})"
+        message: ":x: ${{ env.RUN_NAME }} (https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
Adds a helpful link to the test run. You can follow that to the trigger (dispatch, pr, etc)

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
