### PR TITLE
test: Update prop policy for deletion and propagate discovery label to pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.273
-	github.com/aws/karpenter-core v0.28.1
+	github.com/aws/karpenter-core v0.28.1-0.20230626164842-7909e131de42
 	github.com/go-playground/validator/v10 v10.13.0
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.273 h1:CX8O0gK+cGrgUyv7bgJ6QQP9mQg7u5mweHdNzULH47c=
 github.com/aws/aws-sdk-go v1.44.273/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.28.1 h1:pRe3D1+qr/njT49tlfVvm2kF2udNhe+atSvkGRUfbUY=
-github.com/aws/karpenter-core v0.28.1/go.mod h1:BiPQ/eMeJ1rkfNWctOHmBxvabf8s9IFAWZz5hpHP3Bc=
+github.com/aws/karpenter-core v0.28.1-0.20230626164842-7909e131de42 h1:gkDEGZbQ2X8Z3ZQGgxMkTi3SpUdyPPTXZBOwXhMRWDg=
+github.com/aws/karpenter-core v0.28.1-0.20230626164842-7909e131de42/go.mod h1:BiPQ/eMeJ1rkfNWctOHmBxvabf8s9IFAWZz5hpHP3Bc=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -60,7 +60,7 @@ func (env *Environment) ExpectCreated(objects ...client.Object) {
 
 func (env *Environment) ExpectDeletedWithOffset(offset int, objects ...client.Object) {
 	for _, object := range objects {
-		ExpectWithOffset(offset+1, env.Client.Delete(env, object, &client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)})).To(Succeed())
+		ExpectWithOffset(offset+1, env.Client.Delete(env, object, client.PropagationPolicy(metav1.DeletePropagationForeground), &client.DeleteOptions{GracePeriodSeconds: ptr.Int64(0)})).To(Succeed())
 	}
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Update the propagation policy to be `ForegroundDeletion` for all `ExpectDeleted` operations that take place during E2E testing
- This also pulls in the `karpenter-core` change that adds the `testing.karpenter.sh` discovery label onto pods that are deployed by deployments: https://github.com/aws/karpenter-core/pull/384

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
