### PR TITLE
ci: Conformance tests should run on Sunday evenings

### DIFF
--- a/.github/workflows/e2e-conformance-trigger.yaml
+++ b/.github/workflows/e2e-conformance-trigger.yaml
@@ -1,7 +1,8 @@
 name: E2EConformanceTrigger
 on:
   schedule:
-    - cron: '7 22 * * 1'
+    # The test will run every Monday at 12:07 AM UTC
+    - cron: '7 0 * * 1'
   workflow_dispatch:
 jobs:
   conformance:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Conformance tests should run every Sunday Evening, so that the E2E tests can be reviewed for karpenter ops meeting

**How was this change tested?**
- Manually tested

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
