### PR TITLE
Remove mutating webhook that doesn't do anything

### DIFF
--- a/charts/karpenter/templates/webhooks.yaml
+++ b/charts/karpenter/templates/webhooks.yaml
@@ -20,17 +20,6 @@ webhooks:
     sideEffects: None
     rules:
       - apiGroups:
-          - karpenter.k8s.aws
-        apiVersions:
-          - v1alpha1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - awsnodetemplates
-          - awsnodetemplates/status
-        scope: '*'
-      - apiGroups:
           - karpenter.sh
         apiVersions:
           - v1alpha5


### PR DESCRIPTION
Fixes 
Remove mutating webhook that isn't doing anything for awsnodetemplates

Description
Currently node template doesn't have any side effects in setDefaults https://github.com/aws/karpenter/blob/86229e15ba129992b5829b14a580bcded0d5f2fb/pkg/apis/v1alpha1/awsnodetemplate_defaults.go#L22. To reduce unnecessary components and calls to Karpenter we should remove this rule.

Move metric relabelings that add additional info to the metrics into the ServiceMonitor
How was this change tested?
Ran helm template locally against the new webhook template. Mutating webhook new configuration looks like: (without defaulting against awsnodetemplates
```
---
# Source: karpenter/templates/webhooks.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  name: defaulting.webhook.karpenter.k8s.aws
  labels:
    helm.sh/chart: karpenter-0.28.0
    app.kubernetes.io/name: karpenter
    app.kubernetes.io/instance: karpenter
    app.kubernetes.io/version: "0.28.0"
    app.kubernetes.io/managed-by: Helm
webhooks:
  - name: defaulting.webhook.karpenter.k8s.aws
    admissionReviewVersions: ["v1"]
    clientConfig:
      service:
        name: karpenter
        namespace: karpenter
        port: 8443
    failurePolicy: Fail
    sideEffects: None
    rules:
      - apiGroups:
          - karpenter.sh
        apiVersions:
          - v1alpha5
        resources:
          - provisioners
          - provisioners/status
        operations:
          - CREATE
          - UPDATE
---
```


make apply on local cluster

Does this change impact docs?
No. I don't believe there are docs regarding this defaulting behavior 

[] Yes, PR includes docs updates
[] Yes, issue opened: #
 No
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.