### PR TITLE
ci: Flaky Start-up Taint Drift Test 

### DIFF
--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -272,8 +272,13 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				return nodes[i].CreationTimestamp.Before(&nodes[j].CreationTimestamp)
 			})
 			nodeTwo := nodes[1]
-			nodeTwo.Spec.Taints = []v1.Taint{}
-			env.ExpectCreatedOrUpdated(nodeTwo)
+			Eventually(func(g Gomega) {
+				n := &v1.Node{}
+				g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeTwo), n)).To(Succeed())
+				stored := n.DeepCopy()
+				n.Spec.Taints = []v1.Taint{}
+				g.Expect(env.Client.Patch(env.Context, n, client.MergeFrom(stored))).To(Succeed())
+			}).Should(Succeed())
 		}
 
 		env.EventuallyExpectNotFound(pod, node)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Startup taints seem to be failing due to the node object being changed while e2e test removes start-up taints on the nodes. 

**How was this change tested?**
- Manually tested 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.