### PR TITLE
fix: Allow specifying root volume in block device mappings

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -149,6 +149,11 @@ spec:
                             in the Amazon Elastic Compute Cloud User Guide.
                           type: string
                       type: object
+                    rootVolume:
+                      description: RootVolume is a flag indicating if this device
+                        is mounted as kubelet root dir. You can configure at most
+                        one root volume in BlockDeviceMappings.
+                      type: boolean
                   type: object
                 type: array
               context:

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -206,6 +206,9 @@ type BlockDeviceMapping struct {
 	// EBS contains parameters used to automatically set up EBS volumes when an instance is launched.
 	// +optional
 	EBS *BlockDevice `json:"ebs,omitempty"`
+	// RootVolume is a flag indicating if this device is mounted as kubelet root dir. You can
+	// configure at most one root volume in BlockDeviceMappings.
+	RootVolume bool `json:"rootVolume,omitempty"`
 }
 
 type BlockDevice struct {

--- a/pkg/apis/v1beta1/ec2nodeclass_validation.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation.go
@@ -194,10 +194,17 @@ func (in *EC2NodeClassSpec) validateStringEnum(value, field string, validValues 
 }
 
 func (in *EC2NodeClassSpec) validateBlockDeviceMappings() (errs *apis.FieldError) {
+	numRootVolume := 0
 	for i, blockDeviceMapping := range in.BlockDeviceMappings {
 		if err := in.validateBlockDeviceMapping(blockDeviceMapping); err != nil {
 			errs = errs.Also(err.ViaFieldIndex(blockDeviceMappingsPath, i))
 		}
+		if blockDeviceMapping.RootVolume {
+			numRootVolume++
+		}
+	}
+	if numRootVolume > 1 {
+		errs = errs.Also(apis.ErrMultipleOneOf("more than 1 root volume configured"))
 	}
 	return errs
 }

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -208,6 +208,12 @@ func memory(ctx context.Context, info *ec2.InstanceTypeInfo) *resource.Quantity 
 // Setting ephemeral-storage to be either the default value or what is defined in blockDeviceMappings
 func ephemeralStorage(amiFamily amifamily.AMIFamily, blockDeviceMappings []*v1beta1.BlockDeviceMapping) *resource.Quantity {
 	if len(blockDeviceMappings) != 0 {
+		// First check if there's a root volume configured in blockDeviceMappings.
+		if blockDeviceMapping, ok := lo.Find(blockDeviceMappings, func(bdm *v1beta1.BlockDeviceMapping) bool {
+			return bdm.RootVolume
+		}); ok && blockDeviceMapping.EBS.VolumeSize != nil {
+			return blockDeviceMapping.EBS.VolumeSize
+		}
 		switch amiFamily.(type) {
 		case *amifamily.Custom:
 			// We can't know if a custom AMI is going to have a volume size.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3962 <!-- issue number -->

**Description**
* Karpenter doesn't support specifying root volumes within block device mappings. This update introduces a `RootVolume` flag to the `BlockDeviceMapping`, enabling Karpenter to utilize the configured volume size for pod packing.

**How was this change tested?**
Unit tests.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [x] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.