### PR TITLE
docs: Update step08-apply-helm-chart.sh

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
@@ -1,6 +1,9 @@
 # Logout of helm registry to perform an unauthenticated pull against the public ECR
 helm registry logout public.ecr.aws
 
+# Set context to the newly created cluster.
+aws eks update-kubeconfig --name ${CLUSTER_NAME} --region ${AWS_DEFAULT_REGION}
+
 helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set settings.aws.clusterName=${CLUSTER_NAME} \

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
@@ -1,6 +1,9 @@
 # Logout of helm registry to perform an unauthenticated pull against the public ECR
 helm registry logout public.ecr.aws
 
+# Set context to the newly created cluster.
+aws eks update-kubeconfig --name ${CLUSTER_NAME} --region ${AWS_DEFAULT_REGION}
+
 helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set settings.aws.clusterName=${CLUSTER_NAME} \

--- a/website/content/en/v0.26/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/v0.26/getting-started/getting-started-with-eksctl/scripts/step08-apply-helm-chart.sh
@@ -1,4 +1,8 @@
 docker logout public.ecr.aws
+
+# Set context to the newly created cluster.
+aws eks update-kubeconfig --name ${CLUSTER_NAME} --region ${AWS_DEFAULT_REGION}
+
 helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set settings.aws.clusterName=${CLUSTER_NAME} \

--- a/website/content/en/v0.27/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/v0.27/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
@@ -1,6 +1,9 @@
 # Logout of docker to perform an unauthenticated pull against the public ECR
 docker logout public.ecr.aws
 
+# Set context to the newly created cluster.
+aws eks update-kubeconfig --name ${CLUSTER_NAME} --region ${AWS_DEFAULT_REGION}
+
 helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set settings.aws.clusterName=${CLUSTER_NAME} \

--- a/website/content/en/v0.28/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/v0.28/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
@@ -1,6 +1,9 @@
 # Logout of helm registry to perform an unauthenticated pull against the public ECR
 helm registry logout public.ecr.aws
 
+# Set context to the newly created cluster.
+aws eks update-kubeconfig --name ${CLUSTER_NAME} --region ${AWS_DEFAULT_REGION}
+
 helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set settings.aws.clusterName=${CLUSTER_NAME} \

--- a/website/content/en/v0.29/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
+++ b/website/content/en/v0.29/getting-started/getting-started-with-karpenter/scripts/step08-apply-helm-chart.sh
@@ -1,6 +1,9 @@
 # Logout of helm registry to perform an unauthenticated pull against the public ECR
 helm registry logout public.ecr.aws
 
+# Set context to the newly created cluster.
+aws eks update-kubeconfig --name ${CLUSTER_NAME} --region ${AWS_DEFAULT_REGION}
+
 helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
   --set settings.aws.clusterName=${CLUSTER_NAME} \


### PR DESCRIPTION
**Problem**:
Once you run the helm command, you will see the following error if your kubectl context is set to the previously created cluster.

```cli
Error: Kubernetes cluster unreachable: Get "https://<cluster-id>.gr7.us-west-2.eks.amazonaws.com/version": dial tcp: lookup <cluster-id>.gr7.us-west-2.eks.amazonaws.com: no such host
```


**Solution**:
You need to update the cluster context in kubeconfig file to the newly created cluster in the last step.
```cli
# Set context to the newly created cluster.
aws eks update-kubeconfig --name ${CLUSTER_NAME} --region ${AWS_DEFAULT_REGION}
```

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.