### PR TITLE
fix: Add support for CFS quota field in Bottlerocket

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bottlerocket.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocket.go
@@ -74,6 +74,9 @@ func (b Bottlerocket) Script() (string, error) {
 		if b.KubeletConfig.ImageGCLowThresholdPercent != nil {
 			s.Settings.Kubernetes.ImageGCLowThresholdPercent = lo.ToPtr(strconv.FormatInt(int64(*b.KubeletConfig.ImageGCLowThresholdPercent), 10))
 		}
+		if b.KubeletConfig.CPUCFSQuota != nil {
+			s.Settings.Kubernetes.CPUCFSQuota = b.KubeletConfig.CPUCFSQuota
+		}
 	}
 
 	s.Settings.Kubernetes.NodeTaints = map[string][]string{}

--- a/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
+++ b/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go
@@ -70,6 +70,7 @@ type BottlerocketKubernetes struct {
 	TopologyManagerScope        *string                          `toml:"topology-manager-scope,omitempty"`
 	ImageGCHighThresholdPercent *string                          `toml:"image-gc-high-threshold-percent,omitempty"`
 	ImageGCLowThresholdPercent  *string                          `toml:"image-gc-low-threshold-percent,omitempty"`
+	CPUCFSQuota                 *bool                            `toml:"cpu-cfs-quota-enforced,omitempty"`
 }
 
 type BottlerocketStaticPod struct {


### PR DESCRIPTION
**Description**
Adds support to set the cfs quota field and have it passed through to Bottlerocket config. Currently `spec.kubeletConfiguration.cpuCFSQuota: false` is ignored on Bottlerocket hosts.

**How was this change tested?**
Deployed this image into a test cluster - this meant when `spec.kubeletConfiguration.cpuCFSQuota: false` was set this properly was fed down to the Kubelet on a Bottlerocket host.

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
