### PR TITLE
docs: Add "ci:" to PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,10 +1,11 @@
 <!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
 feat:            <-- New features that require a MINOR version update
 fix:             <-- Bug fixes that require at PATCH version update
-docs:            <-- Documentation change that does not impact code
-chore:           <-- Metadata changes such as dependency update or configuration files
-test:            <-- Test changes that do not impact behavior
+chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
 perf:            <-- Code changes that improve performance but do not impact behavior
+docs:            <-- Documentation changes that do not impact code
+test:            <-- Test changes that do not impact behavior
+ci:              <-- Changes that affect test or rollout automation
 !${type}:        <-- Include ! if your change includes a backwards incompatible change.
 -->
 
@@ -15,8 +16,8 @@ Fixes #N/A <!-- issue number -->
 **How was this change tested?**
 
 **Does this change impact docs?**
-- [] Yes, PR includes docs updates
-- [] Yes, issue opened: # <!-- issue number -->
+- [ ] Yes, PR includes docs updates
+- [ ] Yes, issue opened: # <!-- issue number -->
 - [x] No
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Add "ci:" option to PR template
- Reorder existing suggestions
- Update some of the description lingo for existing suggestions

**How was this change tested?**

**Does this change impact docs?**
- [] Yes, PR includes docs updates
- [] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
