### PR TITLE
test: Separate the expiration test suite and cleanup deprovisioning failure checks

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [Integration, Machine, Consolidation, Utilization, Interruption, Drift, Chaos, IPv6]
+        suite: [Integration, Machine, Consolidation, Utilization, Interruption, Drift, Expiration, Chaos, IPv6]
     uses: ./.github/workflows/e2e.yaml
     with:
       suite: ${{ matrix.suite }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,6 +20,7 @@ on:
           - Utilization
           - Interruption
           - Drift
+          - Expiration
           - Chaos
           - IPv6
           - Scale

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -27,6 +27,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
@@ -272,12 +274,12 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				return nodes[i].CreationTimestamp.Before(&nodes[j].CreationTimestamp)
 			})
 			nodeTwo := nodes[1]
+			// Remove the startup taints from the new nodes to initialize them
 			Eventually(func(g Gomega) {
-				n := &v1.Node{}
-				g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeTwo), n)).To(Succeed())
-				stored := n.DeepCopy()
-				n.Spec.Taints = []v1.Taint{}
-				g.Expect(env.Client.Patch(env.Context, n, client.MergeFrom(stored))).To(Succeed())
+				g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(nodeTwo), nodeTwo)).To(Succeed())
+				stored := nodeTwo.DeepCopy()
+				nodeTwo.Spec.Taints = lo.Reject(nodeTwo.Spec.Taints, func(t v1.Taint, _ int) bool { return t.Key == "example.com/another-taint-2" })
+				g.Expect(env.Client.Patch(env.Context, nodeTwo, client.MergeFrom(stored))).To(Succeed())
 			}).Should(Succeed())
 		}
 
@@ -354,7 +356,9 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				},
 			})
 			env.ExpectCreated(dep, nodeTemplate, provisioner)
-			env.EventuallyExpectNodeCount("==", 2)
+
+			startingMachineState := env.EventuallyExpectCreatedMachineCount("==", int(numPods))
+			env.EventuallyExpectCreatedNodeCount("==", int(numPods))
 
 			// Drift the machine with bad configuration
 			parameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
@@ -365,9 +369,8 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			env.ExpectCreatedOrUpdated(nodeTemplate)
 
 			// Should see the machine has drifted
-			statingMachineState := env.EventuallyExpectCreatedMachineCount("==", int(numPods))
 			Eventually(func(g Gomega) {
-				for _, machine := range statingMachineState {
+				for _, machine := range startingMachineState {
 					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
 					g.Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue()).To(BeTrue())
 				}
@@ -383,20 +386,20 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
 			}).WithTimeout(11 * time.Minute).Should(Succeed())
 
-			endMachineState := &v1alpha5.MachineList{}
 			Eventually(func(g Gomega) {
-				g.Expect(env.Client.List(env, endMachineState, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
-				g.Expect(len(endMachineState.Items)).To(BeNumerically("==", int(numPods)))
+				machines := &v1alpha5.MachineList{}
+				g.Expect(env.Client.List(env, machines, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+				g.Expect(machines.Items).To(HaveLen(int(numPods)))
 			}).WithTimeout(6 * time.Minute).Should(Succeed())
 
+			// Expect all the Machines that existed on the initial provisioning loop are not removed
 			Consistently(func(g Gomega) {
-				g.Expect(lo.EveryBy(statingMachineState, func(sm *v1alpha5.Machine) bool {
-					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(sm), sm)).To(Succeed())
-					return lo.ContainsBy(endMachineState.Items, func(em v1alpha5.Machine) bool {
-						g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(&em), &em)).To(Succeed())
-						return sm.Name == em.Name
-					})
-				})).To(BeTrue())
+				machines := &v1alpha5.MachineList{}
+				g.Expect(env.Client.List(env, machines, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+
+				startingMachineUIDs := lo.Map(startingMachineState, func(m *v1alpha5.Machine, _ int) types.UID { return m.UID })
+				machineUIDs := lo.Map(machines.Items, func(m v1alpha5.Machine, _ int) types.UID { return m.UID })
+				g.Expect(sets.New(machineUIDs...).IsSuperset(sets.New(startingMachineUIDs...))).To(BeTrue())
 			}, "2m").Should(Succeed())
 		})
 		It("should not continue to drift if a node registers but never becomes initialized", func() {
@@ -415,16 +418,17 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				},
 			})
 			env.ExpectCreated(dep, nodeTemplate, provisioner)
-			statingNodeState := env.EventuallyExpectNodeCount("==", int(numPods))
 
-			// Drift the machine with bad configuration
+			startingMachineState := env.EventuallyExpectCreatedMachineCount("==", int(numPods))
+			env.EventuallyExpectCreatedNodeCount("==", int(numPods))
+
+			// Drift the machine with bad configuration that never initializes
 			provisioner.Spec.StartupTaints = []v1.Taint{{Key: "example.com/taint", Effect: v1.TaintEffectPreferNoSchedule}}
 			env.ExpectCreatedOrUpdated(provisioner)
 
 			// Should see the machine has drifted
-			machines := env.EventuallyExpectCreatedMachineCount("==", int(numPods))
 			Eventually(func(g Gomega) {
-				for _, machine := range machines {
+				for _, machine := range startingMachineState {
 					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
 					g.Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue()).To(BeTrue())
 				}
@@ -439,16 +443,24 @@ var _ = Describe("Drift", Label("AWS"), func() {
 				g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(cordonedNodes[0]), cordonedNodes[0]))
 				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
 			}).WithTimeout(12 * time.Minute).Should(Succeed())
-			endingNodeState := env.EventuallyExpectNodeCount("==", 3)
 
+			// Expect that the new machine/node is kept around after the un-cordon
+			nodeList := &v1.NodeList{}
+			Expect(env.Client.List(env, nodeList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+			Expect(nodeList.Items).To(HaveLen(int(numPods) + 1))
+
+			machineList := &v1alpha5.MachineList{}
+			Expect(env.Client.List(env, machineList, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+			Expect(machineList.Items).To(HaveLen(int(numPods) + 1))
+
+			// Expect all the Machines that existed on the initial provisioning loop are not removed
 			Consistently(func(g Gomega) {
-				g.Expect(lo.EveryBy(statingNodeState, func(sn *v1.Node) bool {
-					g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(sn), sn)).To(Succeed())
-					return lo.ContainsBy(endingNodeState, func(en *v1.Node) bool {
-						g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(en), en)).To(Succeed())
-						return sn.Name == en.Name
-					})
-				})).To(BeTrue())
+				machines := &v1alpha5.MachineList{}
+				g.Expect(env.Client.List(env, machines, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
+
+				startingMachineUIDs := lo.Map(startingMachineState, func(m *v1alpha5.Machine, _ int) types.UID { return m.UID })
+				machineUIDs := lo.Map(machines.Items, func(m v1alpha5.Machine, _ int) types.UID { return m.UID })
+				g.Expect(sets.New(machineUIDs...).IsSuperset(sets.New(startingMachineUIDs...))).To(BeTrue())
 			}, "2m").Should(Succeed())
 		})
 	})

--- a/test/suites/integration/emptiness_test.go
+++ b/test/suites/integration/emptiness_test.go
@@ -20,14 +20,14 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	awstest "github.com/aws/karpenter/pkg/test"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Emptiness", func() {


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR separates the expiration tests into a separate test suite that runs in parallel so that the long-running tests in that suite don't bottleneck the overall test time.

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.