### PR TITLE
test: Move metric relabeling to service monitor layer

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -36,20 +36,28 @@ runs:
   - name: install-karpenter
     shell: bash
     run: |
-      aws eks update-kubeconfig --name ${{ inputs.cluster_name }}
+      aws eks update-kubeconfig --name "${{ inputs.cluster_name }}"
       helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter \
         -n karpenter \
-        --version v0-$(git rev-parse HEAD) \
+        --version "v0-$(git rev-parse HEAD)" \
         --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/karpenter-irsa-${{ inputs.cluster_name }}" \
-        --set settings.aws.clusterName=${{ inputs.cluster_name }} \
-        --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${{ inputs.cluster_name }} \
-        --set settings.aws.interruptionQueueName=${{ inputs.cluster_name }} \
+        --set settings.aws.clusterName="${{ inputs.cluster_name }}" \
+        --set settings.aws.defaultInstanceProfile="KarpenterNodeInstanceProfile-${{ inputs.cluster_name }}" \
+        --set settings.aws.interruptionQueueName="${{ inputs.cluster_name }}" \
         --set controller.resources.requests.cpu=3 \
         --set controller.resources.requests.memory=3Gi \
         --set controller.resources.limits.cpu=3 \
         --set controller.resources.limits.memory=3Gi \
         --set serviceMonitor.enabled=true \
         --set serviceMonitor.additionalLabels.scrape=enabled \
+        --set "serviceMonitor.endpointConfig.relabelings[0].targetLabel=clusterName" \
+        --set "serviceMonitor.endpointConfig.relabelings[0].replacement=${{ inputs.cluster_name }}" \
+        --set "serviceMonitor.endpointConfig.relabelings[1].targetLabel=gitRef" \
+        --set "serviceMonitor.endpointConfig.relabelings[1].replacement=$(git rev-parse HEAD)" \
+        --set "serviceMonitor.endpointConfig.relabelings[2].targetLabel=mostRecentTag" \
+        --set "serviceMonitor.endpointConfig.relabelings[2].replacement=$(git describe --abbrev=0 --tags)" \
+        --set "serviceMonitor.endpointConfig.relabelings[3].targetLabel=commitsAfterTag" \
+        --set "serviceMonitor.endpointConfig.relabelings[3].replacement=\"$(git describe --tags | cut -d '-' -f 2)\"" \
         --wait
   - name: diff-karpenter
     shell: bash

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -43,11 +43,4 @@ runs:
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}" \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[0].target_label=clusterName \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[0].replacement=${{ inputs.cluster_name }} \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[1].target_label=gitRef \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[1].replacement=$(git rev-parse HEAD) \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[2].target_label=mostRecentTag \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[2].replacement=$(git describe --abbrev=0 --tags) \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[3].target_label=commitsAfterTag \
-          --set prometheus.prometheusSpec.additionalScrapeConfigs[0].relabel_configs[3].replacement=$(git describe --tags | cut -d '-' -f 2)
+          --wait

--- a/.github/actions/e2e/install-prometheus/values.yaml
+++ b/.github/actions/e2e/install-prometheus/values.yaml
@@ -53,10 +53,3 @@ prometheus:
           maxSamplesPerSend: 1000
           maxShards: 200
           capacity: 2500
-    additionalScrapeConfigs:
-    - job_name: karpenter
-      kubernetes_sd_configs:
-      - role: endpoints
-        namespaces:
-          names:
-          - karpenter


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Move metric relabelings that add additional info to the metrics into the `ServiceMonitor`
- Reduces metric duplication between both performing a separate scrape job and using the servicemonitor for service discovery

**How was this change tested?**

`make apply` on local cluster

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
