### PR TITLE
test: Prevent Drift from deleting nodes for unhealthy replacement nodes

### DIFF
--- a/test/suites/integration/expiration_test.go
+++ b/test/suites/integration/expiration_test.go
@@ -15,8 +15,11 @@ limitations under the License.
 package integration_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -25,6 +28,9 @@ import (
 	"knative.dev/pkg/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssm"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter/pkg/apis/settings"
@@ -35,15 +41,22 @@ import (
 )
 
 var _ = Describe("Expiration", func() {
-	It("should expire the node after the TTLSecondsUntilExpired is reached", func() {
-		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
+	var nodeTemplate *v1alpha1.AWSNodeTemplate
+	var provisioner *v1alpha5.Provisioner
+	BeforeEach(func() {
+		nodeTemplate = awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 		}})
-		provisioner := test.Provisioner(test.ProvisionerOptions{
-			ProviderRef:            &v1alpha5.MachineTemplateRef{Name: provider.Name},
+		provisioner = test.Provisioner(test.ProvisionerOptions{
+			ProviderRef:            &v1alpha5.MachineTemplateRef{Name: nodeTemplate.Name},
 			TTLSecondsUntilExpired: ptr.Int64(30),
 		})
+		env.ExpectSettingsOverridden(map[string]string{
+			"featureGates.driftEnabled": "false",
+		})
+	})
+	It("should expire the node after the TTLSecondsUntilExpired is reached", func() {
 		var numPods int32 = 1
 
 		dep := test.Deployment(test.DeploymentOptions{
@@ -58,7 +71,7 @@ var _ = Describe("Expiration", func() {
 			},
 		})
 		selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
-		env.ExpectCreated(provisioner, provider, dep)
+		env.ExpectCreated(provisioner, nodeTemplate, dep)
 
 		machine := env.EventuallyExpectCreatedMachineCount("==", 1)[0]
 		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
@@ -100,13 +113,6 @@ var _ = Describe("Expiration", func() {
 		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
 	})
 	It("should replace expired node with a single node and schedule all pods", func() {
-		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
-			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
-			SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
-		}})
-		provisioner := test.Provisioner(test.ProvisionerOptions{
-			ProviderRef: &v1alpha5.MachineTemplateRef{Name: provider.Name},
-		})
 		var numPods int32 = 5
 
 		// We should setup a PDB that will only allow a minimum of 1 pod to be pending at a time
@@ -129,7 +135,7 @@ var _ = Describe("Expiration", func() {
 			},
 		})
 		selector := labels.SelectorFromSet(dep.Spec.Selector.MatchLabels)
-		env.ExpectCreated(provisioner, provider, pdb, dep)
+		env.ExpectCreated(provisioner, nodeTemplate, pdb, dep)
 
 		machine := env.EventuallyExpectCreatedMachineCount("==", 1)[0]
 		node := env.EventuallyExpectCreatedNodeCount("==", 1)[0]
@@ -173,5 +179,120 @@ var _ = Describe("Expiration", func() {
 		env.EventuallyExpectCreatedMachineCount("==", 1)
 		env.EventuallyExpectCreatedNodeCount("==", 1)
 		env.EventuallyExpectHealthyPodCount(selector, int(numPods))
+	})
+	Context("Expiration Failure", func() {
+		It("should not continue to expire if a node never registers", func() {
+			// launch a new machine
+			var numPods int32 = 2
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: 2,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "inflate"}},
+					PodAntiRequirements: []v1.PodAffinityTerm{{
+						TopologyKey: v1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "inflate"},
+						}},
+					},
+				},
+			})
+			env.ExpectCreated(dep, nodeTemplate, provisioner)
+			env.EventuallyExpectNodeCount("==", 2)
+
+			// Set a configuration that will not register a machine
+			parameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
+				Name: aws.String("/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			nodeTemplate.Spec.AMISelector = map[string]string{"aws::ids": *parameter.Parameter.Value}
+			env.ExpectCreatedOrUpdated(nodeTemplate)
+
+			// Should see the machine has expired
+			statingMachineState := env.EventuallyExpectCreatedMachineCount("==", int(numPods))
+			Eventually(func(g Gomega) {
+				for _, machine := range statingMachineState {
+					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
+					g.Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineExpired).IsTrue()).To(BeTrue())
+				}
+			}).Should(Succeed())
+
+			// Expect nodes To get cordoned
+			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+
+			// Expire should fail and the original node should be uncordoned
+			// TODO: reduce timeouts when deprovisioning waits are factored out
+			Eventually(func(g Gomega) {
+				g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(cordonedNodes[0]), cordonedNodes[0]))
+				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
+			}).WithTimeout(11 * time.Minute).Should(Succeed())
+
+			endMachineState := &v1alpha5.MachineList{}
+			Eventually(func(g Gomega) {
+				g.Expect(env.Client.List(env, endMachineState, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+				g.Expect(len(endMachineState.Items)).To(BeNumerically("==", int(numPods)))
+			}).WithTimeout(6 * time.Minute).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				g.Expect(lo.EveryBy(statingMachineState, func(sm *v1alpha5.Machine) bool {
+					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(sm), sm)).To(Succeed())
+					return lo.ContainsBy(endMachineState.Items, func(em v1alpha5.Machine) bool {
+						g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(&em), &em)).To(Succeed())
+						return sm.Name == em.Name
+					})
+				})).To(BeTrue())
+			}, "2m").Should(Succeed())
+		})
+		It("should not continue to expiration if a node registers but never becomes initialized", func() {
+			// launch a new machine
+			var numPods int32 = 2
+			dep := test.Deployment(test.DeploymentOptions{
+				Replicas: 2,
+				PodOptions: test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "inflate"}},
+					PodAntiRequirements: []v1.PodAffinityTerm{{
+						TopologyKey: v1.LabelHostname,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "inflate"},
+						}},
+					},
+				},
+			})
+			env.ExpectCreated(dep, nodeTemplate, provisioner)
+			statingNodeState := env.EventuallyExpectNodeCount("==", int(numPods))
+
+			// Set a configuration that will not initialize a machine
+			provisioner.Spec.StartupTaints = []v1.Taint{{Key: "example.com/taint", Effect: v1.TaintEffectPreferNoSchedule}}
+			env.ExpectCreatedOrUpdated(provisioner)
+
+			// Should see the machine has expired
+			machines := env.EventuallyExpectCreatedMachineCount("==", int(numPods))
+			Eventually(func(g Gomega) {
+				for _, machine := range machines {
+					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
+					g.Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineExpired).IsTrue()).To(BeTrue())
+				}
+			}).Should(Succeed())
+
+			// Expect nodes To be cordoned
+			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+
+			// Expire should fail and original node should be uncordoned
+			// TODO: reduce timeouts when deprovisioning waits are factored out
+			Eventually(func(g Gomega) {
+				g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(cordonedNodes[0]), cordonedNodes[0]))
+				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
+			}).WithTimeout(15 * time.Minute).Should(Succeed())
+			endingNodeState := env.EventuallyExpectNodeCount("==", 3)
+
+			Consistently(func(g Gomega) {
+				g.Expect(lo.EveryBy(statingNodeState, func(sn *v1.Node) bool {
+					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(sn), sn)).To(Succeed())
+					return lo.ContainsBy(endingNodeState, func(en *v1.Node) bool {
+						g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(en), en)).To(Succeed())
+						return sn.Name == en.Name
+					})
+				})).To(BeTrue())
+			}, "2m").Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Testing to ensure that expiration and drift do not continue if a machine fails to initialize and register 
- E2E testing for https://github.com/aws/karpenter-core/pull/451

**How was this change tested?**
- `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.