### PR TITLE
fix: eksctl version v0.147.0

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -37,6 +37,8 @@ runs:
     with:
       ref: ${{ inputs.git_ref }}
   - uses: ./.github/actions/e2e/install-eksctl
+    with:
+      eksctl_version: v0.147.0
   - name: create iam policies
     shell: bash
     run: |

--- a/.github/actions/e2e/install-eksctl/action.yaml
+++ b/.github/actions/e2e/install-eksctl/action.yaml
@@ -1,5 +1,9 @@
 name: InstallEKSCTL
 description: 'Installs eksctl'
+inputs:
+  eksctl_version:
+    description: "Version of EKSCTL to use for the launched cluster"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -8,9 +12,9 @@ runs:
         # for ARM systems, set ARCH to: `arm64`, `armv6` or `armv7`
         ARCH=amd64
         PLATFORM=$(uname -s)_$ARCH
-        curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
+        curl -sLO "https://github.com/weaveworks/eksctl/releases/download/${{ inputs.eksctl_version }}/eksctl_$PLATFORM.tar.gz"
 
         # (Optional) Verify checksum
-        curl -sL "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
+        curl -sL "https://github.com/weaveworks/eksctl/releases/download/${{ inputs.eksctl_version }}/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
         tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
         sudo mv /tmp/eksctl /usr/local/bin


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Need to pin eksctl to v0.147.0
- v0.148.0 is failing on e2etest runs
- 
**How was this change tested?**
- manually tested

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
