### PR TITLE
Cluster ca bundle setting

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -170,6 +170,8 @@ settings:
     assumeRoleARN: ""
     # -- Duration of assumed credentials in minutes. Default value is 15 minutes. Not used unless aws.assumeRoleARN set.
     assumeRoleDuration: 15m
+    # -- Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
+    clusterCABundle: ""
     # -- Cluster name.
     clusterName: ""
     # -- Cluster endpoint. If not set, will be discovered during startup (EKS only)

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -37,6 +37,7 @@ var ContextKey = settingsKeyType{}
 var defaultSettings = &Settings{
 	AssumeRoleARN:              "",
 	AssumeRoleDuration:         time.Minute * 15,
+	ClusterCABundle:            "",
 	ClusterName:                "",
 	ClusterEndpoint:            "",
 	DefaultInstanceProfile:     "",
@@ -53,7 +54,8 @@ var defaultSettings = &Settings{
 type Settings struct {
 	AssumeRoleARN              string
 	AssumeRoleDuration         time.Duration `validate:"min=15m"`
-	ClusterName                string        `validate:"required"`
+	ClusterCABundle            string
+	ClusterName                string `validate:"required"`
 	ClusterEndpoint            string
 	DefaultInstanceProfile     string
 	EnablePodENI               bool
@@ -76,6 +78,7 @@ func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context,
 	if err := configmap.Parse(cm.Data,
 		configmap.AsString("aws.assumeRoleARN", &s.AssumeRoleARN),
 		configmap.AsDuration("aws.assumeRoleDuration", &s.AssumeRoleDuration),
+		configmap.AsString("aws.clusterCABundle", &s.ClusterCABundle),
 		configmap.AsString("aws.clusterName", &s.ClusterName),
 		configmap.AsString("aws.clusterEndpoint", &s.ClusterEndpoint),
 		configmap.AsString("aws.defaultInstanceProfile", &s.DefaultInstanceProfile),

--- a/pkg/apis/settings/suite_test.go
+++ b/pkg/apis/settings/suite_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Validation", func() {
 		s := settings.FromContext(ctx)
 		Expect(s.AssumeRoleARN).To(Equal(""))
 		Expect(s.AssumeRoleDuration).To(Equal(time.Duration(15) * time.Minute))
+		Expect(s.ClusterCABundle).To(Equal(""))
 		Expect(s.DefaultInstanceProfile).To(Equal(""))
 		Expect(s.EnablePodENI).To(BeFalse())
 		Expect(s.EnableENILimitedPodDensity).To(BeTrue())
@@ -61,6 +62,7 @@ var _ = Describe("Validation", func() {
 			Data: map[string]string{
 				"aws.assumeRoleARN":              "arn:aws:iam::111222333444:role/testrole",
 				"aws.assumeRoleDuration":         "27m",
+				"aws.clusterCABundle":            "ca-bundle",
 				"aws.clusterEndpoint":            "https://00000000000000000000000.gr7.us-west-2.eks.amazonaws.com",
 				"aws.clusterName":                "my-cluster",
 				"aws.defaultInstanceProfile":     "karpenter",
@@ -77,6 +79,7 @@ var _ = Describe("Validation", func() {
 		s := settings.FromContext(ctx)
 		Expect(s.AssumeRoleARN).To(Equal("arn:aws:iam::111222333444:role/testrole"))
 		Expect(s.AssumeRoleDuration).To(Equal(time.Duration(27) * time.Minute))
+		Expect(s.ClusterCABundle).To(Equal("ca-bundle"))
 		Expect(s.DefaultInstanceProfile).To(Equal("karpenter"))
 		Expect(s.EnablePodENI).To(BeTrue())
 		Expect(s.EnableENILimitedPodDensity).To(BeFalse())

--- a/website/content/en/preview/concepts/settings.md
+++ b/website/content/en/preview/concepts/settings.md
@@ -49,6 +49,8 @@ data:
   aws.assumeRoleARN: arn:aws:iam::111222333444:role/examplerole
   # Duration of assumed credentials in minutes. Default value is 15 minutes. Not used unless aws.assumeRole set.
   aws.assumeRoleDuration: 15m
+  # Cluster CA bundle for nodes to use for TLS connections with the API server. If not set, this is taken from the controller's TLS configuration.
+  aws.clusterCABundle: "LS0tLS1..."
   # [REQUIRED] The kubernetes cluster name for resource discovery
   aws.clusterName: karpenter-cluster
   # [REQUIRED] The external kubernetes cluster endpoint for new nodes to connect with


### PR DESCRIPTION
**Description**
Adding clusterCABundle as a Karpenter setting. This is needed for our use case where a Karpenter controller needs to communicate with a cluster, but does not use TLS itself - instead it talks to a local proxy over HTTP. Without this change, the CA bundle would be unresolvable and the CA bundle passed to the node would be empty, preventing that node from joining the cluster.

One call out I had was that this was failing silently for our use case before I caught this - this is because the validation below assumes that the rest config is TLS-enabled. Should we add a separate check to verify that the CAData string isn't empty before returning?

https://github.com/neerajvshah/karpenter/blob/main/pkg/operator/operator.go#L210-L223

EDIT - technically Kubernetes api-servers can be configured to ignore CA data from nodes with `--insecure-skip-tls-verify`, so it makes sense to not have the above check.

**How was this change tested?**
I tested this locally and saw that the CA bundle set by the global config map was ingested by Karpenter.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.