### PR TITLE
docs: Describe cloudformation.yaml for docs

### DIFF
--- a/website/content/en/preview/concepts/setup.md
+++ b/website/content/en/preview/concepts/setup.md
@@ -1,11 +1,11 @@
 ---
 title: "Karpenter CloudFormation Setup"
-linkTitle: "Karpenter CloudFormation Setup"
+linkTitle: "CloudFormation Setup"
 weight: 5
 description: >
   Descriptions of how Karpenter uses CloudFormation to set up permissions
 ---
-When you create a cluster to use with Karpenter in the [Getting Started with Karpenter]({{< relref "../getting-started/" >}}) guide, the procedure uses CloudFormation to prepare the cluster for Karpenter to be able to create and manage nodes, as well as gather and respond to interruption events.
+When you create a cluster to use with Karpenter in the [Getting Started with Karpenter]({{< relref "../getting-started/getting-started-with-karpenter" >}}) guide, the procedure uses CloudFormation to prepare the cluster for Karpenter to be able to create and manage nodes, as well as gather and respond to interruption events.
 This document describes the `cloudformation.yaml` file used in that guide.
 These descriptions will be useful to understand:
 

--- a/website/content/en/preview/concepts/setup.md
+++ b/website/content/en/preview/concepts/setup.md
@@ -5,7 +5,7 @@ weight: 5
 description: >
   Descriptions of how Karpenter uses CloudFormation to set up permissions
 ---
-When you create a cluster to use with Karpenter in the [Getting Started with Karpenter]({{< relref "../getting-started-with-karpenter/" >}}) guide, the procedure uses CloudFormation to prepare the cluster for Karpenter to be able to create and manage nodes, as well as gather and respond to interruption events.
+When you create a cluster to use with Karpenter in the [Getting Started with Karpenter]({{< relref "../getting-started/" >}}) guide, the procedure uses CloudFormation to prepare the cluster for Karpenter to be able to create and manage nodes, as well as gather and respond to interruption events.
 This document describes the `cloudformation.yaml` file used in that guide.
 These descriptions will be useful to understand:
 

--- a/website/content/en/preview/concepts/setup.md
+++ b/website/content/en/preview/concepts/setup.md
@@ -1,9 +1,9 @@
 ---
-title: "Karpenter Setup"
-linkTitle: "Karpenter Setup"
+title: "Karpenter CloudFormation Setup"
+linkTitle: "Karpenter CloudFormation Setup"
 weight: 5
 description: >
-  Descriptions of how Karpenter sets up infrastructure
+  Descriptions of how Karpenter uses CloudFormation to set up permissions
 ---
 When you create a cluster to use with Karpenter in the [Getting Started with Karpenter]({{< relref "../getting-started-with-karpenter/" >}}) guide, the procedure uses CloudFormation to prepare the cluster for Karpenter to be able to create and manage nodes.
 This document describes the `cloudformation.yaml` file used in that guide.

--- a/website/content/en/preview/concepts/setup.md
+++ b/website/content/en/preview/concepts/setup.md
@@ -1,0 +1,499 @@
+---
+title: "Karpenter Setup"
+linkTitle: "Karpenter Setup"
+weight: 5
+description: >
+  Descriptions of how Karpenter sets up infrastructure
+---
+When you create a cluster to use with Karpenter in the [Getting Started with Karpenter]({{< relref "../getting-started-with-karpenter/" >}}) guide, the procedure uses CloudFormation to prepare the cluster for Karpenter to be able to create and manage nodes.
+This document describes the `cloudformation.yaml` file used in that guide.
+These descriptions will be useful to understand:
+
+* How Karpenter is integrated with your new cluster or
+* What you need to do with an existing cluster if you want to add Karpenter manually.
+
+# Review the cloudformation.yaml file
+
+To download a particular version of `cloudformation.yaml`, set the version and use `curl` to pull the file to your local system:
+
+```bash
+export KARPENTER_VERSION=v0.29.0
+curl https://raw.githubusercontent.com/aws/karpenter/"${KARPENTER_VERSION}"/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml > cloudformation.yaml
+```
+
+The `cloudformation.yaml` file starts with the following information:
+
+```
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Resources used by https://github.com/aws/karpenter
+Parameters:
+  ClusterName:
+    Type: String
+    Description: "EKS cluster name"
+Resources:
+```
+
+The rest of the `cloudformation.yaml` file describes the resources that CloudFormation deploys.
+Those resources include:
+
+* KarpenterNodeInstanceProfile
+* KarpenterNodeRole
+* KarpenterControllerPolicy
+* KarpenterInterruptionQueue
+* KarpenterInterruptionQueuePolicy
+* ScheduledChangeRule
+* SpotInterruptionRule
+* RebalanceRule
+* InstanceStateChangeRule
+
+The following text divides the `cloudformation.yaml` you just downloaded into those sections and describes them.
+
+# Description of Karpenter cloudformation.yaml
+
+A lot of the object naming that is done by `cloudformation.yaml` is based on the following:
+
+* Cluster name: With a user name of `joe` the Getting Started Guide would name your cluster `joe-karpenter-demo`
+That name would then be appended to any name below where `${ClusterName}` is included.
+
+* Partition: Any time an ARN is used, it includes the partition name to identify where the object is found. In most cases, that partition name is `aws`. However, it could also be `aws-cn` (for China Regions) or `aws-us-gov` (for AWS GovCloud US Regions).
+
+
+## Create instance profile (KarpenterNodeInstanceProfile)
+This section creates an [EC2 Instance Profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) that includes the node role named `KarpenterNodeRole`, with the cluster name appended.
+For example, with a cluster name of  `joe-karpenter-demo`, the instance profile name would look like:
+
+`KarpenterNodeInstanceProfile-joe-karpenter-demo`
+
+
+```
+  KarpenterNodeInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      InstanceProfileName: !Sub "KarpenterNodeInstanceProfile-${ClusterName}"
+      Path: "/"
+      Roles:
+        - !Ref "KarpenterNodeRole"
+```
+To do this manually for an existing cluster, you would find your cluster's InstanceProfileName and use that to attach the role needed.
+To list all instance profiles, type:
+
+```bash
+aws iam list-instance-profiles
+```
+
+To see information for a particular instance profile (for example, `MyRoleForInstances`), type:
+
+```bash
+aws iam get-instance-profile --instance-profile-name "MyRoleForInstances"
+```
+```
+INSTANCEPROFILE arn:aws:iam::973227887653:instance-profile/MyRoleForInstances  2020-12-10T19:45:31+00:00       AIPA6FGHHBQS4F2FFHYYV   MyRoleForInstances     /
+ROLES   arn:aws:iam::111111111111:role/MyRoleForInstances      2020-12-10T19:45:30+00:00       /       AROA6FGHHBQSQ5NKPJT2H   MyRoleForInstances
+ASSUMEROLEPOLICYDOCUMENT        2012-10-17
+STATEMENT       sts:AssumeRole  Allow
+PRINCIPAL       ec2.amazonaws.com
+```
+
+## Create node role permissions (KarpenterNodeRole)
+
+This section creates the node role that is attached to the `KarpenterNodeInstanceProfile` instance profile created earlier.
+Given a cluster name of `joe-karpenter-demo`, this role would end up being named `"KarpenterNodeRole-joe-karpenter-demo`.
+
+```
+  KarpenterNodeRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub "KarpenterNodeRole-${ClusterName}"
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                !Sub "ec2.${AWS::URLSuffix}"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+```
+The role created here includes several AWS managed policies, which are designed to provide permissions for specific uses needed by Karpenter to create and manage nodes.
+These include:
+
+* [AmazonEKS_CNI_Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKS_CNI_Policy.html): Provides permission Amazon VPC CNI Plugin needs to configure EKS worker nodes.
+* [AmazonEKSWorkerNodePolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKSWorkerNodePolicy.html): Lets Amazon EKS worker nodes connect to EKS Clusters.
+* [AmazonEC2ContainerRegistryReadOnly](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryReadOnly.html): Allows access to repositories in the Amazon EC2 Container Registry.
+* [AmazonSSMManagedInstanceCore](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html): Adds AWS Systems Manager service core functions for Amazon EC2.
+
+
+## KarpenterControllerPolicy
+
+This section sets the permissions that the Karpenter Controller has to create and manage EC2 resources.
+Because the scope of the KarpenterControllerPolicy is an AWS region, the cluster's AWS region is included in the AllowScopedEC2InstanceActions.
+
+A KarpenterControllerPolicy sets the name of the policy, then defines of a set of resources and actions allowed for those resources.
+For our example, the KarpenterControllerPolicy would be named: `KarpenterControllerPolicy-joe-karpenter-demo`
+```
+  KarpenterControllerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
+      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+      # value in one of its key parameters which isn't natively supported by CloudFormation
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+```
+
+### AllowScopedEC2InstanceActions
+
+The AllowScopedEC2InstanceActions statement ID (Sid) identifies a set of EC2 resources that are allowed to be used with
+[RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html) and [CreateFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html) actions.
+
+```
+            {
+              "Sid": "AllowScopedEC2InstanceActions",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+              ],
+              "Action": [
+                "ec2:RunInstances",
+                "ec2:CreateFleet"
+              ]
+            },
+
+```
+
+### AllowScopedEC2LaunchTemplateActions
+The AllowScopedEC2LaunchTemplateActions Sid allows the [CreateLaunchTemplate](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateLaunchTemplate.html)
+action for all Karpenter provisioners, provided that the request comes from the cluster owner.
+
+```
+            {
+              "Sid": "AllowScopedEC2LaunchTemplateActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+              "Action": "ec2:CreateLaunchTemplate",
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                }
+              }
+            },
+```
+
+### AllowScopedEC2InstanceActionsWithTags
+The AllowScopedEC2InstanceActionsWithTags Sid allows the 
+[RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html) and [CreateFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html)
+actions for all Karpenter provisioners, provided that the request comes from the cluster owner.
+
+```
+            {
+              "Sid": "AllowScopedEC2InstanceActionsWithTags",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+              ],
+              "Action": [
+                "ec2:RunInstances",
+                "ec2:CreateFleet"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                }
+              }
+            },
+
+```
+
+### AllowScopedResourceCreationTagging
+The AllowScopedResourceCreationTagging Sid allows [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html)
+actions on fleet, instance, volume, network-interface, and launch-template resources,
+ for all Karpenter provisioners, provided that the request comes from the cluster owner and that it is part of a RunInstance, CreateFleet, or CreateLaunchTemplate CreateAction.
+
+```
+            {
+              "Sid": "AllowScopedResourceCreationTagging",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+              ],
+              "Action": "ec2:CreateTags",
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "ec2:CreateAction": [
+                    "RunInstances",
+                    "CreateFleet",
+                    "CreateLaunchTemplate"
+                  ]
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                }
+              }
+            },
+```
+
+### AllowMachineMigrationTagging
+The AllowMachineMigrationTagging Sid allows [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html)
+actions on instance resources.
+The request must come from the cluster owner of the cluster and the instance must be managed by the cluster.
+
+??? I NEED MORE INFO HERE ???
+
+```
+            {
+              "Sid": "AllowMachineMigrationTagging",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+              "Action": "ec2:CreateTags",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                },
+                "ForAllValues:StringEquals": {
+                  "aws:TagKeys": [
+                    "karpenter.sh/provisioner-name",
+                    "karpenter.sh/managed-by"
+                  ]
+                }
+              }
+            },
+```
+
+### AllowScopedDeletion
+The AllowScopedDeletion Sid allows the owner of a cluster through any provisioner name to use [TerminateInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html) and [DeleteLaunchTemplate](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteLaunchTemplate.html) actions to delete instance and launch-template resources.
+
+```
+            {
+              "Sid": "AllowScopedDeletion",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+              ],
+              "Action": [
+                "ec2:TerminateInstances",
+                "ec2:DeleteLaunchTemplate"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                }
+              }
+            },
+```
+
+### AllowRegionalReadActions
+
+The AllowRegionalReadActions Sid allows [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
+
+```
+            {
+              "Sid": "AllowRegionalReadActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": [
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypeOfferings",
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeLaunchTemplates",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeSubnets"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "${AWS::Region}"
+                }
+              }
+            },
+```
+
+### AllowGlobalRead Actions
+
+```
+            {
+              "Sid": "AllowGlobalReadActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": [
+                "pricing:GetProducts",
+                "ssm:GetParameter"
+              ]
+            },
+```
+
+### AllowInterruptionQueueActions
+
+```
+            {
+              "Sid": "AllowInterruptionQueueActions",
+              "Effect": "Allow",
+              "Resource": "${KarpenterInterruptionQueue.Arn}",
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+                "sqs:ReceiveMessage"
+              ]
+            },
+```
+
+### AllowPassingInstanceRole
+
+```
+            {
+              "Sid": "AllowPassingInstanceRole",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+              "Action": "iam:PassRole",
+              "Condition": {
+                "StringEquals": {
+                  "iam:PassedToService": "ec2.amazonaws.com"
+                }
+              }
+            },
+```
+
+### AllowAPIServerEndpointDiscovery
+
+```
+            {
+              "Sid": "AllowAPIServerEndpointDiscovery",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Action": "eks:DescribeCluster"
+            }
+          ]
+        }
+```
+
+## KarpenterInterruptionQueue
+
+```
+  KarpenterInterruptionQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${ClusterName}"
+      MessageRetentionPeriod: 300
+      SqsManagedSseEnabled: true
+```
+
+## KarpenterInterruptionQueuePolicy
+
+```
+  KarpenterInterruptionQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref KarpenterInterruptionQueue
+      PolicyDocument:
+        Id: EC2InterruptionPolicy
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+                - sqs.amazonaws.com
+            Action: sqs:SendMessage
+            Resource: !GetAtt KarpenterInterruptionQueue.Arn
+```
+
+## ScheduledChangeRule
+
+```
+  ScheduledChangeRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.health
+        detail-type:
+          - AWS Health Event
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn
+```
+
+## SpotInterruptionRule
+
+```
+  SpotInterruptionRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Spot Instance Interruption Warning
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn
+```
+
+## RebalanceRule
+
+```
+  RebalanceRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Instance Rebalance Recommendation
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn
+```
+
+## InstanceStateChangeRule
+
+```
+  InstanceStateChangeRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Instance State-change Notification
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn
+```

--- a/website/content/en/preview/concepts/setup.md
+++ b/website/content/en/preview/concepts/setup.md
@@ -42,12 +42,12 @@ The sections of that file can be grouped together under the following general he
 
 A lot of the object naming that is done by `cloudformation.yaml` is based on the following:
 
-* Cluster name: With a user name of `joe` the Getting Started Guide would name your cluster `joe-karpenter-demo`
+* Cluster name: With a user name of `bob` the Getting Started Guide would name your cluster `bob-karpenter-demo`
 That name would then be appended to any name below where `${ClusterName}` is included.
 
 * Partition: Any time an ARN is used, it includes the partition name to identify where the object is found. In most cases, that partition name is `aws`. However, it could also be `aws-cn` (for China Regions) or `aws-us-gov` (for AWS GovCloud US Regions).
 
-# Node Authorization in cloudformation.yaml
+# Node Authorization 
 
 The following sections of the `cloudformation.yaml` file set up permissions related to what Kubernetes nodes created by Karpenter can do with EC2 and other AWS features.
 In particular, this involves setting up an instance profile and attaching a node role to that profile with the following objects:
@@ -57,9 +57,9 @@ In particular, this involves setting up an instance profile and attaching a node
 
 ## KarpenterNodeInstanceProfile
 This section creates an [EC2 Instance Profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) that includes the node role named `KarpenterNodeRole`, with the cluster name appended.
-For example, with a cluster name of `joe-karpenter-demo`, the instance profile name would look like:
+For example, with a cluster name of `bob-karpenter-demo`, the instance profile name would look like:
 
-`KarpenterNodeInstanceProfile-joe-karpenter-demo`
+`KarpenterNodeInstanceProfile-bob-karpenter-demo`
 
 
 ```
@@ -94,7 +94,7 @@ PRINCIPAL       ec2.amazonaws.com
 ## KarpenterNodeRole
 
 This section creates the node role that is attached to the `KarpenterNodeInstanceProfile` instance profile created earlier.
-Given a cluster name of `joe-karpenter-demo`, this role would end up being named `"KarpenterNodeRole-joe-karpenter-demo`.
+Given a cluster name of `bob-karpenter-demo`, this role would end up being named `"KarpenterNodeRole-bob-karpenter-demo`.
 
 ```
   KarpenterNodeRole:
@@ -125,21 +125,15 @@ The role created here includes several AWS managed policies, which are designed 
 * [AmazonEC2ContainerRegistryReadOnly](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryReadOnly.html): Allows read-only access to repositories in the Amazon EC2 Container Registry.
 * [AmazonSSMManagedInstanceCore](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html): Adds AWS Systems Manager service core functions for Amazon EC2.
 
-# Karpenter Controller Authorization in cloudformation.yaml
+# Karpenter Controller Authorization 
 
 This section sets the permissions that the Karpenter Controller has to create and manage EC2 and other AWS resources.
 In particular, the section creates a service account (karpenter) that is combined with the KarpenterControllerPolicy.
 The permissions here go beyond the permissions assigned to Karpenter nodes in the previous section.
 
-The resources defined in this section include:
+The resources defined in this section are associated with:
 
 * KarpenterControllerPolicy
-* KarpenterInterruptionQueue
-* KarpenterInterruptionQueuePolicy
-* ScheduledChangeRule
-* SpotInterruptionRule
-* RebalanceRule
-* InstanceStateChangeRule
 
 Because the scope of the KarpenterControllerPolicy is an AWS region, the cluster's AWS region is included in the `AllowScopedEC2InstanceActions`.
 
@@ -147,7 +141,7 @@ Because the scope of the KarpenterControllerPolicy is an AWS region, the cluster
 
 A `KarpenterControllerPolicy` object sets the name of the policy, then defines a set of resources and actions allowed for those resources.
 The policy creates authorization for the Karpenter Controller to AWS resources, instead of using the NodeInstanceProfile which probably has less permissions to AWS resources.
-For our example, the KarpenterControllerPolicy would be named: `KarpenterControllerPolicy-joe-karpenter-demo`
+For our example, the KarpenterControllerPolicy would be named: `KarpenterControllerPolicy-bob-karpenter-demo`
 
 ```
   KarpenterControllerPolicy:
@@ -428,7 +422,7 @@ The AllowAPIServerEndpointDiscovery Sid allows the Karpenter controller to get t
 
 
 
-# Interruption Handling in cloudformation.yaml
+# Interruption Handling 
 Settings in this section allow the Karpenter controller to interact with interruption queues.
 So, for example, if Spot instances are being reclaimed or a node crashes, seeing messages from these queues allows Karpenter to be proactive in moving workloads or adding new nodes.
 Defining the `KarpenterInterruptionQueuePolicy` allows Karpenter to see and respond to the following:
@@ -437,6 +431,15 @@ Defining the `KarpenterInterruptionQueuePolicy` allows Karpenter to see and resp
 * Spot interruptions
 * Spot rebalance recommendations
 * Instance state changes
+
+The resources defined in this section include:
+
+* KarpenterInterruptionQueue
+* KarpenterInterruptionQueuePolicy
+* ScheduledChangeRule
+* SpotInterruptionRule
+* RebalanceRule
+* InstanceStateChangeRule
 
 ## KarpenterInterruptionQueue
 The [AWS::SQS::Queue](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html) resource is used to create an Amazon SQS standard queue.

--- a/website/content/en/preview/reference/_index.md
+++ b/website/content/en/preview/reference/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Reference"
+linkTitle: "Reference"
+weight: 100
+description: >
+  Reference documentation for Karpenter
+---

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -3,16 +3,16 @@ title: "CloudFormation"
 linkTitle: "CloudFormation"
 weight: 5
 description: >
-  Refernece of how Karpenter uses CloudFormation to set up permissions
+  A description of the Getting Started CloudFormation file and permissions
 ---
 The [Getting Started with Karpenter]({{< relref "../getting-started/getting-started-with-karpenter" >}}) guide uses CloudFormation to bootstrap the cluster to enable Karpenter to create and manage nodes, as well as to allow Karpenter to respond to interruption events.
 This document describes the `cloudformation.yaml` file used in that guide.
 These descriptions should allow you to understand:
 
-* What Karpenter is authorized to do wbith your EKS cluster and AWS resources when using the `cloudformation.yaml` file
+* What Karpenter is authorized to do with your EKS cluster and AWS resources when using the `cloudformation.yaml` file
 * What permissions you need to set up if you are adding Karpenter to an existing cluster
 
-# Review the cloudformation.yaml file
+## Overview
 
 To download a particular version of `cloudformation.yaml`, set the version and use `curl` to pull the file to your local system:
 
@@ -25,7 +25,7 @@ Following some header information, the rest of the `cloudformation.yaml` file de
 The sections of that file can be grouped together under the following general headings:
 
 * [**Node Authorization**]({{< relref "#node-authorization" >}}): Creates a NodeInstanceProfile, attaches a NodeRole to it, and connects it to an IAM Identity Mapping used to authorize nodes to the cluster. This defines the permissions each node managed by Karpenter has to access EC2 and other AWS resources. This doesn't actually create the IAM Identity Mapping. That part is orchestrated by `eksctl` in the Getting Started guide.
-* [**Karpenter Controller Authorization**]({{< relref "#karpenter-controller-authorization" >}}):  Creates the `KarpenterControllerPolicy` that is attached to the service account.
+* [**Controller Authorization**]({{< relref "#controller-authorization" >}}):  Creates the `KarpenterControllerPolicy` that is attached to the service account.
 Again, the actual service account creation (`karpenter`), that is combined with the `KarpenterControllerPolicy`, is orchestrated by `eksctl` in the Getting Started guide.
 * [**Interruption Handling**]({{< relref "#interruption-handling" >}}): Allows the Karpenter controller to see and respond to interruptions that occur with the nodes that Karpenter is managing. See the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page for details.
 
@@ -36,38 +36,38 @@ That name would then be appended to any name below where `${ClusterName}` is inc
 
 * Partition: Any time an ARN is used, it includes the [partition name](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html) to identify where the object is found. In most cases, that partition name is `aws`. However, it could also be `aws-cn` (for China Regions) or `aws-us-gov` (for AWS GovCloud US Regions).
 
-# Node Authorization 
+## Node Authorization 
 
 The following sections of the `cloudformation.yaml` file set up IAM permissions for Kubernetes nodes created by Karpenter.
 In particular, this involves setting up a node role that can be attached and passed to instance profiles that Karpenter generates at runtime:
 
 * KarpenterNodeRole
 
-## KarpenterNodeRole
+### KarpenterNodeRole
 
 This section of the template defines the IAM role attached to generated instance profiles.
 Given a cluster name of `bob-karpenter-demo`, this role would end up being named `"KarpenterNodeRole-bob-karpenter-demo`.
 
-```
-  KarpenterNodeRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      RoleName: !Sub "KarpenterNodeRole-${ClusterName}"
-      Path: /
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                !Sub "ec2.${AWS::URLSuffix}"
-            Action:
-              - "sts:AssumeRole"
-      ManagedPolicyArns:
-        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
-        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+```yaml
+KarpenterNodeRole:
+  Type: "AWS::IAM::Role"
+  Properties:
+    RoleName: !Sub "KarpenterNodeRole-${ClusterName}"
+    Path: /
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              !Sub "ec2.${AWS::URLSuffix}"
+          Action:
+            - "sts:AssumeRole"
+    ManagedPolicyArns:
+      - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+      - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+      - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+      - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 ```
 
 The role created here includes several AWS managed policies, which are designed to provide permissions for specific uses needed by the nodes to work with EC2 and other AWS resources. These include:
@@ -77,9 +77,9 @@ The role created here includes several AWS managed policies, which are designed 
 * [AmazonEC2ContainerRegistryReadOnly](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryReadOnly.html): Allows read-only access to repositories in the Amazon EC2 Container Registry.
 * [AmazonSSMManagedInstanceCore](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html): Adds AWS Systems Manager service core functions for Amazon EC2.
 
-If you were to use a node role from an existing cluster, you could skip this provisioning step and pass this node role to any EC2NodeClasses that you create. Additionally, you would ensure that the [Karpenter Controller Policy]({{< relref "#karpentercontrollerpolicy" >}}) has `iam:PassRole` permission to the role attached to the generated instance profiles.
+If you were to use a node role from an existing cluster, you could skip this provisioning step and pass this node role to any EC2NodeClasses that you create. Additionally, you would ensure that the [Controller Policy]({{< relref "#controllerpolicy" >}}) has `iam:PassRole` permission to the role attached to the generated instance profiles.
 
-# Karpenter Controller Authorization 
+## Controller Authorization 
 
 This section sets the AWS permissions for the Karpenter Controller. When used in the Getting Started guide, `eksctl` uses these permissions to create a service account (karpenter) that is combined with the KarpenterControllerPolicy.
 
@@ -89,367 +89,379 @@ The resources defined in this section are associated with:
 
 Because the scope of the KarpenterControllerPolicy is an AWS region, the cluster's AWS region is included in the `AllowScopedEC2InstanceActions`.
 
-## KarpenterControllerPolicy
+### KarpenterControllerPolicy
 
 A `KarpenterControllerPolicy` object sets the name of the policy, then defines a set of resources and actions allowed for those resources.
 For our example, the KarpenterControllerPolicy would be named: `KarpenterControllerPolicy-bob-karpenter-demo`
 
+```yaml
+KarpenterControllerPolicy:
+  Type: AWS::IAM::ManagedPolicy
+  Properties:
+    ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
+    # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+    # value in one of its key parameters which isn't natively supported by CloudFormation
+    PolicyDocument: !Sub |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
 ```
-  KarpenterControllerPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
-      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
-      # value in one of its key parameters which isn't natively supported by CloudFormation
-      PolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-```
+
 Someone wanting to add Karpenter to an existing cluster, instead of using `cloudformation.yaml`, would need to create the IAM policy directly and assign that policy to the role leveraged by the service account using IRSA.
 
-### AllowScopedEC2InstanceActions
+#### AllowScopedEC2InstanceActions
 
 The AllowScopedEC2InstanceActions statement ID (Sid) identifies a set of EC2 resources that are allowed to be accessed with
 [RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html) and [CreateFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html) actions.
 For `RunInstances` and `CreateFleet` actions, the Karpenter controller can read (but not create) `image`, `snapshot`, `spot-instances-request`, `security-group`, `subnet` and `launch-template` EC2 resources, scoped for the particular AWS partition and region.
 
-```
-            {
-              "Sid": "AllowScopedEC2InstanceActions",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet"
-              ]
-            },
+```json
+{
+  "Sid": "AllowScopedEC2InstanceActions",
+  "Effect": "Allow",
+  "Resource": [
+    "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+  ],
+  "Action": [
+    "ec2:RunInstances",
+    "ec2:CreateFleet"
+  ]
+}
 ```
 
-### AllowScopedEC2InstanceActionsWithTags
+#### AllowScopedEC2InstanceActionsWithTags
+
 The AllowScopedEC2InstanceActionsWithTags Sid allows the 
 [RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html), [CreateFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html), and [CreateLaunchTemplate](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateLaunchTemplate.html)
 actions requested by the Karpenter controller to create all `fleet`, `instance`, `volume`, `network-interface`, or `launch-template` EC2 resources (for the partition and region), and requires that the `kubernetes.io/cluster/${ClusterName}` tag be set to `owned` and a `karpenter.sh/nodepool` tag be set to any value. This ensures that Karpenter is only allowed to create instances for a single EKS cluster.
 
+```json
+{
+  "Sid": "AllowScopedEC2InstanceActionsWithTags",
+  "Effect": "Allow",
+  "Resource": [
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+  ],
+  "Action": [
+    "ec2:RunInstances",
+    "ec2:CreateFleet",
+    "ec2:CreateLaunchTemplate"
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
+    },
+    "StringLike": {
+      "aws:RequestTag/karpenter.sh/nodepool": "*"
+    }
+  }
+}
 ```
-            {
-              "Sid": "AllowScopedEC2InstanceActionsWithTags",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:RunInstances",
-                "ec2:CreateFleet",
-                "ec2:CreateLaunchTemplate"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/nodepool": "*"
-                }
-              }
-            },
 
-```
+#### AllowScopedResourceCreationTagging
 
-### AllowScopedResourceCreationTagging
 The AllowScopedResourceCreationTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html)
 actions on `fleet`, `instance`, `volume`, `network-interface`, and `launch-template` resources, While making `RunInstance`, `CreateFleet`, or `CreateLaunchTemplate` calls. Additionally, this ensures that resources can't be tagged arbitrarily by Karpenter after they are created.
 
-```
-            {
-              "Sid": "AllowScopedResourceCreationTagging",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "ec2:CreateAction": [
-                    "RunInstances",
-                    "CreateFleet",
-                    "CreateLaunchTemplate"
-                  ]
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/nodepool": "*"
-                }
-              }
-            },
+```json
+{
+  "Sid": "AllowScopedResourceCreationTagging",
+  "Effect": "Allow",
+  "Resource": [
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+  ],
+  "Action": "ec2:CreateTags",
+  "Condition": {
+    "StringEquals": {
+      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+      "ec2:CreateAction": [
+        "RunInstances",
+        "CreateFleet",
+        "CreateLaunchTemplate"
+      ]
+    },
+    "StringLike": {
+      "aws:RequestTag/karpenter.sh/nodepool": "*"
+    }
+  }
+}
 ```
 
-### AllowScopedResourceTagging
+#### AllowScopedResourceTagging
 
 The AllowScopedResourceTagging Sid allows EC2 [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) actions on all instances created by Karpenter after their creation. It enforces that Karpenter is only able to update the tags on cluster instances it is operating on through the `karpenter.sh/cluster/${ClusterName}`" and `karpenter.sh/nodepool` tags.
-```
-            {
-              "Sid": "AllowScopedResourceTagging",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-              "Action": "ec2:CreateTags",
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/karpenter.sh/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/nodepool": "*"
-                },
-                "ForAllValues:StringEquals": {
-                  "aws:TagKeys": [
-                    "karpenter.sh/nodeclaim",
-                    "Name"
-                  ]
-                }
-              }
-            },
+```json
+{
+  "Sid": "AllowScopedResourceTagging",
+  "Effect": "Allow",
+  "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+  "Action": "ec2:CreateTags",
+  "Condition": {
+    "StringEquals": {
+      "aws:ResourceTag/karpenter.sh/cluster/${ClusterName}": "owned"
+    },
+    "StringLike": {
+      "aws:ResourceTag/karpenter.sh/nodepool": "*"
+    },
+    "ForAllValues:StringEquals": {
+      "aws:TagKeys": [
+        "karpenter.sh/nodeclaim",
+        "Name"
+      ]
+    }
+  }
+}
 ```
 
-### AllowScopedDeletion
+#### AllowScopedDeletion
+
 The AllowScopedDeletion Sid allows [TerminateInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html) and [DeleteLaunchTemplate](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteLaunchTemplate.html) actions to delete instance and launch-template resources, provided that `karpenter.sh/nodepool` and `kubernetes.io/cluster/${ClusterName}` tags are set. These tags must be present on all resources that Karpenter is going to delete. This ensures that Karpenter can only delete instances and launch templates that are associated with it.
 
-```
-            {
-              "Sid": "AllowScopedDeletion",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
-              ],
-              "Action": [
-                "ec2:TerminateInstances",
-                "ec2:DeleteLaunchTemplate"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/nodepool": "*"
-                }
-              }
-            },
+```json
+{
+  "Sid": "AllowScopedDeletion",
+  "Effect": "Allow",
+  "Resource": [
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+    "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+  ],
+  "Action": [
+    "ec2:TerminateInstances",
+    "ec2:DeleteLaunchTemplate"
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+    },
+    "StringLike": {
+      "aws:ResourceTag/karpenter.sh/nodepool": "*"
+    }
+  }
+}
 ```
 
-### AllowRegionalReadActions
+#### AllowRegionalReadActions
 
 The AllowRegionalReadActions Sid allows [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html), [DescribeImages](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html), [DescribeInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), [DescribeInstanceTypeOfferings](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html), [DescribeInstanceTypes](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html), [DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html), [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [DescribeSpotPriceHistory](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html), and [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) actions for the current AWS region.
 This allows the Karpenter controller to do any of those read-only actions across all related resources for that AWS region.
 
-```
-            {
-              "Sid": "AllowRegionalReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeLaunchTemplates",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSpotPriceHistory",
-                "ec2:DescribeSubnets"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestedRegion": "${AWS::Region}"
-                }
-              }
-            },
+```json
+{
+  "Sid": "AllowRegionalReadActions",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": [
+    "ec2:DescribeAvailabilityZones",
+    "ec2:DescribeImages",
+    "ec2:DescribeInstances",
+    "ec2:DescribeInstanceTypeOfferings",
+    "ec2:DescribeInstanceTypes",
+    "ec2:DescribeLaunchTemplates",
+    "ec2:DescribeSecurityGroups",
+    "ec2:DescribeSpotPriceHistory",
+    "ec2:DescribeSubnets"
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:RequestedRegion": "${AWS::Region}"
+    }
+  }
+}
 ```
 
-### AllowSSMReadActions
+#### AllowSSMReadActions
+
 The AllowSSMReadActions Sid allows the Karpenter controller to read SSM parameters (`ssm:GetParameter`) from the current region for SSM parameters generated by ASW services.
 
 **NOTE**: If potentially sensitive information is stored in SSM parameters, you could consider restricting access to these messages further.
-```
-            {
-              "Sid": "AllowSSMReadActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
-              "Action": "ssm:GetParameter"
-            },
+```json
+{
+  "Sid": "AllowSSMReadActions",
+  "Effect": "Allow",
+  "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+  "Action": "ssm:GetParameter"
+}
 ```
 
-### AllowPricingReadActions
+#### AllowPricingReadActions
+
 Because pricing information does not exist in every region at the moment, the AllowPricingReadActions Sid allows the Karpenter controller to get product pricing information (`pricing:GetProducts`) for all related resources across all regions.
 
-```
-            {
-              "Sid": "AllowPricingReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": "pricing:GetProducts"
-            },
+```json
+{
+  "Sid": "AllowPricingReadActions",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": "pricing:GetProducts"
+}
 ```
 
-### AllowInterruptionQueueActions
+#### AllowInterruptionQueueActions
+
 Karpenter supports interruption queues, that you can create as described in the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page.
 This section of the cloudformation.yaml template can give Karpenter permission to access those queues by specifying the resource ARN.
 For the interruption queue you created (`${KarepenterInterruptionQueue.Arn}`), the AllowInterruptionQueueActions Sid lets the Karpenter controller have permission to delete messages ([DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html)), get queue attributes ([GetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html)), get queue URL ([GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html)), and receive messages ([ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).
 
-```
-            {
-              "Sid": "AllowInterruptionQueueActions",
-              "Effect": "Allow",
-              "Resource": "${KarpenterInterruptionQueue.Arn}",
-              "Action": [
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-                "sqs:ReceiveMessage"
-              ]
-            },
+```json
+{
+  "Sid": "AllowInterruptionQueueActions",
+  "Effect": "Allow",
+  "Resource": "${KarpenterInterruptionQueue.Arn}",
+  "Action": [
+    "sqs:DeleteMessage",
+    "sqs:GetQueueAttributes",
+    "sqs:GetQueueUrl",
+    "sqs:ReceiveMessage"
+  ]
+}
 ```
 
-### AllowPassingInstanceRole
+#### AllowPassingInstanceRole
+
 The AllowPassingInstanceRole Sid gives the Karpenter controller permission to pass (`iam:PassRole`) the node role (`KarpenterNodeRole-${ClusterName}`) to generated instance profiles.
 This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${ClusterName}` when assigning permissions to generated instance profiles while launching nodes.
 
-```
-            {
-              "Sid": "AllowPassingInstanceRole",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
-              "Action": "iam:PassRole",
-              "Condition": {
-                "StringEquals": {
-                  "iam:PassedToService": "ec2.amazonaws.com"
-                }
-              }
-            },
+```json
+{
+  "Sid": "AllowPassingInstanceRole",
+  "Effect": "Allow",
+  "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}",
+  "Action": "iam:PassRole",
+  "Condition": {
+    "StringEquals": {
+      "iam:PassedToService": "ec2.amazonaws.com"
+    }
+  }
+}
 ```
 
-### AllowScopedInstanceProfileCreationActions
+#### AllowScopedInstanceProfileCreationActions
+
 The AllowScopedInstanceProfileCreationActions Sid gives the Karpenter controller permission to create a new instance profile with [`iam:CreateInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html),
 provided that the request is made to a cluster with `kubernetes.io/cluster/${ClusterName` set to owned and is made in the current region.
 Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karpenter can generate instance profiles on your behalf based on roles specified in your `EC2NodeClasses` that you use to configure Karpenter.
-```
- {
-              "Sid": "AllowScopedInstanceProfileCreationActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "iam:CreateInstanceProfile"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/nodeclass": "*"
-                }
-              }
-            },
+
+```json
+{
+  "Sid": "AllowScopedInstanceProfileCreationActions",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": [
+    "iam:CreateInstanceProfile"
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+      "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+    },
+    "StringLike": {
+      "aws:RequestTag/karpenter.sh/nodeclass": "*"
+    }
+  }
+}
 ```
 
-### AllowScopedInstanceProfileTagActions
+#### AllowScopedInstanceProfileTagActions
+
 The AllowScopedInstanceProfileTagActions Sid gives the Karpenter controller permission to tag an instance profile with [`iam:TagInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagInstanceProfile.html), based on the values shown below,
 Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karpenter is only able to act on instance profiles that it provisions for this cluster.
 
-```
-            {
-              "Sid": "AllowScopedInstanceProfileTagActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "iam:TagInstanceProfile"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/nodeclass": "*",
-                  "aws:RequestTag/karpenter.sh/nodeclass": "*"
-                }
-              }
-            },
+```json
+{
+  "Sid": "AllowScopedInstanceProfileTagActions",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": [
+    "iam:TagInstanceProfile"
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+      "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
+      "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+      "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+    },
+    "StringLike": {
+      "aws:ResourceTag/karpenter.sh/nodeclass": "*",
+      "aws:RequestTag/karpenter.sh/nodeclass": "*"
+    }
+  }
+}
 ```
 
 
-### AllowScopedInstanceProfileActions
+#### AllowScopedInstanceProfileActions
+
 The AllowScopedInstanceProfileActions Sid gives the Karpenter controller permission to perform [`iam:AddRoleToInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddRoleToInstanceProfile.html), [`iam:RemoveRoleFromInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_RemoveRoleFromInstanceProfile.html), and [`iam:DeleteInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteInstanceProfile.html) actions, 
 provided that the request is made to a cluster with `kubernetes.io/cluster/${ClusterName` set to owned and is made in the current region.
 Also, `karpenter.sh/nodeclass` must be set to some value. This permission is further enforced by the `iam:PassRole` permission. If Karpenter attempts to add a role to an instance profile that it doesn't have `iam:PassRole` permission on, that call will fail. Therefore, if you configure Karpenter to use a new role through the `EC2NodeClass`, ensure that you also specify that role within your `iam:PassRole` permission.
 
+```json
+{
+  "Sid": "AllowScopedInstanceProfileActions",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": [
+    "iam:AddRoleToInstanceProfile",
+    "iam:RemoveRoleFromInstanceProfile",
+    "iam:DeleteInstanceProfile"
+  ],
+  "Condition": {
+    "StringEquals": {
+      "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+      "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
+    },
+    "StringLike": {
+      "aws:ResourceTag/karpenter.sh/nodeclass": "*"
+    }
+  }
+}
 ```
-            {
-              "Sid": "AllowScopedInstanceProfileActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": [
-                "iam:AddRoleToInstanceProfile",
-                "iam:RemoveRoleFromInstanceProfile",
-                "iam:DeleteInstanceProfile"
-              ],
-              "Condition": {
-                "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
-                },
-                "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/nodeclass": "*"
-                }
-              }
-            },
-```
-### AllowInstanceProfileActions
+
+#### AllowInstanceProfileActions
+
 The AllowInstanceProfileActions Sid gives the Karpenter controller permission to perform [`iam:GetInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetInstanceProfile.html) actions to retrieve information about a specified instance profile, including understanding if an instance profile has been provisioned for an `EC2NodeClass` or needs to be re-provisioned.
 
-```
-            {
-              "Sid": "AllowInstanceProfileReadActions",
-              "Effect": "Allow",
-              "Resource": "*",
-              "Action": "iam:GetInstanceProfile"
-            },
-            {
+```json
+{
+  "Sid": "AllowInstanceProfileReadActions",
+  "Effect": "Allow",
+  "Resource": "*",
+  "Action": "iam:GetInstanceProfile"
+}
 ```
 
-### AllowAPIServerEndpointDiscovery
+#### AllowAPIServerEndpointDiscovery
+
 You can optionally allow the Karpenter controller to discover the Kubernetes cluster's external API endpoint to enable EC2 nodes to successfully join the EKS cluster.
 
 > **Note**: If you are not using an EKS control plane, you will have to specify this endpoint explicitly. See the description of the `aws.clusterEndpoint` setting in the [ConfigMap](.settings/#configmap) documentation for details.
 
 The AllowAPIServerEndpointDiscovery Sid allows the Karpenter controller to get that information (`eks:DescribeCluster`) for the cluster (`cluster/${ClusterName}`).
-```
-            {
-              "Sid": "AllowAPIServerEndpointDiscovery",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
-              "Action": "eks:DescribeCluster"
-            }
-          ]
-        }
+```json
+{
+  "Sid": "AllowAPIServerEndpointDiscovery",
+  "Effect": "Allow",
+  "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+  "Action": "eks:DescribeCluster"
+}
 ```
 
-# Interruption Handling 
+## Interruption Handling 
+
 Settings in this section allow the Karpenter controller to stand-up an interruption queue to receive notification messages from other AWS services about the health and status of instances. For example, this interruption queue allows Karpenter to be aware of spot instance interruptions that are sent 2 minutes before spot instances are reclaimed by EC2. Adding this queue allows Karpenter to be proactive in migrating workloads to new nodes.
 See the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page for details.
 
@@ -469,65 +481,68 @@ The resources defined in this section include:
 * RebalanceRule
 * InstanceStateChangeRule
 
-## KarpenterInterruptionQueue
+### KarpenterInterruptionQueue
+
 The [AWS::SQS::Queue](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html) resource is used to create an Amazon SQS standard queue.
 Properties of that resource set the `QueueName` to the name of your cluster, the time for which SQS retains each message (`MessageRetentionPeriod`) to 300 seconds, and enabling serverside-side encryption using SQS owned encryption keys (`SqsManagedSseEnabled`) to `true`.
 See [SetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html) for descriptions of some of these attributes.
 
-```
-  KarpenterInterruptionQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${ClusterName}"
-      MessageRetentionPeriod: 300
-      SqsManagedSseEnabled: true
+```yaml
+KarpenterInterruptionQueue:
+  Type: AWS::SQS::Queue
+  Properties:
+    QueueName: !Sub "${ClusterName}"
+    MessageRetentionPeriod: 300
+    SqsManagedSseEnabled: true
 ```
 
-## KarpenterInterruptionQueuePolicy
+### KarpenterInterruptionQueuePolicy
+
 The Karpenter interruption queue policy is created to allow AWS services that we want to receive instance notifications from to push notification messages to the queue.
 The [AWS::SQS::QueuePolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queuepolicy.html) resource here applies `EC2InterruptionPolicy` to the `KarpenterInterruptionQueue`. The policy allows [sqs:SendMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html) actions to `events.amazonaws.com` and `sqs.amazonaws.com` services. It also allows the `GetAtt` function to get attributes from `KarpenterInterruptionQueue.Arn`.
 
-```
-  KarpenterInterruptionQueuePolicy:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      Queues:
-        - !Ref KarpenterInterruptionQueue
-      PolicyDocument:
-        Id: EC2InterruptionPolicy
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - events.amazonaws.com
-                - sqs.amazonaws.com
-            Action: sqs:SendMessage
-            Resource: !GetAtt KarpenterInterruptionQueue.Arn
+```yaml
+KarpenterInterruptionQueuePolicy:
+  Type: AWS::SQS::QueuePolicy
+  Properties:
+    Queues:
+      - !Ref KarpenterInterruptionQueue
+    PolicyDocument:
+      Id: EC2InterruptionPolicy
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - events.amazonaws.com
+              - sqs.amazonaws.com
+          Action: sqs:SendMessage
+          Resource: !GetAtt KarpenterInterruptionQueue.Arn
 ```
 
-## Rules
+### Rules
+
 This section allows Karpenter to gather [AWS Health Events](https://docs.aws.amazon.com/health/latest/ug/cloudwatch-events-health.html#about-public-events) and direct them to a queue where they can be consumed by Karpenter.
 These rules include:
 
 * ScheduledChangeRule: The [AWS::Events::Rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html) creates a rule where the [EventPattern](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html) is set to send events from the `aws.health` source to `KarpenterInterruptionQueue`.
 
-   ```
-     ScheduledChangeRule:
-       Type: 'AWS::Events::Rule'
-       Properties:
-         EventPattern:
-           source:
-             - aws.health
-           detail-type:
-             - AWS Health Event
-         Targets:
-           - Id: KarpenterInterruptionQueueTarget
-             Arn: !GetAtt KarpenterInterruptionQueue.Arn
-   ```
+  ```yaml
+  ScheduledChangeRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+     EventPattern:
+       source:
+         - aws.health
+       detail-type:
+         - AWS Health Event
+     Targets:
+       - Id: KarpenterInterruptionQueueTarget
+         Arn: !GetAtt KarpenterInterruptionQueue.Arn
+  ```
 
 * SpotInterruptionRule: An EC2 Spot Instance Interruption warning tells you that AWS is about to reclaim a Spot instance you are using. This rule allows Karpenter to gather [EC2 Spot Instance Interruption Warning](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html) events and direct them to a queue where they can be consumed by Karpenter. In particular, the [AWS::Events::Rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html) here creates a rule where the [EventPattern](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html) is set to send events from the `aws.ec2` source to `KarpenterInterruptionQueue`.
 
-```
+  ```yaml
   SpotInterruptionRule:
     Type: 'AWS::Events::Rule'
     Properties:
@@ -539,37 +554,36 @@ These rules include:
       Targets:
         - Id: KarpenterInterruptionQueueTarget
           Arn: !GetAtt KarpenterInterruptionQueue.Arn
-```
+  ```
 
 * RebalanceRule: An EC2 Instance Rebalance Recommendation signal tells you that a Spot instance is at a heightened risk of being interrupted, allowing Karpenter to get new instances or simply rebalance workloads.  This rule allows Karpenter to gather [EC2 Instance Rebalance Recommendation](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/rebalance-recommendations.html) signals and direct them to a queue where they can be consumed by Karpenter. In particular, the [AWS::Events::Rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html) here creates a rule where the [EventPattern](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html) is set to send events from the `aws.ec2` source to `KarpenterInterruptionQueue`.
 
-   ```
-     RebalanceRule:
-       Type: 'AWS::Events::Rule'
-       Properties:
-         EventPattern:
-           source:
-             - aws.ec2
-           detail-type:
-             - EC2 Instance Rebalance Recommendation
-         Targets:
-           - Id: KarpenterInterruptionQueueTarget
-             Arn: !GetAtt KarpenterInterruptionQueue.Arn
-   ```
+  ```yaml
+  RebalanceRule:
+   Type: 'AWS::Events::Rule'
+   Properties:
+     EventPattern:
+       source:
+         - aws.ec2
+       detail-type:
+         - EC2 Instance Rebalance Recommendation
+     Targets:
+       - Id: KarpenterInterruptionQueueTarget
+         Arn: !GetAtt KarpenterInterruptionQueue.Arn
+  ```
 
 * InstanceStateChangeRule: An EC2 Instance State-change Notification signal tells you that the state of an instance has changed to one of the following states: pending, running, stopping, stopped, shutting-down, or terminated. This rule allows Karpenter to gather [EC2 Instance State-change](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instance-state-changes.html) signals and direct them to a queue where they can be consumed by Karpenter. In particular, the [AWS::Events::Rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html) here creates a rule where the [EventPattern](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html) is set to send events from the `aws.ec2` source to `KarpenterInterruptionQueue`.
 
-
-   ```
-     InstanceStateChangeRule:
-       Type: 'AWS::Events::Rule'
-       Properties:
-         EventPattern:
-           source:
-             - aws.ec2
-           detail-type:
-             - EC2 Instance State-change Notification
-         Targets:
-           - Id: KarpenterInterruptionQueueTarget
-             Arn: !GetAtt KarpenterInterruptionQueue.Arn
-   ```
+  ```yaml
+  InstanceStateChangeRule:
+   Type: 'AWS::Events::Rule'
+   Properties:
+     EventPattern:
+       source:
+         - aws.ec2
+       detail-type:
+         - EC2 Instance State-change Notification
+     Targets:
+       - Id: KarpenterInterruptionQueueTarget
+         Arn: !GetAtt KarpenterInterruptionQueue.Arn
+  ```


### PR DESCRIPTION
**Description**: This PR adds new documentation describing how CloudFormation is used to setup permissions needed by Karpenter to manage cloud and EKS resources. This is part of a larger effort to describe Karpenter requirements for those migrating existing clusters to use Karpenter.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.