### PR TITLE
docs: Simplify developer guide to use a single ECR repository across multiple projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${K
 # CR for local builds of Karpenter
 SYSTEM_NAMESPACE ?= karpenter
 KARPENTER_VERSION ?= $(shell git tag --sort=committerdate | tail -1)
-KO_DOCKER_REPO ?= ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/karpenter
+KO_DOCKER_REPO ?= ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/dev
 GETTING_STARTED_SCRIPT_DIR = website/content/en/preview/getting-started/getting-started-with-karpenter/scripts
 
 # Common Directories
@@ -131,13 +131,13 @@ licenses: download ## Verifies dependency licenses
 setup: ## Sets up the IAM roles needed prior to deploying the karpenter-controller. This command only needs to be run once
 	CLUSTER_NAME=${CLUSTER_NAME} ./$(GETTING_STARTED_SCRIPT_DIR)/add-roles.sh $(KARPENTER_VERSION)
 
-build: ## Build the Karpenter controller images using ko build
-	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) KO_DOCKER_REPO="$(KO_DOCKER_REPO)" ko build -B github.com/aws/karpenter/cmd/controller))
+image: ## Build the Karpenter controller images using ko build
+	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) KO_DOCKER_REPO="$(KO_DOCKER_REPO)" ko build --bare github.com/aws/karpenter/cmd/controller))
 	$(eval IMG_REPOSITORY=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 1))
 	$(eval IMG_TAG=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 1 | cut -d ":" -f 2 -s))
 	$(eval IMG_DIGEST=$(shell echo $(CONTROLLER_IMG) | cut -d "@" -f 2))
 
-apply: build ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
+apply: image ## Deploy the controller from the current state of your git repository into your ~/.kube/config cluster
 	helm upgrade --install karpenter charts/karpenter --namespace ${SYSTEM_NAMESPACE} \
 		$(HELM_OPTS) \
 		--set controller.image.repository=$(IMG_REPOSITORY) \

--- a/website/content/en/docs/contributing/development-guide.md
+++ b/website/content/en/docs/contributing/development-guide.md
@@ -62,7 +62,7 @@ make presubmit # run codegen, lint, and tests
 If you are only interested in building the Karpenter images and not deploying the updated release to your cluster immediately with Helm, you can run
 
 ```bash
-make build # build and push the karpenter images
+make image # build and push the karpenter images
 ```
 
 ### Testing
@@ -106,15 +106,12 @@ stern -n karpenter -l app.kubernetes.io/name=karpenter
 ### AWS
 
 For local development on Karpenter you will need a Docker repo which can manage your images for Karpenter components.
-You can use the following command to provision an ECR repository.
+You can use the following command to provision an ECR repository. We recommend using a single "dev" repository for 
+development across multiple projects, and to use specific image hashes instead of image tags. 
 
 ```bash
 aws ecr create-repository \
-    --repository-name karpenter/controller \
-    --image-scanning-configuration scanOnPush=true \
-    --region "${AWS_DEFAULT_REGION}"
-aws ecr create-repository \
-    --repository-name karpenter/webhook \
+    --repository-name dev \
     --image-scanning-configuration scanOnPush=true \
     --region "${AWS_DEFAULT_REGION}"
 ```
@@ -122,7 +119,7 @@ aws ecr create-repository \
 Once you have your ECR repository provisioned, configure your Docker daemon to authenticate with your newly created repository.
 
 ```bash
-export KO_DOCKER_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/karpenter"
+export KO_DOCKER_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/dev"
 aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "${KO_DOCKER_REPO}"
 ```
 

--- a/website/content/en/preview/contributing/development-guide.md
+++ b/website/content/en/preview/contributing/development-guide.md
@@ -62,7 +62,7 @@ make presubmit # run codegen, lint, and tests
 If you are only interested in building the Karpenter images and not deploying the updated release to your cluster immediately with Helm, you can run
 
 ```bash
-make build # build and push the karpenter images
+make image # build and push the karpenter images
 ```
 
 ### Testing
@@ -106,15 +106,12 @@ stern -n karpenter -l app.kubernetes.io/name=karpenter
 ### AWS
 
 For local development on Karpenter you will need a Docker repo which can manage your images for Karpenter components.
-You can use the following command to provision an ECR repository.
+You can use the following command to provision an ECR repository. We recommend using a single "dev" repository for 
+development across multiple projects, and to use specific image hashes instead of image tags. 
 
 ```bash
 aws ecr create-repository \
-    --repository-name karpenter/controller \
-    --image-scanning-configuration scanOnPush=true \
-    --region "${AWS_DEFAULT_REGION}"
-aws ecr create-repository \
-    --repository-name karpenter/webhook \
+    --repository-name dev \
     --image-scanning-configuration scanOnPush=true \
     --region "${AWS_DEFAULT_REGION}"
 ```
@@ -122,7 +119,7 @@ aws ecr create-repository \
 Once you have your ECR repository provisioned, configure your Docker daemon to authenticate with your newly created repository.
 
 ```bash
-export KO_DOCKER_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/karpenter"
+export KO_DOCKER_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/dev"
 aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "${KO_DOCKER_REPO}"
 ```
 

--- a/website/content/en/v0.29/contributing/development-guide.md
+++ b/website/content/en/v0.29/contributing/development-guide.md
@@ -62,7 +62,7 @@ make presubmit # run codegen, lint, and tests
 If you are only interested in building the Karpenter images and not deploying the updated release to your cluster immediately with Helm, you can run
 
 ```bash
-make build # build and push the karpenter images
+make image # build and push the karpenter images
 ```
 
 ### Testing


### PR DESCRIPTION
Fixes #NA

**Description**

Simplify dev loop to use a single ECR Repo. Respects existing KO_DOCKER_REPO if set.

**How was this change tested?**

```
❯ make apply
2023/08/04 11:40:21 Using base cgr.dev/chainguard/static:latest@sha256:6b35c7e7084349b3a71e70219f61ea49b22d663b89b0ea07474e5b44cbc70860 for github.com/aws/karpenter/cmd/controller
2023/08/04 11:40:22 Building github.com/aws/karpenter/cmd/controller for linux/amd64
2023/08/04 11:40:25 Publishing 767520670908.dkr.ecr.us-west-2.amazonaws.com/dev:latest
2023/08/04 11:40:26 existing blob: sha256:eb0ae35341366ba2c164b0c88e84954fdb05fe9a8bbdf4228f5e7354546a0e6e
2023/08/04 11:40:26 pushed blob: sha256:ee527539410af8964e835a154c6a0166f666d042d876fec78d900ce51d9c6adb
2023/08/04 11:40:26 pushed blob: sha256:747972ef767bf37a2f20f4b744e23dd9d4538c267c5f3668c5b334f45007fbf9
2023/08/04 11:40:26 pushed blob: sha256:6131518f47df0dcb263e6828fbc40e8805d6f3a08d1cfc5144813c9697bcf14a
2023/08/04 11:40:26 pushed blob: sha256:88afcab33c46d90352adfd1be0605b83ba751c86f2c098884dffd4e410a8d938
2023/08/04 11:40:26 767520670908.dkr.ecr.us-west-2.amazonaws.com/dev:sha256-cc60416ab6919762832051e7d0f9cd94f9d7333eb81919e1eb364958f4e25226.sbom: digest: sha256:0eb581b4cc4939be67fe3e40fdbdb830171e4a7420b3516c0e42617d00a1a114 size: 375
2023/08/04 11:40:26 Published SBOM 767520670908.dkr.ecr.us-west-2.amazonaws.com/dev:sha256-cc60416ab6919762832051e7d0f9cd94f9d7333eb81919e1eb364958f4e25226.sbom
2023/08/04 11:40:57 pushed blob: sha256:f7753576870270acebb0f96875ac2c74b7bed1885b5fd2c3e2616161835e7b93
2023/08/04 11:40:57 767520670908.dkr.ecr.us-west-2.amazonaws.com/dev:latest: digest: sha256:cc60416ab6919762832051e7d0f9cd94f9d7333eb81919e1eb364958f4e25226 size: 1212
2023/08/04 11:40:57 Published 767520670908.dkr.ecr.us-west-2.amazonaws.com/dev@sha256:cc60416ab6919762832051e7d0f9cd94f9d7333eb81919e1eb364958f4e25226
helm upgrade --install karpenter charts/karpenter --namespace karpenter \
                --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::767520670908:role/dev-karpenter --set settings.aws.clusterName=dev --set settings.aws.clusterEndpoint=https://188497939A2B3EE4B52405372D342D4E.gr7.us-west-2.eks.amazonaws.com --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-dev --set settings.aws.interruptionQueueName=dev --set settings.featureGates.driftEnabled=true --set controller.resources.requests.cpu=1 --set controller.resources.requests.memory=1Gi --set controller.resources.limits.cpu=1 --set controller.resources.limits.memory=1Gi --create-namespace \
                --set controller.image.repository=767520670908.dkr.ecr.us-west-2.amazonaws.com/dev \
                --set controller.image.tag= \
                --set controller.image.digest=sha256:cc60416ab6919762832051e7d0f9cd94f9d7333eb81919e1eb364958f4e25226
walk.go:74: found symbolic link in path: /Users/etarn/go/src/github.com/aws/karpenter/charts/karpenter/crds resolves to /Users/etarn/go/src/github.com/aws/karpenter/pkg/apis/crds. Contents of linked file included and used
Release "karpenter" has been upgraded. Happy Helming!
NAME: karpenter
LAST DEPLOYED: Fri Aug  4 11:40:59 2023
NAMESPACE: karpenter
STATUS: deployed
REVISION: 8
TEST SUITE: None
```

```
❯ KO_DOCKER_REPO=767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter make apply
2023/08/04 11:42:25 Using base cgr.dev/chainguard/static:latest@sha256:6b35c7e7084349b3a71e70219f61ea49b22d663b89b0ea07474e5b44cbc70860 for github.com/aws/karpenter/cmd/controller
2023/08/04 11:42:26 Building github.com/aws/karpenter/cmd/controller for linux/amd64
2023/08/04 11:42:28 Publishing 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter:latest
2023/08/04 11:42:29 existing blob: sha256:eb0ae35341366ba2c164b0c88e84954fdb05fe9a8bbdf4228f5e7354546a0e6e
2023/08/04 11:42:29 pushed blob: sha256:ae0543b98b24ec29547a07574c941b786f40e551b071ca8e161ecbc05bfbe9a3
2023/08/04 11:42:29 pushed blob: sha256:351b2a5de6801aac23bc381d946af75eb9cd7c07c44dc14a64c9c8d5e665dd0f
2023/08/04 11:42:29 pushed blob: sha256:88afcab33c46d90352adfd1be0605b83ba751c86f2c098884dffd4e410a8d938
2023/08/04 11:42:29 pushed blob: sha256:45f1ea1c0a081d3c103ab47a181e691bced03e45a1d5f4217be1665910f622d5
2023/08/04 11:42:30 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter:sha256-725acd361ab4905c18ba59d5ac8de55dccff98689c23444cd0096454d6956e41.sbom: digest: sha256:f4623796f0258db42cf9c8948e0c521b82742895c3f320b22047e0bdc7510318 size: 375
2023/08/04 11:42:30 Published SBOM 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter:sha256-725acd361ab4905c18ba59d5ac8de55dccff98689c23444cd0096454d6956e41.sbom
2023/08/04 11:43:03 pushed blob: sha256:f17b154ab17754992f1f0ad1d079a763dbba756ccbdb09b397b9cfae04298b2b
2023/08/04 11:43:03 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter:latest: digest: sha256:725acd361ab4905c18ba59d5ac8de55dccff98689c23444cd0096454d6956e41 size: 1212
2023/08/04 11:43:03 Published 767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter@sha256:725acd361ab4905c18ba59d5ac8de55dccff98689c23444cd0096454d6956e41
helm upgrade --install karpenter charts/karpenter --namespace karpenter \
                --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::767520670908:role/dev-karpenter --set settings.aws.clusterName=dev --set settings.aws.clusterEndpoint=https://188497939A2B3EE4B52405372D342D4E.gr7.us-west-2.eks.amazonaws.com --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-dev --set settings.aws.interruptionQueueName=dev --set settings.featureGates.driftEnabled=true --set controller.resources.requests.cpu=1 --set controller.resources.requests.memory=1Gi --set controller.resources.limits.cpu=1 --set controller.resources.limits.memory=1Gi --create-namespace \
                --set controller.image.repository=767520670908.dkr.ecr.us-west-2.amazonaws.com/karpenter \
                --set controller.image.tag= \
                --set controller.image.digest=sha256:725acd361ab4905c18ba59d5ac8de55dccff98689c23444cd0096454d6956e41
walk.go:74: found symbolic link in path: /Users/etarn/go/src/github.com/aws/karpenter/charts/karpenter/crds resolves to /Users/etarn/go/src/github.com/aws/karpenter/pkg/apis/crds. Contents of linked file included and used
Release "karpenter" has been upgraded. Happy Helming!
NAME: karpenter
LAST DEPLOYED: Fri Aug  4 11:43:05 2023
NAMESPACE: karpenter
STATUS: deployed
REVISION: 9
TEST SUITE: None
```

**Does this change impact docs?**
- [X] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.