### PR TITLE
feat: template custom userdata

### DIFF
--- a/pkg/providers/amifamily/bootstrap/bootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/bootstrap.go
@@ -35,6 +35,7 @@ type Options struct {
 	KubeletConfig           *v1alpha5.KubeletConfiguration
 	Taints                  []core.Taint      `hash:"set"`
 	Labels                  map[string]string `hash:"set"`
+	InstanceTypes           []string
 	CABundle                *string
 	AWSENILimitedPodDensity bool
 	ContainerRuntime        *string

--- a/pkg/providers/amifamily/bootstrap/bootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/bootstrap.go
@@ -35,7 +35,6 @@ type Options struct {
 	KubeletConfig           *v1alpha5.KubeletConfiguration
 	Taints                  []core.Taint      `hash:"set"`
 	Labels                  map[string]string `hash:"set"`
-	InstanceTypes           []string
 	CABundle                *string
 	AWSENILimitedPodDensity bool
 	ContainerRuntime        *string

--- a/pkg/providers/amifamily/bootstrap/custom.go
+++ b/pkg/providers/amifamily/bootstrap/custom.go
@@ -27,9 +27,8 @@ type Custom struct {
 }
 
 type TemplateData struct {
-	Taints        []v1.Taint        `hash:"set"`
-	Labels        map[string]string `hash:"set"`
-	InstanceTypes []string
+	Taints []v1.Taint        `hash:"set"`
+	Labels map[string]string `hash:"set"`
 }
 
 func (e Custom) Script() (string, error) {
@@ -48,9 +47,8 @@ func (e Custom) templateUserData(rawUserData string) (string, error) {
 	}
 
 	data := TemplateData{
-		Taints:        e.Options.Taints,
-		Labels:        e.Options.Labels,
-		InstanceTypes: e.Options.InstanceTypes,
+		Taints: e.Options.Taints,
+		Labels: e.Options.Labels,
 	}
 
 	var buf bytes.Buffer

--- a/pkg/providers/amifamily/custom.go
+++ b/pkg/providers/amifamily/custom.go
@@ -30,17 +30,11 @@ type Custom struct {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (c Custom) UserData(_ *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, _ *string, instanceTypes []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
-	var iTypes []string
-	for _, i := range instanceTypes {
-		iTypes = append(iTypes, i.Name)
-	}
-
+func (c Custom) UserData(_ *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, _ *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
 	return bootstrap.Custom{
 		Options: bootstrap.Options{
 			Taints:         taints,
 			Labels:         labels,
-			InstanceTypes:  iTypes,
 			CustomUserData: customUserData,
 		},
 	}

--- a/pkg/providers/amifamily/custom.go
+++ b/pkg/providers/amifamily/custom.go
@@ -30,9 +30,17 @@ type Custom struct {
 }
 
 // UserData returns the default userdata script for the AMI Family
-func (c Custom) UserData(_ *v1alpha5.KubeletConfiguration, _ []v1.Taint, _ map[string]string, _ *string, _ []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+func (c Custom) UserData(_ *v1alpha5.KubeletConfiguration, taints []v1.Taint, labels map[string]string, _ *string, instanceTypes []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper {
+	var iTypes []string
+	for _, i := range instanceTypes {
+		iTypes = append(iTypes, i.Name)
+	}
+
 	return bootstrap.Custom{
 		Options: bootstrap.Options{
+			Taints:         taints,
+			Labels:         labels,
+			InstanceTypes:  iTypes,
 			CustomUserData: customUserData,
 		},
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Allows Custom User Data for amiFamily Custom to be templated. This basically allows labels and taints to be templated into the user data which is useful for custom deployments. For example I am using RKE1 (from Rancher) with Rancher on EC2 instances and bootstrap the ec2 nodes using custom data.

Example template (pseudo code, not full)

```console
sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:v2.6.9 \
      --server https://rancher2 \
      --token token \
      --ca-checksum checksum \
      {{ with .Labels }}{{ range $k, $v := . }}--label {{ $k }}={{ $v }} {{ end }} \{{ end }}
      --worker
```

**How was this change tested?**

Deployment into clusters, struggled to get the test suite working with lack of docs (or couldn't locate it)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.