### PR TITLE
feat: LaunchTemplate Drift

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -38,6 +38,7 @@ func main() {
 		op.AMIProvider,
 		op.SecurityGroupProvider,
 		op.SubnetProvider,
+		op.LaunchTemplateProvider,
 	)
 	lo.Must0(op.AddHealthzCheck("cloud-provider", awsCloudProvider.LivenessProbe))
 	cloudProvider := metrics.Decorate(awsCloudProvider)
@@ -65,6 +66,7 @@ func main() {
 			op.SecurityGroupProvider,
 			op.PricingProvider,
 			op.AMIProvider,
+			op.LaunchTemplateProvider,
 		)...).
 		WithWebhooks(ctx, webhooks.NewWebhooks()...).
 		Start(ctx)

--- a/designs/node-upgrades.md
+++ b/designs/node-upgrades.md
@@ -6,6 +6,8 @@ Karpenter users are requesting for Node Upgrades, generally asking for [more com
 
 For the initial implementation, Karpenter's drift will reconcile when a node's AMI drifts from provisioning requirements. This mechanism will be scalable to other methods of drift reconciliation in the future. Addtionally, Karpenter can implement Imperative Upgrades or Maintenance Windows in the future.
 
+Since the initial version, drift detection has been added for subnet drift, security group drift and launch template drift.
+
 This document will answer the following questions:
 
 * How will Karpenter upgrade nodes?
@@ -122,7 +124,7 @@ PDBs, the `do-not-evict` pod annotation, and other finalizers are ways that user
 
 ## Which nodes should Karpenter upgrade?
 
-When provisioning a node, Karpenter generates a launch template and fills it with an AMI selected by the `AWSNodeTemplate` `AMISelector`. As hinted above, drifted nodes with AMIs not matching the `AWSNodeTemplate` `AMISelector` will be upgraded.
+When provisioning a node, Karpenter generates a launch template and fills it with an AMI selected by the `AWSNodeTemplate` `AMISelector`. As hinted above, drifted nodes with AMIs, subnets, security groups or launch templates not matching the `AWSNodeTemplate` `AMISelector` will be upgraded.
 
 Karpenter will not upgrade drifted nodes that have the `do-not-evict: true` annotation, [misconfigured PDBs, or blocking PDBs](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/#how-api-initiated-eviction-works). Karpenter's deprovisioning controller will respect this as well.
 

--- a/hack/docs/instancetypes_gen_docs.go
+++ b/hack/docs/instancetypes_gen_docs.go
@@ -87,7 +87,7 @@ func main() {
 		Manager:             &FakeManager{},
 		KubernetesInterface: kubernetes.NewForConfigOrDie(&rest.Config{}),
 	})
-	cp := awscloudprovider.New(op.InstanceTypesProvider, op.InstanceProvider, op.GetClient(), op.AMIProvider, op.SecurityGroupProvider, op.SubnetProvider)
+	cp := awscloudprovider.New(op.InstanceTypesProvider, op.InstanceProvider, op.GetClient(), op.AMIProvider, op.SecurityGroupProvider, op.SubnetProvider, op.LaunchTemplateProvider)
 
 	provider := v1alpha1.AWS{SubnetSelector: map[string]string{
 		"*": "*",

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -43,6 +43,7 @@ import (
 	"github.com/aws/karpenter/pkg/providers/amifamily"
 	"github.com/aws/karpenter/pkg/providers/instance"
 	"github.com/aws/karpenter/pkg/providers/instancetype"
+	"github.com/aws/karpenter/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
 
@@ -59,23 +60,25 @@ func init() {
 var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)
 
 type CloudProvider struct {
-	instanceTypeProvider  *instancetype.Provider
-	instanceProvider      *instance.Provider
-	kubeClient            client.Client
-	amiProvider           *amifamily.Provider
-	securityGroupProvider *securitygroup.Provider
-	subnetProvider        *subnet.Provider
+	instanceTypeProvider   *instancetype.Provider
+	instanceProvider       *instance.Provider
+	kubeClient             client.Client
+	amiProvider            *amifamily.Provider
+	securityGroupProvider  *securitygroup.Provider
+	subnetProvider         *subnet.Provider
+	launchTemplateProvider *launchtemplate.Provider
 }
 
 func New(instanceTypeProvider *instancetype.Provider, instanceProvider *instance.Provider,
-	kubeClient client.Client, amiProvider *amifamily.Provider, securityGroupProvider *securitygroup.Provider, subnetProvider *subnet.Provider) *CloudProvider {
+	kubeClient client.Client, amiProvider *amifamily.Provider, securityGroupProvider *securitygroup.Provider, subnetProvider *subnet.Provider, launchTemplateProvider *launchtemplate.Provider) *CloudProvider {
 	return &CloudProvider{
-		instanceTypeProvider:  instanceTypeProvider,
-		instanceProvider:      instanceProvider,
-		kubeClient:            kubeClient,
-		amiProvider:           amiProvider,
-		securityGroupProvider: securityGroupProvider,
-		subnetProvider:        subnetProvider,
+		instanceTypeProvider:   instanceTypeProvider,
+		instanceProvider:       instanceProvider,
+		kubeClient:             kubeClient,
+		amiProvider:            amiProvider,
+		securityGroupProvider:  securityGroupProvider,
+		subnetProvider:         subnetProvider,
+		launchTemplateProvider: launchTemplateProvider,
 	}
 }
 

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -32,6 +32,7 @@ import (
 	machinelink "github.com/aws/karpenter/pkg/controllers/machine/link"
 	"github.com/aws/karpenter/pkg/controllers/nodetemplate"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
+	"github.com/aws/karpenter/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter/pkg/providers/pricing"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
@@ -42,13 +43,13 @@ import (
 
 func NewControllers(ctx context.Context, sess *session.Session, clk clock.Clock, kubeClient client.Client, recorder events.Recorder,
 	unavailableOfferings *cache.UnavailableOfferings, cloudProvider *cloudprovider.CloudProvider, subnetProvider *subnet.Provider,
-	securityGroupProvider *securitygroup.Provider, pricingProvider *pricing.Provider, amiProvider *amifamily.Provider) []controller.Controller {
+	securityGroupProvider *securitygroup.Provider, pricingProvider *pricing.Provider, amiProvider *amifamily.Provider, launchTemplateProvider *launchtemplate.Provider) []controller.Controller {
 
 	logging.FromContext(ctx).With("version", project.Version).Debugf("discovered version")
 
 	linkController := machinelink.NewController(kubeClient, cloudProvider)
 	controllers := []controller.Controller{
-		nodetemplate.NewController(kubeClient, subnetProvider, securityGroupProvider, amiProvider),
+		nodetemplate.NewController(kubeClient, subnetProvider, securityGroupProvider, amiProvider, launchTemplateProvider),
 		linkController,
 		machinegarbagecollection.NewController(kubeClient, cloudProvider, linkController),
 	}

--- a/pkg/controllers/machine/garbagecollection/suite_test.go
+++ b/pkg/controllers/machine/garbagecollection/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
 	awsEnv = test.NewEnvironment(ctx, env)
-	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider)
+	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider, awsEnv.LaunchTemplateProvider)
 	linkedMachineCache = cache.New(time.Minute*10, time.Second*10)
 	linkController := &link.Controller{
 		Cache: linkedMachineCache,

--- a/pkg/controllers/machine/link/suite_test.go
+++ b/pkg/controllers/machine/link/suite_test.go
@@ -66,7 +66,7 @@ var _ = BeforeSuite(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
 	awsEnv = test.NewEnvironment(ctx, env)
-	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider)
+	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider, awsEnv.LaunchTemplateProvider)
 	linkController = link.NewController(env.Client, cloudProvider)
 })
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodetemplate/controller.go
+++ b/pkg/controllers/nodetemplate/controller.go
@@ -36,6 +36,7 @@ import (
 	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
+	"github.com/aws/karpenter/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
 )
@@ -49,7 +50,7 @@ type Controller struct {
 	amiProvider           *amifamily.Provider
 }
 
-func NewController(kubeClient client.Client, subnetProvider *subnet.Provider, securityGroups *securitygroup.Provider, amiprovider *amifamily.Provider) corecontroller.Controller {
+func NewController(kubeClient client.Client, subnetProvider *subnet.Provider, securityGroups *securitygroup.Provider, amiprovider *amifamily.Provider, launchTemplateProvider *launchtemplate.Provider) corecontroller.Controller {
 	return corecontroller.Typed[*v1alpha1.AWSNodeTemplate](kubeClient, &Controller{
 		kubeClient:            kubeClient,
 		subnetProvider:        subnetProvider,

--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	awsEnv = test.NewEnvironment(ctx, env)
 
-	controller = nodetemplate.NewController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider)
+	controller = nodetemplate.NewController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.LaunchTemplateProvider)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -46,25 +46,27 @@ type CapacityPool struct {
 // EC2Behavior must be reset between tests otherwise tests will
 // pollute each other.
 type EC2Behavior struct {
-	DescribeImagesOutput                AtomicPtr[ec2.DescribeImagesOutput]
-	DescribeLaunchTemplatesOutput       AtomicPtr[ec2.DescribeLaunchTemplatesOutput]
-	DescribeSubnetsOutput               AtomicPtr[ec2.DescribeSubnetsOutput]
-	DescribeSecurityGroupsOutput        AtomicPtr[ec2.DescribeSecurityGroupsOutput]
-	DescribeInstanceTypesOutput         AtomicPtr[ec2.DescribeInstanceTypesOutput]
-	DescribeInstanceTypeOfferingsOutput AtomicPtr[ec2.DescribeInstanceTypeOfferingsOutput]
-	DescribeAvailabilityZonesOutput     AtomicPtr[ec2.DescribeAvailabilityZonesOutput]
-	DescribeSpotPriceHistoryInput       AtomicPtr[ec2.DescribeSpotPriceHistoryInput]
-	DescribeSpotPriceHistoryOutput      AtomicPtr[ec2.DescribeSpotPriceHistoryOutput]
-	CreateFleetBehavior                 MockedFunction[ec2.CreateFleetInput, ec2.CreateFleetOutput]
-	TerminateInstancesBehavior          MockedFunction[ec2.TerminateInstancesInput, ec2.TerminateInstancesOutput]
-	DescribeInstancesBehavior           MockedFunction[ec2.DescribeInstancesInput, ec2.DescribeInstancesOutput]
-	CreateTagsBehavior                  MockedFunction[ec2.CreateTagsInput, ec2.CreateTagsOutput]
-	CalledWithCreateLaunchTemplateInput AtomicPtrSlice[ec2.CreateLaunchTemplateInput]
-	CalledWithDescribeImagesInput       AtomicPtrSlice[ec2.DescribeImagesInput]
-	Instances                           sync.Map
-	LaunchTemplates                     sync.Map
-	InsufficientCapacityPools           atomic.Slice[CapacityPool]
-	NextError                           AtomicError
+	DescribeImagesOutput                 AtomicPtr[ec2.DescribeImagesOutput]
+	DescribeLaunchTemplatesOutput        AtomicPtr[ec2.DescribeLaunchTemplatesOutput]
+	DescribeLaunchTemplateVersionsOutput AtomicPtr[ec2.DescribeLaunchTemplateVersionsOutput]
+	DescribeSubnetsOutput                AtomicPtr[ec2.DescribeSubnetsOutput]
+	DescribeSecurityGroupsOutput         AtomicPtr[ec2.DescribeSecurityGroupsOutput]
+	DescribeInstanceTypesOutput          AtomicPtr[ec2.DescribeInstanceTypesOutput]
+	DescribeInstanceTypeOfferingsOutput  AtomicPtr[ec2.DescribeInstanceTypeOfferingsOutput]
+	DescribeAvailabilityZonesOutput      AtomicPtr[ec2.DescribeAvailabilityZonesOutput]
+	DescribeSpotPriceHistoryInput        AtomicPtr[ec2.DescribeSpotPriceHistoryInput]
+	DescribeSpotPriceHistoryOutput       AtomicPtr[ec2.DescribeSpotPriceHistoryOutput]
+	CreateFleetBehavior                  MockedFunction[ec2.CreateFleetInput, ec2.CreateFleetOutput]
+	TerminateInstancesBehavior           MockedFunction[ec2.TerminateInstancesInput, ec2.TerminateInstancesOutput]
+	DescribeInstancesBehavior            MockedFunction[ec2.DescribeInstancesInput, ec2.DescribeInstancesOutput]
+	CreateTagsBehavior                   MockedFunction[ec2.CreateTagsInput, ec2.CreateTagsOutput]
+	CalledWithCreateLaunchTemplateInput  AtomicPtrSlice[ec2.CreateLaunchTemplateInput]
+	CalledWithDescribeImagesInput        AtomicPtrSlice[ec2.DescribeImagesInput]
+	Instances                            sync.Map
+	LaunchTemplates                      sync.Map
+	LaunchTemplateVersions               sync.Map
+	InsufficientCapacityPools            atomic.Slice[CapacityPool]
+	NextError                            AtomicError
 }
 
 type EC2API struct {
@@ -80,6 +82,7 @@ var DefaultSupportedUsageClasses = aws.StringSlice([]string{"on-demand", "spot"}
 func (e *EC2API) Reset() {
 	e.DescribeImagesOutput.Reset()
 	e.DescribeLaunchTemplatesOutput.Reset()
+	e.DescribeLaunchTemplateVersionsOutput.Reset()
 	e.DescribeSubnetsOutput.Reset()
 	e.DescribeSecurityGroupsOutput.Reset()
 	e.DescribeInstanceTypesOutput.Reset()
@@ -98,6 +101,10 @@ func (e *EC2API) Reset() {
 	})
 	e.LaunchTemplates.Range(func(k, v any) bool {
 		e.LaunchTemplates.Delete(k)
+		return true
+	})
+	e.LaunchTemplateVersions.Range(func(k, v any) bool {
+		e.LaunchTemplateVersions.Delete(k)
 		return true
 	})
 	e.InsufficientCapacityPools.Reset()
@@ -358,6 +365,28 @@ func (e *EC2API) DescribeLaunchTemplatesWithContext(_ context.Context, input *ec
 		return true
 	})
 	if len(output.LaunchTemplates) == 0 {
+		return nil, awserr.New("InvalidLaunchTemplateName.NotFoundException", "not found", nil)
+	}
+	return output, nil
+}
+
+func (e *EC2API) DescribeLaunchTemplateVersionsWithContext(_ context.Context, input *ec2.DescribeLaunchTemplateVersionsInput, _ ...request.Option) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+	if !e.NextError.IsNil() {
+		defer e.NextError.Reset()
+		return nil, e.NextError.Get()
+	}
+	if !e.DescribeLaunchTemplateVersionsOutput.IsNil() {
+		return e.DescribeLaunchTemplateVersionsOutput.Clone(), nil
+	}
+	output := &ec2.DescribeLaunchTemplateVersionsOutput{}
+	e.LaunchTemplateVersions.Range(func(key, value interface{}) bool {
+		launchTemplateVersion := value.(*ec2.LaunchTemplateVersion)
+		if aws.StringValue(input.LaunchTemplateName) == aws.StringValue(launchTemplateVersion.LaunchTemplateName) {
+			output.LaunchTemplateVersions = append(output.LaunchTemplateVersions, launchTemplateVersion)
+		}
+		return true
+	})
+	if len(output.LaunchTemplateVersions) == 0 {
 		return nil, awserr.New("InvalidLaunchTemplateName.NotFoundException", "not found", nil)
 	}
 	return output, nil

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func() {
 	ctx = coresettings.ToContext(ctx, coretest.Settings())
 	ctx = settings.ToContext(ctx, test.Settings())
 	awsEnv = test.NewEnvironment(ctx, env)
-	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider)
+	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider, awsEnv.LaunchTemplateProvider)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -91,7 +91,7 @@ var _ = BeforeSuite(func() {
 	awsEnv = test.NewEnvironment(ctx, env)
 
 	fakeClock = &clock.FakeClock{}
-	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider)
+	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider, awsEnv.LaunchTemplateProvider)
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	prov = provisioning.NewProvisioner(env.Client, env.KubernetesInterface.CoreV1(), events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster)
 })

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -353,3 +353,14 @@ func (p *Provider) getInstanceProfile(ctx context.Context, nodeTemplate *v1alpha
 	}
 	return defaultProfile, nil
 }
+
+func (p *Provider) GetLaunchTemplateVersions(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*ec2.LaunchTemplateVersion, error) {
+	input := &ec2.DescribeLaunchTemplateVersionsInput{
+		LaunchTemplateName: nodeTemplate.Spec.LaunchTemplateName,
+	}
+	ltv, err := p.ec2api.DescribeLaunchTemplateVersionsWithContext(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("error getting launch template versions: %w", err)
+	}
+	return ltv.LaunchTemplateVersions, nil
+}

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -88,7 +88,7 @@ var _ = BeforeSuite(func() {
 	awsEnv = test.NewEnvironment(ctx, env)
 
 	fakeClock = &clock.FakeClock{}
-	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider)
+	cloudProvider = cloudprovider.New(awsEnv.InstanceTypesProvider, awsEnv.InstanceProvider, env.Client, awsEnv.AMIProvider, awsEnv.SecurityGroupProvider, awsEnv.SubnetProvider, awsEnv.LaunchTemplateProvider)
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
 	prov = provisioning.NewProvisioner(env.Client, env.KubernetesInterface.CoreV1(), events.NewRecorder(&record.FakeRecorder{}), cloudProvider, cluster)
 })

--- a/tools/allocatable-diff/main.go
+++ b/tools/allocatable-diff/main.go
@@ -82,6 +82,7 @@ func main() {
 		op.AMIProvider,
 		op.SecurityGroupProvider,
 		op.SubnetProvider,
+		op.LaunchTemplateProvider,
 	)
 	raw := &runtime.RawExtension{}
 	lo.Must0(raw.UnmarshalJSON(lo.Must(json.Marshal(&v1alpha1.AWS{

--- a/website/content/en/docs/concepts/deprovisioning.md
+++ b/website/content/en/docs/concepts/deprovisioning.md
@@ -55,7 +55,7 @@ There are both automated and manual ways of deprovisioning nodes provisioned by 
 * **Consolidation**: Karpenter works to actively reduce cluster cost by identifying when:
   * Nodes can be removed as their workloads will run on other nodes in the cluster.
   * Nodes can be replaced with cheaper variants due to a change in the workloads.
-* **Drift**: Karpenter will annotate nodes as drifted and deprovision nodes that have drifted from their desired specification. Currently, Karpenter will only automatically mark nodes as drifted in the case of a drifted AMI.
+* **Drift**: Karpenter will annotate nodes as drifted and deprovision nodes that have drifted from their desired specification. Currently, Karpenter will only automatically mark nodes as drifted in the case of a drifted AMI, drifted subnets, drifted security groups or a drifted launch template.
 * **Interruption**: If enabled, Karpenter will watch for upcoming involuntary interruption events that could affect your nodes (health events, spot interruption, etc.) and will cordon, drain, and terminate the node(s) ahead of the event to reduce workload disruption.
 
 {{% alert title="Note" color="primary" %}}
@@ -178,8 +178,16 @@ Read the [Drift Design](https://github.com/aws/karpenter-core/pull/366/files) fo
 | Metadata Options           |    x   |         |            |             |
 | Block Device Mappings      |    x   |         |            |             |
 | Detailed Monitoring        |    x   |         |            |             |
+| Launch Template Name       |    x   |         |            |             |
 |                            |        |         |            |             |
 
+### Launch Template Drift
+
+Launch template drift is a bit different than the others in that it is triggered only from launch template changes in AWS. This is useful for folks who manage their own launch templates, perhaps with kOps or by hand using the AWS UI.
+
+*Important note:* Launch template drift occurs when an instance create time is older than the latest launch template version. Due to this somewhat naive implementation, Karpenter will not detect drift if the default version on a launch template is set to an old launch template version.
+
+### Feature Flag
 
 To enable the drift feature flag, refer to the [Settings Feature Gates]({{<ref "./settings#feature-gates" >}}).
 


### PR DESCRIPTION
Fixes #N/A

**Description**

This feature detects launch template drift when LaunchTemplateName is used in Provisioners. If there is a new launch template version for the given launch template, Karpenter considers nodes to have drifted.

This is useful for us because we currently have kOps-managed launch templates and use the LaunchTemplateName field in our AWSNodeTemplates.

**How was this change tested?**

Tests were added to the group of drift-related tests in `pkg/cloudprovider/suite_test.go`.

`make test`
`make battletest`

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.