### PR TITLE
fix: Use paginated result for `DescribeInstancesPagesWithContext`

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -145,8 +145,8 @@ func (p *Provider) Get(ctx context.Context, id string) (*Instance, error) {
 }
 
 func (p *Provider) List(ctx context.Context) ([]*Instance, error) {
-	// Use the machine name data to determine which instances match this machine
-	out, err := p.ec2api.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{
+	var out = &ec2.DescribeInstancesOutput{}
+	err := p.ec2api.DescribeInstancesPagesWithContext(ctx, &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag-key"),
@@ -158,6 +158,9 @@ func (p *Provider) List(ctx context.Context) ([]*Instance, error) {
 			},
 			instanceStateFilter,
 		},
+	}, func(page *ec2.DescribeInstancesOutput, _ bool) bool {
+		out.Reservations = append(out.Reservations, page.Reservations...)
+		return true
 	})
 	if err != nil {
 		return nil, fmt.Errorf("describing ec2 instances, %w", err)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- The cloudprovider list call used `DescribeInstancesWithContext` which wouldn't handle paginated results appropriately
- This change uses the proper `DescribeInstancesPagesWithContext` to handle the paginated results.

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
