### PR TITLE
docs: Fix node `apiVersion` in annotation example

### DIFF
--- a/website/content/en/docs/concepts/deprovisioning.md
+++ b/website/content/en/docs/concepts/deprovisioning.md
@@ -232,7 +232,7 @@ This annotation will have no effect for static pods, pods that tolerate `NoSched
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 
 ```yaml
-apiVersion: karpenter.sh/v1alpha5
+apiVersion: v1
 kind: Node
 metadata:
   annotations:

--- a/website/content/en/preview/concepts/deprovisioning.md
+++ b/website/content/en/preview/concepts/deprovisioning.md
@@ -232,7 +232,7 @@ This annotation will have no effect for static pods, pods that tolerate `NoSched
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 
 ```yaml
-apiVersion: karpenter.sh/v1alpha5
+apiVersion: v1
 kind: Node
 metadata:
   annotations:

--- a/website/content/en/v0.26/concepts/deprovisioning.md
+++ b/website/content/en/v0.26/concepts/deprovisioning.md
@@ -191,7 +191,7 @@ This annotation will have no effect for static pods, pods that tolerate `NoSched
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 
 ```yaml
-apiVersion: karpenter.sh/v1alpha5
+apiVersion: v1
 kind: Node
 metadata:
   annotations:

--- a/website/content/en/v0.27/concepts/deprovisioning.md
+++ b/website/content/en/v0.27/concepts/deprovisioning.md
@@ -193,7 +193,7 @@ This annotation will have no effect for static pods, pods that tolerate `NoSched
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 
 ```yaml
-apiVersion: karpenter.sh/v1alpha5
+apiVersion: v1
 kind: Node
 metadata:
   annotations:

--- a/website/content/en/v0.28/concepts/deprovisioning.md
+++ b/website/content/en/v0.28/concepts/deprovisioning.md
@@ -232,7 +232,7 @@ This annotation will have no effect for static pods, pods that tolerate `NoSched
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 
 ```yaml
-apiVersion: karpenter.sh/v1alpha5
+apiVersion: v1
 kind: Node
 metadata:
   annotations:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4144 

**Description**

- The Node annotation example for deprovisioning was erroneously set to `karpenter.sh/v1alpha5` when it should have been set to `v1` from the Kubernetes `core/v1` api package.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
