### PR TITLE
docs: Fix ttlSecondsAfterEmpty capailtilization in docs for consistency

### DIFF
--- a/website/content/en/docs/concepts/provisioners.md
+++ b/website/content/en/docs/concepts/provisioners.md
@@ -436,7 +436,7 @@ This field points to the cloud provider-specific custom resource. Learn more abo
 
 ## spec.consolidation
 
-You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.TTLSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
+You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.ttlSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
 
 ## Example Use-Cases
 

--- a/website/content/en/preview/concepts/provisioners.md
+++ b/website/content/en/preview/concepts/provisioners.md
@@ -436,7 +436,7 @@ This field points to the cloud provider-specific custom resource. Learn more abo
 
 ## spec.consolidation
 
-You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.TTLSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
+You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.ttlSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
 
 ## Example Use-Cases
 

--- a/website/content/en/v0.26/concepts/provisioners.md
+++ b/website/content/en/v0.26/concepts/provisioners.md
@@ -425,7 +425,7 @@ This field points to the cloud provider-specific custom resource. Learn more abo
 
 ## spec.consolidation
 
-You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.TTLSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
+You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.ttlSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
 
 ## Example Use-Cases
 

--- a/website/content/en/v0.27/concepts/provisioners.md
+++ b/website/content/en/v0.27/concepts/provisioners.md
@@ -435,7 +435,7 @@ This field points to the cloud provider-specific custom resource. Learn more abo
 
 ## spec.consolidation
 
-You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.TTLSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
+You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.ttlSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
 
 ## Example Use-Cases
 

--- a/website/content/en/v0.28/concepts/provisioners.md
+++ b/website/content/en/v0.28/concepts/provisioners.md
@@ -435,7 +435,7 @@ This field points to the cloud provider-specific custom resource. Learn more abo
 
 ## spec.consolidation
 
-You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.TTLSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
+You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.ttlSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
 
 ## Example Use-Cases
 

--- a/website/content/en/v0.29/concepts/provisioners.md
+++ b/website/content/en/v0.29/concepts/provisioners.md
@@ -436,7 +436,7 @@ This field points to the cloud provider-specific custom resource. Learn more abo
 
 ## spec.consolidation
 
-You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.TTLSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
+You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.ttlSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
 
 ## Example Use-Cases
 

--- a/website/content/en/v0.30.0-rc/concepts/provisioners.md
+++ b/website/content/en/v0.30.0-rc/concepts/provisioners.md
@@ -436,7 +436,7 @@ This field points to the cloud provider-specific custom resource. Learn more abo
 
 ## spec.consolidation
 
-You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.TTLSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
+You can configure Karpenter to deprovision instances through your Provisioner in multiple ways. You can use `spec.ttlSecondsAfterEmpty`, `spec.ttlSecondsUntilExpired` or `spec.consolidation.enabled`. Read [Deprovisioning](../deprovisioning/) for more.
 
 ## Example Use-Cases
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

docs: Fix ttlSecondsAfterEmpty capailtilization in docs for consistency

**How was this change tested?**

n/a

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.