### PR TITLE
website: fix ref to v0.26 prometheus and grafana

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -71,6 +71,7 @@ params:
     - v0.29
     - v0.28
     - v0.27
+    - v0.26
     - preview
 menu:
   main:

--- a/website/content/en/v0.26/getting-started/getting-started-with-eksctl/scripts/step09-add-prometheus-grafana.sh
+++ b/website/content/en/v0.26/getting-started/getting-started-with-eksctl/scripts/step09-add-prometheus-grafana.sh
@@ -4,8 +4,8 @@ helm repo update
 
 kubectl create namespace monitoring
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/prometheus-values.yaml | tee prometheus-values.yaml
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-eksctl/prometheus-values.yaml | tee prometheus-values.yaml
 helm install --namespace monitoring prometheus prometheus-community/prometheus --values prometheus-values.yaml
 
-curl -fsSL https://raw.githubusercontent.com/aws/karpenter/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/grafana-values.yaml | tee grafana-values.yaml
+curl -fsSL https://raw.githubusercontent.com/aws/karpenter/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-eksctl/grafana-values.yaml | tee grafana-values.yaml
 helm install --namespace monitoring grafana grafana-charts/grafana --values grafana-values.yaml


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4319

**Description**
v0.26 has a different name for the getting started guides. Rectifying this so that it refers to an actual manifest file.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.