### PR TITLE
fix: unblock release Stable-PR

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -12,6 +12,7 @@ config(){
   CURRENT_MAJOR_VERSION="0"
   RELEASE_PLATFORM="--platform=linux/amd64,linux/arm64"
 
+  MAIN_GITHUB_ACCOUNT="aws"
   RELEASE_TYPE_STABLE="stable"
   RELEASE_TYPE_SNAPSHOT="snapshot"
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Release action is failing due to not defining `MAIN_GITHUB_ACCOUNT: unbound variable` 
- https://github.com/aws/karpenter/actions/runs/5827248497/job/15803358804

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.