### PR TITLE
docs: Add `PermittedResourceTagKeys` as parameter to CF

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -49,20 +49,14 @@ runs:
       # Update the Cloudformation policy to add the permissionBoundary to the NodeRole
       yq -i '.Resources.KarpenterNodeRole.Properties.PermissionsBoundary="arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"' $CLOUDFORMATION_PATH
       
-      # Iterate through the policy and add more permissive tagging for tests to succeed
-      # There are various tests that add more tags than are permitted by the default policy
-      EXTRA_TAGS=""
-      for TAG in "TestTag" "example.com\/tag" "custom-tag" "custom-tag2"; do
-        EXTRA_TAGS="$EXTRA_TAGS\n                    \"$TAG\","
-      done
-      sed -i "s/\"aws:TagKeys\": \[/\"aws:TagKeys\": \[$EXTRA_TAGS/" "$CLOUDFORMATION_PATH"
-      
       aws iam create-service-linked-role --aws-service-name spot.amazonaws.com || true
       aws cloudformation deploy \
         --stack-name iam-${{ inputs.cluster_name }} \
         --template-file $CLOUDFORMATION_PATH \
         --capabilities CAPABILITY_NAMED_IAM \
-        --parameter-overrides "ClusterName=${{ inputs.cluster_name }}" \
+        --parameter-overrides \
+        "ClusterName=${{ inputs.cluster_name }}" \
+        "PermittedResourceTagKeys=TestTag,example.com/tag,custom-tag,custom-tag2" \
         --tags "testing.karpenter.sh/type=e2e" "github.com/run-url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
   - name: create or upgrade cluster
     shell: bash

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -4,6 +4,12 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
+  PermittedResourceTagKeys:
+    Type: CommaDelimitedList
+    Description: "Additional permitted tag keys to allow Karpenter to launch resources with"
+Conditions:
+  # Checks if the user specified any tag keys by comparing with the empty string
+  HasUserTagKeys: !Not [!Equals [!Join ['', !Ref PermittedResourceTagKeys], '']]
 Resources:
   KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
@@ -37,214 +43,225 @@ Resources:
       ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
       # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
       # value in one of its key parameters which isn't natively supported by CloudFormation
-      PolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "AllowScopedEC2InstanceActions",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ]
-            },
-            {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+      PolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AllowScopedEC2InstanceActions",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ]
+              },
+              {
+                "Sid": "AllowScopedEC2LaunchTemplateActions",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+                "Action": "ec2:CreateLaunchTemplate",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedEC2InstanceActionsWithTags",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedEC2InstanceActionsWithTags",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedResourceCreationTagging",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "ec2:CreateAction": [
-                    "RunInstances",
-                    "CreateFleet",
-                    "CreateLaunchTemplate"
-                  ]
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedResourceCreationTagging",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "ec2:CreateAction": [
+                      "RunInstances",
+                      "CreateFleet",
+                      "CreateLaunchTemplate"
+                    ]
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowMachineMigrationTagging",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "karpenter.sh/provisioner-name",
-                    "karpenter.sh/managed-by"
-                  ]
+              },
+              {
+                "Sid": "AllowMachineMigrationTagging",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "karpenter.sh/provisioner-name",
+                      "karpenter.sh/managed-by"
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedDeletion",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:TerminateInstances",
-                "ec2:DeleteLaunchTemplate"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+              },
+              {
+                "Sid": "AllowScopedDeletion",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:TerminateInstances",
+                  "ec2:DeleteLaunchTemplate"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowRegionalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeLaunchTemplates",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSpotPriceHistory",
-                "ec2:DescribeSubnets"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestedRegion": "${AWS::Region}"
+              },
+              {
+                "Sid": "AllowRegionalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "ec2:DescribeAvailabilityZones",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceTypeOfferings",
+                  "ec2:DescribeInstanceTypes",
+                  "ec2:DescribeLaunchTemplates",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeSpotPriceHistory",
+                  "ec2:DescribeSubnets"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "${AWS::Region}"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowGlobalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
-            },
-            {
-              "Sid": "AllowInterruptionQueueActions",
-              "Effect": "Allow",
-              "Resource": "${KarpenterInterruptionQueue.Arn}",
-              "Action": [
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-                "sqs:ReceiveMessage"
-              ]
-            },
-            {
-              "Sid": "AllowPassingInstanceRole",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
-              "Action": "iam:PassRole",
-              "Condition": {
-                "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+              },
+              {
+                "Sid": "AllowGlobalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "pricing:GetProducts",
+                  "ssm:GetParameter"
+                ]
+              },
+              {
+                "Sid": "AllowInterruptionQueueActions",
+                "Effect": "Allow",
+                "Resource": "${KarpenterInterruptionQueue.Arn}",
+                "Action": [
+                  "sqs:DeleteMessage",
+                  "sqs:GetQueueAttributes",
+                  "sqs:GetQueueUrl",
+                  "sqs:ReceiveMessage"
+                ]
+              },
+              {
+                "Sid": "AllowPassingInstanceRole",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+                "Action": "iam:PassRole",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PassedToService": "ec2.amazonaws.com"
+                  }
                 }
+              },
+              {
+                "Sid": "AllowAPIServerEndpointDiscovery",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+                "Action": "eks:DescribeCluster"
               }
-            },
-            {
-              "Sid": "AllowAPIServerEndpointDiscovery",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
-              "Action": "eks:DescribeCluster"
-            }
-          ]
-        }
+            ]
+          }
+        # Add user-specified tag keys to the controller policy to allow more permissive resource tagging by Karpenter
+        - UserTagKeys: !If
+            - HasUserTagKeys
+            - !Sub
+              - ',"${Tags}"'
+              - Tags: !Join ['","', !Ref "PermittedResourceTagKeys"]
+            - ""
   KarpenterInterruptionQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -4,6 +4,12 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
+  PermittedResourceTagKeys:
+    Type: CommaDelimitedList
+    Description: "Additional permitted tag keys to allow Karpenter to launch resources with"
+Conditions:
+  # Checks if the user specified any tag keys by comparing with the empty string
+  HasUserTagKeys: !Not [!Equals [!Join ['', !Ref PermittedResourceTagKeys], '']]
 Resources:
   KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
@@ -37,214 +43,225 @@ Resources:
       ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
       # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
       # value in one of its key parameters which isn't natively supported by CloudFormation
-      PolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "AllowScopedEC2InstanceActions",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ]
-            },
-            {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+      PolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AllowScopedEC2InstanceActions",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ]
+              },
+              {
+                "Sid": "AllowScopedEC2LaunchTemplateActions",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+                "Action": "ec2:CreateLaunchTemplate",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedEC2InstanceActionsWithTags",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedEC2InstanceActionsWithTags",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedResourceCreationTagging",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "ec2:CreateAction": [
-                    "RunInstances",
-                    "CreateFleet",
-                    "CreateLaunchTemplate"
-                  ]
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedResourceCreationTagging",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "ec2:CreateAction": [
+                      "RunInstances",
+                      "CreateFleet",
+                      "CreateLaunchTemplate"
+                    ]
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowMachineMigrationTagging",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "karpenter.sh/provisioner-name",
-                    "karpenter.sh/managed-by"
-                  ]
+              },
+              {
+                "Sid": "AllowMachineMigrationTagging",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "karpenter.sh/provisioner-name",
+                      "karpenter.sh/managed-by"
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedDeletion",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:TerminateInstances",
-                "ec2:DeleteLaunchTemplate"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+              },
+              {
+                "Sid": "AllowScopedDeletion",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:TerminateInstances",
+                  "ec2:DeleteLaunchTemplate"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowRegionalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeLaunchTemplates",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSpotPriceHistory",
-                "ec2:DescribeSubnets"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestedRegion": "${AWS::Region}"
+              },
+              {
+                "Sid": "AllowRegionalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "ec2:DescribeAvailabilityZones",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceTypeOfferings",
+                  "ec2:DescribeInstanceTypes",
+                  "ec2:DescribeLaunchTemplates",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeSpotPriceHistory",
+                  "ec2:DescribeSubnets"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "${AWS::Region}"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowGlobalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
-            },
-            {
-              "Sid": "AllowInterruptionQueueActions",
-              "Effect": "Allow",
-              "Resource": "${KarpenterInterruptionQueue.Arn}",
-              "Action": [
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-                "sqs:ReceiveMessage"
-              ]
-            },
-            {
-              "Sid": "AllowPassingInstanceRole",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
-              "Action": "iam:PassRole",
-              "Condition": {
-                "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+              },
+              {
+                "Sid": "AllowGlobalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "pricing:GetProducts",
+                  "ssm:GetParameter"
+                ]
+              },
+              {
+                "Sid": "AllowInterruptionQueueActions",
+                "Effect": "Allow",
+                "Resource": "${KarpenterInterruptionQueue.Arn}",
+                "Action": [
+                  "sqs:DeleteMessage",
+                  "sqs:GetQueueAttributes",
+                  "sqs:GetQueueUrl",
+                  "sqs:ReceiveMessage"
+                ]
+              },
+              {
+                "Sid": "AllowPassingInstanceRole",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+                "Action": "iam:PassRole",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PassedToService": "ec2.amazonaws.com"
+                  }
                 }
+              },
+              {
+                "Sid": "AllowAPIServerEndpointDiscovery",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+                "Action": "eks:DescribeCluster"
               }
-            },
-            {
-              "Sid": "AllowAPIServerEndpointDiscovery",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
-              "Action": "eks:DescribeCluster"
-            }
-          ]
-        }
+            ]
+          }
+        # Add user-specified tag keys to the controller policy to allow more permissive resource tagging by Karpenter
+        - UserTagKeys: !If
+            - HasUserTagKeys
+            - !Sub
+              - ',"${Tags}"'
+              - Tags: !Join ['","', !Ref "PermittedResourceTagKeys"]
+            - ""
   KarpenterInterruptionQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/website/content/en/v0.26/getting-started/getting-started-with-eksctl/cloudformation.yaml
+++ b/website/content/en/v0.26/getting-started/getting-started-with-eksctl/cloudformation.yaml
@@ -4,6 +4,12 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
+  PermittedResourceTagKeys:
+    Type: CommaDelimitedList
+    Description: "Additional permitted tag keys to allow Karpenter to launch resources with"
+Conditions:
+  # Checks if the user specified any tag keys by comparing with the empty string
+  HasUserTagKeys: !Not [!Equals [!Join ['', !Ref PermittedResourceTagKeys], '']]
 Resources:
   KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
@@ -11,7 +17,7 @@ Resources:
       InstanceProfileName: !Sub "KarpenterNodeInstanceProfile-${ClusterName}"
       Path: "/"
       Roles:
-        - Ref: "KarpenterNodeRole"
+        - !Ref "KarpenterNodeRole"
   KarpenterNodeRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -35,48 +41,227 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Resource: "*"
-            Action:
-              # Write Operations
-              - ec2:CreateFleet
-              - ec2:CreateLaunchTemplate
-              - ec2:CreateTags
-              - ec2:DeleteLaunchTemplate
-              - ec2:RunInstances
-              - ec2:TerminateInstances
-              # Read Operations
-              - ec2:DescribeAvailabilityZones
-              - ec2:DescribeImages
-              - ec2:DescribeInstances
-              - ec2:DescribeInstanceTypeOfferings
-              - ec2:DescribeInstanceTypes
-              - ec2:DescribeLaunchTemplates
-              - ec2:DescribeSecurityGroups
-              - ec2:DescribeSpotPriceHistory
-              - ec2:DescribeSubnets
-              - pricing:GetProducts
-              - ssm:GetParameter
-          - Effect: Allow
-            Action:
-              # Write Operations
-              - sqs:DeleteMessage
-              # Read Operations
-              - sqs:GetQueueAttributes
-              - sqs:GetQueueUrl
-              - sqs:ReceiveMessage
-            Resource: !GetAtt KarpenterInterruptionQueue.Arn
-          - Effect: Allow
-            Action:
-              - iam:PassRole
-            Resource: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}"
-          - Effect: Allow
-            Action:
-              - eks:DescribeCluster
-            Resource: !Sub "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}"
+      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+      # value in one of its key parameters which isn't natively supported by CloudFormation
+      PolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AllowScopedEC2InstanceActions",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ]
+              },
+              {
+                "Sid": "AllowScopedEC2LaunchTemplateActions",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+                "Action": "ec2:CreateLaunchTemplate",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
+                }
+              },
+              {
+                "Sid": "AllowScopedEC2InstanceActionsWithTags",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}"
+                      ${UserTagKeys}
+                    ]
+                  }
+                }
+              },
+              {
+                "Sid": "AllowScopedResourceCreationTagging",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "ec2:CreateAction": [
+                      "RunInstances",
+                      "CreateFleet",
+                      "CreateLaunchTemplate"
+                    ]
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
+                }
+              },
+              {
+                "Sid": "AllowMachineMigrationTagging",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "karpenter.sh/provisioner-name",
+                      "karpenter.sh/managed-by"
+                    ]
+                  }
+                }
+              },
+              {
+                "Sid": "AllowScopedDeletion",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:TerminateInstances",
+                  "ec2:DeleteLaunchTemplate"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                  }
+                }
+              },
+              {
+                "Sid": "AllowRegionalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "ec2:DescribeAvailabilityZones",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceTypeOfferings",
+                  "ec2:DescribeInstanceTypes",
+                  "ec2:DescribeLaunchTemplates",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeSpotPriceHistory",
+                  "ec2:DescribeSubnets"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "${AWS::Region}"
+                  }
+                }
+              },
+              {
+                "Sid": "AllowGlobalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "pricing:GetProducts",
+                  "ssm:GetParameter"
+                ]
+              },
+              {
+                "Sid": "AllowInterruptionQueueActions",
+                "Effect": "Allow",
+                "Resource": "${KarpenterInterruptionQueue.Arn}",
+                "Action": [
+                  "sqs:DeleteMessage",
+                  "sqs:GetQueueAttributes",
+                  "sqs:GetQueueUrl",
+                  "sqs:ReceiveMessage"
+                ]
+              },
+              {
+                "Sid": "AllowPassingInstanceRole",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+                "Action": "iam:PassRole",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PassedToService": "ec2.amazonaws.com"
+                  }
+                }
+              },
+              {
+                "Sid": "AllowAPIServerEndpointDiscovery",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+                "Action": "eks:DescribeCluster"
+              }
+            ]
+          }
+        # Add user-specified tag keys to the controller policy to allow more permissive resource tagging by Karpenter
+        - UserTagKeys: !If
+            - HasUserTagKeys
+            - !Sub
+              - ',"${Tags}"'
+              - Tags: !Join ['","', !Ref "PermittedResourceTagKeys"]
+            - ""
   KarpenterInterruptionQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/website/content/en/v0.27/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.27/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -4,6 +4,12 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
+  PermittedResourceTagKeys:
+    Type: CommaDelimitedList
+    Description: "Additional permitted tag keys to allow Karpenter to launch resources with"
+Conditions:
+  # Checks if the user specified any tag keys by comparing with the empty string
+  HasUserTagKeys: !Not [!Equals [!Join ['', !Ref PermittedResourceTagKeys], '']]
 Resources:
   KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
@@ -37,214 +43,225 @@ Resources:
       ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
       # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
       # value in one of its key parameters which isn't natively supported by CloudFormation
-      PolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "AllowScopedEC2InstanceActions",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ]
-            },
-            {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+      PolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AllowScopedEC2InstanceActions",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ]
+              },
+              {
+                "Sid": "AllowScopedEC2LaunchTemplateActions",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+                "Action": "ec2:CreateLaunchTemplate",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedEC2InstanceActionsWithTags",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedEC2InstanceActionsWithTags",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedResourceCreationTagging",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "ec2:CreateAction": [
-                    "RunInstances",
-                    "CreateFleet",
-                    "CreateLaunchTemplate"
-                  ]
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedResourceCreationTagging",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "ec2:CreateAction": [
+                      "RunInstances",
+                      "CreateFleet",
+                      "CreateLaunchTemplate"
+                    ]
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowMachineMigrationTagging",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "karpenter.sh/provisioner-name",
-                    "karpenter.sh/managed-by"
-                  ]
+              },
+              {
+                "Sid": "AllowMachineMigrationTagging",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "karpenter.sh/provisioner-name",
+                      "karpenter.sh/managed-by"
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedDeletion",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:TerminateInstances",
-                "ec2:DeleteLaunchTemplate"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+              },
+              {
+                "Sid": "AllowScopedDeletion",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:TerminateInstances",
+                  "ec2:DeleteLaunchTemplate"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowRegionalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeLaunchTemplates",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSpotPriceHistory",
-                "ec2:DescribeSubnets"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestedRegion": "${AWS::Region}"
+              },
+              {
+                "Sid": "AllowRegionalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "ec2:DescribeAvailabilityZones",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceTypeOfferings",
+                  "ec2:DescribeInstanceTypes",
+                  "ec2:DescribeLaunchTemplates",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeSpotPriceHistory",
+                  "ec2:DescribeSubnets"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "${AWS::Region}"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowGlobalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
-            },
-            {
-              "Sid": "AllowInterruptionQueueActions",
-              "Effect": "Allow",
-              "Resource": "${KarpenterInterruptionQueue.Arn}",
-              "Action": [
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-                "sqs:ReceiveMessage"
-              ]
-            },
-            {
-              "Sid": "AllowPassingInstanceRole",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
-              "Action": "iam:PassRole",
-              "Condition": {
-                "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+              },
+              {
+                "Sid": "AllowGlobalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "pricing:GetProducts",
+                  "ssm:GetParameter"
+                ]
+              },
+              {
+                "Sid": "AllowInterruptionQueueActions",
+                "Effect": "Allow",
+                "Resource": "${KarpenterInterruptionQueue.Arn}",
+                "Action": [
+                  "sqs:DeleteMessage",
+                  "sqs:GetQueueAttributes",
+                  "sqs:GetQueueUrl",
+                  "sqs:ReceiveMessage"
+                ]
+              },
+              {
+                "Sid": "AllowPassingInstanceRole",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+                "Action": "iam:PassRole",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PassedToService": "ec2.amazonaws.com"
+                  }
                 }
+              },
+              {
+                "Sid": "AllowAPIServerEndpointDiscovery",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+                "Action": "eks:DescribeCluster"
               }
-            },
-            {
-              "Sid": "AllowAPIServerEndpointDiscovery",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
-              "Action": "eks:DescribeCluster"
-            }
-          ]
-        }
+            ]
+          }
+        # Add user-specified tag keys to the controller policy to allow more permissive resource tagging by Karpenter
+        - UserTagKeys: !If
+            - HasUserTagKeys
+            - !Sub
+              - ',"${Tags}"'
+              - Tags: !Join ['","', !Ref "PermittedResourceTagKeys"]
+            - ""
   KarpenterInterruptionQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/website/content/en/v0.28/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.28/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -4,6 +4,12 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
+  PermittedResourceTagKeys:
+    Type: CommaDelimitedList
+    Description: "Additional permitted tag keys to allow Karpenter to launch resources with"
+Conditions:
+  # Checks if the user specified any tag keys by comparing with the empty string
+  HasUserTagKeys: !Not [!Equals [!Join ['', !Ref PermittedResourceTagKeys], '']]
 Resources:
   KarpenterNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
@@ -37,214 +43,225 @@ Resources:
       ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
       # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
       # value in one of its key parameters which isn't natively supported by CloudFormation
-      PolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "AllowScopedEC2InstanceActions",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ]
-            },
-            {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+      PolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "AllowScopedEC2InstanceActions",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ]
+              },
+              {
+                "Sid": "AllowScopedEC2LaunchTemplateActions",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+                "Action": "ec2:CreateLaunchTemplate",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedEC2InstanceActionsWithTags",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedEC2InstanceActionsWithTags",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                ],
+                "Action": [
+                  "ec2:RunInstances",
+                  "ec2:CreateFleet"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedResourceCreationTagging",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "ec2:CreateAction": [
-                    "RunInstances",
-                    "CreateFleet",
-                    "CreateLaunchTemplate"
-                  ]
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "Name",
-                    "karpenter.sh/managed-by",
-                    "karpenter.sh/provisioner-name",
-                    "kubernetes.io/cluster/${ClusterName}",
-                    "karpenter.k8s.aws/cluster"
-                  ]
+              },
+              {
+                "Sid": "AllowScopedResourceCreationTagging",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "ec2:CreateAction": [
+                      "RunInstances",
+                      "CreateFleet",
+                      "CreateLaunchTemplate"
+                    ]
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "Name",
+                      "karpenter.sh/managed-by",
+                      "karpenter.sh/provisioner-name",
+                      "kubernetes.io/cluster/${ClusterName}",
+                      "karpenter.k8s.aws/cluster"
+                      ${UserTagKeys}
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowMachineMigrationTagging",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "karpenter.sh/provisioner-name",
-                    "karpenter.sh/managed-by"
-                  ]
+              },
+              {
+                "Sid": "AllowMachineMigrationTagging",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "Action": "ec2:CreateTags",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                    "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
+                  },
+                  "StringLike": {
+                    "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  },
+                  "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                      "karpenter.sh/provisioner-name",
+                      "karpenter.sh/managed-by"
+                    ]
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowScopedDeletion",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:TerminateInstances",
-                "ec2:DeleteLaunchTemplate"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+              },
+              {
+                "Sid": "AllowScopedDeletion",
+                "Effect": "Allow",
+                "Resource": [
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                  "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+                ],
+                "Action": [
+                  "ec2:TerminateInstances",
+                  "ec2:DeleteLaunchTemplate"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                  },
+                  "StringLike": {
+                    "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowRegionalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeLaunchTemplates",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSpotPriceHistory",
-                "ec2:DescribeSubnets"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestedRegion": "${AWS::Region}"
+              },
+              {
+                "Sid": "AllowRegionalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "ec2:DescribeAvailabilityZones",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceTypeOfferings",
+                  "ec2:DescribeInstanceTypes",
+                  "ec2:DescribeLaunchTemplates",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeSpotPriceHistory",
+                  "ec2:DescribeSubnets"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "${AWS::Region}"
+                  }
                 }
-              }
-            },
-            {
-              "Sid": "AllowGlobalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
-            },
-            {
-              "Sid": "AllowInterruptionQueueActions",
-              "Effect": "Allow",
-              "Resource": "${KarpenterInterruptionQueue.Arn}",
-              "Action": [
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-                "sqs:ReceiveMessage"
-              ]
-            },
-            {
-              "Sid": "AllowPassingInstanceRole",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
-              "Action": "iam:PassRole",
-              "Condition": {
-                "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
+              },
+              {
+                "Sid": "AllowGlobalReadActions",
+                "Effect": "Allow",
+                "Resource": "*",
+                "Action": [
+                  "pricing:GetProducts",
+                  "ssm:GetParameter"
+                ]
+              },
+              {
+                "Sid": "AllowInterruptionQueueActions",
+                "Effect": "Allow",
+                "Resource": "${KarpenterInterruptionQueue.Arn}",
+                "Action": [
+                  "sqs:DeleteMessage",
+                  "sqs:GetQueueAttributes",
+                  "sqs:GetQueueUrl",
+                  "sqs:ReceiveMessage"
+                ]
+              },
+              {
+                "Sid": "AllowPassingInstanceRole",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+                "Action": "iam:PassRole",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PassedToService": "ec2.amazonaws.com"
+                  }
                 }
+              },
+              {
+                "Sid": "AllowAPIServerEndpointDiscovery",
+                "Effect": "Allow",
+                "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+                "Action": "eks:DescribeCluster"
               }
-            },
-            {
-              "Sid": "AllowAPIServerEndpointDiscovery",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
-              "Action": "eks:DescribeCluster"
-            }
-          ]
-        }
+            ]
+          }
+        # Add user-specified tag keys to the controller policy to allow more permissive resource tagging by Karpenter
+        - UserTagKeys: !If
+            - HasUserTagKeys
+            - !Sub
+              - ',"${Tags}"'
+              - Tags: !Join ['","', !Ref "PermittedResourceTagKeys"]
+            - ""
   KarpenterInterruptionQueue:
     Type: AWS::SQS::Queue
     Properties:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Allow users to specify the paramter `PermittedResourceTagKeys" which gives the KarpenterControllerPolicy the list of permitted instance tag keys it is allowed to tag 

**How was this change tested?**

`aws cloudformation deploy --stack-name "Karpenter-joinnis-karpenter-demo" --template-file ./website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml --capabilities CAPABILITY_NAMED_IAM --parameter-overrid
es "ClusterName=joinnis-karpenter-demo" "PermittedResourceTagKeys=TestTag,example.com/tag,custom-tag,custom-tag2"`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
