### PR TITLE
Allow `node-restriction.kubernetes.io/` prefix in the label set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.328
-	github.com/aws/karpenter-core v0.30.0-rc.0.0.20230822175121-c71cf73b5a52
+	github.com/aws/karpenter-core v0.30.0-rc.0.0.20230823194033-acb9571f6da5
 	github.com/go-playground/validator/v10 v10.15.1
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.328 h1:WBwlf8ym9SDQ/GTIBO9eXyvwappKJyOetWJKl4mT7ZU=
 github.com/aws/aws-sdk-go v1.44.328/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.30.0-rc.0.0.20230822175121-c71cf73b5a52 h1:vjppWOFi+YWrtNE3KhKka/2YLMet9obGiq/dsikxDJQ=
-github.com/aws/karpenter-core v0.30.0-rc.0.0.20230822175121-c71cf73b5a52/go.mod h1:AQl8m8OtgO2N8IlZlzAU6MTrJTJSbe6K4GwdRUNSJVc=
+github.com/aws/karpenter-core v0.30.0-rc.0.0.20230823194033-acb9571f6da5 h1:zRYWS4cpDPfE0rV+/hiwJWbR6DrSchJA/gPmdO92Zko=
+github.com/aws/karpenter-core v0.30.0-rc.0.0.20230823194033-acb9571f6da5/go.mod h1:AQl8m8OtgO2N8IlZlzAU6MTrJTJSbe6K4GwdRUNSJVc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -266,6 +266,35 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 		env.EventuallyExpectHealthyPodCountWithTimeout(time.Minute*15, labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
 		env.ExpectCreatedNodeCount("==", 1)
 	})
+	It("should support the node-restriction.kubernetes.io label domain", func() {
+		// Assign labels to the provisioner so that it has known values
+		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+			{
+				Key:      v1.LabelNamespaceNodeRestriction + "/team",
+				Operator: v1.NodeSelectorOpExists,
+			},
+			{
+				Key:      v1.LabelNamespaceNodeRestriction + "/custom-label",
+				Operator: v1.NodeSelectorOpExists,
+			},
+		}
+		nodeSelector := map[string]string{
+			v1.LabelNamespaceNodeRestriction + "/team":         "team-1",
+			v1.LabelNamespaceNodeRestriction + "/custom-label": "custom-value",
+		}
+		selectors.Insert(lo.Keys(nodeSelector)...) // Add node selector keys to selectors used in testing to ensure we test all labels
+		requirements := lo.MapToSlice(nodeSelector, func(key string, value string) v1.NodeSelectorRequirement {
+			return v1.NodeSelectorRequirement{Key: key, Operator: v1.NodeSelectorOpIn, Values: []string{value}}
+		})
+		deployment := test.Deployment(test.DeploymentOptions{Replicas: 1, PodOptions: test.PodOptions{
+			NodeSelector:     nodeSelector,
+			NodePreferences:  requirements,
+			NodeRequirements: requirements,
+		}})
+		env.ExpectCreated(provisioner, provider, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
+		env.ExpectCreatedNodeCount("==", 1)
+	})
 	It("should provision a node for naked pods", func() {
 		pod := test.Pod()
 

--- a/test/suites/integration/webhook_test.go
+++ b/test/suites/integration/webhook_test.go
@@ -155,6 +155,14 @@ var _ = Describe("Webhooks", func() {
 					},
 				}))).ToNot(Succeed())
 			})
+			It("should allow a restricted label exception to be used in labels (node-restriction.kubernetes.io/custom-label)", func() {
+				Expect(env.Client.Create(env, test.Provisioner(test.ProvisionerOptions{
+					ProviderRef: &v1alpha5.MachineTemplateRef{Name: "test"},
+					Labels: map[string]string{
+						v1.LabelNamespaceNodeRestriction + "/custom-label": "custom-value",
+					},
+				}))).To(Succeed())
+			})
 			It("should error when a requirement references a restricted label (karpenter.sh/provisioner-name)", func() {
 				Expect(env.Client.Create(env, test.Provisioner(test.ProvisionerOptions{
 					ProviderRef: &v1alpha5.MachineTemplateRef{Name: "test"},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change allows users to pass labels prefixed with `node-restriction.kubernetes.io` into Karpenter labels and requirements and ensures that labels that have this domain are not passed into the userData and into the kubelet startup CLI arguments (which would cause the kubelet to fail startup).

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.