### PR TITLE
docs: Add karpenter working group call link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Karpenter improves the efficiency and cost of running workloads on Kubernetes cl
 * **Provisioning** nodes that meet the requirements of the pods
 * **Removing** the nodes when the nodes are no longer needed
 
-Come discuss Karpenter in the [#karpenter](https://kubernetes.slack.com/archives/C02SFFZSA2K) channel in the [Kubernetes slack](https://slack.k8s.io/)!
+Come discuss Karpenter in the [#karpenter](https://kubernetes.slack.com/archives/C02SFFZSA2K) channel in the [Kubernetes slack](https://slack.k8s.io/) or join the [Karpenter working group](https://karpenter.sh/docs/contributing/working-group/) bi-weekly calls.
 
 Check out the [Docs](https://karpenter.sh/) to learn more.
 


### PR DESCRIPTION

Fixes: N/A

**Description**
Added link to karpenter working group call to readme to increase visibility.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
