### PR TITLE
test: add cluster name and git ref into prometheus common labels

### DIFF
--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -46,4 +46,8 @@ runs:
           --set prometheus.prometheusSpec.commonLabels[0].name=clusterName \
           --set prometheus.prometheusSpec.commonLabels[0].value=${{ inputs.cluster_name }} \
           --set prometheus.prometheusSpec.commonLabels[1].name=gitRef \
-          --set prometheus.prometheusSpec.commonLabels[1].value=${{ inputs.git_ref }}
+          --set prometheus.prometheusSpec.commonLabels[1].value=${{ inputs.git_ref }} \
+          --set prometheus.prometheusSpec.commonLabels[2].name=mostRecentTag \
+          --set prometheus.prometheusSpec.commonLabels[2].value=$(git describe --abbrev=0 --tags) \
+          --set prometheus.prometheusSpec.commonLabels[3].name=commitsAfterTag \
+          --set prometheus.prometheusSpec.commonLabels[3].value=$(git describe --tags | cut -d '-' -f 2)

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -43,3 +43,7 @@ runs:
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}"
+          --set prometheus.prometheusSpec.commonLabels[0].name=clusterName \
+          --set prometheus.prometheusSpec.commonLabels[0].value=${{ inputs.cluster_name }} \
+          --set prometheus.prometheusSpec.commonLabels[1].name=gitRef \
+          --set prometheus.prometheusSpec.commonLabels[1].value=${{ inputs.git_ref }}

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -18,6 +18,10 @@ inputs:
     required: true
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
+  most_recent_tag:
+    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
+  commits_after_tag:
+    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
 runs:
   using: "composite"
   steps:
@@ -45,5 +49,5 @@ runs:
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}"
           --set prometheus.prometheusSpec.commonLabels.clusterName=${{ inputs.cluster_name }} \
           --set prometheus.prometheusSpec.commonLabels.gitRef=${{ inputs.git_ref }} \
-          --set prometheus.prometheusSpec.commonLabels.mostRecentTag=$(git describe --abbrev=0 --tags) \
-          --set prometheus.prometheusSpec.commonLabels.commitsAfterTag=$(git describe --tags | cut -d '-' -f 2)
+          --set prometheus.prometheusSpec.commonLabels.mostRecentTag=${{ inputs.most_recent_tag }} \
+          --set prometheus.prometheusSpec.commonLabels.commitsAfterTag=${{ inputs.commits_after_tag }}

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -46,8 +46,8 @@ runs:
           -f ./.github/actions/e2e/install-prometheus/values.yaml \
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
-          --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}"
+          --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}" \
           --set prometheus.prometheusSpec.commonLabels.clusterName=${{ inputs.cluster_name }} \
           --set prometheus.prometheusSpec.commonLabels.gitRef=${{ inputs.git_ref }} \
-          --set prometheus.prometheusSpec.commonLabels.mostRecentTag=${{ inputs.most_recent_tag }} \
-          --set prometheus.prometheusSpec.commonLabels.commitsAfterTag=${{ inputs.commits_after_tag }}
+          --set prometheus.prometheusSpec.commonLabels.mostRecentTag=$(git describe --abbrev=0 --tags) \
+          --set prometheus.prometheusSpec.commonLabels.commitsAfterTag=$(git describe --tags | cut -d '-' -f 2)

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -43,7 +43,11 @@ runs:
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}" \
-          --set prometheus.prometheusSpec.static_config.labels.clusterName=${{ inputs.cluster_name }} \
-          --set prometheus.prometheusSpec.static_config.labels.gitRef=${{ inputs.git_ref }} \
-          --set prometheus.prometheusSpec.static_config.labels.mostRecentTag=$(git describe --abbrev=0 --tags) \
-          --set prometheus.prometheusSpec.static_config.labels.commitsAfterTag=$(git describe --tags | cut -d '-' -f 2)
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[0].target_label=clusterName \
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[0].replacement=${{ inputs.cluster_name }} \
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[1].target_label=gitRef \
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[1].replacement=${{ inputs.git_ref }} \
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[2].target_label=mostRecentTag \
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[2].replacement=$(git describe --abbrev=0 --tags) \
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[3].target_label=commitsAfterTag \
+          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[3].replacement=$(git describe --tags | cut -d '-' -f 2)

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -43,11 +43,7 @@ runs:
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}"
-          --set prometheus.prometheusSpec.commonLabels[0].name=clusterName \
-          --set prometheus.prometheusSpec.commonLabels[0].value=${{ inputs.cluster_name }} \
-          --set prometheus.prometheusSpec.commonLabels[1].name=gitRef \
-          --set prometheus.prometheusSpec.commonLabels[1].value=${{ inputs.git_ref }} \
-          --set prometheus.prometheusSpec.commonLabels[2].name=mostRecentTag \
-          --set prometheus.prometheusSpec.commonLabels[2].value=$(git describe --abbrev=0 --tags) \
-          --set prometheus.prometheusSpec.commonLabels[3].name=commitsAfterTag \
-          --set prometheus.prometheusSpec.commonLabels[3].value=$(git describe --tags | cut -d '-' -f 2)
+          --set prometheus.prometheusSpec.commonLabels.clusterName=${{ inputs.cluster_name }} \
+          --set prometheus.prometheusSpec.commonLabels.gitRef=${{ inputs.git_ref }} \
+          --set prometheus.prometheusSpec.commonLabels.mostRecentTag=$(git describe --abbrev=0 --tags) \
+          --set prometheus.prometheusSpec.commonLabels.commitsAfterTag=$(git describe --tags | cut -d '-' -f 2)

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -18,10 +18,6 @@ inputs:
     required: true
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
-  most_recent_tag:
-    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
-  commits_after_tag:
-    description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -43,7 +43,7 @@ runs:
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}" \
-          --set prometheus.prometheusSpec.commonLabels.clusterName=${{ inputs.cluster_name }} \
-          --set prometheus.prometheusSpec.commonLabels.gitRef=${{ inputs.git_ref }} \
-          --set prometheus.prometheusSpec.commonLabels.mostRecentTag=$(git describe --abbrev=0 --tags) \
-          --set prometheus.prometheusSpec.commonLabels.commitsAfterTag=$(git describe --tags | cut -d '-' -f 2)
+          --set prometheus.prometheusSpec.static_config.labels.clusterName=${{ inputs.cluster_name }} \
+          --set prometheus.prometheusSpec.static_config.labels.gitRef=${{ inputs.git_ref }} \
+          --set prometheus.prometheusSpec.static_config.labels.mostRecentTag=$(git describe --abbrev=0 --tags) \
+          --set prometheus.prometheusSpec.static_config.labels.commitsAfterTag=$(git describe --tags | cut -d '-' -f 2)

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       GIT_REF: ${{ steps.resolve-step.outputs.GIT_REF }}
+      MOST_RECENT_TAG: ${{ steps.resolve-step.outputs.GIT_REF }}
+      COMMITS_AFTER_TAG: ${{ steps.resolve-step.outputs.GIT_REF }}
     steps:
       # Download the artifact and resolve the commit if initiated by PR snapshot
       # Otherwise, use the currently checked-out branch to run the E2E tests against
@@ -30,8 +32,12 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             echo GIT_REF=$(tail -n 1 /tmp/artifacts/metadata.txt) >> $GITHUB_OUTPUT
+            echo MOST_RECENT_TAG=$(git describe --abbrev=0 --tags) >> $GITHUB_OUTPUT
+            echo COMMITS_AFTER_TAG=$(git describe --tags | cut -d '-' -f 2) >> $GITHUB_OUTPUT
           else
             echo GIT_REF="" >> $GITHUB_OUTPUT
+            echo MOST_RECENT_TAG="" >> $GITHUB_OUTPUT
+            echo COMMITS_AFTER_TAG="" >> $GITHUB_OUTPUT
           fi
   e2e:
     needs: [resolve-git-ref]

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       GIT_REF: ${{ steps.resolve-step.outputs.GIT_REF }}
-      MOST_RECENT_TAG: ${{ steps.resolve-step.outputs.GIT_REF }}
-      COMMITS_AFTER_TAG: ${{ steps.resolve-step.outputs.GIT_REF }}
     steps:
       # Download the artifact and resolve the commit if initiated by PR snapshot
       # Otherwise, use the currently checked-out branch to run the E2E tests against
@@ -32,12 +30,8 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             echo GIT_REF=$(tail -n 1 /tmp/artifacts/metadata.txt) >> $GITHUB_OUTPUT
-            echo MOST_RECENT_TAG=$(git describe --abbrev=0 --tags) >> $GITHUB_OUTPUT
-            echo COMMITS_AFTER_TAG=$(git describe --tags | cut -d '-' -f 2) >> $GITHUB_OUTPUT
           else
             echo GIT_REF="" >> $GITHUB_OUTPUT
-            echo MOST_RECENT_TAG="" >> $GITHUB_OUTPUT
-            echo COMMITS_AFTER_TAG="" >> $GITHUB_OUTPUT
           fi
   e2e:
     needs: [resolve-git-ref]


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This adds in the git ref and cluster name into all metrics so that we can differentiate all metrics by run.
It also adds in the mostRecentTag and commitsAfterTag so that users can aggregate off of the most recent tag or use the commitsAfterTag to isolate different commits.

**How was this change tested?**
- karpenter snapshot

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
