### PR TITLE
ci: Add relabelings to kubelet serviceMonitor

### DIFF
--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -43,4 +43,12 @@ runs:
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}" \
+          --set "kubelet.serviceMonitor.relabelings[0].targetLabel=clusterName" \
+          --set "kubelet.serviceMonitor.relabelings[0].replacement=${{ inputs.cluster_name }}" \
+          --set "kubelet.serviceMonitor.relabelings[1].targetLabel=gitRef" \
+          --set "kubelet.serviceMonitor.relabelings[1].replacement=$(git rev-parse HEAD)" \
+          --set "kubelet.serviceMonitor.relabelings[2].targetLabel=mostRecentTag" \
+          --set "kubelet.serviceMonitor.relabelings[2].replacement=$(git describe --abbrev=0 --tags)" \
+          --set "kubelet.serviceMonitor.relabelings[3].targetLabel=commitsAfterTag" \
+          --set "kubelet.serviceMonitor.relabelings[3].replacement=\"$(git describe --tags | cut -d '-' -f 2)\"" \
           --wait


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Add relabelings to add additional details into the kubelet serviceMonitor scraping
- Currently, only the karpenter serviceMonitor has these labelings

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.