### PR TITLE
docs: Add updated guidance on `do-not-evict` annotation

### DIFF
--- a/website/content/en/preview/concepts/deprovisioning.md
+++ b/website/content/en/preview/concepts/deprovisioning.md
@@ -190,12 +190,13 @@ Karpenter will remove the  `karpenter.sh/voluntary-disruption: "drifted"` annota
 
 If the node is marked as voluntarily disrupted by another controller, karpenter will do nothing.
 
-## Disabling Deprovisioning
+## Controls
 
-### Pod Eviction
+### Pod-Level Controls
 
-Pods can be opted out of eviction by setting the annotation `karpenter.sh/do-not-evict: "true"` on the pod. This is useful for pods that you want to run from start to finish without interruption.
-Examples might include a real-time, interactive game that you don't want to interrupt, or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
+You can block Karpenter from voluntarily choosing to disrupt certain pods by setting the `karpenter.sh/do-not-evict: "true"` annotation on the pod. This is useful for pods that you want to run from start to finish without disruption. By opting pods out of this disruption, you are telling Karpenter that it should not voluntarily remove a node containing this pod.
+
+Examples of pods that you might want to opt-out of disruption include an interactive game that you don't want to interrupt or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
 
 ```yaml
 apiVersion: apps/v1
@@ -207,10 +208,9 @@ spec:
         karpenter.sh/do-not-evict: "true"
 ```
 
-By opting pods out of eviction, you are telling Karpenter that it should not voluntarily remove nodes containing this pod.
-
-However, if a do-not-evict pod is added to a node while the node is draining, the remaining pods will still evict, but that pod will block termination until it is removed.
-In either case, the node will be cordoned to prevent additional work from scheduling.
+{{% alert title="Note" color="primary" %}}
+This annotation will be ignored for [terminating pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase), [terminal pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) (Failed/Succeeded), [DaemonSet pods](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/), or [static pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/).
+{{% /alert %}}
 
 Examples of voluntary node removal that will be prevented by this annotation include:
 - [Consolidation]({{<ref "#consolidation" >}})
@@ -219,14 +219,10 @@ Examples of voluntary node removal that will be prevented by this annotation inc
 - Expiration
 
 {{% alert title="Note" color="primary" %}}
-Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`, both considered involuntary events, since node removal cannot be delayed.
+Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`. Both of these are considered involuntary events, since node removal cannot be delayed.
 {{% /alert %}}
 
-{{% alert title="Note" color="primary" %}}
-This annotation will have no effect for static pods, pods that tolerate `NoSchedule`, or pods terminating past their graceful termination period.
-{{% /alert %}}
-
-### Node Consolidation
+### Node-Level Controls
 
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 

--- a/website/content/en/v0.26/concepts/deprovisioning.md
+++ b/website/content/en/v0.26/concepts/deprovisioning.md
@@ -150,12 +150,13 @@ Karpenter will only automatically mark nodes as drifted in the case of a drifted
 
 To enable the drift feature flag, refer to the [Settings Feature Gates]({{<ref "./settings#feature-gates" >}}).
 
-## Disabling Deprovisioning
+## Controls
 
-### Pod Eviction
+### Pod-Level Controls
 
-Pods can be opted out of eviction by setting the annotation `karpenter.sh/do-not-evict: "true"` on the pod. This is useful for pods that you want to run from start to finish without interruption.
-Examples might include a real-time, interactive game that you don't want to interrupt, or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
+You can block Karpenter from voluntarily choosing to disrupt certain pods by setting the `karpenter.sh/do-not-evict: "true"` annotation on the pod. This is useful for pods that you want to run from start to finish without disruption. By opting pods out of this disruption, you are telling Karpenter that it should not voluntarily remove a node containing this pod.
+
+Examples of pods that you might want to opt-out of disruption include an interactive game that you don't want to interrupt or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
 
 ```yaml
 apiVersion: apps/v1
@@ -167,10 +168,9 @@ spec:
         karpenter.sh/do-not-evict: "true"
 ```
 
-By opting pods out of eviction, you are telling Karpenter that it should not voluntarily remove nodes containing this pod.
-
-However, if a do-not-evict pod is added to a node while the node is draining, the remaining pods will still evict, but that pod will block termination until it is removed.
-In either case, the node will be cordoned to prevent additional work from scheduling.
+{{% alert title="Note" color="primary" %}}
+This annotation will be ignored for [terminating pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase), [terminal pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) (Failed/Succeeded), [DaemonSet pods](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/), or [static pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/).
+{{% /alert %}}
 
 Examples of voluntary node removal that will be prevented by this annotation include:
 - [Consolidation]({{<ref "#consolidation" >}})
@@ -179,14 +179,10 @@ Examples of voluntary node removal that will be prevented by this annotation inc
 - Expiration
 
 {{% alert title="Note" color="primary" %}}
-Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`, both considered involuntary events, since node removal cannot be delayed.
+Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`. Both of these are considered involuntary events, since node removal cannot be delayed.
 {{% /alert %}}
 
-{{% alert title="Note" color="primary" %}}
-This annotation will have no effect for static pods, pods that tolerate `NoSchedule`, or pods terminating past their graceful termination period.
-{{% /alert %}}
-
-### Node Consolidation
+### Node-Level Controls
 
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 

--- a/website/content/en/v0.27/concepts/deprovisioning.md
+++ b/website/content/en/v0.27/concepts/deprovisioning.md
@@ -152,12 +152,13 @@ Karpenter will only automatically mark nodes as drifted in the case of a drifted
 
 To enable the drift feature flag, refer to the [Settings Feature Gates]({{<ref "./settings#feature-gates" >}}).
 
-## Disabling Deprovisioning
+## Controls
 
-### Pod Eviction
+### Pod-Level Controls
 
-Pods can be opted out of eviction by setting the annotation `karpenter.sh/do-not-evict: "true"` on the pod. This is useful for pods that you want to run from start to finish without interruption.
-Examples might include a real-time, interactive game that you don't want to interrupt, or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
+You can block Karpenter from voluntarily choosing to disrupt certain pods by setting the `karpenter.sh/do-not-evict: "true"` annotation on the pod. This is useful for pods that you want to run from start to finish without disruption. By opting pods out of this disruption, you are telling Karpenter that it should not voluntarily remove a node containing this pod.
+
+Examples of pods that you might want to opt-out of disruption include an interactive game that you don't want to interrupt or a long batch job (such as you might have with machine learning) that would need to start over if it were interrupted.
 
 ```yaml
 apiVersion: apps/v1
@@ -169,10 +170,9 @@ spec:
         karpenter.sh/do-not-evict: "true"
 ```
 
-By opting pods out of eviction, you are telling Karpenter that it should not voluntarily remove nodes containing this pod.
-
-However, if a do-not-evict pod is added to a node while the node is draining, the remaining pods will still evict, but that pod will block termination until it is removed.
-In either case, the node will be cordoned to prevent additional work from scheduling.
+{{% alert title="Note" color="primary" %}}
+This annotation will be ignored for [terminating pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase), [terminal pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) (Failed/Succeeded), [DaemonSet pods](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/), or [static pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/).
+{{% /alert %}}
 
 Examples of voluntary node removal that will be prevented by this annotation include:
 - [Consolidation]({{<ref "#consolidation" >}})
@@ -181,14 +181,10 @@ Examples of voluntary node removal that will be prevented by this annotation inc
 - Expiration
 
 {{% alert title="Note" color="primary" %}}
-Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`, both considered involuntary events, since node removal cannot be delayed.
+Voluntary node removal does not include [Interruption]({{<ref "#interruption" >}}) or manual deletion initiated through `kubectl delete node`. Both of these are considered involuntary events, since node removal cannot be delayed.
 {{% /alert %}}
 
-{{% alert title="Note" color="primary" %}}
-This annotation will have no effect for static pods, pods that tolerate `NoSchedule`, or pods terminating past their graceful termination period.
-{{% /alert %}}
-
-### Node Consolidation
+### Node-Level Controls
 
 Nodes can be opted out of consolidation deprovisioning by setting the annotation `karpenter.sh/do-not-consolidate: "true"` on the node.
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Fixes a mistake surrounding the `NoSchedule` taint with respect to the `do-not-evict` annotation and cleans up some wording and grammar.

**How was this change tested?**

Viewing the preview docs

**Does this change impact docs?**
- [x] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.