### PR TITLE
docs: add redirect for changed getting started guide

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -3,5 +3,5 @@
 /v0.27.5/*                      /v0.27/:splat
 /v0.26.1/*                      /v0.26/:splat
 /v0.26/getting-started/getting-started-with-karpenter/*  /v0.26/getting-started/getting-started-with-eksctl/:splat
-/v0.27/getting-started/getting-started-with-eksctl/* /v0.27/getting-started/getting-stated-with-karpenter/:splat
-/v0.28/getting-started/getting-started-with-eksctl/* /v0.28/getting-started/getting-stated-with-karpenter/:splat
+/v0.27/getting-started/getting-started-with-eksctl/* /v0.27/getting-started/getting-started-with-karpenter/:splat
+/v0.28/getting-started/getting-started-with-eksctl/* /v0.28/getting-started/getting-started-with-karpenter/:splat

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -3,3 +3,5 @@
 /v0.27.5/*                      /v0.27/:splat
 /v0.26.1/*                      /v0.26/:splat
 /v0.26/getting-started/getting-started-with-karpenter/*  /v0.26/getting-started/getting-started-with-eksctl/:splat
+/v0.27/getting-started/getting-started-with-eksctl/* /v0.27/getting-started/getting-stated-with-karpenter/:splat
+/v0.28/getting-started/getting-started-with-eksctl/* /v0.28/getting-started/getting-stated-with-karpenter/:splat

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -2,3 +2,4 @@
 /v0.28.0/*                      /v0.28/:splat
 /v0.27.5/*                      /v0.27/:splat
 /v0.26.1/*                      /v0.26/:splat
+/v0.26/getting-started/getting-started-with-karpenter/*  /v0.26/getting-started/getting-started-with-eksctl/:splat


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
v0.26 had the guide named `getting-started-with-eksctl`, and afterwards it's `getting-started-with-karpenter`. Adding a redirect so there aren't any 404s.

**How was this change tested?**
- `make website` doesn't properly test redirects, so I tested this with the website deploy.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
