### PR TITLE
chore: eks:TagResource on nodegroup for e2e tests

### DIFF
--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -164,6 +164,7 @@ Resources:
             Action:
               - eks:DeleteNodegroup
               - eks:DescribeNodegroup
+              - eks:TagResource
             Resource: 
               - !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:nodegroup/*"
             Condition:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- e2e tests are failing on Cluster Create due to a missing eks:TagResource permission on the Node Group resource.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.