### PR TITLE
BREAKING CHANGE: Adjust Metrics and Webhook service port to align with pod ports 

### DIFF
--- a/charts/karpenter/templates/service.yaml
+++ b/charts/karpenter/templates/service.yaml
@@ -13,11 +13,11 @@ spec:
   type: ClusterIP
   ports:
     - name: http-metrics
-      port: 8000
+      port: {{ .Values.controller.metrics.port }}
       targetPort: http-metrics
       protocol: TCP
     - name: https-webhook
-      port: 443
+      port: {{ .Values.webhook.port }}
       targetPort: https-webhook
       protocol: TCP
   selector:

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -103,7 +103,7 @@ Snapshot releases are tagged with the git commit hash prefixed by the Karpenter 
 ## Released Upgrade Notes
 
 ### Upgrading to v0.29.0+
-* Karpenter has changed the default metrics service port from 8080 to 8000. In `v0.28.0`, the Karpenter pod port was changed to 8000, but referenced the service by name, allowing users to scrape the service at port 8080 for metrics. `v0.29.0` aligns the two ports so that service and pod metrics ports are the same. These ports are both set by `controller.metrics.port` and `webhook.port`, so if you have previously set these to non-default values, you may need to update your Prometheus scraper to match these new values.
+* Karpenter has changed the default metrics service port from 8080 to 8000 and the default webhook service port from 443 to 8443. In `v0.28.0`, the Karpenter pod port was changed to 8000, but referenced the service by name, allowing users to scrape the service at port 8080 for metrics. `v0.29.0` aligns the two ports so that service and pod metrics ports are the same. These ports are set by the `controller.metrics.port` and `webhook.port` helm chart values, so if you have previously set these to non-default values, you may need to update your Prometheus scraper to match these new values.
 
 ### Upgrading to v0.28.0+
 

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -103,7 +103,7 @@ Snapshot releases are tagged with the git commit hash prefixed by the Karpenter 
 ## Released Upgrade Notes
 
 ### Upgrading to v0.29.0+
-* Karpenter has changed the default metrics service port from 8080 to 8000. In `v0.28.0`, the Karpenter pod port was changed to 8000, but referenced the service by name, allowing users to scrape the service at port 8080 for metrics. `v0.29.0` aligns the two ports so that default service and default pod metrics ports are the same.
+* Karpenter has changed the default metrics service port from 8080 to 8000. In `v0.28.0`, the Karpenter pod port was changed to 8000, but referenced the service by name, allowing users to scrape the service at port 8080 for metrics. `v0.29.0` aligns the two ports so that service and pod metrics ports are the same. These ports are both set by `controller.metrics.port` and `webhook.port`, so if you have previously set these to non-default values, you may need to update your Prometheus scraper to match these new values.
 
 ### Upgrading to v0.28.0+
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->
**Description**

- Fixed an issue were we see that metrics and Webhook ports were not able to configured.

**How was this change tested?**

- Manually tested

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
