### PR TITLE
chore: stop passing --container-runtime to EKS bootstrap for K8s >= 1.27

### DIFF
--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -457,7 +457,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			})
 		})
 		It("should resolve amiSelector AMIs and requirements into status", func() {
-			version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
+			version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx)).String()
 
 			awsEnv.SSMAPI.Parameters = map[string]string{
 				fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):                                                   "ami-id-123",
@@ -576,7 +576,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			}))
 		})
 		It("should resolve amiSelector AMis and requirements into status when all SSM aliases don't resolve", func() {
-			version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
+			version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx)).String()
 			// This parameter set doesn't include any of the Nvidia AMIs
 			awsEnv.SSMAPI.Parameters = map[string]string{
 				fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version): "ami-id-123",

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/aws-sdk-go/aws"
 	v1 "k8s.io/api/core/v1"
@@ -73,9 +74,11 @@ func (a AL2) DefaultAMIs(version string) []DefaultAMIOutput {
 // even if elements of those inputs are in differing orders,
 // guaranteeing it won't cause spurious hash differences.
 // AL2 userdata also works on Ubuntu
-func (a AL2) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (a AL2) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, kubeServerVersion *version.Version, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	containerRuntime := aws.String("containerd")
-	if kubeletConfig != nil && kubeletConfig.ContainerRuntime != nil {
+	if kubeServerVersion.Minor() >= 27 {
+		containerRuntime = aws.String("")
+	} else if kubeletConfig != nil && kubeletConfig.ContainerRuntime != nil {
 		containerRuntime = kubeletConfig.ContainerRuntime
 	}
 	return bootstrap.EKS{

--- a/pkg/providers/amifamily/ami_test.go
+++ b/pkg/providers/amifamily/ami_test.go
@@ -126,7 +126,7 @@ var _ = AfterSuite(func() {
 var _ = Describe("AMI Provider", func() {
 	var version string
 	BeforeEach(func() {
-		version = lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
+		version = lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx)).String()
 	})
 	It("should succeed to resolve AMIs (AL2)", func() {
 		nodeTemplate = test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/samber/lo"
 
@@ -89,7 +90,7 @@ func (b Bottlerocket) DefaultAMIs(version string) []DefaultAMIOutput {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (b Bottlerocket) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (b Bottlerocket) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, _ *version.Version, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.Bottlerocket{
 		Options: bootstrap.Options{
 			ClusterName:             b.Options.ClusterName,

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/samber/lo"

--- a/pkg/providers/amifamily/custom.go
+++ b/pkg/providers/amifamily/custom.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -30,7 +31,7 @@ type Custom struct {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (c Custom) UserData(_ *v1alpha5.KubeletConfiguration, _ []v1.Taint, _ map[string]string, _ *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (c Custom) UserData(_ *v1alpha5.KubeletConfiguration, _ *version.Version, _ []v1.Taint, _ map[string]string, _ *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.Custom{
 		Options: bootstrap.Options{
 			CustomUserData: customUserData,

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -124,13 +124,9 @@ func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 		return nil, err
 	}
 
-	kubeVersionStr, err := r.amiProvider.KubeServerVersion(ctx)
+	kubeVersion, err := r.amiProvider.KubeServerVersion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting kubernetes version %w", err)
-	}
-	kubeVersion, err := version.ParseGeneric(kubeVersionStr)
-	if err != nil {
-		return nil, fmt.Errorf("parsing kubernetes version %w", err)
 	}
 
 	var resolvedTemplates []*LaunchTemplate

--- a/pkg/providers/amifamily/ubuntu.go
+++ b/pkg/providers/amifamily/ubuntu.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/pkg/providers/amifamily/ubuntu.go
+++ b/pkg/providers/amifamily/ubuntu.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/aws-sdk-go/aws"
 	v1 "k8s.io/api/core/v1"
@@ -52,7 +53,7 @@ func (u Ubuntu) DefaultAMIs(version string) []DefaultAMIOutput {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (u Ubuntu) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (u Ubuntu) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, _ *version.Version, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.EKS{
 		Options: bootstrap.Options{
 			ClusterName:             u.Options.ClusterName,

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/karpenter-core/pkg/scheduling"
 
@@ -55,7 +56,7 @@ func (w Windows) DefaultAMIs(version string) []DefaultAMIOutput {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (w Windows) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (w Windows) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, _ *version.Version, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.Windows{
 		Options: bootstrap.Options{
 			ClusterName:     w.Options.ClusterName,

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -16,6 +16,7 @@ package amifamily
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/aws/karpenter-core/pkg/scheduling"

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -133,7 +133,7 @@ var _ = BeforeEach(func() {
 	cluster.Reset()
 	awsEnv.Reset()
 
-	lo.Must0(awsEnv.KubernetesVersionCache.Add("kubernetesVersion", env.Version.String(), 0), "failed to cache Kubernetes version")
+	lo.Must0(awsEnv.KubernetesVersionCache.Add("kubernetesVersion", env.Version, 0), "failed to cache Kubernetes version")
 
 	awsEnv.LaunchTemplateProvider.KubeDNSIP = net.ParseIP("10.0.100.10")
 	awsEnv.LaunchTemplateProvider.ClusterEndpoint = "https://test-cluster"
@@ -1662,7 +1662,7 @@ var _ = Describe("LaunchTemplates", func() {
 			It("should choose amis from SSM if no selector specified in AWSNodeTemplate", func() {
 				version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
 				awsEnv.SSMAPI.Parameters = map[string]string{
-					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version): "test-ami-123",
+					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version.String()): "test-ami-123",
 				}
 				awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 					{

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1430,14 +1430,10 @@ var _ = Describe("LaunchTemplates", func() {
 				pod := coretest.UnschedulablePod()
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				ExpectScheduled(ctx, env.Client, pod)
-				content, err = os.ReadFile("testdata/al2_userdata_merged.golden")
+				testdata := lo.Ternary(env.Version.Minor() >= 27, "testdata/al2_userdata_merged.golden", "testdata/al2_userdata_merged_pre_1_27.golden")
+				content, err = os.ReadFile(testdata)
 				Expect(err).To(BeNil())
-				var expectedUserData string
-				if env.Version.Minor() >= 27 {
-					expectedUserData = fmt.Sprintf(string(content), "", newProvisioner.Name)
-				} else {
-					expectedUserData = fmt.Sprintf(string(content), "\n--container-runtime containerd \\\n", newProvisioner.Name)
-				}
+				expectedUserData := fmt.Sprintf(string(content), newProvisioner.Name)
 				ExpectLaunchTemplatesCreatedWithUserData(expectedUserData)
 			})
 			It("should merge in custom user data not in multi-part mime format", func() {
@@ -1454,14 +1450,10 @@ var _ = Describe("LaunchTemplates", func() {
 				pod := coretest.UnschedulablePod()
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				ExpectScheduled(ctx, env.Client, pod)
-				content, err = os.ReadFile("testdata/al2_userdata_merged.golden")
+				testdata := lo.Ternary(env.Version.Minor() >= 27, "testdata/al2_userdata_merged.golden", "testdata/al2_userdata_merged_pre_1_27.golden")
+				content, err = os.ReadFile(testdata)
 				Expect(err).To(BeNil())
-				var expectedUserData string
-				if env.Version.Minor() >= 27 {
-					expectedUserData = fmt.Sprintf(string(content), "", newProvisioner.Name)
-				} else {
-					expectedUserData = fmt.Sprintf(string(content), "\n--container-runtime containerd \\\n", newProvisioner.Name)
-				}
+				expectedUserData := fmt.Sprintf(string(content), newProvisioner.Name)
 				ExpectLaunchTemplatesCreatedWithUserData(expectedUserData)
 			})
 			It("should handle empty custom user data", func() {
@@ -1475,14 +1467,10 @@ var _ = Describe("LaunchTemplates", func() {
 				pod := coretest.UnschedulablePod()
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				ExpectScheduled(ctx, env.Client, pod)
-				content, err := os.ReadFile("testdata/al2_userdata_unmerged.golden")
+				testdata := lo.Ternary(env.Version.Minor() >= 27, "testdata/al2_userdata_unmerged.golden", "testdata/al2_userdata_unmerged_pre_1_27.golden")
+				content, err := os.ReadFile(testdata)
 				Expect(err).To(BeNil())
-				var expectedUserData string
-				if env.Version.Minor() >= 27 {
-					expectedUserData = fmt.Sprintf(string(content), "", newProvisioner.Name)
-				} else {
-					expectedUserData = fmt.Sprintf(string(content), "\n--container-runtime containerd \\\n", newProvisioner.Name)
-				}
+				expectedUserData := fmt.Sprintf(string(content), newProvisioner.Name)
 				ExpectLaunchTemplatesCreatedWithUserData(expectedUserData)
 			})
 		})

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
@@ -12,8 +12,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
---container-runtime containerd \
+/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \%s
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
 --kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110'

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_merged_pre_1_27.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_merged_pre_1_27.golden
@@ -13,6 +13,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
+--container-runtime containerd \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
 --kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110'

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
@@ -6,7 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \%s
+/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
 --kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110'

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
@@ -6,8 +6,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
---container-runtime containerd \
+/etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \%s
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
 --kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110'

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged_pre_1_27.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged_pre_1_27.golden
@@ -4,15 +4,10 @@ Content-Type: multipart/mixed; boundary="//"
 --//
 Content-Type: text/x-shellscript; charset="us-ascii"
 
-#!/bin/bash
-echo "Running custom user data script"
-
---//
-Content-Type: text/x-shellscript; charset="us-ascii"
-
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
+--container-runtime containerd \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
 --kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110'


### PR DESCRIPTION
Fixes #4241

**Description**
No longer passes the `--container-runtime` flag to the EKS bootstrap script when the kubernetes server version is >= 1.27. The flag is currently ignored and is going to be removed in a future release.

**How was this change tested?**

`make test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.