### PR TITLE
chore: Enable `v1beta1/NodeClass` conversion for CloudProvider

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -25,11 +25,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/utils/functional"
+	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/utils"
+	nodeclassutil "github.com/aws/karpenter/pkg/utils/nodeclass"
 
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/utils/resources"
@@ -41,6 +46,7 @@ import (
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 	cloudproviderevents "github.com/aws/karpenter/pkg/cloudprovider/events"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
 	"github.com/aws/karpenter/pkg/providers/instance"
@@ -85,23 +91,22 @@ func New(instanceTypeProvider *instancetype.Provider, instanceProvider *instance
 
 // Create a machine given the constraints.
 func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (*v1alpha5.Machine, error) {
-	nodeTemplate, err := c.resolveNodeTemplate(ctx, []byte(machine.
-		Annotations[v1alpha5.ProviderCompatabilityAnnotationKey]), machine.
-		Spec.MachineTemplateRef)
+	nodeClaim := nodeclaimutil.New(machine)
+	nodeClass, err := c.resolveNodeClassFromNodeClaim(ctx, nodeClaim)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.recorder.Publish(cloudproviderevents.MachineFailedToResolveNodeTemplate(machine))
 		}
-		return nil, fmt.Errorf("resolving node template, %w", err)
+		return nil, fmt.Errorf("resolving node class, %w", err)
 	}
-	instanceTypes, err := c.resolveInstanceTypes(ctx, machine, nodeTemplate)
+	instanceTypes, err := c.resolveInstanceTypes(ctx, nodeClaim, nodeClass)
 	if err != nil {
 		return nil, fmt.Errorf("resolving instance types, %w", err)
 	}
 	if len(instanceTypes) == 0 {
 		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all requested instance types were unavailable during launch"))
 	}
-	instance, err := c.instanceProvider.Create(ctx, nodeTemplate, machine, instanceTypes)
+	instance, err := c.instanceProvider.Create(ctx, nodeClass, nodeClaim, instanceTypes)
 	if err != nil {
 		return nil, fmt.Errorf("creating instance, %w", err)
 	}
@@ -110,7 +115,7 @@ func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (
 	})
 	m := c.instanceToMachine(instance, instanceType)
 	m.Annotations = lo.Assign(m.Annotations, map[string]string{
-		v1alpha1.AnnotationNodeTemplateHash: nodeTemplate.Hash(),
+		v1alpha1.AnnotationNodeTemplateHash: nodeClass.Hash(),
 	})
 	return m, nil
 }
@@ -166,21 +171,18 @@ func (c *CloudProvider) LivenessProbe(req *http.Request) error {
 // GetInstanceTypes returns all available InstanceTypes
 func (c *CloudProvider) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
 	if provisioner == nil {
-		return c.instanceTypeProvider.List(ctx, &v1alpha5.KubeletConfiguration{}, &v1alpha1.AWSNodeTemplate{})
+		return c.instanceTypeProvider.List(ctx, &corev1beta1.KubeletConfiguration{}, &v1beta1.NodeClass{})
 	}
-	var rawProvider []byte
-	if provisioner.Spec.Provider != nil {
-		rawProvider = provisioner.Spec.Provider.Raw
-	}
-	nodeTemplate, err := c.resolveNodeTemplate(ctx, rawProvider, provisioner.Spec.ProviderRef)
+	nodePool := nodepoolutil.New(provisioner)
+	nodeClass, err := c.resolveNodeClassFromNodePool(ctx, nodePool)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.recorder.Publish(cloudproviderevents.ProvisionerFailedToResolveNodeTemplate(provisioner))
 		}
-		return nil, client.IgnoreNotFound(err)
+		return nil, client.IgnoreNotFound(fmt.Errorf("resolving node class, %w", err))
 	}
 	// TODO, break this coupling
-	instanceTypes, err := c.instanceTypeProvider.List(ctx, provisioner.Spec.KubeletConfiguration, nodeTemplate)
+	instanceTypes, err := c.instanceTypeProvider.List(ctx, nodePool.Spec.Template.Spec.KubeletConfiguration, nodeClass)
 	if err != nil {
 		return nil, err
 	}
@@ -227,6 +229,42 @@ func (c *CloudProvider) Name() string {
 	return "aws"
 }
 
+func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeClaim *corev1beta1.NodeClaim) (*v1beta1.NodeClass, error) {
+	if nodeClaim.IsMachine {
+		nodeTemplate, err := c.resolveNodeTemplate(ctx,
+			[]byte(nodeClaim.Annotations[v1alpha5.ProviderCompatabilityAnnotationKey]),
+			machineutil.NewMachineTemplateRef(nodeClaim.Spec.NodeClass))
+		if err != nil {
+			return nil, fmt.Errorf("resolving node template, %w", err)
+		}
+		return nodeclassutil.New(nodeTemplate), nil
+	}
+	nodeClass := &v1beta1.NodeClass{}
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodeClaim.Spec.NodeClass.Name}, nodeClass); err != nil {
+		return nil, err
+	}
+	return nodeClass, nil
+}
+
+func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePool *corev1beta1.NodePool) (*v1beta1.NodeClass, error) {
+	if nodePool.IsProvisioner {
+		var rawProvider []byte
+		if nodePool.Spec.Template.Spec.Provider != nil {
+			rawProvider = nodePool.Spec.Template.Spec.Provider.Raw
+		}
+		nodeTemplate, err := c.resolveNodeTemplate(ctx, rawProvider, machineutil.NewMachineTemplateRef(nodePool.Spec.Template.Spec.NodeClass))
+		if err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		return nodeclassutil.New(nodeTemplate), nil
+	}
+	nodeClass := &v1beta1.NodeClass{}
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePool.Spec.Template.Spec.NodeClass.Name}, nodeClass); err != nil {
+		return nil, err
+	}
+	return nodeClass, nil
+}
+
 func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, raw []byte, objRef *v1alpha5.MachineTemplateRef) (*v1alpha1.AWSNodeTemplate, error) {
 	nodeTemplate := &v1alpha1.AWSNodeTemplate{}
 	if objRef != nil {
@@ -243,16 +281,16 @@ func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, raw []byte, obj
 	return nodeTemplate, nil
 }
 
-func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, machine *v1alpha5.Machine, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*cloudprovider.InstanceType, error) {
-	instanceTypes, err := c.instanceTypeProvider.List(ctx, machine.Spec.Kubelet, nodeTemplate)
+func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, nodeClaim *corev1beta1.NodeClaim, nodeClass *v1beta1.NodeClass) ([]*cloudprovider.InstanceType, error) {
+	instanceTypes, err := c.instanceTypeProvider.List(ctx, nodeClaim.Spec.KubeletConfiguration, nodeClass)
 	if err != nil {
 		return nil, fmt.Errorf("getting instance types, %w", err)
 	}
-	reqs := scheduling.NewNodeSelectorRequirements(machine.Spec.Requirements...)
+	reqs := scheduling.NewNodeSelectorRequirements(nodeClaim.Spec.Requirements...)
 	return lo.Filter(instanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
 		return reqs.Compatible(i.Requirements) == nil &&
 			len(i.Offerings.Requirements(reqs).Available()) > 0 &&
-			resources.Fits(machine.Spec.Resources.Requests, i.Allocatable())
+			resources.Fits(nodeClaim.Spec.Resources.Requests, i.Allocatable())
 	}), nil
 }
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -95,7 +95,7 @@ func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (
 	nodeClass, err := c.resolveNodeClassFromNodeClaim(ctx, nodeClaim)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			c.recorder.Publish(cloudproviderevents.MachineFailedToResolveNodeTemplate(machine))
+			c.recorder.Publish(cloudproviderevents.NodeClaimFailedToResolveNodeClass(nodeClaim))
 		}
 		return nil, fmt.Errorf("resolving node class, %w", err)
 	}
@@ -177,7 +177,7 @@ func (c *CloudProvider) GetInstanceTypes(ctx context.Context, provisioner *v1alp
 	nodeClass, err := c.resolveNodeClassFromNodePool(ctx, nodePool)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			c.recorder.Publish(cloudproviderevents.ProvisionerFailedToResolveNodeTemplate(provisioner))
+			c.recorder.Publish(cloudproviderevents.NodePoolFailedToResolveNodeClass(nodePool))
 		}
 		return nil, client.IgnoreNotFound(fmt.Errorf("resolving node class, %w", err))
 	}
@@ -214,9 +214,9 @@ func (c *CloudProvider) IsMachineDrifted(ctx context.Context, machine *v1alpha5.
 	nodeClass, err := c.resolveNodeClassFromNodePool(ctx, nodePool)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			c.recorder.Publish(cloudproviderevents.ProvisionerFailedToResolveNodeTemplate(provisioner))
+			c.recorder.Publish(cloudproviderevents.NodePoolFailedToResolveNodeClass(nodePool))
 		}
-		return "", client.IgnoreNotFound(fmt.Errorf("resolving node template, %w", err))
+		return "", client.IgnoreNotFound(fmt.Errorf("resolving node class, %w", err))
 	}
 	driftReason, err := c.isNodeClassDrifted(ctx, nodeClaim, nodePool, nodeClass)
 	if err != nil {
@@ -255,7 +255,7 @@ func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePo
 		}
 		nodeTemplate, err := c.resolveNodeTemplate(ctx, rawProvider, machineutil.NewMachineTemplateRef(nodePool.Spec.Template.Spec.NodeClass))
 		if err != nil {
-			return nil, client.IgnoreNotFound(err)
+			return nil, fmt.Errorf("resolving node template, %w", err)
 		}
 		return nodeclassutil.New(nodeTemplate), nil
 	}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -114,9 +114,7 @@ func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (
 		return i.Name == instance.Type
 	})
 	m := c.instanceToMachine(instance, instanceType)
-	m.Annotations = lo.Assign(m.Annotations, map[string]string{
-		v1alpha1.AnnotationNodeTemplateHash: nodeClass.Hash(),
-	})
+	m.Annotations = lo.Assign(m.Annotations, nodeclassutil.HashAnnotation(nodeClass))
 	return m, nil
 }
 
@@ -231,6 +229,7 @@ func (c *CloudProvider) Name() string {
 }
 
 func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeClaim *corev1beta1.NodeClaim) (*v1beta1.NodeClass, error) {
+	// TODO @joinnis: Remove this handling for Machine resolution when we remove v1alpha5
 	if nodeClaim.IsMachine {
 		nodeTemplate, err := c.resolveNodeTemplate(ctx,
 			[]byte(nodeClaim.Annotations[v1alpha5.ProviderCompatabilityAnnotationKey]),
@@ -248,6 +247,7 @@ func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeC
 }
 
 func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePool *corev1beta1.NodePool) (*v1beta1.NodeClass, error) {
+	// TODO @joinnis: Remove this handling for Provisioner resolution when we remove v1alpha5
 	if nodePool.IsProvisioner {
 		var rawProvider []byte
 		if nodePool.Spec.Template.Spec.Provider != nil {
@@ -266,6 +266,7 @@ func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePo
 	return nodeClass, nil
 }
 
+// TODO @joinnis: Remove this handling for NodeTemplate resolution when we remove v1alpha5
 func (c *CloudProvider) resolveNodeTemplate(ctx context.Context, raw []byte, objRef *v1alpha5.MachineTemplateRef) (*v1alpha1.AWSNodeTemplate, error) {
 	nodeTemplate := &v1alpha1.AWSNodeTemplate{}
 	if objRef != nil {

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -21,10 +21,12 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	provisionerutil "github.com/aws/karpenter-core/pkg/utils/provisioner"
 	"github.com/aws/karpenter-core/pkg/utils/sets"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
 	"github.com/aws/karpenter/pkg/providers/instance"
 	"github.com/aws/karpenter/pkg/utils"
@@ -37,45 +39,45 @@ const (
 	NodeTemplateDrift  cloudprovider.DriftReason = "NodeTemplateDrift"
 )
 
-func (c *CloudProvider) isNodeTemplateDrifted(ctx context.Context, machine *v1alpha5.Machine, provisioner *v1alpha5.Provisioner, nodeTemplate *v1alpha1.AWSNodeTemplate) (cloudprovider.DriftReason, error) {
-	instance, err := c.getInstance(ctx, machine.Status.ProviderID)
+func (c *CloudProvider) isNodeClassDrifted(ctx context.Context, nodeClaim *corev1beta1.NodeClaim, nodePool *corev1beta1.NodePool, nodeClass *v1beta1.NodeClass) (cloudprovider.DriftReason, error) {
+	instance, err := c.getInstance(ctx, nodeClaim.Status.ProviderID)
 	if err != nil {
 		return "", err
 	}
-	amiDrifted, err := c.isAMIDrifted(ctx, machine, provisioner, instance, nodeTemplate)
+	amiDrifted, err := c.isAMIDrifted(ctx, nodeClaim, nodePool, instance, nodeClass)
 	if err != nil {
 		return "", fmt.Errorf("calculating ami drift, %w", err)
 	}
-	securitygroupDrifted, err := c.areSecurityGroupsDrifted(instance, nodeTemplate)
+	securitygroupDrifted, err := c.areSecurityGroupsDrifted(instance, nodeClass)
 	if err != nil {
 		return "", fmt.Errorf("calculating securitygroup drift, %w", err)
 	}
-	subnetDrifted, err := c.isSubnetDrifted(instance, nodeTemplate)
+	subnetDrifted, err := c.isSubnetDrifted(instance, nodeClass)
 	if err != nil {
 		return "", fmt.Errorf("calculating subnet drift, %w", err)
 	}
-	drifted := lo.FindOrElse([]cloudprovider.DriftReason{amiDrifted, securitygroupDrifted, subnetDrifted, c.areStaticFieldsDrifted(machine, nodeTemplate)}, "", func(i cloudprovider.DriftReason) bool {
+	drifted := lo.FindOrElse([]cloudprovider.DriftReason{amiDrifted, securitygroupDrifted, subnetDrifted, c.areStaticFieldsDrifted(nodeClaim, nodeClass)}, "", func(i cloudprovider.DriftReason) bool {
 		return string(i) != ""
 	})
 	return drifted, nil
 }
 
-func (c *CloudProvider) isAMIDrifted(ctx context.Context, machine *v1alpha5.Machine, provisioner *v1alpha5.Provisioner,
-	instance *instance.Instance, nodeTemplate *v1alpha1.AWSNodeTemplate) (cloudprovider.DriftReason, error) {
-	instanceTypes, err := c.GetInstanceTypes(ctx, provisioner)
+func (c *CloudProvider) isAMIDrifted(ctx context.Context, nodeClaim *corev1beta1.NodeClaim, nodePool *corev1beta1.NodePool,
+	instance *instance.Instance, nodeClass *v1beta1.NodeClass) (cloudprovider.DriftReason, error) {
+	instanceTypes, err := c.GetInstanceTypes(ctx, provisionerutil.New(nodePool))
 	if err != nil {
 		return "", fmt.Errorf("getting instanceTypes, %w", err)
 	}
 	nodeInstanceType, found := lo.Find(instanceTypes, func(instType *cloudprovider.InstanceType) bool {
-		return instType.Name == machine.Labels[v1.LabelInstanceTypeStable]
+		return instType.Name == nodeClaim.Labels[v1.LabelInstanceTypeStable]
 	})
 	if !found {
-		return "", fmt.Errorf(`finding node instance type "%s"`, machine.Labels[v1.LabelInstanceTypeStable])
+		return "", fmt.Errorf(`finding node instance type "%s"`, nodeClaim.Labels[v1.LabelInstanceTypeStable])
 	}
-	if nodeTemplate.Spec.LaunchTemplateName != nil {
+	if nodeClass.Spec.LaunchTemplateName != nil {
 		return "", nil
 	}
-	amis, err := c.amiProvider.Get(ctx, nodeTemplate, &amifamily.Options{})
+	amis, err := c.amiProvider.Get(ctx, nodeClass, &amifamily.Options{})
 	if err != nil {
 		return "", fmt.Errorf("getting amis, %w", err)
 	}
@@ -92,12 +94,12 @@ func (c *CloudProvider) isAMIDrifted(ctx context.Context, machine *v1alpha5.Mach
 	return "", nil
 }
 
-func (c *CloudProvider) isSubnetDrifted(instance *instance.Instance, nodeTemplate *v1alpha1.AWSNodeTemplate) (cloudprovider.DriftReason, error) {
+func (c *CloudProvider) isSubnetDrifted(instance *instance.Instance, nodeClass *v1beta1.NodeClass) (cloudprovider.DriftReason, error) {
 	// If the node template status does not have subnets, wait for the subnets to be populated before continuing
-	if nodeTemplate.Status.Subnets == nil {
+	if nodeClass.Status.Subnets == nil {
 		return "", fmt.Errorf("AWSNodeTemplate has no subnets")
 	}
-	_, found := lo.Find(nodeTemplate.Status.Subnets, func(subnet v1alpha1.Subnet) bool {
+	_, found := lo.Find(nodeClass.Status.Subnets, func(subnet v1beta1.Subnet) bool {
 		return subnet.ID == instance.SubnetID
 	})
 	if !found {
@@ -108,13 +110,13 @@ func (c *CloudProvider) isSubnetDrifted(instance *instance.Instance, nodeTemplat
 
 // Checks if the security groups are drifted, by comparing the AWSNodeTemplate.Status.SecurityGroups
 // to the ec2 instance security groups
-func (c *CloudProvider) areSecurityGroupsDrifted(ec2Instance *instance.Instance, nodeTemplate *v1alpha1.AWSNodeTemplate) (cloudprovider.DriftReason, error) {
-	// nodeTemplate.Spec.SecurityGroupSelector can be nil if the user is using a launchTemplateName to define SecurityGroups
+func (c *CloudProvider) areSecurityGroupsDrifted(ec2Instance *instance.Instance, nodeClass *v1beta1.NodeClass) (cloudprovider.DriftReason, error) {
+	// nodeClass.Spec.SecurityGroupSelector can be nil if the user is using a launchTemplateName to define SecurityGroups
 	// Karpenter will not drift on changes to securitygroup in the launchTemplateName
-	if nodeTemplate.Spec.LaunchTemplateName != nil {
+	if nodeClass.Spec.LaunchTemplateName != nil {
 		return "", nil
 	}
-	securityGroupIds := sets.New(lo.Map(nodeTemplate.Status.SecurityGroups, func(sg v1alpha1.SecurityGroup, _ int) string { return sg.ID })...)
+	securityGroupIds := sets.New(lo.Map(nodeClass.Status.SecurityGroups, func(sg v1beta1.SecurityGroup, _ int) string { return sg.ID })...)
 	if len(securityGroupIds) == 0 {
 		return "", fmt.Errorf("no security groups exist in the AWSNodeTemplate Status")
 	}
@@ -125,13 +127,19 @@ func (c *CloudProvider) areSecurityGroupsDrifted(ec2Instance *instance.Instance,
 	return "", nil
 }
 
-func (c *CloudProvider) areStaticFieldsDrifted(machine *v1alpha5.Machine, nodeTemplate *v1alpha1.AWSNodeTemplate) cloudprovider.DriftReason {
-	nodeTemplateHash, foundHashNodeTemplate := nodeTemplate.ObjectMeta.Annotations[v1alpha1.AnnotationNodeTemplateHash]
-	machineHash, foundHashMachine := machine.ObjectMeta.Annotations[v1alpha1.AnnotationNodeTemplateHash]
-	if !foundHashNodeTemplate || !foundHashMachine {
+func (c *CloudProvider) areStaticFieldsDrifted(nodeClaim *corev1beta1.NodeClaim, nodeClass *v1beta1.NodeClass) cloudprovider.DriftReason {
+	var ownerHashKey string
+	if nodeClaim.IsMachine {
+		ownerHashKey = v1alpha1.AnnotationNodeTemplateHash
+	} else {
+		ownerHashKey = v1beta1.AnnotationNodeClassHash
+	}
+	nodeClassHash, foundHashNodeClass := nodeClass.Annotations[ownerHashKey]
+	nodeClaimHash, foundHashNodeClaim := nodeClaim.Annotations[ownerHashKey]
+	if !foundHashNodeClass || !foundHashNodeClaim {
 		return ""
 	}
-	if nodeTemplateHash != machineHash {
+	if nodeClassHash != nodeClaimHash {
 		return NodeTemplateDrift
 	}
 	return ""

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -96,7 +96,7 @@ func (c *CloudProvider) isAMIDrifted(ctx context.Context, nodeClaim *corev1beta1
 
 func (c *CloudProvider) isSubnetDrifted(instance *instance.Instance, nodeClass *v1beta1.NodeClass) (cloudprovider.DriftReason, error) {
 	// If the node template status does not have subnets, wait for the subnets to be populated before continuing
-	if nodeClass.Status.Subnets == nil {
+	if len(nodeClass.Status.Subnets) == 0 {
 		return "", fmt.Errorf("AWSNodeTemplate has no subnets")
 	}
 	_, found := lo.Find(nodeClass.Status.Subnets, func(subnet v1beta1.Subnet) bool {

--- a/pkg/controllers/nodetemplate/controller.go
+++ b/pkg/controllers/nodetemplate/controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/karpenter/pkg/providers/amifamily"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
+	nodeclassutil "github.com/aws/karpenter/pkg/utils/nodeclass"
 )
 
 var _ corecontroller.TypedController[*v1alpha1.AWSNodeTemplate] = (*Controller)(nil)
@@ -102,7 +103,7 @@ func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontrolle
 }
 
 func (c *Controller) resolveSubnets(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) error {
-	subnetList, err := c.subnetProvider.List(ctx, nodeTemplate)
+	subnetList, err := c.subnetProvider.List(ctx, nodeclassutil.New(nodeTemplate))
 	if err != nil {
 		return err
 	}
@@ -126,7 +127,7 @@ func (c *Controller) resolveSubnets(ctx context.Context, nodeTemplate *v1alpha1.
 }
 
 func (c *Controller) resolveSecurityGroups(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) error {
-	securityGroups, err := c.securityGroupProvider.List(ctx, nodeTemplate)
+	securityGroups, err := c.securityGroupProvider.List(ctx, nodeclassutil.New(nodeTemplate))
 	if err != nil {
 		return err
 	}
@@ -146,7 +147,7 @@ func (c *Controller) resolveSecurityGroups(ctx context.Context, nodeTemplate *v1
 }
 
 func (c *Controller) resolveAMIs(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) error {
-	amis, err := c.amiProvider.Get(ctx, nodeTemplate, &amifamily.Options{})
+	amis, err := c.amiProvider.Get(ctx, nodeclassutil.New(nodeTemplate), &amifamily.Options{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -104,20 +104,20 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test2",
 					Zone: "test-zone-1b",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
-			}))
+			))
 		})
 		It("Should have the correct ordering for the Subnets", func() {
 			awsEnv.EC2API.DescribeSubnetsOutput.Set(&ec2.DescribeSubnetsOutput{Subnets: []*ec2.Subnet{
@@ -128,36 +128,36 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test2",
 					Zone: "test-zone-1b",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-			}))
+			))
 		})
 		It("Should resolve a valid selectors for Subnet by tags", func() {
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`Name`: `test-subnet-1,test-subnet-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test2",
 					Zone: "test-zone-1b",
 				},
-			}))
+			))
 		})
 		It("Should resolve a valid selectors for Subnet by ids", func() {
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`aws-ids`: `subnet-test1`}
@@ -175,65 +175,65 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test2",
 					Zone: "test-zone-1b",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
-			}))
+			))
 
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`Name`: `test-subnet-1,test-subnet-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test2",
 					Zone: "test-zone-1b",
 				},
-			}))
+			))
 		})
 		It("Should update Subnet status when the Subnet selector gets updated by ids", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test2",
 					Zone: "test-zone-1b",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
-			}))
+			))
 
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`aws-ids`: `subnet-test1`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-			}))
+			))
 		})
 		It("Should not resolve a invalid selectors for Subnet", func() {
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`foo`: `invalid`}
@@ -246,20 +246,20 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.Subnets).To(Equal([]v1alpha1.Subnet{
-				{
+			Expect(nodeTemplate.Status.Subnets).To(ConsistOf(
+				v1alpha1.Subnet{
 					ID:   "subnet-test1",
 					Zone: "test-zone-1a",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test2",
 					Zone: "test-zone-1b",
 				},
-				{
+				v1alpha1.Subnet{
 					ID:   "subnet-test3",
 					Zone: "test-zone-1c",
 				},
-			}))
+			))
 
 			nodeTemplate.Spec.SubnetSelector = map[string]string{`foo`: `invalid`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
@@ -280,112 +280,112 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test2",
 					Name: "securityGroup-test2",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test3",
 					Name: "securityGroup-test3",
 				},
-			}))
+			))
 		})
 		It("Should resolve a valid selectors for Security Groups by tags", func() {
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`Name`: `test-security-group-1,test-security-group-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test2",
 					Name: "securityGroup-test2",
 				},
-			}))
+			))
 		})
 		It("Should resolve a valid selectors for Security Groups by ids", func() {
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`aws-ids`: `sg-test1`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-			}))
+			))
 		})
 		It("Should update Security Groups status when the Security Groups selector gets updated by tags", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test2",
 					Name: "securityGroup-test2",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test3",
 					Name: "securityGroup-test3",
 				},
-			}))
+			))
 
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`Name`: `test-security-group-1,test-security-group-2`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test2",
 					Name: "securityGroup-test2",
 				},
-			}))
+			))
 		})
 		It("Should update Security Groups status when the Security Groups selector gets updated by ids", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test2",
 					Name: "securityGroup-test2",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test3",
 					Name: "securityGroup-test3",
 				},
-			}))
+			))
 
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`aws-ids`: `sg-test1`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-			}))
+			))
 		})
 		It("Should not resolve a invalid selectors for Security Groups", func() {
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`foo`: `invalid`}
@@ -398,20 +398,20 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			Expect(nodeTemplate.Status.SecurityGroups).To(Equal([]v1alpha1.SecurityGroup{
-				{
+			Expect(nodeTemplate.Status.SecurityGroups).To(ConsistOf(
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test1",
 					Name: "securityGroup-test1",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test2",
 					Name: "securityGroup-test2",
 				},
-				{
+				v1alpha1.SecurityGroup{
 					ID:   "sg-test3",
 					Name: "securityGroup-test3",
 				},
-			}))
+			))
 
 			nodeTemplate.Spec.SecurityGroupSelector = map[string]string{`foo`: `invalid`}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
@@ -504,8 +504,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			sortRequirements(nodeTemplate.Status.AMIs)
-			Expect(nodeTemplate.Status.AMIs).To(ContainElements([]v1alpha1.AMI{
+			ExpectConsistOfAMIs([]v1alpha1.AMI{
 				{
 					Name: "test-ami-1",
 					ID:   "ami-id-123",
@@ -574,7 +573,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 						},
 					},
 				},
-			}))
+			}, nodeTemplate.Status.AMIs)
 		})
 		It("should resolve amiSelector AMis and requirements into status when all SSM aliases don't resolve", func() {
 			version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
@@ -612,8 +611,8 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			sortRequirements(nodeTemplate.Status.AMIs)
-			Expect(nodeTemplate.Status.AMIs).To(ContainElements([]v1alpha1.AMI{
+
+			ExpectConsistOfAMIs([]v1alpha1.AMI{
 				{
 					Name: "test-ami-1",
 					ID:   "ami-id-123",
@@ -652,7 +651,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 						},
 					},
 				},
-			}))
+			}, nodeTemplate.Status.AMIs)
 		})
 		It("Should resolve a valid AMI selector", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
@@ -695,8 +694,8 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(nodeTemplate))
 			nodeTemplate = ExpectExists(ctx, env.Client, nodeTemplate)
-			sortRequirements(nodeTemplate.Status.AMIs)
-			Expect(nodeTemplate.Status.AMIs).To(ContainElements([]v1alpha1.AMI{
+
+			ExpectConsistOfAMIs([]v1alpha1.AMI{
 				{
 					Name: "test-ami-4",
 					ID:   "ami-test4",
@@ -717,8 +716,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 						},
 					},
 				},
-			},
-			))
+			}, nodeTemplate.Status.AMIs)
 		})
 	})
 	Context("AWSNodeTemplate Static Drift Hash", func() {
@@ -778,10 +776,16 @@ var _ = Describe("AWSNodeTemplateController", func() {
 	})
 })
 
-func sortRequirements(amis []v1alpha1.AMI) {
-	for i := range amis {
-		sort.Slice(amis[i].Requirements, func(p, q int) bool {
-			return amis[i].Requirements[p].Key > amis[i].Requirements[q].Key
-		})
+func ExpectConsistOfAMIs(expected, actual []v1alpha1.AMI) {
+	GinkgoHelper()
+	Expect(actual).To(HaveLen(len(expected)))
+
+	for _, list := range [][]v1alpha1.AMI{expected, actual} {
+		for _, elem := range list {
+			sort.Slice(elem.Requirements, func(i, j int) bool {
+				return elem.Requirements[i].Key < elem.Requirements[j].Key
+			})
+		}
 	}
+	Expect(actual).To(ConsistOf(lo.Map(expected, func(a v1alpha1.AMI, _ int) interface{} { return a })...))
 }

--- a/pkg/fake/atomic.go
+++ b/pkg/fake/atomic.go
@@ -155,9 +155,20 @@ func (a *AtomicPtrSlice[T]) Len() int {
 func (a *AtomicPtrSlice[T]) Pop() *T {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+
 	last := a.values[len(a.values)-1]
 	a.values = a.values[0 : len(a.values)-1]
 	return last
+}
+
+func (a *AtomicPtrSlice[T]) PopAll() (ret []*T) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for len(a.values) > 0 {
+		ret = append(ret, a.values[len(a.values)-1])
+		a.values = a.values[0 : len(a.values)-1]
+	}
+	return ret
 }
 
 func (a *AtomicPtrSlice[T]) ForEach(fn func(*T)) {

--- a/pkg/fake/atomic.go
+++ b/pkg/fake/atomic.go
@@ -161,16 +161,6 @@ func (a *AtomicPtrSlice[T]) Pop() *T {
 	return last
 }
 
-func (a *AtomicPtrSlice[T]) PopAll() (ret []*T) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	for len(a.values) > 0 {
-		ret = append(ret, a.values[len(a.values)-1])
-		a.values = a.values[0 : len(a.values)-1]
-	}
-	return ret
-}
-
 func (a *AtomicPtrSlice[T]) ForEach(fn func(*T)) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -324,7 +324,9 @@ func (e *EC2API) DescribeImagesWithContext(_ context.Context, input *ec2.Describ
 	}
 	e.CalledWithDescribeImagesInput.Add(input)
 	if !e.DescribeImagesOutput.IsNil() {
-		return e.DescribeImagesOutput.Clone(), nil
+		describeImagesOutput := e.DescribeImagesOutput.Clone()
+		describeImagesOutput.Images = FilterDescribeImages(describeImagesOutput.Images, input.Filters)
+		return describeImagesOutput, nil
 	}
 	if aws.StringValue(input.Filters[0].Values[0]) == "invalid" {
 		return &ec2.DescribeImagesOutput{}, nil

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -21,7 +21,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/scheduling"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -73,7 +75,7 @@ func (a AL2) DefaultAMIs(version string) []DefaultAMIOutput {
 // even if elements of those inputs are in differing orders,
 // guaranteeing it won't cause spurious hash differences.
 // AL2 userdata also works on Ubuntu
-func (a AL2) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (a AL2) UserData(kubeletConfig *corev1beta1.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	containerRuntime := aws.String("containerd")
 	if kubeletConfig != nil && kubeletConfig.ContainerRuntime != nil {
 		containerRuntime = kubeletConfig.ContainerRuntime
@@ -94,8 +96,8 @@ func (a AL2) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.
 }
 
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
-func (a AL2) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
-	return []*v1alpha1.BlockDeviceMapping{{
+func (a AL2) DefaultBlockDeviceMappings() []*v1beta1.BlockDeviceMapping {
+	return []*v1beta1.BlockDeviceMapping{{
 		DeviceName: a.EphemeralBlockDevice(),
 		EBS:        &DefaultEBS,
 	}}

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -129,7 +129,7 @@ func (p *Provider) Get(ctx context.Context, nodeClass *v1beta1.NodeClass, option
 		}
 	}
 	amis = groupAMIsByRequirements(SortAMIsByCreationDate(amis))
-	if p.cm.HasChanged(fmt.Sprintf("amis/%s", nodeClass.Name), amis) {
+	if p.cm.HasChanged(fmt.Sprintf("amis/%t/%s", nodeClass.IsNodeTemplate, nodeClass.Name), amis) {
 		logging.FromContext(ctx).With("ids", amiList(amis), "count", len(amis)).Debugf("discovered amis")
 	}
 	return amis, nil

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -212,7 +212,7 @@ func (p *Provider) getAMIsFromSelectorTerms(ctx context.Context, terms []v1beta1
 }
 
 func (p *Provider) fetchAMIsFromEC2(ctx context.Context, terms []v1beta1.AMISelectorTerm) ([]*ec2.Image, error) {
-	filterAndOwnerSets := getFilterAndOwnerSets(terms)
+	filterAndOwnerSets := GetFilterAndOwnerSets(terms)
 	hash, err := hashstructure.Hash(filterAndOwnerSets, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	if err != nil {
 		return nil, err
@@ -258,7 +258,7 @@ type FiltersAndOwner struct {
 
 // TODO @joinnis: It's possible that we could make this filtering logic more efficient by combining selectors
 // that only use the term "id" into a single filtered term or that only use the term "name" into a single filtered term
-func getFilterAndOwnerSets(terms []v1beta1.AMISelectorTerm) []FiltersAndOwner {
+func GetFilterAndOwnerSets(terms []v1beta1.AMISelectorTerm) []FiltersAndOwner {
 	return lo.Map(terms, func(t v1beta1.AMISelectorTerm, _ int) FiltersAndOwner {
 		return getFiltersAndOwner(t)
 	})

--- a/pkg/providers/amifamily/ami_test.go
+++ b/pkg/providers/amifamily/ami_test.go
@@ -51,10 +51,10 @@ func TestAWS(t *testing.T) {
 }
 
 const (
-	amd64AMIName       = "amd64-ami"
-	arm64AMIName       = "arm64-ami"
-	amd64NvidiaAMIName = "amd64-nvidia-ami"
-	arm64NvidiaAMIName = "arm64-nvidia-ami"
+	amd64AMI       = "amd64-ami-id"
+	arm64AMI       = "arm64-ami-id"
+	amd64NvidiaAMI = "amd64-nvidia-ami-id"
+	arm64NvidiaAMI = "arm64-nvidia-ami-id"
 )
 
 var _ = BeforeSuite(func() {
@@ -69,42 +69,42 @@ var _ = BeforeEach(func() {
 	awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{
 		Images: []*ec2.Image{
 			{
-				Name:         aws.String(amd64AMIName),
+				Name:         aws.String(amd64AMI),
 				ImageId:      aws.String("amd64-ami-id"),
 				CreationDate: aws.String(time.Now().Format(time.RFC3339)),
 				Architecture: aws.String("x86_64"),
 				Tags: []*ec2.Tag{
-					{Key: aws.String("Name"), Value: aws.String(amd64AMIName)},
+					{Key: aws.String("Name"), Value: aws.String(amd64AMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
 			},
 			{
-				Name:         aws.String(arm64AMIName),
+				Name:         aws.String(arm64AMI),
 				ImageId:      aws.String("arm64-ami-id"),
 				CreationDate: aws.String(time.Now().Add(time.Minute).Format(time.RFC3339)),
 				Architecture: aws.String("arm64"),
 				Tags: []*ec2.Tag{
-					{Key: aws.String("Name"), Value: aws.String(arm64AMIName)},
+					{Key: aws.String("Name"), Value: aws.String(arm64AMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
 			},
 			{
-				Name:         aws.String(amd64NvidiaAMIName),
+				Name:         aws.String(amd64NvidiaAMI),
 				ImageId:      aws.String("amd64-nvidia-ami-id"),
 				CreationDate: aws.String(time.Now().Add(2 * time.Minute).Format(time.RFC3339)),
 				Architecture: aws.String("x86_64"),
 				Tags: []*ec2.Tag{
-					{Key: aws.String("Name"), Value: aws.String(amd64NvidiaAMIName)},
+					{Key: aws.String("Name"), Value: aws.String(amd64NvidiaAMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
 			},
 			{
-				Name:         aws.String(arm64NvidiaAMIName),
+				Name:         aws.String(arm64NvidiaAMI),
 				ImageId:      aws.String("arm64-nvidia-ami-id"),
 				CreationDate: aws.String(time.Now().Add(2 * time.Minute).Format(time.RFC3339)),
 				Architecture: aws.String("arm64"),
 				Tags: []*ec2.Tag{
-					{Key: aws.String("Name"), Value: aws.String(arm64NvidiaAMIName)},
+					{Key: aws.String("Name"), Value: aws.String(arm64NvidiaAMI)},
 					{Key: aws.String("foo"), Value: aws.String("bar")},
 				},
 			},
@@ -129,9 +129,9 @@ var _ = Describe("AMIProvider", func() {
 	It("should succeed to resolve AMIs (AL2)", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyAL2
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):       amd64AMIName,
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version):   amd64NvidiaAMIName,
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version): arm64AMIName,
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):       amd64AMI,
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version):   amd64NvidiaAMI,
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version): arm64AMI,
 		}
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
 		Expect(err).ToNot(HaveOccurred())
@@ -140,10 +140,10 @@ var _ = Describe("AMIProvider", func() {
 	It("should succeed to resolve AMIs (Bottlerocket)", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyBottlerocket
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version):        amd64AMIName,
-			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version): amd64NvidiaAMIName,
-			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_id", version):         arm64AMIName,
-			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/arm64/latest/image_id", version):  arm64NvidiaAMIName,
+			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version):        amd64AMI,
+			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version): amd64NvidiaAMI,
+			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_id", version):         arm64AMI,
+			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/arm64/latest/image_id", version):  arm64NvidiaAMI,
 		}
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
 		Expect(err).ToNot(HaveOccurred())
@@ -152,8 +152,8 @@ var _ = Describe("AMIProvider", func() {
 	It("should succeed to resolve AMIs (Ubuntu)", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyUbuntu
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/amd64/hvm/ebs-gp2/ami-id", version): amd64AMIName,
-			fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/arm64/hvm/ebs-gp2/ami-id", version): arm64AMIName,
+			fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/amd64/hvm/ebs-gp2/ami-id", version): amd64AMI,
+			fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/arm64/hvm/ebs-gp2/ami-id", version): arm64AMI,
 		}
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
 		Expect(err).ToNot(HaveOccurred())
@@ -162,7 +162,7 @@ var _ = Describe("AMIProvider", func() {
 	It("should succeed to resolve AMIs (Windows2019)", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyWindows2019
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-%s/image_id", version): amd64AMIName,
+			fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-%s/image_id", version): amd64AMI,
 		}
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
 		Expect(err).ToNot(HaveOccurred())
@@ -171,7 +171,7 @@ var _ = Describe("AMIProvider", func() {
 	It("should succeed to resolve AMIs (Windows2022)", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyWindows2022
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-%s/image_id", version): amd64AMIName,
+			fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-%s/image_id", version): amd64AMI,
 		}
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
 		Expect(err).ToNot(HaveOccurred())
@@ -188,8 +188,8 @@ var _ = Describe("AMIProvider", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyAL2
 		// No GPU AMI exists here
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):       amd64AMIName,
-			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version): arm64AMIName,
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):       amd64AMI,
+			fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version): arm64AMI,
 		}
 		// Only 2 of the requirements sets for the SSM aliases will resolve
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
@@ -200,9 +200,9 @@ var _ = Describe("AMIProvider", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyBottlerocket
 		// No GPU AMI exists for AM64 here
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version):        amd64AMIName,
-			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version): amd64NvidiaAMIName,
-			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_id", version):         arm64AMIName,
+			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version):        amd64AMI,
+			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version): amd64NvidiaAMI,
+			fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/arm64/latest/image_id", version):         arm64AMI,
 		}
 		// Only 4 of the requirements sets for the SSM aliases will resolve
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
@@ -213,7 +213,7 @@ var _ = Describe("AMIProvider", func() {
 		nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyUbuntu
 		// No AMD64 AMI exists here
 		awsEnv.SSMAPI.Parameters = map[string]string{
-			fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/arm64/hvm/ebs-gp2/ami-id", version): arm64AMIName,
+			fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/arm64/hvm/ebs-gp2/ami-id", version): arm64AMI,
 		}
 		// Only 1 of the requirements sets for the SSM aliases will resolve
 		amis, err := awsEnv.AMIProvider.Get(ctx, nodeClass, &amifamily.Options{})
@@ -230,13 +230,17 @@ var _ = Describe("AMIProvider", func() {
 				},
 			}
 			filterAndOwnersSets := amifamily.GetFilterAndOwnerSets(amiSelectorTerms)
-			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwner{
+			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwners{
 				{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("tag:Name"),
 							Values: aws.StringSlice([]string{"my-ami"}),
 						},
+					},
+					Owners: []string{
+						"amazon",
+						"self",
 					},
 				},
 			}, filterAndOwnersSets)
@@ -248,13 +252,17 @@ var _ = Describe("AMIProvider", func() {
 				},
 			}
 			filterAndOwnersSets := amifamily.GetFilterAndOwnerSets(amiSelectorTerms)
-			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwner{
+			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwners{
 				{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("name"),
 							Values: aws.StringSlice([]string{"my-ami"}),
 						},
+					},
+					Owners: []string{
+						"amazon",
+						"self",
 					},
 				},
 			}, filterAndOwnersSets)
@@ -269,20 +277,12 @@ var _ = Describe("AMIProvider", func() {
 				},
 			}
 			filterAndOwnersSets := amifamily.GetFilterAndOwnerSets(amiSelectorTerms)
-			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwner{
+			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwners{
 				{
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("image-id"),
-							Values: aws.StringSlice([]string{"ami-abcd1234"}),
-						},
-					},
-				},
-				{
-					Filters: []*ec2.Filter{
-						{
-							Name:   aws.String("image-id"),
-							Values: aws.StringSlice([]string{"ami-cafeaced"}),
+							Values: aws.StringSlice([]string{"ami-abcd1234", "ami-cafeaced"}),
 						},
 					},
 				},
@@ -298,91 +298,12 @@ var _ = Describe("AMIProvider", func() {
 				},
 			}
 			filterAndOwnersSets := amifamily.GetFilterAndOwnerSets(amiSelectorTerms)
-			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwner{
+			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwners{
 				{
-					Owner: "abcdef",
+					Owners: []string{"abcdef"},
 				},
 				{
-					Owner: "123456789012",
-				},
-			}, filterAndOwnersSets)
-		})
-		It("should allow prefixed id, prefixed name, and prefixed owners", func() {
-			amiSelectorTerms := []v1beta1.AMISelectorTerm{
-				{
-					Name:  "my-ami",
-					ID:    "ami-abcd1234",
-					Owner: "self",
-				},
-				{
-					Name:  "my-ami",
-					ID:    "ami-cafeaced",
-					Owner: "self",
-				},
-				{
-					Name:  "my-ami",
-					ID:    "ami-abcd1234",
-					Owner: "amazon",
-				},
-				{
-					Name:  "my-ami",
-					ID:    "ami-cafeaced",
-					Owner: "amazon",
-				},
-			}
-			filterAndOwnersSets := amifamily.GetFilterAndOwnerSets(amiSelectorTerms)
-			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwner{
-				{
-					Owner: "self",
-					Filters: []*ec2.Filter{
-						{
-							Name:   aws.String("name"),
-							Values: aws.StringSlice([]string{"my-ami"}),
-						},
-						{
-							Name:   aws.String("image-id"),
-							Values: aws.StringSlice([]string{"ami-abcd1234"}),
-						},
-					},
-				},
-				{
-					Owner: "self",
-					Filters: []*ec2.Filter{
-						{
-							Name:   aws.String("name"),
-							Values: aws.StringSlice([]string{"my-ami"}),
-						},
-						{
-							Name:   aws.String("image-id"),
-							Values: aws.StringSlice([]string{"ami-cafeaced"}),
-						},
-					},
-				},
-				{
-					Owner: "amazon",
-					Filters: []*ec2.Filter{
-						{
-							Name:   aws.String("name"),
-							Values: aws.StringSlice([]string{"my-ami"}),
-						},
-						{
-							Name:   aws.String("image-id"),
-							Values: aws.StringSlice([]string{"ami-abcd1234"}),
-						},
-					},
-				},
-				{
-					Owner: "amazon",
-					Filters: []*ec2.Filter{
-						{
-							Name:   aws.String("name"),
-							Values: aws.StringSlice([]string{"my-ami"}),
-						},
-						{
-							Name:   aws.String("image-id"),
-							Values: aws.StringSlice([]string{"ami-cafeaced"}),
-						},
-					},
+					Owners: []string{"123456789012"},
 				},
 			}, filterAndOwnersSets)
 		})
@@ -398,9 +319,9 @@ var _ = Describe("AMIProvider", func() {
 				},
 			}
 			filterAndOwnersSets := amifamily.GetFilterAndOwnerSets(amiSelectorTerms)
-			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwner{
+			ExpectConsistsOfFiltersAndOwners([]amifamily.FiltersAndOwners{
 				{
-					Owner: "0123456789",
+					Owners: []string{"0123456789"},
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("name"),
@@ -409,7 +330,7 @@ var _ = Describe("AMIProvider", func() {
 					},
 				},
 				{
-					Owner: "self",
+					Owners: []string{"self"},
 					Filters: []*ec2.Filter{
 						{
 							Name:   aws.String("name"),
@@ -479,21 +400,22 @@ var _ = Describe("AMIProvider", func() {
 	})
 })
 
-func ExpectConsistsOfFiltersAndOwners(expected, actual []amifamily.FiltersAndOwner) {
+func ExpectConsistsOfFiltersAndOwners(expected, actual []amifamily.FiltersAndOwners) {
 	GinkgoHelper()
 	Expect(actual).To(HaveLen(len(expected)))
 
-	for _, list := range [][]amifamily.FiltersAndOwner{expected, actual} {
+	for _, list := range [][]amifamily.FiltersAndOwners{expected, actual} {
 		for _, elem := range list {
 			for _, f := range elem.Filters {
 				sort.Slice(f.Values, func(i, j int) bool {
 					return lo.FromPtr(f.Values[i]) < lo.FromPtr(f.Values[j])
 				})
 			}
+			sort.Slice(elem.Owners, func(i, j int) bool { return elem.Owners[i] < elem.Owners[j] })
 			sort.Slice(elem.Filters, func(i, j int) bool {
 				return lo.FromPtr(elem.Filters[i].Name) < lo.FromPtr(elem.Filters[j].Name)
 			})
 		}
 	}
-	Expect(actual).To(ConsistOf(lo.Map(expected, func(f amifamily.FiltersAndOwner, _ int) interface{} { return f })...))
+	Expect(actual).To(ConsistOf(lo.Map(expected, func(f amifamily.FiltersAndOwners, _ int) interface{} { return f })...))
 }

--- a/pkg/providers/amifamily/ami_test.go
+++ b/pkg/providers/amifamily/ami_test.go
@@ -236,7 +236,7 @@ var _ = Describe("AMI Provider", func() {
 			amiSelector := map[string]string{
 				"Name": "my-ami",
 			}
-			filters, owners := amifamily.GetFiltersAndOwners(amiSelector)
+			filters, owners := amifamily.getFiltersAndOwners(amiSelector)
 			Expect(owners).Should(ConsistOf(defaultOwners))
 			Expect(filters).Should(ConsistOf([]*ec2.Filter{
 				{
@@ -249,7 +249,7 @@ var _ = Describe("AMI Provider", func() {
 			amiSelector := map[string]string{
 				"aws::name": "my-ami",
 			}
-			filters, owners := amifamily.GetFiltersAndOwners(amiSelector)
+			filters, owners := amifamily.getFiltersAndOwners(amiSelector)
 			Expect(owners).Should(ConsistOf(defaultOwners))
 			Expect(filters).Should(ConsistOf([]*ec2.Filter{
 				{
@@ -262,7 +262,7 @@ var _ = Describe("AMI Provider", func() {
 			amiSelector := map[string]string{
 				"aws-ids": "ami-abcd1234,ami-cafeaced",
 			}
-			filters, owners := amifamily.GetFiltersAndOwners(amiSelector)
+			filters, owners := amifamily.getFiltersAndOwners(amiSelector)
 			Expect(owners).Should(BeNil())
 			Expect(filters).Should(ConsistOf([]*ec2.Filter{
 				{
@@ -278,7 +278,7 @@ var _ = Describe("AMI Provider", func() {
 			amiSelector := map[string]string{
 				"aws::ids": "ami-abcd1234,ami-cafeaced",
 			}
-			filters, owners := amifamily.GetFiltersAndOwners(amiSelector)
+			filters, owners := amifamily.getFiltersAndOwners(amiSelector)
 			Expect(owners).Should(BeNil())
 			Expect(filters).Should(ConsistOf([]*ec2.Filter{
 				{
@@ -294,7 +294,7 @@ var _ = Describe("AMI Provider", func() {
 			amiSelector := map[string]string{
 				"aws::owners": "abcdef,123456789012",
 			}
-			_, owners := amifamily.GetFiltersAndOwners(amiSelector)
+			_, owners := amifamily.getFiltersAndOwners(amiSelector)
 			Expect(owners).Should(ConsistOf(
 				[]*string{aws.String("abcdef"), aws.String("123456789012")},
 			))
@@ -305,7 +305,7 @@ var _ = Describe("AMI Provider", func() {
 				"aws::ids":    "ami-abcd1234,ami-cafeaced",
 				"aws::owners": "self,amazon",
 			}
-			filters, owners := amifamily.GetFiltersAndOwners(amiSelector)
+			filters, owners := amifamily.getFiltersAndOwners(amiSelector)
 			Expect(owners).Should(ConsistOf(defaultOwners))
 			Expect(filters).Should(ConsistOf([]*ec2.Filter{
 				{
@@ -326,7 +326,7 @@ var _ = Describe("AMI Provider", func() {
 				"aws::name":   "my-ami",
 				"aws::owners": "0123456789,self",
 			}
-			filters, owners := amifamily.GetFiltersAndOwners(amiSelector)
+			filters, owners := amifamily.getFiltersAndOwners(amiSelector)
 			Expect(owners).Should(ConsistOf([]*string{
 				aws.String("0123456789"),
 				aws.String("self"),

--- a/pkg/providers/amifamily/bootstrap/bootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/ptr"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/utils/resources"
 )
 
@@ -32,7 +33,7 @@ import (
 type Options struct {
 	ClusterName             string
 	ClusterEndpoint         string
-	KubeletConfig           *v1alpha5.KubeletConfiguration
+	KubeletConfig           *corev1beta1.KubeletConfiguration
 	Taints                  []core.Taint      `hash:"set"`
 	Labels                  map[string]string `hash:"set"`
 	CABundle                *string

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/samber/lo"
 
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -89,7 +91,7 @@ func (b Bottlerocket) DefaultAMIs(version string) []DefaultAMIOutput {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (b Bottlerocket) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (b Bottlerocket) UserData(kubeletConfig *corev1beta1.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.Bottlerocket{
 		Options: bootstrap.Options{
 			ClusterName:             b.Options.ClusterName,
@@ -105,10 +107,10 @@ func (b Bottlerocket) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, tai
 }
 
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
-func (b Bottlerocket) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
+func (b Bottlerocket) DefaultBlockDeviceMappings() []*v1beta1.BlockDeviceMapping {
 	xvdaEBS := DefaultEBS
 	xvdaEBS.VolumeSize = lo.ToPtr(resource.MustParse("4Gi"))
-	return []*v1alpha1.BlockDeviceMapping{
+	return []*v1beta1.BlockDeviceMapping{
 		{
 			DeviceName: aws.String("/dev/xvda"),
 			EBS:        &xvdaEBS,

--- a/pkg/providers/amifamily/custom.go
+++ b/pkg/providers/amifamily/custom.go
@@ -17,10 +17,10 @@ package amifamily
 import (
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 
-	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
 )
 
@@ -30,7 +30,7 @@ type Custom struct {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (c Custom) UserData(_ *v1alpha5.KubeletConfiguration, _ []v1.Taint, _ map[string]string, _ *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (c Custom) UserData(_ *corev1beta1.KubeletConfiguration, _ []v1.Taint, _ map[string]string, _ *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.Custom{
 		Options: bootstrap.Options{
 			CustomUserData: customUserData,
@@ -42,7 +42,7 @@ func (c Custom) DefaultAMIs(_ string) []DefaultAMIOutput {
 	return nil
 }
 
-func (c Custom) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
+func (c Custom) DefaultBlockDeviceMappings() []*v1beta1.BlockDeviceMapping {
 	// By returning nil, we ensure that EC2 will automatically choose the volumes defined by the AMI
 	// and we don't need to describe the AMI ourselves.
 	return nil

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -26,15 +26,16 @@ import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 )
 
-var DefaultEBS = v1alpha1.BlockDevice{
+var DefaultEBS = v1beta1.BlockDevice{
 	Encrypted:  aws.Bool(true),
 	VolumeType: aws.String(ec2.VolumeTypeGp3),
 	VolumeSize: lo.ToPtr(resource.MustParse("20Gi")),
@@ -64,8 +65,8 @@ type Options struct {
 type LaunchTemplate struct {
 	*Options
 	UserData            bootstrap.Bootstrapper
-	BlockDeviceMappings []*v1alpha1.BlockDeviceMapping
-	MetadataOptions     *v1alpha1.MetadataOptions
+	BlockDeviceMappings []*v1beta1.BlockDeviceMapping
+	MetadataOptions     *v1beta1.MetadataOptions
 	AMIID               string
 	InstanceTypes       []*cloudprovider.InstanceType `hash:"ignore"`
 	DetailedMonitoring  bool
@@ -74,9 +75,9 @@ type LaunchTemplate struct {
 // AMIFamily can be implemented to override the default logic for generating dynamic launch template parameters
 type AMIFamily interface {
 	DefaultAMIs(version string) []DefaultAMIOutput
-	UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string, instanceTypes []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper
-	DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping
-	DefaultMetadataOptions() *v1alpha1.MetadataOptions
+	UserData(kubeletConfig *corev1beta1.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string, instanceTypes []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper
+	DefaultBlockDeviceMappings() []*v1beta1.BlockDeviceMapping
+	DefaultMetadataOptions() *v1beta1.MetadataOptions
 	EphemeralBlockDevice() *string
 	FeatureFlags() FeatureFlags
 }
@@ -115,9 +116,9 @@ func New(amiProvider *Provider) *Resolver {
 
 // Resolve generates launch templates using the static options and dynamically generates launch template parameters.
 // Multiple ResolvedTemplates are returned based on the instanceTypes passed in to support special AMIs for certain instance types like GPUs.
-func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, machine *v1alpha5.Machine, instanceTypes []*cloudprovider.InstanceType, options *Options) ([]*LaunchTemplate, error) {
-	amiFamily := GetAMIFamily(nodeTemplate.Spec.AMIFamily, options)
-	amis, err := r.amiProvider.Get(ctx, nodeTemplate, options)
+func (r Resolver) Resolve(ctx context.Context, nodeClass *v1beta1.NodeClass, nodeClaim *corev1beta1.NodeClaim, instanceTypes []*cloudprovider.InstanceType, options *Options) ([]*LaunchTemplate, error) {
+	amiFamily := GetAMIFamily(nodeClass.Spec.AMIFamily, options)
+	amis, err := r.amiProvider.Get(ctx, nodeClass, options)
 	if err != nil {
 		return nil, err
 	}
@@ -137,9 +138,9 @@ func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 		// we need to pass down the max-pods calculation to the kubelet.
 		// This requires that we resolve a unique launch template per max-pods value.
 		for maxPods, instanceTypes := range maxPodsToInstanceTypes {
-			kubeletConfig := &v1alpha5.KubeletConfiguration{}
-			if machine.Spec.Kubelet != nil {
-				if err := mergo.Merge(kubeletConfig, machine.Spec.Kubelet); err != nil {
+			kubeletConfig := &corev1beta1.KubeletConfiguration{}
+			if nodeClaim.Spec.KubeletConfiguration != nil {
+				if err := mergo.Merge(kubeletConfig, nodeClaim.Spec.KubeletConfiguration); err != nil {
 					return nil, err
 				}
 			}
@@ -150,15 +151,15 @@ func (r Resolver) Resolve(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTem
 				Options: options,
 				UserData: amiFamily.UserData(
 					r.defaultClusterDNS(options, kubeletConfig),
-					append(machine.Spec.Taints, machine.Spec.StartupTaints...),
+					append(nodeClaim.Spec.Taints, nodeClaim.Spec.StartupTaints...),
 					options.Labels,
 					options.CABundle,
 					instanceTypes,
-					nodeTemplate.Spec.UserData,
+					nodeClass.Spec.UserData,
 				),
-				BlockDeviceMappings: nodeTemplate.Spec.BlockDeviceMappings,
-				MetadataOptions:     nodeTemplate.Spec.MetadataOptions,
-				DetailedMonitoring:  aws.BoolValue(nodeTemplate.Spec.DetailedMonitoring),
+				BlockDeviceMappings: nodeClass.Spec.BlockDeviceMappings,
+				MetadataOptions:     nodeClass.Spec.MetadataOptions,
+				DetailedMonitoring:  aws.BoolValue(nodeClass.Spec.DetailedMonitoring),
 				AMIID:               amiID,
 				InstanceTypes:       instanceTypes,
 			}
@@ -191,8 +192,8 @@ func GetAMIFamily(amiFamily *string, options *Options) AMIFamily {
 	}
 }
 
-func (o Options) DefaultMetadataOptions() *v1alpha1.MetadataOptions {
-	return &v1alpha1.MetadataOptions{
+func (o Options) DefaultMetadataOptions() *v1beta1.MetadataOptions {
+	return &v1beta1.MetadataOptions{
 		HTTPEndpoint:            aws.String(ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled),
 		HTTPProtocolIPv6:        aws.String(lo.Ternary(o.KubeDNSIP == nil || o.KubeDNSIP.To4() != nil, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Disabled, ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled)),
 		HTTPPutResponseHopLimit: aws.Int64(2),
@@ -200,7 +201,7 @@ func (o Options) DefaultMetadataOptions() *v1alpha1.MetadataOptions {
 	}
 }
 
-func (r Resolver) defaultClusterDNS(opts *Options, kubeletConfig *v1alpha5.KubeletConfiguration) *v1alpha5.KubeletConfiguration {
+func (r Resolver) defaultClusterDNS(opts *Options, kubeletConfig *corev1beta1.KubeletConfiguration) *corev1beta1.KubeletConfiguration {
 	if opts.KubeDNSIP == nil {
 		return kubeletConfig
 	}
@@ -208,7 +209,7 @@ func (r Resolver) defaultClusterDNS(opts *Options, kubeletConfig *v1alpha5.Kubel
 		return kubeletConfig
 	}
 	if kubeletConfig == nil {
-		return &v1alpha5.KubeletConfiguration{
+		return &corev1beta1.KubeletConfiguration{
 			ClusterDNS: []string{opts.KubeDNSIP.String()},
 		}
 	}

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -163,7 +163,7 @@ func (r Resolver) Resolve(ctx context.Context, nodeClass *v1beta1.NodeClass, nod
 				AMIID:               amiID,
 				InstanceTypes:       instanceTypes,
 			}
-			if resolved.BlockDeviceMappings == nil {
+			if len(resolved.BlockDeviceMappings) == 0 {
 				resolved.BlockDeviceMappings = amiFamily.DefaultBlockDeviceMappings()
 			}
 			if resolved.MetadataOptions == nil {

--- a/pkg/providers/amifamily/ubuntu.go
+++ b/pkg/providers/amifamily/ubuntu.go
@@ -20,7 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -52,7 +53,7 @@ func (u Ubuntu) DefaultAMIs(version string) []DefaultAMIOutput {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (u Ubuntu) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (u Ubuntu) UserData(kubeletConfig *corev1beta1.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.EKS{
 		Options: bootstrap.Options{
 			ClusterName:             u.Options.ClusterName,
@@ -68,8 +69,8 @@ func (u Ubuntu) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []
 }
 
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
-func (u Ubuntu) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
-	return []*v1alpha1.BlockDeviceMapping{{
+func (u Ubuntu) DefaultBlockDeviceMappings() []*v1beta1.BlockDeviceMapping {
+	return []*v1beta1.BlockDeviceMapping{{
 		DeviceName: u.EphemeralBlockDevice(),
 		EBS:        &DefaultEBS,
 	}}

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -17,7 +17,9 @@ package amifamily
 import (
 	"fmt"
 
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/scheduling"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -55,7 +57,7 @@ func (w Windows) DefaultAMIs(version string) []DefaultAMIOutput {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (w Windows) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (w Windows) UserData(kubeletConfig *corev1beta1.KubeletConfiguration, taints []v1.Taint, labels map[string]string, caBundle *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.Windows{
 		Options: bootstrap.Options{
 			ClusterName:     w.Options.ClusterName,
@@ -70,10 +72,10 @@ func (w Windows) UserData(kubeletConfig *v1alpha5.KubeletConfiguration, taints [
 }
 
 // DefaultBlockDeviceMappings returns the default block device mappings for the AMI Family
-func (w Windows) DefaultBlockDeviceMappings() []*v1alpha1.BlockDeviceMapping {
+func (w Windows) DefaultBlockDeviceMappings() []*v1beta1.BlockDeviceMapping {
 	sda1EBS := DefaultEBS
 	sda1EBS.VolumeSize = lo.ToPtr(resource.MustParse("50Gi"))
-	return []*v1alpha1.BlockDeviceMapping{{
+	return []*v1beta1.BlockDeviceMapping{{
 		DeviceName: w.EphemeralBlockDevice(),
 		EBS:        &sda1EBS,
 	}}

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -36,12 +36,14 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	coretest "github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/fake"
 	"github.com/aws/karpenter/pkg/test"
+	nodeclassutil "github.com/aws/karpenter/pkg/utils/nodeclass"
 )
 
 var ctx context.Context
@@ -129,7 +131,7 @@ var _ = Describe("InstanceProvider", func() {
 		instanceTypes = lo.Filter(instanceTypes, func(i *corecloudprovider.InstanceType, _ int) bool { return i.Name == "m5.xlarge" })
 
 		// Since all the capacity pools are ICEd. This should return back an ICE error
-		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeTemplate, machine, instanceTypes)
+		instance, err := awsEnv.InstanceProvider.Create(ctx, nodeclassutil.New(nodeTemplate), nodeclaimutil.New(machine), instanceTypes)
 		Expect(corecloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(instance).To(BeNil())
 	})

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -40,6 +40,7 @@ import (
 
 	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
@@ -50,7 +51,9 @@ import (
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	coretest "github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	"github.com/aws/karpenter-core/pkg/utils/resources"
+	nodeclassutil "github.com/aws/karpenter/pkg/utils/nodeclass"
 
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
@@ -658,7 +661,7 @@ var _ = Describe("Instance Types", func() {
 		instanceInfo, err := awsEnv.InstanceTypesProvider.GetInstanceTypes(ctx)
 		Expect(err).To(BeNil())
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 		}
 	})
@@ -666,7 +669,7 @@ var _ = Describe("Instance Types", func() {
 		instanceInfo, err := awsEnv.InstanceTypesProvider.GetInstanceTypes(ctx)
 		Expect(err).To(BeNil())
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			Expect(it.Capacity.Pods().Value()).ToNot(BeNumerically("==", 110))
 		}
 	})
@@ -690,13 +693,13 @@ var _ = Describe("Instance Types", func() {
 			EnableENILimitedPodDensity: lo.ToPtr(true),
 		}))
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", windowsNodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(windowsNodeTemplate), nil)
 			Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 		}
 	})
 
 	It("should expose vcpu metrics for instance types", func() {
-		instanceInfo, err := awsEnv.InstanceTypesProvider.List(ctx, provisioner.Spec.KubeletConfiguration, nodeTemplate)
+		instanceInfo, err := awsEnv.InstanceTypesProvider.List(ctx, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), nodeclassutil.New(nodeTemplate))
 		Expect(err).To(BeNil())
 		Expect(len(instanceInfo)).To(BeNumerically(">", 0))
 		for _, info := range instanceInfo {
@@ -710,7 +713,7 @@ var _ = Describe("Instance Types", func() {
 		}
 	})
 	It("should expose memory metrics for instance types", func() {
-		instanceInfo, err := awsEnv.InstanceTypesProvider.List(ctx, provisioner.Spec.KubeletConfiguration, nodeTemplate)
+		instanceInfo, err := awsEnv.InstanceTypesProvider.List(ctx, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), nodeclassutil.New(nodeTemplate))
 		Expect(err).To(BeNil())
 		Expect(len(instanceInfo)).To(BeNumerically(">", 0))
 		for _, info := range instanceInfo {
@@ -749,7 +752,7 @@ var _ = Describe("Instance Types", func() {
 		})
 		Context("System Reserved Resources", func() {
 			It("should use defaults when no kubelet is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &v1alpha5.KubeletConfiguration{}, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.SystemReserved.Cpu().String()).To(Equal("0"))
 				Expect(it.Overhead.SystemReserved.Memory().String()).To(Equal("0"))
 				Expect(it.Overhead.SystemReserved.StorageEphemeral().String()).To(Equal("0"))
@@ -764,7 +767,7 @@ var _ = Describe("Instance Types", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.SystemReserved.Cpu().String()).To(Equal("2"))
 				Expect(it.Overhead.SystemReserved.Memory().String()).To(Equal("20Gi"))
 				Expect(it.Overhead.SystemReserved.StorageEphemeral().String()).To(Equal("10Gi"))
@@ -772,13 +775,13 @@ var _ = Describe("Instance Types", func() {
 		})
 		Context("Kube Reserved Resources", func() {
 			It("should use defaults when no kubelet is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &v1alpha5.KubeletConfiguration{}, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.KubeReserved.Cpu().String()).To(Equal("80m"))
 				Expect(it.Overhead.KubeReserved.Memory().String()).To(Equal("893Mi"))
 				Expect(it.Overhead.KubeReserved.StorageEphemeral().String()).To(Equal("1Gi"))
 			})
 			It("should override kube reserved when specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &v1alpha5.KubeletConfiguration{
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(&v1alpha5.KubeletConfiguration{
 					SystemReserved: v1.ResourceList{
 						v1.ResourceCPU:              resource.MustParse("1"),
 						v1.ResourceMemory:           resource.MustParse("20Gi"),
@@ -789,7 +792,7 @@ var _ = Describe("Instance Types", func() {
 						v1.ResourceMemory:           resource.MustParse("10Gi"),
 						v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
-				}, "", nodeTemplate, nil)
+				}), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.KubeReserved.Cpu().String()).To(Equal("2"))
 				Expect(it.Overhead.KubeReserved.Memory().String()).To(Equal("10Gi"))
 				Expect(it.Overhead.KubeReserved.StorageEphemeral().String()).To(Equal("2Gi"))
@@ -816,7 +819,7 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
 				})
 				It("should override eviction threshold when specified as a percentage value", func() {
@@ -833,7 +836,7 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 				})
 				It("should consider the eviction threshold disabled when specified as 100%", func() {
@@ -850,7 +853,7 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("0"))
 				})
 				It("should used default eviction threshold for memory when evictionHard not specified", func() {
@@ -867,7 +870,7 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("50Mi"))
 				})
 			})
@@ -886,7 +889,7 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
 				})
 				It("should override eviction threshold when specified as a percentage value", func() {
@@ -906,7 +909,7 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 				})
 				It("should consider the eviction threshold disabled when specified as 100%", func() {
@@ -923,7 +926,7 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("0"))
 				})
 				It("should ignore eviction threshold when using Bottlerocket AMI", func() {
@@ -944,12 +947,12 @@ var _ = Describe("Instance Types", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("1Gi"))
 				})
 			})
 			It("should take the default eviction threshold when none is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &v1alpha5.KubeletConfiguration{}, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Cpu().String()).To(Equal("0"))
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				Expect(it.Overhead.EvictionThreshold.StorageEphemeral().AsApproximateFloat64()).To(BeNumerically("~", resources.Quantity("2Gi").AsApproximateFloat64()))
@@ -971,7 +974,7 @@ var _ = Describe("Instance Types", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("3Gi"))
 			})
 			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
@@ -991,7 +994,7 @@ var _ = Describe("Instance Types", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.05, 10))
 			})
 			It("should take the greater of evictionHard and evictionSoft for overhead with mixed percentage/value", func() {
@@ -1011,7 +1014,7 @@ var _ = Describe("Instance Types", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 			})
 		})
@@ -1021,11 +1024,11 @@ var _ = Describe("Instance Types", func() {
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{})
 			for _, info := range instanceInfo {
 				if *info.InstanceType == "t3.large" {
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 35))
 				}
 				if *info.InstanceType == "m6idn.32xlarge" {
-					it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 345))
 				}
 			}
@@ -1035,7 +1038,7 @@ var _ = Describe("Instance Types", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{MaxPods: ptr.Int32(10)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 10))
 			}
 		})
@@ -1048,7 +1051,7 @@ var _ = Describe("Instance Types", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{MaxPods: ptr.Int32(10)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 10))
 			}
 		})
@@ -1063,7 +1066,7 @@ var _ = Describe("Instance Types", func() {
 				return *info.InstanceType == "t3.large"
 			})
 			Expect(ok).To(Equal(true))
-			it := instancetype.NewInstanceType(ctx, t3Large, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, t3Large, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			// t3.large
 			// maxInterfaces = 3
 			// maxIPv4PerInterface = 12
@@ -1083,7 +1086,7 @@ var _ = Describe("Instance Types", func() {
 				return *info.InstanceType == "t3.large"
 			})
 			Expect(ok).To(Equal(true))
-			it := instancetype.NewInstanceType(ctx, t3Large, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, t3Large, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			// t3.large
 			// maxInterfaces = 3
 			// maxIPv4PerInterface = 12
@@ -1098,7 +1101,7 @@ var _ = Describe("Instance Types", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(1)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", ptr.Int64Value(info.VCpuInfo.DefaultVCpus)))
 			}
 		})
@@ -1107,7 +1110,7 @@ var _ = Describe("Instance Types", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(4), MaxPods: ptr.Int32(20)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", lo.Min([]int64{20, ptr.Int64Value(info.VCpuInfo.DefaultVCpus) * 4})))
 			}
 		})
@@ -1117,7 +1120,7 @@ var _ = Describe("Instance Types", func() {
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(1)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				limitedPods := instancetype.ENILimitedPods(ctx, info)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", limitedPods.Value()))
 			}
@@ -1131,7 +1134,7 @@ var _ = Describe("Instance Types", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(0)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 			}
 		})

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -41,6 +41,7 @@ import (
 	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -49,6 +50,7 @@ import (
 	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
 	"github.com/aws/karpenter/pkg/providers/instancetype"
 	"github.com/aws/karpenter/pkg/test"
+	nodeclassutil "github.com/aws/karpenter/pkg/utils/nodeclass"
 
 	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -777,7 +779,7 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
-			it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("993Mi"))
 		})
@@ -788,7 +790,7 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
-			it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("993Mi"))
 		})
@@ -827,7 +829,7 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-			it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("993Mi"))
 		})
@@ -838,7 +840,7 @@ var _ = Describe("LaunchTemplates", func() {
 			}))
 
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
-			it := instancetype.NewInstanceType(ctx, info, provisioner.Spec.KubeletConfiguration, "", nodeTemplate, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
 			overhead := it.Overhead.Total()
 			Expect(overhead.Memory().String()).To(Equal("1565Mi"))
 		})

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -274,27 +274,15 @@ var _ = Describe("LaunchTemplates", func() {
 					ImageId:      aws.String("ami-123"),
 					Architecture: aws.String("x86_64"),
 					CreationDate: aws.String("2022-08-15T12:00:00Z"),
-					Tags: []*ec2.Tag{
-						{
-							Key:   aws.String("karpenter.sh/discovery"),
-							Value: aws.String("my-cluster"),
-						},
-					},
 				},
 				{
 					Name:         aws.String(coretest.RandomName()),
 					ImageId:      aws.String("ami-456"),
 					Architecture: aws.String("arm64"),
 					CreationDate: aws.String("2022-08-10T12:00:00Z"),
-					Tags: []*ec2.Tag{
-						{
-							Key:   aws.String("karpenter.sh/discovery"),
-							Value: aws.String("my-cluster"),
-						},
-					},
 				},
 			}})
-			nodeTemplate.Spec.AMISelector = map[string]string{"karpenter.sh/discovery": "my-cluster"}
+			nodeTemplate.Spec.AMISelector = map[string]string{"*": "*"}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			newProvisioner := test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.MachineTemplateRef{Name: nodeTemplate.Name}})
 			ExpectApplied(ctx, env.Client, newProvisioner)
@@ -1468,19 +1456,13 @@ var _ = Describe("LaunchTemplates", func() {
 		})
 		Context("Custom AMI Selector", func() {
 			It("should use ami selector specified in AWSNodeTemplate", func() {
-				nodeTemplate.Spec.AMISelector = map[string]string{"karpenter.sh/discovery": "my-cluster"}
+				nodeTemplate.Spec.AMISelector = map[string]string{"*": "*"}
 				awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 					{
 						Name:         aws.String(coretest.RandomName()),
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
-						Tags: []*ec2.Tag{
-							{
-								Key:   aws.String("karpenter.sh/discovery"),
-								Value: aws.String("my-cluster"),
-							},
-						},
 					},
 				}})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
@@ -1496,7 +1478,7 @@ var _ = Describe("LaunchTemplates", func() {
 			})
 			It("should copy over userData untouched when AMIFamily is Custom", func() {
 				nodeTemplate.Spec.UserData = aws.String("special user data")
-				nodeTemplate.Spec.AMISelector = map[string]string{"karpenter.sh/discovery": "my-cluster"}
+				nodeTemplate.Spec.AMISelector = map[string]string{"*": "*"}
 				nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyCustom
 				awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 					{
@@ -1504,12 +1486,6 @@ var _ = Describe("LaunchTemplates", func() {
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
-						Tags: []*ec2.Tag{
-							{
-								Key:   aws.String("karpenter.sh/discovery"),
-								Value: aws.String("my-cluster"),
-							},
-						},
 					},
 				}})
 				ExpectApplied(ctx, env.Client, nodeTemplate)
@@ -1565,10 +1541,6 @@ var _ = Describe("LaunchTemplates", func() {
 								Key:   aws.String(v1.LabelInstanceTypeStable),
 								Value: aws.String("m5.large"),
 							},
-							{
-								Key:   aws.String("karpenter.sh/discovery"),
-								Value: aws.String("my-cluster"),
-							},
 						},
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
@@ -1581,15 +1553,11 @@ var _ = Describe("LaunchTemplates", func() {
 								Key:   aws.String(v1.LabelInstanceTypeStable),
 								Value: aws.String("m5.xlarge"),
 							},
-							{
-								Key:   aws.String("karpenter.sh/discovery"),
-								Value: aws.String("my-cluster"),
-							},
 						},
 						CreationDate: aws.String("2022-08-10T12:00:00Z"),
 					},
 				}})
-				nodeTemplate.Spec.AMISelector = map[string]string{"karpenter.sh/discovery": "my-cluster"}
+				nodeTemplate.Spec.AMISelector = map[string]string{"*": "*"}
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.MachineTemplateRef{Name: nodeTemplate.Name}})
 				ExpectApplied(ctx, env.Client, newProvisioner)
@@ -1611,24 +1579,12 @@ var _ = Describe("LaunchTemplates", func() {
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
 						CreationDate: aws.String("2020-01-01T12:00:00Z"),
-						Tags: []*ec2.Tag{
-							{
-								Key:   aws.String("karpenter.sh/discovery"),
-								Value: aws.String("my-cluster"),
-							},
-						},
 					},
 					{
 						Name:         aws.String(coretest.RandomName()),
 						ImageId:      aws.String("ami-456"),
 						Architecture: aws.String("x86_64"),
 						CreationDate: aws.String("2021-01-01T12:00:00Z"),
-						Tags: []*ec2.Tag{
-							{
-								Key:   aws.String("karpenter.sh/discovery"),
-								Value: aws.String("my-cluster"),
-							},
-						},
 					},
 					{
 						// Incompatible because required ARM64
@@ -1636,15 +1592,9 @@ var _ = Describe("LaunchTemplates", func() {
 						ImageId:      aws.String("ami-789"),
 						Architecture: aws.String("arm64"),
 						CreationDate: aws.String("2022-01-01T12:00:00Z"),
-						Tags: []*ec2.Tag{
-							{
-								Key:   aws.String("karpenter.sh/discovery"),
-								Value: aws.String("my-cluster"),
-							},
-						},
 					},
 				}})
-				nodeTemplate.Spec.AMISelector = map[string]string{"karpenter.sh/discovery": "my-cluster"}
+				nodeTemplate.Spec.AMISelector = map[string]string{"*": "*"}
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(coretest.ProvisionerOptions{
 					ProviderRef: &v1alpha5.MachineTemplateRef{Name: nodeTemplate.Name},
@@ -1668,7 +1618,7 @@ var _ = Describe("LaunchTemplates", func() {
 
 			It("should fail if no amis match selector.", func() {
 				awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{}})
-				nodeTemplate.Spec.AMISelector = map[string]string{"karpenter.sh/discovery": "my-cluster"}
+				nodeTemplate.Spec.AMISelector = map[string]string{"*": "*"}
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.MachineTemplateRef{Name: nodeTemplate.Name}})
 				ExpectApplied(ctx, env.Client, newProvisioner)
@@ -1680,7 +1630,7 @@ var _ = Describe("LaunchTemplates", func() {
 			It("should fail if no instanceType matches ami requirements.", func() {
 				awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{Images: []*ec2.Image{
 					{Name: aws.String(coretest.RandomName()), ImageId: aws.String("ami-123"), Architecture: aws.String("newnew"), CreationDate: aws.String("2022-01-01T12:00:00Z")}}})
-				nodeTemplate.Spec.AMISelector = map[string]string{"karpenter.sh/discovery": "my-cluster"}
+				nodeTemplate.Spec.AMISelector = map[string]string{"*": "*"}
 				ExpectApplied(ctx, env.Client, nodeTemplate)
 				newProvisioner := test.Provisioner(coretest.ProvisionerOptions{ProviderRef: &v1alpha5.MachineTemplateRef{Name: nodeTemplate.Name}})
 				ExpectApplied(ctx, env.Client, newProvisioner)

--- a/pkg/providers/securitygroup/securitygroup.go
+++ b/pkg/providers/securitygroup/securitygroup.go
@@ -65,7 +65,7 @@ func (p *Provider) List(ctx context.Context, nodeClass *v1beta1.NodeClass) ([]*e
 	if err != nil {
 		return nil, err
 	}
-	if p.cm.HasChanged(fmt.Sprintf("security-groups/%s", nodeClass.Name), securityGroups) {
+	if p.cm.HasChanged(fmt.Sprintf("security-groups/%t/%s", nodeClass.IsNodeTemplate, nodeClass.Name), securityGroups) {
 		logging.FromContext(ctx).
 			With("security-groups", lo.Map(securityGroups, func(s *ec2.SecurityGroup, _ int) string {
 				return aws.StringValue(s.GroupId)
@@ -93,7 +93,7 @@ func (p *Provider) getSecurityGroups(ctx context.Context, filterSets [][]*ec2.Fi
 			securityGroups[lo.FromPtr(sg.GroupId)] = sg
 		}
 	}
-	p.cache.SetDefault(fmt.Sprint(hash), securityGroups)
+	p.cache.SetDefault(fmt.Sprint(hash), lo.Values(securityGroups))
 	return lo.Values(securityGroups), nil
 }
 

--- a/pkg/providers/securitygroup/suite_test.go
+++ b/pkg/providers/securitygroup/suite_test.go
@@ -18,13 +18,8 @@ import (
 	"context"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "knative.dev/pkg/logging/testing"
@@ -32,10 +27,10 @@ import (
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/test"
 
 	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
-	corev1alpha5 "github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
@@ -48,8 +43,7 @@ var stop context.CancelFunc
 var opts options.Options
 var env *coretest.Environment
 var awsEnv *test.Environment
-var provisioner *corev1alpha5.Provisioner
-var nodeTemplate *v1alpha1.AWSNodeTemplate
+var nodeClass *v1beta1.NodeClass
 
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -74,35 +68,25 @@ var _ = BeforeEach(func() {
 	ctx = injection.WithOptions(ctx, opts)
 	ctx = coresettings.ToContext(ctx, coretest.Settings())
 	ctx = settings.ToContext(ctx, test.Settings())
-	nodeTemplate = &v1alpha1.AWSNodeTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: coretest.RandomName(),
-		},
-		Spec: v1alpha1.AWSNodeTemplateSpec{
-			AWS: v1alpha1.AWS{
-				AMIFamily:             aws.String(v1alpha1.AMIFamilyAL2),
-				SubnetSelector:        map[string]string{"*": "*"},
-				SecurityGroupSelector: map[string]string{"*": "*"},
+	nodeClass = test.NodeClass(v1beta1.NodeClass{
+		Spec: v1beta1.NodeClassSpec{
+			AMIFamily: aws.String(v1alpha1.AMIFamilyAL2),
+			SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
+				{
+					Tags: map[string]string{
+						"*": "*",
+					},
+				},
+			},
+			SecurityGroupSelectorTerms: []v1beta1.SecurityGroupSelectorTerm{
+				{
+					Tags: map[string]string{
+						"*": "*",
+					},
+				},
 			},
 		},
-	}
-	nodeTemplate.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   v1alpha1.SchemeGroupVersion.Group,
-		Version: v1alpha1.SchemeGroupVersion.Version,
-		Kind:    "AWSNodeTemplate",
 	})
-	provisioner = test.Provisioner(coretest.ProvisionerOptions{
-		Requirements: []v1.NodeSelectorRequirement{{
-			Key:      v1alpha1.LabelInstanceCategory,
-			Operator: v1.NodeSelectorOpExists,
-		}},
-		ProviderRef: &corev1alpha5.MachineTemplateRef{
-			APIVersion: nodeTemplate.APIVersion,
-			Kind:       nodeTemplate.Kind,
-			Name:       nodeTemplate.Name,
-		},
-	})
-
 	awsEnv.Reset()
 })
 
@@ -110,10 +94,9 @@ var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 })
 
-var _ = Describe("Security Group Provider", func() {
+var _ = Describe("SecurityGroupProvider", func() {
 	It("should default to the clusters security groups", func() {
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
 		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
 			{
@@ -158,8 +141,7 @@ var _ = Describe("Security Group Provider", func() {
 			{GroupName: aws.String("test-sgName-1"), GroupId: aws.String("test-sg-1"), Tags: []*ec2.Tag{{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("test-sg-1")}}},
 			{GroupName: aws.String("test-sgName-2"), GroupId: aws.String("test-sg-2"), Tags: []*ec2.Tag{{Key: aws.String("kubernetes.io/cluster/test-cluster"), Value: aws.String("test-sg-2")}}},
 		}})
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
 		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
 			{
@@ -181,9 +163,15 @@ var _ = Describe("Security Group Provider", func() {
 		}))
 	})
 	It("should discover security groups by multiple tag values", func() {
-		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"Name": "test-security-group-1,test-security-group-2"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+			{
+				Tags: map[string]string{"Name": "test-security-group-1"},
+			},
+			{
+				Tags: map[string]string{"Name": "test-security-group-2"},
+			},
+		}
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
 		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
 			{
@@ -211,9 +199,12 @@ var _ = Describe("Security Group Provider", func() {
 		}))
 	})
 	It("should discover security groups by ID", func() {
-		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+			{
+				ID: "sg-test1",
+			},
+		}
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
 		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
 			{
@@ -230,9 +221,15 @@ var _ = Describe("Security Group Provider", func() {
 		}))
 	})
 	It("should discover security groups by IDs", func() {
-		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1,sg-test2"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+			{
+				ID: "sg-test1",
+			},
+			{
+				ID: "sg-test2",
+			},
+		}
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
 		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
 			{
@@ -260,9 +257,17 @@ var _ = Describe("Security Group Provider", func() {
 		}))
 	})
 	It("should discover security groups by IDs and tags", func() {
-		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test1,sg-test2", "foo": "bar"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+			{
+				ID:   "sg-test1",
+				Tags: map[string]string{"foo": "bar"},
+			},
+			{
+				ID:   "sg-test2",
+				Tags: map[string]string{"foo": "bar"},
+			},
+		}
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
 		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
 			{
@@ -290,9 +295,13 @@ var _ = Describe("Security Group Provider", func() {
 		}))
 	})
 	It("should discover security groups by IDs intersected with tags", func() {
-		nodeTemplate.Spec.SecurityGroupSelector = map[string]string{"aws-ids": "sg-test2", "foo": "bar"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeTemplate)
+		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+			{
+				ID:   "sg-test2",
+				Tags: map[string]string{"foo": "bar"},
+			},
+		}
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
 		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
 			{
@@ -301,6 +310,73 @@ var _ = Describe("Security Group Provider", func() {
 				Tags: []*ec2.Tag{{
 					Key:   aws.String("Name"),
 					Value: aws.String("test-security-group-2"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
+	})
+	It("should discover security groups by names", func() {
+		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+			{
+				Name: "securityGroup-test2",
+			},
+			{
+				Name: "securityGroup-test3",
+			},
+		}
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
+		Expect(err).To(BeNil())
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test2"),
+				GroupName: aws.String("securityGroup-test2"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-2"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+			{
+				GroupId:   aws.String("sg-test3"),
+				GroupName: aws.String("securityGroup-test3"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-3"),
+				}, {
+					Key: aws.String("TestTag"),
+				}, {
+					Key:   aws.String("foo"),
+					Value: aws.String("bar"),
+				}},
+			},
+		}))
+	})
+	It("should discover security groups by names intersected with tags", func() {
+		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+			{
+				Name: "securityGroup-test2",
+				Tags: map[string]string{"TestTag": "*"},
+			},
+			{
+				Name: "securityGroup-test3",
+				Tags: map[string]string{"TestTag": "*"},
+			},
+		}
+		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
+		Expect(err).To(BeNil())
+		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+			{
+				GroupId:   aws.String("sg-test3"),
+				GroupName: aws.String("securityGroup-test3"),
+				Tags: []*ec2.Tag{{
+					Key:   aws.String("Name"),
+					Value: aws.String("test-security-group-3"),
+				}, {
+					Key: aws.String("TestTag"),
 				}, {
 					Key:   aws.String("foo"),
 					Value: aws.String("bar"),

--- a/pkg/providers/securitygroup/suite_test.go
+++ b/pkg/providers/securitygroup/suite_test.go
@@ -256,10 +256,6 @@ var _ = Describe("SecurityGroupProvider", func() {
 	It("should discover security groups by names intersected with tags", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
 			{
-				Name: "securityGroup-test2",
-				Tags: map[string]string{"TestTag": "*"},
-			},
-			{
 				Name: "securityGroup-test3",
 				Tags: map[string]string{"TestTag": "*"},
 			},

--- a/pkg/providers/securitygroup/suite_test.go
+++ b/pkg/providers/securitygroup/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/aws/karpenter/pkg/apis"
@@ -98,43 +99,20 @@ var _ = Describe("SecurityGroupProvider", func() {
 	It("should default to the clusters security groups", func() {
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test1"),
 				GroupName: aws.String("securityGroup-test1"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-1"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
 			{
 				GroupId:   aws.String("sg-test2"),
 				GroupName: aws.String("securityGroup-test2"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-2"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
 			{
 				GroupId:   aws.String("sg-test3"),
 				GroupName: aws.String("securityGroup-test3"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-3"),
-				}, {
-					Key: aws.String("TestTag"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by tag", func() {
 		awsEnv.EC2API.DescribeSecurityGroupsOutput.Set(&ec2.DescribeSecurityGroupsOutput{SecurityGroups: []*ec2.SecurityGroup{
@@ -143,24 +121,16 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}})
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
-				GroupName: aws.String("test-sgName-1"),
 				GroupId:   aws.String("test-sg-1"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-					Value: aws.String("test-sg-1"),
-				}},
+				GroupName: aws.String("test-sgName-1"),
 			},
 			{
-				GroupName: aws.String("test-sgName-2"),
 				GroupId:   aws.String("test-sg-2"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("kubernetes.io/cluster/test-cluster"),
-					Value: aws.String("test-sg-2"),
-				}},
+				GroupName: aws.String("test-sgName-2"),
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by multiple tag values", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -173,30 +143,16 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test1"),
 				GroupName: aws.String("securityGroup-test1"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-1"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
 			{
 				GroupId:   aws.String("sg-test2"),
 				GroupName: aws.String("securityGroup-test2"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-2"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by ID", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -206,19 +162,12 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test1"),
 				GroupName: aws.String("securityGroup-test1"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-1"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by IDs", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -231,30 +180,16 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test1"),
 				GroupName: aws.String("securityGroup-test1"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-1"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
 			{
 				GroupId:   aws.String("sg-test2"),
 				GroupName: aws.String("securityGroup-test2"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-2"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by IDs and tags", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -269,30 +204,16 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test1"),
 				GroupName: aws.String("securityGroup-test1"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-1"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
 			{
 				GroupId:   aws.String("sg-test2"),
 				GroupName: aws.String("securityGroup-test2"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-2"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by IDs intersected with tags", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -303,19 +224,12 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test2"),
 				GroupName: aws.String("securityGroup-test2"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-2"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by names", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -328,32 +242,16 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test2"),
 				GroupName: aws.String("securityGroup-test2"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-2"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
 			{
 				GroupId:   aws.String("sg-test3"),
 				GroupName: aws.String("securityGroup-test3"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-3"),
-				}, {
-					Key: aws.String("TestTag"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 	It("should discover security groups by names intersected with tags", func() {
 		nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -368,20 +266,23 @@ var _ = Describe("SecurityGroupProvider", func() {
 		}
 		securityGroups, err := awsEnv.SecurityGroupProvider.List(ctx, nodeClass)
 		Expect(err).To(BeNil())
-		Expect(securityGroups).To(Equal([]*ec2.SecurityGroup{
+		ExpectConsistsOfSecurityGroups([]*ec2.SecurityGroup{
 			{
 				GroupId:   aws.String("sg-test3"),
 				GroupName: aws.String("securityGroup-test3"),
-				Tags: []*ec2.Tag{{
-					Key:   aws.String("Name"),
-					Value: aws.String("test-security-group-3"),
-				}, {
-					Key: aws.String("TestTag"),
-				}, {
-					Key:   aws.String("foo"),
-					Value: aws.String("bar"),
-				}},
 			},
-		}))
+		}, securityGroups)
 	})
 })
+
+func ExpectConsistsOfSecurityGroups(expected, actual []*ec2.SecurityGroup) {
+	GinkgoHelper()
+	Expect(actual).To(HaveLen(len(expected)))
+	for _, elem := range expected {
+		_, ok := lo.Find(actual, func(s *ec2.SecurityGroup) bool {
+			return lo.FromPtr(s.GroupId) == lo.FromPtr(elem.GroupId) &&
+				lo.FromPtr(s.GroupName) == lo.FromPtr(elem.GroupName)
+		})
+		Expect(ok).To(BeTrue(), `Expected security group with {"GroupId": %q, "GroupName": %q} to exist`, lo.FromPtr(elem.GroupId), lo.FromPtr(elem.GroupName))
+	}
+}

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -83,7 +83,7 @@ func (p *Provider) List(ctx context.Context, nodeClass *v1beta1.NodeClass) ([]*e
 			delete(p.inflightIPs, lo.FromPtr(elem.SubnetId)) // remove any previously tracked IP addresses since we just refreshed from EC2
 		}
 	}
-	p.cache.SetDefault(fmt.Sprint(hash), subnets)
+	p.cache.SetDefault(fmt.Sprint(hash), lo.Values(subnets))
 	if p.cm.HasChanged(fmt.Sprintf("subnets/%t/%s", nodeClass.IsNodeTemplate, nodeClass.Name), subnets) {
 		logging.FromContext(ctx).
 			With("subnets", lo.Map(lo.Values(subnets), func(s *ec2.Subnet, _ int) string {

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -29,7 +29,7 @@ import (
 	"github.com/samber/lo"
 	"knative.dev/pkg/logging"
 
-	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/utils/functional"
@@ -56,10 +56,10 @@ func NewProvider(ec2api ec2iface.EC2API, cache *cache.Cache) *Provider {
 	}
 }
 
-func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) ([]*ec2.Subnet, error) {
+func (p *Provider) List(ctx context.Context, nodeClass *v1beta1.NodeClass) ([]*ec2.Subnet, error) {
 	p.Lock()
 	defer p.Unlock()
-	filters := getFilters(nodeTemplate)
+	filters := getFilters(nodeClass)
 	if len(filters) == 0 {
 		return []*ec2.Subnet{}, nil
 	}
@@ -79,7 +79,7 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 	for _, subnet := range output.Subnets {
 		delete(p.inflightIPs, *subnet.SubnetId)
 	}
-	if p.cm.HasChanged(fmt.Sprintf("subnets/%s", nodeTemplate.Name), output.Subnets) {
+	if p.cm.HasChanged(fmt.Sprintf("subnets/%s", nodeClass.Name), output.Subnets) {
 		logging.FromContext(ctx).
 			With("subnets", lo.Map(output.Subnets, func(s *ec2.Subnet, _ int) string {
 				return fmt.Sprintf("%s (%s)", aws.StringValue(s.SubnetId), aws.StringValue(s.AvailabilityZone))
@@ -90,8 +90,8 @@ func (p *Provider) List(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTempl
 }
 
 // CheckAnyPublicIPAssociations returns a bool indicating whether all referenced subnets assign public IPv4 addresses to EC2 instances created therein
-func (p *Provider) CheckAnyPublicIPAssociations(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate) (bool, error) {
-	subnets, err := p.List(ctx, nodeTemplate)
+func (p *Provider) CheckAnyPublicIPAssociations(ctx context.Context, nodeClass *v1beta1.NodeClass) (bool, error) {
+	subnets, err := p.List(ctx, nodeClass)
 	if err != nil {
 		return false, err
 	}
@@ -102,13 +102,14 @@ func (p *Provider) CheckAnyPublicIPAssociations(ctx context.Context, nodeTemplat
 }
 
 // ZonalSubnetsForLaunch returns a mapping of zone to the subnet with the most available IP addresses and deducts the passed ips from the available count
-func (p *Provider) ZonalSubnetsForLaunch(ctx context.Context, nodeTemplate *v1alpha1.AWSNodeTemplate, instanceTypes []*cloudprovider.InstanceType, capacityType string) (map[string]*ec2.Subnet, error) {
-	subnets, err := p.List(ctx, nodeTemplate)
+func (p *Provider) ZonalSubnetsForLaunch(ctx context.Context, nodeClass *v1beta1.NodeClass, instanceTypes []*cloudprovider.InstanceType, capacityType string) (map[string]*ec2.Subnet, error) {
+	subnets, err := p.List(ctx, nodeClass)
 	if err != nil {
 		return nil, err
 	}
 	if len(subnets) == 0 {
-		return nil, fmt.Errorf("no subnets matched selector %v", nodeTemplate.Spec.SubnetSelector)
+		// TODO @joinnis: Come back here and make sure that this prints in a nice format
+		return nil, fmt.Errorf("no subnets matched selector %v", nodeClass.Spec.SubnetSelectorTerms)
 	}
 	p.Lock()
 	defer p.Unlock()
@@ -225,10 +226,10 @@ func (p *Provider) minPods(instanceTypes []*cloudprovider.InstanceType, zone str
 	return pods
 }
 
-func getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {
+// TODO @joinnis: Need to re-write the filtering logic here to generate multiple requests if needed
+func getFilters(nodeClass *v1beta1.NodeClass) []*ec2.Filter {
 	var filters []*ec2.Filter
-	// Filter by subnet
-	for key, value := range nodeTemplate.Spec.SubnetSelector {
+	for key, value := range nodeClass.Spec.SubnetSelectorTerms {
 		switch key {
 		case "aws-ids", "aws::ids":
 			filters = append(filters, &ec2.Filter{

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -113,7 +113,6 @@ func (p *Provider) ZonalSubnetsForLaunch(ctx context.Context, nodeClass *v1beta1
 		return nil, err
 	}
 	if len(subnets) == 0 {
-		// TODO @joinnis: Come back here and make sure that this prints in a nice format
 		return nil, fmt.Errorf("no subnets matched selector %v", nodeClass.Spec.SubnetSelectorTerms)
 	}
 	p.Lock()

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -18,12 +18,7 @@ import (
 	"context"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/aws/aws-sdk-go/aws"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "knative.dev/pkg/logging/testing"
@@ -31,10 +26,10 @@ import (
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/test"
 
 	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
-	corev1alpha5 "github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
@@ -47,8 +42,7 @@ var stop context.CancelFunc
 var opts options.Options
 var env *coretest.Environment
 var awsEnv *test.Environment
-var provisioner *corev1alpha5.Provisioner
-var nodeTemplate *v1alpha1.AWSNodeTemplate
+var nodeClass *v1beta1.NodeClass
 
 func TestAWS(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -73,35 +67,25 @@ var _ = BeforeEach(func() {
 	ctx = injection.WithOptions(ctx, opts)
 	ctx = coresettings.ToContext(ctx, coretest.Settings())
 	ctx = settings.ToContext(ctx, test.Settings())
-	nodeTemplate = &v1alpha1.AWSNodeTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: coretest.RandomName(),
-		},
-		Spec: v1alpha1.AWSNodeTemplateSpec{
-			AWS: v1alpha1.AWS{
-				AMIFamily:             aws.String(v1alpha1.AMIFamilyAL2),
-				SubnetSelector:        map[string]string{"*": "*"},
-				SecurityGroupSelector: map[string]string{"*": "*"},
+	nodeClass = test.NodeClass(v1beta1.NodeClass{
+		Spec: v1beta1.NodeClassSpec{
+			AMIFamily: aws.String(v1alpha1.AMIFamilyAL2),
+			SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
+				{
+					Tags: map[string]string{
+						"*": "*",
+					},
+				},
+			},
+			SecurityGroupSelectorTerms: []v1beta1.SecurityGroupSelectorTerm{
+				{
+					Tags: map[string]string{
+						"*": "*",
+					},
+				},
 			},
 		},
-	}
-	nodeTemplate.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   v1alpha1.SchemeGroupVersion.Group,
-		Version: v1alpha1.SchemeGroupVersion.Version,
-		Kind:    "AWSNodeTemplate",
 	})
-	provisioner = test.Provisioner(coretest.ProvisionerOptions{
-		Requirements: []v1.NodeSelectorRequirement{{
-			Key:      v1alpha1.LabelInstanceCategory,
-			Operator: v1.NodeSelectorOpExists,
-		}},
-		ProviderRef: &corev1alpha5.MachineTemplateRef{
-			APIVersion: nodeTemplate.APIVersion,
-			Kind:       nodeTemplate.Kind,
-			Name:       nodeTemplate.Name,
-		},
-	})
-
 	awsEnv.Reset()
 })
 
@@ -109,93 +93,134 @@ var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
 })
 
-var _ = Describe("Subnet Provider", func() {
-	It("should discover subnet by ID", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test1"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		subnets, err := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
+var _ = Describe("SubnetProvider", func() {
+	Context("List", func() {
+		It("should discover subnet by ID", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					ID: "subnet-test1",
+				},
+			}
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
 
-		Expect(err).To(BeNil())
-		Expect(subnets).To(HaveLen(1))
-		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-	})
-	It("should discover subnets by IDs", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test1,subnet-test2"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		subnets, err := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
-		Expect(err).To(BeNil())
-		Expect(subnets).To(HaveLen(2))
-		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-		Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
-		Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
-		Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-	})
-	It("should discover subnets by IDs and tags", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test1,subnet-test2", "foo": "bar"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		subnets, err := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(1))
+			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
+			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+		})
+		It("should discover subnets by IDs", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					ID: "subnet-test1",
+				},
+				{
+					ID: "subnet-test2",
+				},
+			}
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(2))
+			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
+			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
+			Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
+			Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+		})
+		It("should discover subnets by IDs and tags", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					ID:   "subnet-test1",
+					Tags: map[string]string{"foo": "bar"},
+				},
+				{
+					ID:   "subnet-test2",
+					Tags: map[string]string{"foo": "bar"},
+				},
+			}
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
 
-		Expect(err).To(BeNil())
-		Expect(subnets).To(HaveLen(2))
-		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-		Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
-		Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
-		Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-	})
-	It("should discover subnets by a single tag", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		subnets, err := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(2))
+			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
+			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
+			Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
+			Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+		})
+		It("should discover subnets by a single tag", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					Tags: map[string]string{"Name": "test-subnet-1"},
+				},
+			}
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
 
-		Expect(err).To(BeNil())
-		Expect(subnets).To(HaveLen(1))
-		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-	})
-	It("should discover subnets by multiple tag values", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1,test-subnet-2"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		subnets, err := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(1))
+			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
+			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+		})
+		It("should discover subnets by multiple tag values", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					Tags: map[string]string{"Name": "test-subnet-1"},
+				},
+				{
+					Tags: map[string]string{"Name": "test-subnet-2"},
+				},
+			}
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
 
-		Expect(err).To(BeNil())
-		Expect(subnets).To(HaveLen(2))
-		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-		Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
-		Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
-		Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-	})
-	It("should discover subnets by IDs intersected with tags", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test2", "foo": "bar"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		subnets, err := awsEnv.SubnetProvider.List(ctx, nodeTemplate)
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(2))
+			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
+			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
+			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
+			Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
+			Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+		})
+		It("should discover subnets by IDs intersected with tags", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					ID:   "subnet-test2",
+					Tags: map[string]string{"foo": "bar"},
+				},
+			}
+			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
 
-		Expect(err).To(BeNil())
-		Expect(subnets).To(HaveLen(1))
-		Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test2"))
-		Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1b"))
-		Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			Expect(err).To(BeNil())
+			Expect(subnets).To(HaveLen(1))
+			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test2"))
+			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1b"))
+			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+		})
 	})
-	It("should note that no subnets assign a public IPv4 address to EC2 instances on launch", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"Name": "test-subnet-1,test-subnet-3"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		onlyPrivate, err := awsEnv.SubnetProvider.CheckAnyPublicIPAssociations(ctx, nodeTemplate)
-		Expect(err).To(BeNil())
-		Expect(onlyPrivate).To(BeFalse())
-	})
-	It("should note that at least one subnet assigns a public IPv4 address to EC2instances on launch", func() {
-		nodeTemplate.Spec.SubnetSelector = map[string]string{"aws-ids": "subnet-test2"}
-		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-		onlyPrivate, err := awsEnv.SubnetProvider.CheckAnyPublicIPAssociations(ctx, nodeTemplate)
-		Expect(err).To(BeNil())
-		Expect(onlyPrivate).To(BeTrue())
+	Context("CheckAnyPublicIPAssociations", func() {
+		It("should note that no subnets assign a public IPv4 address to EC2 instances on launch", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					ID:   "subnet-test1",
+					Tags: map[string]string{"foo": "bar"},
+				},
+			}
+			onlyPrivate, err := awsEnv.SubnetProvider.CheckAnyPublicIPAssociations(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(onlyPrivate).To(BeFalse())
+		})
+		It("should note that at least one subnet assigns a public IPv4 address to EC2instances on launch", func() {
+			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					ID: "subnet-test2",
+				},
+			}
+			onlyPrivate, err := awsEnv.SubnetProvider.CheckAnyPublicIPAssociations(ctx, nodeClass)
+			Expect(err).To(BeNil())
+			Expect(onlyPrivate).To(BeTrue())
+		})
 	})
 })

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -19,8 +19,10 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/aws/karpenter/pkg/apis"
@@ -102,12 +104,14 @@ var _ = Describe("SubnetProvider", func() {
 				},
 			}
 			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
-
 			Expect(err).To(BeNil())
-			Expect(subnets).To(HaveLen(1))
-			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			ExpectConsistsOfSubnets([]*ec2.Subnet{
+				{
+					SubnetId:                lo.ToPtr("subnet-test1"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+			}, subnets)
 		})
 		It("should discover subnets by IDs", func() {
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -120,13 +124,18 @@ var _ = Describe("SubnetProvider", func() {
 			}
 			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
 			Expect(err).To(BeNil())
-			Expect(subnets).To(HaveLen(2))
-			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-			Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
-			Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
-			Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			ExpectConsistsOfSubnets([]*ec2.Subnet{
+				{
+					SubnetId:                lo.ToPtr("subnet-test1"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+				{
+					SubnetId:                lo.ToPtr("subnet-test2"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+			}, subnets)
 		})
 		It("should discover subnets by IDs and tags", func() {
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -140,15 +149,19 @@ var _ = Describe("SubnetProvider", func() {
 				},
 			}
 			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
-
 			Expect(err).To(BeNil())
-			Expect(subnets).To(HaveLen(2))
-			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-			Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
-			Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
-			Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			ExpectConsistsOfSubnets([]*ec2.Subnet{
+				{
+					SubnetId:                lo.ToPtr("subnet-test1"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+				{
+					SubnetId:                lo.ToPtr("subnet-test2"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+			}, subnets)
 		})
 		It("should discover subnets by a single tag", func() {
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -157,12 +170,14 @@ var _ = Describe("SubnetProvider", func() {
 				},
 			}
 			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
-
 			Expect(err).To(BeNil())
-			Expect(subnets).To(HaveLen(1))
-			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			ExpectConsistsOfSubnets([]*ec2.Subnet{
+				{
+					SubnetId:                lo.ToPtr("subnet-test1"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+			}, subnets)
 		})
 		It("should discover subnets by multiple tag values", func() {
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -174,15 +189,19 @@ var _ = Describe("SubnetProvider", func() {
 				},
 			}
 			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
-
 			Expect(err).To(BeNil())
-			Expect(subnets).To(HaveLen(2))
-			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test1"))
-			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1a"))
-			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
-			Expect(aws.StringValue(subnets[1].SubnetId)).To(Equal("subnet-test2"))
-			Expect(aws.StringValue(subnets[1].AvailabilityZone)).To(Equal("test-zone-1b"))
-			Expect(aws.Int64Value(subnets[1].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			ExpectConsistsOfSubnets([]*ec2.Subnet{
+				{
+					SubnetId:                lo.ToPtr("subnet-test1"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1a"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+				{
+					SubnetId:                lo.ToPtr("subnet-test2"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+			}, subnets)
 		})
 		It("should discover subnets by IDs intersected with tags", func() {
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
@@ -192,12 +211,14 @@ var _ = Describe("SubnetProvider", func() {
 				},
 			}
 			subnets, err := awsEnv.SubnetProvider.List(ctx, nodeClass)
-
 			Expect(err).To(BeNil())
-			Expect(subnets).To(HaveLen(1))
-			Expect(aws.StringValue(subnets[0].SubnetId)).To(Equal("subnet-test2"))
-			Expect(aws.StringValue(subnets[0].AvailabilityZone)).To(Equal("test-zone-1b"))
-			Expect(aws.Int64Value(subnets[0].AvailableIpAddressCount)).To(BeNumerically("==", 100))
+			ExpectConsistsOfSubnets([]*ec2.Subnet{
+				{
+					SubnetId:                lo.ToPtr("subnet-test2"),
+					AvailabilityZone:        lo.ToPtr("test-zone-1b"),
+					AvailableIpAddressCount: lo.ToPtr[int64](100),
+				},
+			}, subnets)
 		})
 	})
 	Context("CheckAnyPublicIPAssociations", func() {
@@ -224,3 +245,16 @@ var _ = Describe("SubnetProvider", func() {
 		})
 	})
 })
+
+func ExpectConsistsOfSubnets(expected, actual []*ec2.Subnet) {
+	GinkgoHelper()
+	Expect(actual).To(HaveLen(len(expected)))
+	for _, elem := range expected {
+		_, ok := lo.Find(actual, func(s *ec2.Subnet) bool {
+			return lo.FromPtr(s.SubnetId) == lo.FromPtr(elem.SubnetId) &&
+				lo.FromPtr(s.AvailabilityZone) == lo.FromPtr(elem.AvailabilityZone) &&
+				lo.FromPtr(s.AvailableIpAddressCount) == lo.FromPtr(elem.AvailableIpAddressCount)
+		})
+		Expect(ok).To(BeTrue(), `Expected subnet with {"SubnetId": %q, "AvailabilityZone": %q, "AvailableIpAddressCount": %q} to exist`, lo.FromPtr(elem.SubnetId), lo.FromPtr(elem.AvailabilityZone), lo.FromPtr(elem.AvailableIpAddressCount))
+	}
+}

--- a/test/suites/integration/security_group_test.go
+++ b/test/suites/integration/security_group_test.go
@@ -19,17 +19,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	"github.com/aws/karpenter/test/pkg/environment/aws"
 
 	awstest "github.com/aws/karpenter/pkg/test"
 )
@@ -65,8 +66,8 @@ var _ = Describe("SecurityGroups", func() {
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 			AWS: v1alpha1.AWS{
 				SecurityGroupSelector: map[string]string{"Name": fmt.Sprintf("%s,%s",
-					aws.StringValue(lo.FindOrElse(first.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return aws.StringValue(tag.Key) == "Name" }).Value),
-					aws.StringValue(lo.FindOrElse(last.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return aws.StringValue(tag.Key) == "Name" }).Value),
+					lo.FromPtr(lo.FindOrElse(first.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return lo.FromPtr(tag.Key) == "Name" }).Value),
+					lo.FromPtr(lo.FindOrElse(last.Tags, &ec2.Tag{}, func(tag *ec2.Tag) bool { return lo.FromPtr(tag.Key) == "Name" }).Value),
 				)},
 				SubnetSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 			},
@@ -82,65 +83,30 @@ var _ = Describe("SecurityGroups", func() {
 	})
 
 	It("should update the AWSNodeTemplateStatus for security groups", func() {
-		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+		nodeTemplate := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
 			AWS: v1alpha1.AWS{
 				SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 				SubnetSelector:        map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName},
 			},
 		})
 
-		env.ExpectCreated(provider)
-		EventuallyExpectSecurityGroups(provider)
+		env.ExpectCreated(nodeTemplate)
+		EventuallyExpectSecurityGroups(env, nodeTemplate)
 	})
 })
 
-type SecurityGroup struct {
-	ec2.GroupIdentifier
-	Tags []*ec2.Tag
-}
+func EventuallyExpectSecurityGroups(env *aws.Environment, nodeTemplate *v1alpha1.AWSNodeTemplate) {
+	securityGroups := env.GetSecurityGroups(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
+	Expect(securityGroups).ToNot(HaveLen(0))
 
-// getSecurityGroups returns all getSecurityGroups matching the label selector
-func getSecurityGroups(tags map[string]string) []SecurityGroup {
-	var filters []*ec2.Filter
-	for key, val := range tags {
-		filters = append(filters, &ec2.Filter{
-			Name:   aws.String(fmt.Sprintf("tag:%s", key)),
-			Values: []*string{aws.String(val)},
-		})
-	}
-	var securityGroups []SecurityGroup
-	err := env.EC2API.DescribeSecurityGroupsPages(&ec2.DescribeSecurityGroupsInput{Filters: filters}, func(dso *ec2.DescribeSecurityGroupsOutput, _ bool) bool {
-		for _, sg := range dso.SecurityGroups {
-			securityGroups = append(securityGroups, SecurityGroup{
-				Tags:            sg.Tags,
-				GroupIdentifier: ec2.GroupIdentifier{GroupId: sg.GroupId, GroupName: sg.GroupName},
-			})
-		}
-		return true
-	})
-	Expect(err).To(BeNil())
-	return securityGroups
-}
-
-func EventuallyExpectSecurityGroups(provider *v1alpha1.AWSNodeTemplate) {
-	securityGroup := getSecurityGroups(map[string]string{"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName})
-	Expect(len(securityGroup)).ToNot(Equal(0))
-	var securityGroupID []string
-
-	for _, secGroup := range securityGroup {
-		securityGroupID = append(securityGroupID, *secGroup.GroupId)
-	}
-
+	ids := sets.New(lo.Map(securityGroups, func(s aws.SecurityGroup, _ int) string {
+		return lo.FromPtr(s.GroupId)
+	})...)
 	Eventually(func(g Gomega) {
-		var ant v1alpha1.AWSNodeTemplate
-		if err := env.Client.Get(env, client.ObjectKeyFromObject(provider), &ant); err != nil {
-			return
-		}
-
-		securityGroupsInStatus := lo.Map(ant.Status.SecurityGroups, func(securitygroup v1alpha1.SecurityGroup, _ int) string {
-			return securitygroup.ID
-		})
-
-		g.Expect(securityGroupsInStatus).To(Equal(securityGroupID))
+		temp := &v1alpha1.AWSNodeTemplate{}
+		g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nodeTemplate), temp)).To(Succeed())
+		g.Expect(sets.New(lo.Map(temp.Status.SecurityGroups, func(s v1alpha1.SecurityGroup, _ int) string {
+			return s.ID
+		})...).Equal(ids))
 	}).WithTimeout(10 * time.Second).Should(Succeed())
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds support for `v1beta1/NodeClass` and `v1beta1/NodePool` conversion in the CloudProvider. This change is meant to stage out the `v1beta1` changes so that the CRDs can be released more formally later.

Now, with the `v1beta1/NodeClass` APIs, if you add multiple terms to the set of `subnetSelectors`, `securityGroupSelectors`, or `amiSelectors`, this will generate multiple requests to the respective EC2 APIs (unless the selectors reference ids, in which case we combine all id filters into a single request).

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.