### PR TITLE
ci: Tag OIDC using cluster name for clean-up

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -129,14 +129,10 @@ runs:
     if: always()
     shell: bash
     run: |
-      for arn in $(aws iam list-open-id-connect-providers --query "OpenIDConnectProviderList[*].{ARN:Arn}" --output text); do
-          tags=$(aws iam list-open-id-connect-provider-tags --open-id-connect-provider-arn $arn --output json)
-          if [[ $(echo $tags | jq -r '.Tags[] | select(.Key == "alpha.eksctl.io/cluster-name") | .Value') == "${{ inputs.cluster_name }}" ]]; then 
-              aws iam tag-open-id-connect-provider --open-id-connect-provider-arn $arn \
-              --tags Key=testing.karpenter.sh/type,Value=e2e  Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-              break
-          fi
-      done
+      oidc_id=$(aws eks describe-cluster --name ${{ inputs.cluster_name }} --query "cluster.identity.oidc.issuer" --output text | cut -d '/' -f 3,4,5)
+      arn="arn:aws:iam::${{ inputs.account_id }}:oidc-provider/${oidc_id}"
+      aws iam tag-open-id-connect-provider --open-id-connect-provider-arn $arn \
+         --tags Key=testing.karpenter.sh/type,Value=e2e  Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   - name: give KarpenterNodeRole permission to bootstrap
     shell: bash
     run: |


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- E2E tests will are getting rate limited on `ListOpenIDConnectProviderTags` when multiple E2E tests are running
- Removing the List call and using the cluster name to tag the OIDC

**How was this change tested?**
- Manually tested 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.