### PR TITLE
docs: Update provisioners.md doc for Cilium start taints

### DIFF
--- a/website/content/en/docs/concepts/provisioners.md
+++ b/website/content/en/docs/concepts/provisioners.md
@@ -465,7 +465,7 @@ In order for a pod to run on a node defined in this provisioner, it must tolerat
 
 ### Cilium Startup Taint
 
-Per the Cilium [docs](https://docs.cilium.io/en/stable/gettingstarted/taints/),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5

--- a/website/content/en/preview/concepts/provisioners.md
+++ b/website/content/en/preview/concepts/provisioners.md
@@ -465,7 +465,7 @@ In order for a pod to run on a node defined in this provisioner, it must tolerat
 
 ### Cilium Startup Taint
 
-Per the Cilium [docs](https://docs.cilium.io/en/stable/gettingstarted/taints/),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5

--- a/website/content/en/v0.26/concepts/provisioners.md
+++ b/website/content/en/v0.26/concepts/provisioners.md
@@ -454,7 +454,7 @@ In order for a pod to run on a node defined in this provisioner, it must tolerat
 
 ### Cilium Startup Taint
 
-Per the Cilium [docs](https://docs.cilium.io/en/stable/gettingstarted/taints/),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5

--- a/website/content/en/v0.27/concepts/provisioners.md
+++ b/website/content/en/v0.27/concepts/provisioners.md
@@ -464,7 +464,7 @@ In order for a pod to run on a node defined in this provisioner, it must tolerat
 
 ### Cilium Startup Taint
 
-Per the Cilium [docs](https://docs.cilium.io/en/stable/gettingstarted/taints/),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5

--- a/website/content/en/v0.28/concepts/provisioners.md
+++ b/website/content/en/v0.28/concepts/provisioners.md
@@ -465,7 +465,7 @@ In order for a pod to run on a node defined in this provisioner, it must tolerat
 
 ### Cilium Startup Taint
 
-Per the Cilium [docs](https://docs.cilium.io/en/stable/gettingstarted/taints/),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
+Per the Cilium [docs](https://docs.cilium.io/en/stable/installation/taints/#taint-effects),  it's recommended to place a taint of `node.cilium.io/agent-not-ready=true:NoExecute` on nodes to allow Cilium to configure networking prior to other pods starting.  This can be accomplished via the use of Karpenter `startupTaints`.  These taints are placed on the node, but pods aren't required to tolerate these taints to be considered for provisioning.
 
 ```yaml
 apiVersion: karpenter.sh/v1alpha5


### PR DESCRIPTION
**Description**
Cilium start taints documentation link was broken, this commit adds the updated doc link.

**How was this change tested?**
Just a markdown change, link manually tested.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
