### PR TITLE
ci: Fix docgen metrics generation for `nodePoolSubsystem`

### DIFF
--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -79,9 +79,9 @@ description: >
 		"These metrics are available by default at `karpenter.karpenter.svc.cluster.local:8000/metrics` configurable via the `METRICS_PORT` environment variable documented [here](../settings)\n")
 	previousSubsystem := ""
 
-	// Ignore nodeClaimSubsystem metrics until NodeClaims are released
+	// Ignore nodeClaimSubsystem and nodePoolSubsystem metrics until NodeClaims are released
 	allMetrics = lo.Reject(allMetrics, func(m metricInfo, _ int) bool {
-		return m.subsystem == "nodeclaims"
+		return m.subsystem == "nodeclaims" || m.subsystem == "nodepools"
 	})
 	for _, metric := range allMetrics {
 		// Controller Runtime naming is different in that they don't specify a namespace or subsystem
@@ -271,6 +271,7 @@ func getIdentMapping(identName string) (string, error) {
 		"metrics.NodeSubsystem":   "nodes",
 		"machineSubsystem":        "machines",
 		"nodeClaimSubsystem":      "nodeclaims",
+		"nodePoolSubsystem":       "nodepools",
 		"interruptionSubsystem":   "interruption",
 		"nodeTemplateSubsystem":   "nodetemplate",
 		"deprovisioningSubsystem": "deprovisioning",


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Fix docgen metrics generation for `nodePoolSubsystem`

**How was this change tested?**

`make docgen`
`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.