### PR TITLE
chore: mitigate new instance types causing flakey windows tests

### DIFF
--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -191,7 +191,7 @@ var _ = Describe("AMI", func() {
 			provisioner := test.Provisioner(test.ProvisionerOptions{
 				ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
 				// TODO: remove requirements after Ubuntu fixes bootstrap script issue w/
-				// new instance types not included in the max-pods.txt file.
+				// new instance types not included in the max-pods.txt file. (https://github.com/aws/karpenter/issues/4472)
 				Requirements: []v1.NodeSelectorRequirement{
 					{
 						Key:      v1alpha1.LabelInstanceGeneration,

--- a/test/suites/integration/kubelet_config_test.go
+++ b/test/suites/integration/kubelet_config_test.go
@@ -133,7 +133,13 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 					Key:      v1.LabelOSStable,
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{string(v1.Windows)},
-				})
+				},
+					// TODO: remove this requirement once VPC RC rolls out m7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+					v1.NodeSelectorRequirement{
+						Key:      v1alpha1.LabelInstanceGeneration,
+						Operator: v1.NodeSelectorOpLt,
+						Values:   []string{"7"},
+					})
 				pod := test.Pod(test.PodOptions{
 					Image: aws.WindowsDefaultImage,
 					NodeSelector: map[string]string{

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -255,7 +255,13 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 		provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{
 			Key:      v1.LabelOSStable,
 			Operator: v1.NodeSelectorOpExists,
-		})
+		},
+			// TODO: remove this requirement once VPC RC rolls out m7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+			v1.NodeSelectorRequirement{
+				Key:      v1alpha1.LabelInstanceGeneration,
+				Operator: v1.NodeSelectorOpLt,
+				Values:   []string{"7"},
+			})
 		env.ExpectCreated(provisioner, provider, deployment)
 		env.EventuallyExpectHealthyPodCountWithTimeout(time.Minute*15, labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
 		env.ExpectCreatedNodeCount("==", 1)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
 - Fix test flakes in windows due to missing ENI data in VPC RC and ref tracking issue in TODO comment

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.