### PR TITLE
test: Remove `DeleteAllOf` and bump client-side QPS

### DIFF
--- a/test/pkg/environment/aws/setup.go
+++ b/test/pkg/environment/aws/setup.go
@@ -19,15 +19,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/utils/functional"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 )
 
 var persistedSettings *v1.ConfigMap
 
 var (
-	CleanableObjects = []functional.Pair[client.Object, client.ObjectList]{
-		{First: &v1alpha1.AWSNodeTemplate{}, Second: &v1alpha1.AWSNodeTemplateList{}},
+	CleanableObjects = []client.Object{
+		&v1alpha1.AWSNodeTemplate{},
 	}
 )
 

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	coreapis "github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/utils/project"
@@ -80,7 +81,9 @@ func NewEnvironment(t *testing.T) *Environment {
 
 func NewConfig() *rest.Config {
 	config := controllerruntime.GetConfigOrDie()
-	config.UserAgent = fmt.Sprintf("testing.karpenter.sh-%s", project.Version)
+	config.UserAgent = fmt.Sprintf("%s-%s", v1alpha5.TestingGroup, project.Version)
+	config.QPS = 1e6
+	config.Burst = 1e6
 	return config
 }
 

--- a/test/suites/machine/machine_test.go
+++ b/test/suites/machine/machine_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
-	"github.com/aws/karpenter-core/pkg/utils/functional"
 	"github.com/aws/karpenter-core/pkg/utils/resources"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -44,10 +43,6 @@ var _ = Describe("StandaloneMachine", func() {
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 		}})
-	})
-	// For standalone machines, there is no Provisioner owner, so we just list all machines and delete them all
-	AfterEach(func() {
-		env.CleanupObjects(functional.Pair[client.Object, client.ObjectList]{First: &v1alpha5.Machine{}, Second: &v1alpha5.MachineList{}})
 	})
 	It("should create a standard machine within the 'c' instance family", func() {
 		machine := test.Machine(v1alpha5.Machine{

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), func() {
 		// Get the DS pod count and use it to calculate the DS pod overhead
 		dsCount = env.GetDaemonSetCount(provisioner)
 	})
-	It("should scale successfully on a node-dense scale-up", func(_ context.Context) {
+	It("should scale successfully on a node-dense scale-up", Label(debug.NoEvents), func(_ context.Context) {
 		// Disable Prefix Delegation for the node-dense scale-up to not exhaust the IPs
 		// This is required because of the number of Warm ENIs that will be created and the number of IPs
 		// that will be allocated across this large number of nodes, despite the fact that the ENI CIDR space will


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

`DeleteAllOf` calls were timing out in the case of pod deletions due to the scale of pods that were trying to be deleted in a single call. 60s wasn't sufficient time for all the pods to have their `DeletionTimestamps` set. 

**How was this change tested?**

- `/karpenter snapshot`
- Manual testing of Provisioning Scale Testing

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
