### PR TITLE
chore: mitigate ubuntu issue causing flakey tests on new instance types

### DIFF
--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -189,6 +189,20 @@ var _ = Describe("AMI", func() {
 			}})
 			provisioner := test.Provisioner(test.ProvisionerOptions{
 				ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
+				// TODO: remove requirements after Ubuntu fixes bootstrap script issue w/
+				// new instance types not included in the max-pods.txt file.
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha1.LabelInstanceGeneration,
+						Operator: v1.NodeSelectorOpLt,
+						Values:   []string{"7"},
+					},
+					{
+						Key:      v1.LabelOSStable,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{string(v1.Linux)},
+					},
+				},
 			})
 			pod := test.Pod()
 			env.ExpectCreated(provider, provisioner, pod)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
 - There's a bug in the Ubuntu bootstrap script when an instance type is not included in the max-pods.txt file which generally affects new instance types. This change will only use gen 6 and below for the ubuntu e2e test to stop the flakey failures. 

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.