### PR TITLE
test: Correct naming of IAM CF action to `WriteRecords`

### DIFF
--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -226,7 +226,7 @@ Resources:
                 aws:RequestedRegion: 
                   Ref: Regions
           - Effect: Allow
-            Action: timestream:WriteMetrics
+            Action: timestream:WriteRecords
             Resource: !Sub "arn:${AWS::Partition}:timestream:${AWS::Region}:${AWS::AccountId}:database/${DatabaseName}/table/${TableName}"
           - Effect: Allow
             Action: timestream:DescribeEndpoints


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Correct naming of IAM CloudFormation policy to use `timestream:WriteRecords`

**How was this change tested?**

- Updated IAM policy manually and validated docs

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
