### PR TITLE
chore:Add default securityContext and podSecurityContext to Karpenter deployment #4278

### DIFF
--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -33,6 +33,7 @@ runs:
     run: |
       kubectl create ns karpenter || true
       kubectl label ns karpenter scrape=enabled --overwrite=true
+      kubectl label ns karpenter pod-security.kubernetes.io/enforce=restricted --overwrite=true
   - name: install-karpenter
     shell: bash
     run: |

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -45,10 +45,6 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.metrics.port | int | `8000` | The container port to use for metrics. |
 | controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
 | controller.resources | object | `{}` | Resources for the controller pod. |
-| controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | SecurityContext for the container. |
-| controller.securityContext.allowPrivilegeEscalation | bool | `false` | Disabling privilege escalation for the container. |
-| controller.securityContext.capabilities | object | `{"drop":["ALL"]}` | Dropping all capabilities for the container. |
-| controller.securityContext.readOnlyRootFilesystem | bool | `true` | Set root filesystem to read only for the container. |
 | controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |
 | controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
@@ -66,12 +62,6 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podDisruptionBudget.name | string | `"karpenter"` |  |
 | podLabels | object | `{}` | Additional labels for the pod. |
-| podSecurityContext | object | `{"fsGroup":65536,"runAsGroup":65536,"runAsNonRoot":true,"runAsUser":65536,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext for the pod. |
-| podSecurityContext.fsGroup | int | `65536` | The group to assign as owner for files created in volumeMounts. |
-| podSecurityContext.runAsGroup | int | `65536` | The group to run all containers as. |
-| podSecurityContext.runAsNonRoot | bool | `true` | Enforce that all containers run as non-root. |
-| podSecurityContext.runAsUser | int | `65536` | The user to run all containers as. |
-| podSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | SeccompProfile for all containers. |
 | priorityClassName | string | `"system-cluster-critical"` | PriorityClass name for the pod. |
 | replicas | int | `2` | Number of replicas. |
 | revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback. |

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -45,7 +45,10 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | controller.metrics.port | int | `8000` | The container port to use for metrics. |
 | controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
 | controller.resources | object | `{}` | Resources for the controller pod. |
-| controller.securityContext | object | `{}` | SecurityContext for the controller container. |
+| controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | SecurityContext for the container. |
+| controller.securityContext.allowPrivilegeEscalation | bool | `false` | Disabling privilege escalation for the container. |
+| controller.securityContext.capabilities | object | `{"drop":["ALL"]}` | Dropping all capabilities for the container. |
+| controller.securityContext.readOnlyRootFilesystem | bool | `true` | Set root filesystem to read only for the container. |
 | controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |
 | controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts |
 | dnsConfig | object | `{}` | Configure DNS Config for the pod |
@@ -63,7 +66,12 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podDisruptionBudget.name | string | `"karpenter"` |  |
 | podLabels | object | `{}` | Additional labels for the pod. |
-| podSecurityContext | object | `{"fsGroup":1000}` | SecurityContext for the pod. |
+| podSecurityContext | object | `{"fsGroup":65536,"runAsGroup":65536,"runAsNonRoot":true,"runAsUser":65536,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext for the pod. |
+| podSecurityContext.fsGroup | int | `65536` | The group to assign as owner for files created in volumeMounts. |
+| podSecurityContext.runAsGroup | int | `65536` | The group to run all containers as. |
+| podSecurityContext.runAsNonRoot | bool | `true` | Enforce that all containers run as non-root. |
+| podSecurityContext.runAsUser | int | `65536` | The user to run all containers as. |
+| podSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | SeccompProfile for all containers. |
 | priorityClassName | string | `"system-cluster-critical"` | PriorityClass name for the pod. |
 | replicas | int | `2` | Number of replicas. |
 | revisionHistoryLimit | int | `10` | The number of old ReplicaSets to retain to allow rollback. |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -37,10 +37,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "karpenter.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        fsGroup: 65536
+        runAsUser: 65536
+        runAsGroup: 65536
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -59,10 +62,12 @@ spec:
       {{- end }}
       containers:
         - name: controller
-          {{- with .Values.controller.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           image: {{ include "karpenter.controller.image" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -44,19 +44,6 @@ podAnnotations: {}
 podDisruptionBudget:
   name: karpenter
   maxUnavailable: 1
-# -- SecurityContext for the pod.
-podSecurityContext:
-  # -- The group to assign as owner for files created in volumeMounts.
-  fsGroup: 65536
-  # -- The user to run all containers as.
-  runAsUser: 65536
-  # -- The group to run all containers as.
-  runAsGroup: 65536
-  # -- Enforce that all containers run as non-root.
-  runAsNonRoot: true
-  # -- SeccompProfile for all containers.
-  seccompProfile:
-    type: RuntimeDefault
 # -- PriorityClass name for the pod.
 priorityClassName: system-cluster-critical
 # -- Override the default termination grace period for the pod.
@@ -112,16 +99,6 @@ controller:
     tag: v0.30.0-rc.0
     # -- SHA256 digest of the controller image.
     digest: sha256:06f08a2c9b5125a2da57936a5ccfb54e5796677e247fb0bb960e70e79242a147
-  # -- SecurityContext for the container.
-  securityContext:
-    # -- Disabling privilege escalation for the container.
-    allowPrivilegeEscalation: false
-    # -- Dropping all capabilities for the container.
-    capabilities:
-      drop:
-      - ALL
-    # -- Set root filesystem to read only for the container.
-    readOnlyRootFilesystem: true
   # -- Additional environment variables for the controller pod.
   env: []
   # - name: AWS_REGION

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -46,9 +46,17 @@ podDisruptionBudget:
   maxUnavailable: 1
 # -- SecurityContext for the pod.
 podSecurityContext:
-  fsGroup: 1000
-  runAsUser: 1000
-  runAsGroup: 1000
+  # -- The group to assign as owner for files created in volumeMounts.
+  fsGroup: 65536
+  # -- The user to run all containers as.
+  runAsUser: 65536
+  # -- The group to run all containers as.
+  runAsGroup: 65536
+  # -- Enforce that all containers run as non-root.
+  runAsNonRoot: true
+  # -- SeccompProfile for all containers.
+  seccompProfile:
+    type: RuntimeDefault
 # -- PriorityClass name for the pod.
 priorityClassName: system-cluster-critical
 # -- Override the default termination grace period for the pod.
@@ -101,24 +109,19 @@ controller:
     # -- Repository path to the controller image.
     repository: public.ecr.aws/karpenter/controller
     # -- Tag of the controller image.
-    tag: v0.29.1
+    tag: v0.30.0-rc.0
     # -- SHA256 digest of the controller image.
-    digest: sha256:973fb8353ce6b0b0181bd48dab0eb41549da9b5411f60421356c8894408bcfe4
-  # -- SecurityContext for the controller container.
+    digest: sha256:06f08a2c9b5125a2da57936a5ccfb54e5796677e247fb0bb960e70e79242a147
+  # -- SecurityContext for the container.
   securityContext:
-    # -- Disabling Privileged Escalation for Controller Container
+    # -- Disabling privilege escalation for the container.
     allowPrivilegeEscalation: false
-    # -- Dropping all capabilities of the controller container
+    # -- Dropping all capabilities for the container.
     capabilities:
       drop:
       - ALL
-    # -- Set root filesystem to read only
+    # -- Set root filesystem to read only for the container.
     readOnlyRootFilesystem: true
-    # -- Set the container to run as Non Root
-    runAsNonRoot: true
-    # -- Set SeccomProfile for the controller container
-    seccompProfile:
-      type: RuntimeDefault
   # -- Additional environment variables for the controller pod.
   env: []
   # - name: AWS_REGION

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -103,7 +103,20 @@ controller:
     # -- SHA256 digest of the controller image.
     digest: sha256:06f08a2c9b5125a2da57936a5ccfb54e5796677e247fb0bb960e70e79242a147
   # -- SecurityContext for the controller container.
-  securityContext: {}
+  securityContext:
+    # -- Disabling Privileged Escalation for Controller Container
+    allowPrivilegeEscalation: false
+    # -- Dropping all capabilities of the controller container
+    capabilities:
+      drop:
+      - ALL
+    # -- Set root filesystem to read only
+    readOnlyRootFilesystem: true
+    # -- Set the container to run as Non Root
+    runAsNonRoot: true
+    # -- Set SeccomProfile for the controller container
+    seccompProfile:
+      type: RuntimeDefault
   # -- Additional environment variables for the controller pod.
   env: []
   # - name: AWS_REGION

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -47,6 +47,8 @@ podDisruptionBudget:
 # -- SecurityContext for the pod.
 podSecurityContext:
   fsGroup: 1000
+  runAsUser: 1000
+  runAsGroup: 1000
 # -- PriorityClass name for the pod.
 priorityClassName: system-cluster-critical
 # -- Override the default termination grace period for the pod.
@@ -99,9 +101,9 @@ controller:
     # -- Repository path to the controller image.
     repository: public.ecr.aws/karpenter/controller
     # -- Tag of the controller image.
-    tag: v0.30.0-rc.0
+    tag: v0.29.1
     # -- SHA256 digest of the controller image.
-    digest: sha256:06f08a2c9b5125a2da57936a5ccfb54e5796677e247fb0bb960e70e79242a147
+    digest: sha256:973fb8353ce6b0b0181bd48dab0eb41549da9b5411f60421356c8894408bcfe4
   # -- SecurityContext for the controller container.
   securityContext:
     # -- Disabling Privileged Escalation for Controller Container


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4278 

**Description**
This change is to set the default securityContext for controller pod within the Helm chart values file to enforce secure by default.

**How was this change tested?**
Tried scaling the pods and Karpenter was able to provision the new nodes as expected.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.