### PR TITLE
ci: Fix dirty commit on release

### DIFF
--- a/hack/release/release.sh
+++ b/hack/release/release.sh
@@ -8,12 +8,14 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "${SCRIPT_DIR}/common.sh"
 
 config
-release $HEAD_HASH #release a snapshot version
-## Reset changes if it's a snapshot since we don't need to track these changes
+release "$HEAD_HASH" #release a snapshot version
+
+## Reset and Clean changes if it's a snapshot since we don't need to track these changes
 ## and results in a -dirty commit hash for a stable release
 git reset --hard
+git clean -qdxf
 
-if [[ $(releaseType $GIT_TAG) == $RELEASE_TYPE_STABLE ]]; then
-  release $GIT_TAG
+if [[ $(releaseType "$GIT_TAG") == "$RELEASE_TYPE_STABLE" ]]; then
+  release "$GIT_TAG"
 fi
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #3711 

**Description**

Karpenter has been running dirty commits on release for some time. These dirty commits existed because the [`pullPrivateReplica`](https://github.com/aws/karpenter/blob/main/hack/release/common.sh#L115) function would result in untracked files from the `helm pull` operation. These files can be removed with a `git clean` operation after the `git reset --hard`

### Untracked Files Example

```console
➜  karpenter git:(test-release) ✗ git status
On branch test-release

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        karpenter-crd-v0-cfb942221f59593b96a1a6203028bc20765dd08b.tgz
        karpenter-v0-cfb942221f59593b96a1a6203028bc20765dd08b.tgz
```

### Clean Commit After `git clean`

```console
➜  karpenter git:(test-release) ✗ make install
Upgrading to v0-34d50bf6b02e72096dc6ff6dcdc8b8f52d6a437b
helm upgrade --install karpenter oci://public.ecr.aws/t0c5x4i1/karpenter/karpenter --version v0.0.7-test --namespace karpenter \
                --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::330700974597:role/joinnis-karpenter-demo-karpenter --set settings.aws.clusterName=joinnis-karpenter-demo --set settings.aws.clusterEndpoint=https://A24630863CE1DF01CBE617512CEBD669.gr7.us-west-2.eks.amazonaws.com --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-joinnis-karpenter-demo --set settings.aws.interruptionQueueName=joinnis-karpenter-demo --set settings.featureGates.driftEnabled=true --set controller.resources.requests.cpu=1 --set controller.resources.requests.memory=1Gi --set controller.resources.limits.cpu=1 --set controller.resources.limits.memory=1Gi --create-namespace
Release "karpenter" has been upgraded. Happy Helming!


➜  karpenter git:(test-release) ✗ k logs -n karpenter karpenter-754c7b988d-5xnwl
2023-07-20T08:01:22.660Z        DEBUG   Successfully created the logger.
2023-07-20T08:01:22.660Z        DEBUG   Logging level set to: debug
2023-07-20T08:01:25.384Z        DEBUG   controller      discovered region       {"commit": "2dd10bc", "region": "us-west-2"}
2023-07-20T08:01:25.384Z        DEBUG   controller      discovered cluster endpoint     {"commit": "2dd10bc", "cluster-endpoint": "https://A24630863CE1DF01CBE617512CEBD669.gr7.us-west-2.eks.amazonaws.com"}
2023-07-20T08:01:25.388Z        DEBUG   controller      discovered kube dns     {"commit": "2dd10bc", "kube-dns-ip": "10.100.0.10"}
2023-07-20T08:01:25.389Z        DEBUG   controller      discovered version      {"commit": "2dd10bc", "version": "v0.0.7-test"}
2023-07-20T08:01:25.389Z        DEBUG   controller      Registering 1 clients   {"commit": "2dd10bc"}
2023-07-20T08:01:25.389Z        DEBUG   controller      Registering 2 informer factories        {"commit": "2dd10bc"}
2023-07-20T08:01:25.389Z        DEBUG   controller      Registering 3 informers {"commit": "2dd10bc"}
2023-07-20T08:01:25.389Z        DEBUG   controller      Registering 5 controllers       {"commit": "2dd10bc"}
2023-07-20T08:01:25.390Z        INFO    controller      Starting server {"commit": "2dd10bc", "path": "/metrics", "kind": "metrics", "addr": "[::]:8000"}
2023-07-20T08:01:25.390Z        INFO    controller      Starting server {"commit": "2dd10bc", "kind": "health probe", "addr": "[::]:8081"}
2023-07-20T08:01:25.490Z        INFO    controller      attempting to acquire leader lease karpenter/karpenter-leader-election...
```

**How was this change tested?**

- Published release versions to personal ECR repo and validated clean, tagged commit

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.