### PR TITLE
ci: Add more exempt PR labels from Stalebot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -21,7 +21,7 @@ jobs:
           stale-issue-label: 'lifecycle/stale'
           close-issue-label: 'lifecycle/closed'
           stale-pr-message: 'This PR has been inactive for 14 days. StaleBot will close this stale PR after 14 more days of inactivity.'
-          exempt-pr-labels: 'blocked'
+          exempt-pr-labels: 'blocked,needs-review,needs-design'
           stale-pr-label: 'lifecycle/stale'
           close-pr-label: 'lifecycle/closed'
           days-before-stale: 14


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Adds the `needs-review` and `needs-design` PR labels to be ignored by the stalebot

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.