### PR TITLE
chore: Adding AWSNodeTemplate Hash Annotation

### DIFF
--- a/pkg/apis/v1alpha1/awsnodetemplate.go
+++ b/pkg/apis/v1alpha1/awsnodetemplate.go
@@ -15,6 +15,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -79,7 +82,7 @@ type AWSNodeTemplateSpec struct {
 	AWS      `json:",inline"`
 	// AMISelector discovers AMIs to be used by Amazon EC2 tags.
 	// +optional
-	AMISelector map[string]string `json:"amiSelector,omitempty"`
+	AMISelector map[string]string `json:"amiSelector,omitempty" hash:"ignore"`
 	// DetailedMonitoring controls if detailed monitoring is enabled for instances that are launched
 	// +optional
 	DetailedMonitoring *bool `json:"detailedMonitoring,omitempty"`
@@ -95,6 +98,16 @@ type AWSNodeTemplate struct {
 
 	Spec   AWSNodeTemplateSpec   `json:"spec,omitempty"`
 	Status AWSNodeTemplateStatus `json:"status,omitempty"`
+}
+
+func (a *AWSNodeTemplate) Hash() string {
+	hash, _ := hashstructure.Hash(a.Spec, hashstructure.FormatV2, &hashstructure.HashOptions{
+		SlicesAsSets:    true,
+		IgnoreZeroValue: true,
+		ZeroNil:         true,
+	})
+
+	return fmt.Sprint(hash)
 }
 
 // AWSNodeTemplateList contains a list of AWSNodeTemplate

--- a/pkg/apis/v1alpha1/provider.go
+++ b/pkg/apis/v1alpha1/provider.go
@@ -24,7 +24,7 @@ import (
 type AWS struct {
 	// TypeMeta includes version and kind of the extensions, inferred if not provided.
 	// +optional
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:",inline" hash:"ignore"`
 	// AMIFamily is the AMI family that instances use.
 	// +optional
 	AMIFamily *string `json:"amiFamily,omitempty"`
@@ -37,10 +37,10 @@ type AWS struct {
 	InstanceProfile *string `json:"instanceProfile,omitempty"`
 	// SubnetSelector discovers subnets by tags. A value of "" is a wildcard.
 	// +optional
-	SubnetSelector map[string]string `json:"subnetSelector,omitempty"`
+	SubnetSelector map[string]string `json:"subnetSelector,omitempty" hash:"ignore"`
 	// SecurityGroups specify the names of the security groups.
 	// +optional
-	SecurityGroupSelector map[string]string `json:"securityGroupSelector,omitempty"`
+	SecurityGroupSelector map[string]string `json:"securityGroupSelector,omitempty" hash:"ignore"`
 	// Tags to be applied on ec2 resources like instances and launch templates.
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
@@ -53,7 +53,7 @@ type LaunchTemplate struct {
 	// NOTE: This field is for specifying a custom launch template and is exposed in the Spec
 	// as `launchTemplate` for backwards compatibility.
 	// +optional
-	LaunchTemplateName *string `json:"launchTemplate,omitempty"`
+	LaunchTemplateName *string `json:"launchTemplate,omitempty" hash:"ignore"`
 	// MetadataOptions for the generated launch template of provisioned nodes.
 	//
 	// This specifies the exposure of the Instance Metadata Service to

--- a/pkg/apis/v1alpha1/register.go
+++ b/pkg/apis/v1alpha1/register.go
@@ -107,6 +107,7 @@ var (
 	LabelInstanceAcceleratorName              = LabelDomain + "/instance-accelerator-name"
 	LabelInstanceAcceleratorManufacturer      = LabelDomain + "/instance-accelerator-manufacturer"
 	LabelInstanceAcceleratorCount             = LabelDomain + "/instance-accelerator-count"
+	AnnotationNodeTemplateHash                = LabelDomain + "/nodetemplate-hash"
 )
 
 var (

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -101,7 +101,11 @@ func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (
 	instanceType, _ := lo.Find(instanceTypes, func(i *cloudprovider.InstanceType) bool {
 		return i.Name == instance.Type
 	})
-	return c.instanceToMachine(instance, instanceType), nil
+	m := c.instanceToMachine(instance, instanceType)
+	m.Annotations = lo.Assign(m.Annotations, map[string]string{
+		v1alpha1.AnnotationNodeTemplateHash: nodeTemplate.Hash(),
+	})
+	return m, nil
 }
 
 // Link adds a tag to the cloudprovider machine to tell the cloudprovider that it's now owned by a Machine

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -161,6 +161,14 @@ var _ = Describe("CloudProvider", func() {
 		Expect(corecloudproivder.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(cloudProviderMachine).To(BeNil())
 	})
+	It("should return AWSNodetemplate Hash on the machine", func() {
+		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate, machine)
+		cloudProviderMachine, err := cloudProvider.Create(ctx, machine)
+		Expect(err).To(BeNil())
+		Expect(cloudProviderMachine).ToNot(BeNil())
+		_, ok := cloudProviderMachine.ObjectMeta.Annotations[v1alpha1.AnnotationNodeTemplateHash]
+		Expect(ok).To(BeTrue())
+	})
 	Context("Defaulting", func() {
 		// Intent here is that if updates occur on the provisioningController, the Provisioner doesn't need to be recreated
 		It("should not set the InstanceProfile with the default if none provided in Provisioner", func() {

--- a/website/content/en/preview/concepts/deprovisioning.md
+++ b/website/content/en/preview/concepts/deprovisioning.md
@@ -172,7 +172,8 @@ Read the [Drift Design](https://github.com/aws/karpenter-core/pull/366/files) fo
 | Subnet Selector            |        |    x    |            |      x      |
 | Security Group Selector    |        |    x    |            |      x      |
 | Instance Profile           |    x   |         |            |             |
-| AMI Family/AMI Selector    |        |    x    |            |      x      |
+  AMI Family                 |    x   |         |            |             |
+| AMI Selector               |        |    x    |            |      x      |
 | UserData                   |    x   |         |            |             |
 | Tags                       |    x   |         |            |             |
 | Metadata Options           |    x   |         |            |             |


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Karpenter will create a provisioner hash of the fields that the team considers to be statically drifted
- The will contain the values of each of those fields

**How was this change tested?**
- `make battletest`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.