### PR TITLE
ci: Add metric relabelings to kubelet cAdvisor and disable other endpoints

### DIFF
--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -43,12 +43,15 @@ runs:
           --set prometheus.prometheusSpec.remoteWrite[0].url=https://aps-workspaces.${{ inputs.region }}.amazonaws.com/workspaces/${{ inputs.workspace_id }}/api/v1/remote_write \
           --set prometheus.prometheusSpec.remoteWrite[0].sigv4.region=${{ inputs.region }} \
           --set prometheus.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::${{ inputs.account_id }}:role/prometheus-irsa-${{ inputs.cluster_name }}" \
-          --set "kubelet.serviceMonitor.relabelings[0].targetLabel=clusterName" \
-          --set "kubelet.serviceMonitor.relabelings[0].replacement=${{ inputs.cluster_name }}" \
-          --set "kubelet.serviceMonitor.relabelings[1].targetLabel=gitRef" \
-          --set "kubelet.serviceMonitor.relabelings[1].replacement=$(git rev-parse HEAD)" \
-          --set "kubelet.serviceMonitor.relabelings[2].targetLabel=mostRecentTag" \
-          --set "kubelet.serviceMonitor.relabelings[2].replacement=$(git describe --abbrev=0 --tags)" \
-          --set "kubelet.serviceMonitor.relabelings[3].targetLabel=commitsAfterTag" \
-          --set "kubelet.serviceMonitor.relabelings[3].replacement=\"$(git describe --tags | cut -d '-' -f 2)\"" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[0].targetLabel=metrics_path" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[0].action=replace" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[0].sourceLabels[0]=__metrics_path__" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[1].targetLabel=clusterName" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[1].replacement=${{ inputs.cluster_name }}" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[2].targetLabel=gitRef" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[2].replacement=$(git rev-parse HEAD)" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[3].targetLabel=mostRecentTag" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[3].replacement=$(git describe --abbrev=0 --tags)" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[4].targetLabel=commitsAfterTag" \
+          --set "kubelet.serviceMonitor.cAdvisorRelabelings[4].replacement=\"$(git describe --tags | cut -d '-' -f 2)\"" \
           --wait

--- a/.github/actions/e2e/install-prometheus/values.yaml
+++ b/.github/actions/e2e/install-prometheus/values.yaml
@@ -28,6 +28,15 @@ alertmanager:
         operator: Exists
 kubelet:
   serviceMonitor:
+    # Enable CAdvisor metrics (this is enabled by default but explicitly specified for clarity)
+    # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml#L41
+    cAdvisor: true
+    # Disable probes scrape endpoint
+    # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml#L68
+    probes: false
+    # Disable resource scrape endpoint
+    # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml#L95
+    resource: false
     additionalLabels:
       scrape: enabled
 prometheus:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Add metric relabelings to kubelet cAdvisor and disable other endpoints

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.