### PR TITLE
ci: Deny all IMDSv1 to instances

### DIFF
--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -288,9 +288,6 @@ Resources:
               - ec2:DescribeVpcs
               # Image Permissions
               - ec2:DescribeImages
-            Resource: "*"
-          - Effect: Allow
-            Action:
               # Tag Permissions
               - ec2:CreateTags
               - ec2:DeleteTags
@@ -364,12 +361,7 @@ Resources:
               - ec2:DeleteVpc
               - ec2:DescribeVpcAttribute
               - ec2:ModifyVpcAttribute
-            Resource: "*"
-          - Effect: Allow
-            Action: ec2:RunInstances
-            Resource: "*"
-          - Effect: Allow
-            Action:
+              - ec2:RunInstances
               # Read-Only Permissions to pull ECR images needed by the NodeInstanceRole
               - ecr:GetAuthorizationToken
               - ecr:BatchCheckLayerAvailability
@@ -383,15 +375,9 @@ Resources:
               - ecr:GetLifecyclePolicyPreview
               - ecr:ListTagsForResource
               - ecr:DescribeImageScanFindings
-            Resource: "*"
-          - Effect: Allow
-            Action:
               # EKS ServiceRole permissions needed for AutoScalingGroups
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:UpdateAutoScalingGroup
-            Resource: "*"
-          - Effect: Allow
-            Action:
               # EKS ServiceRole permissions needed to handle LoadBalancer
               - elasticloadbalancing:AddTags
               - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
@@ -424,15 +410,9 @@ Resources:
               - elasticloadbalancing:RegisterTargets
               - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
               - elasticloadbalancing:SetLoadBalancerPoliciesOfListener
-            Resource: "*"
-          - Effect: Allow
-            Action:
               - kms:CreateGrant
               - kms:GenerateDataKeyWithoutPlaintext
               - kms:DescribeKey
-            Resource: "*"
-          - Effect: Allow
-            Action:
               # SSM Permissions for AmazonSSMManagedInstanceCore policy applied to the NodeInstanceRole
               - ssm:DescribeAssociation
               - ssm:GetDeployablePatchSnapshotForInstance
@@ -449,17 +429,11 @@ Resources:
               - ssm:UpdateAssociationStatus
               - ssm:UpdateInstanceAssociationStatus
               - ssm:UpdateInstanceInformation
-            Resource: "*"
-          - Effect: Allow
-            Action:
               # SSM Permissions for AmazonSSMManagedInstanceCore policy applied to the NodeInstanceRole
               - ssmmessages:CreateControlChannel
               - ssmmessages:CreateDataChannel
               - ssmmessages:OpenControlChannel
               - ssmmessages:OpenDataChannel
-            Resource: "*"
-          - Effect: Allow
-            Action:
               # SSM Permissions for AmazonSSMManagedInstanceCore policy applied to the NodeInstanceRole
               - ec2messages:AcknowledgeMessage
               - ec2messages:DeleteMessage
@@ -467,14 +441,14 @@ Resources:
               - ec2messages:GetEndpoint
               - ec2messages:GetMessages
               - ec2messages:SendReply
-            Resource: "*"
-          - Effect: Allow
-            Action:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
               - sqs:GetQueueUrl
               - sqs:SendMessage
               - sqs:ReceiveMessage
+              - pricing:GetProducts
+              - ec2:DescribeSpotPriceHistory
+              - eks:DescribeCluster
             Resource: "*"
           - Effect: Allow
             Action: iam:PassRole
@@ -483,19 +457,28 @@ Resources:
               - !GetAtt FISInterruptionRole.Arn
           - Effect: Allow
             Action:
-             - pricing:GetProducts
-             - ec2:DescribeSpotPriceHistory
-            Resource: "*"
-          - Effect: Allow
-            Action: eks:DescribeCluster
-            Resource: "*"
-          - Effect: Allow
-            Action:
               - aps:RemoteWrite
               - aps:GetSeries
               - aps:GetLabels
               - aps:GetMetricMetadata
             Resource: !Sub "arn:${AWS::Partition}:aps:${AWS::Region}:${AWS::AccountId}:workspace/${PrometheusWorkspaceID}"
+          # Deny ALL IMDSv1 instance launch
+          - Effect: Deny
+            Action:
+              - ec2:RunInstances
+            Resource: "*"
+            Condition:
+              StringNotEquals:
+                ec2:MetadataHttpTokens: required
+          - Effect: Deny
+            Action:
+              - ec2:ModifyInstanceMetadataOptions
+            Resource: "*"
+            Condition:
+              StringEquals:
+                ec2:Attribute: HttpTokens
+              StringNotEquals:
+                ec2:Attribute/HttpTokens: required
   GithubActionsRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- For the e2e tests, we would like to make sure that the tests do not launch any instance with IMDSv1
- Needed to remove lines to prevent from hitting the IAM Policy character size limit of 6,144

**How was this change tested?**
- Tested in a local account

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.