### PR TITLE
chore: Add validation to ensure `id` field is mutually exclusive in selectors

### DIFF
--- a/pkg/apis/v1alpha1/suite_test.go
+++ b/pkg/apis/v1alpha1/suite_test.go
@@ -58,6 +58,108 @@ var _ = Describe("Validation", func() {
 		}
 	})
 
+	Context("SubnetSelector", func() {
+		It("should succeed with a valid subnet selector", func() {
+			ant.Spec.SubnetSelector = map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should succeed with a valid id subnet selector", func() {
+			ant.Spec.SubnetSelector = map[string]string{
+				"aws-ids": "subnet-123,subnet-456",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+
+			ant.Spec.SubnetSelector = map[string]string{
+				"aws::ids": "subnet-123,subnet-456",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should fail when a id subnet selector is used in combination with tags", func() {
+			ant.Spec.SubnetSelector = map[string]string{
+				"aws-ids": "subnet-123",
+				"foo":     "bar",
+			}
+			Expect(ant.Validate(ctx)).ToNot(Succeed())
+
+			ant.Spec.SubnetSelector = map[string]string{
+				"aws::ids": "subnet-123",
+				"foo":      "bar",
+			}
+			Expect(ant.Validate(ctx)).ToNot(Succeed())
+		})
+	})
+	Context("SecurityGroupSelector", func() {
+		It("should succeed with a valid security group selector", func() {
+			ant.Spec.SecurityGroupSelector = map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should succeed with a valid id security group selector", func() {
+			ant.Spec.SecurityGroupSelector = map[string]string{
+				"aws-ids": "sg-123,sg-456",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+
+			ant.Spec.SecurityGroupSelector = map[string]string{
+				"aws::ids": "sg-123,sg-456",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should fail when a id security group selector is used in combination with tags", func() {
+			ant.Spec.SecurityGroupSelector = map[string]string{
+				"aws-ids": "sg-123",
+				"foo":     "bar",
+			}
+			Expect(ant.Validate(ctx)).ToNot(Succeed())
+
+			ant.Spec.SecurityGroupSelector = map[string]string{
+				"aws::ids": "sg-123",
+				"foo":      "bar",
+			}
+			Expect(ant.Validate(ctx)).ToNot(Succeed())
+		})
+	})
+	Context("AMISelector", func() {
+		It("should succeed with a valid ami selector", func() {
+			ant.Spec.AMISelector = map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should succeed with a valid id ami selector", func() {
+			ant.Spec.AMISelector = map[string]string{
+				"aws-ids": "ami-123,ami-456",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+
+			ant.Spec.AMISelector = map[string]string{
+				"aws::ids": "ami-123,ami-456",
+			}
+			Expect(ant.Validate(ctx)).To(Succeed())
+		})
+		It("should fail when a id ami selector is used in combination with tags", func() {
+			ant.Spec.AMISelector = map[string]string{
+				"aws-ids": "ami-123",
+				"foo":     "bar",
+			}
+			Expect(ant.Validate(ctx)).ToNot(Succeed())
+
+			ant.Spec.AMISelector = map[string]string{
+				"aws::ids": "ami-123",
+				"foo":      "bar",
+			}
+			Expect(ant.Validate(ctx)).ToNot(Succeed())
+		})
+	})
 	Context("UserData", func() {
 		It("should succeed if user data is empty", func() {
 			Expect(ant.Validate(ctx)).To(Succeed())

--- a/pkg/apis/v1beta1/nodeclass_validation.go
+++ b/pkg/apis/v1beta1/nodeclass_validation.go
@@ -82,7 +82,9 @@ func (in *NodeClassSpec) validateSubnetSelectorTerms() (errs *apis.FieldError) {
 func (in *SubnetSelectorTerm) validate() (errs *apis.FieldError) {
 	errs = errs.Also(validateTags(in.Tags).ViaField("tags"))
 	if len(in.Tags) == 0 && in.ID == "" {
-		errs = errs.Also(apis.ErrGeneric("expect at least one, got none", "tags", "id"))
+		errs = errs.Also(apis.ErrGeneric("expected at least one, got none", "tags", "id"))
+	} else if in.ID != "" && len(in.Tags) > 0 {
+		errs = errs.Also(apis.ErrGeneric(`"id" is mutually exclusive, cannot be set with a combination of other fields in`))
 	}
 	return errs
 }
@@ -97,10 +99,15 @@ func (in *NodeClassSpec) validateSecurityGroupSelectorTerms() (errs *apis.FieldE
 	return errs
 }
 
+//nolint:gocyclo
 func (in *SecurityGroupSelectorTerm) validate() (errs *apis.FieldError) {
 	errs = errs.Also(validateTags(in.Tags).ViaField("tags"))
 	if len(in.Tags) == 0 && in.ID == "" && in.Name == "" {
 		errs = errs.Also(apis.ErrGeneric("expect at least one, got none", "tags", "id", "name"))
+	} else if in.ID != "" && (len(in.Tags) > 0 || in.Name != "") {
+		errs = errs.Also(apis.ErrGeneric(`"id" is mutually exclusive, cannot be set with a combination of other fields in`))
+	} else if in.Name != "" && (len(in.Tags) > 0 || in.ID != "") {
+		errs = errs.Also(apis.ErrGeneric(`"name" is mutually exclusive, cannot be set with a combination of other fields in`))
 	}
 	return errs
 }
@@ -112,10 +119,13 @@ func (in *NodeClassSpec) validateAMISelectorTerms() (errs *apis.FieldError) {
 	return errs
 }
 
+//nolint:gocyclo
 func (in *AMISelectorTerm) validate() (errs *apis.FieldError) {
 	errs = errs.Also(validateTags(in.Tags).ViaField("tags"))
 	if len(in.Tags) == 0 && in.ID == "" && in.Name == "" && in.SSM == "" {
 		errs = errs.Also(apis.ErrGeneric("expect at least one, got none", "tags", "id", "name", "ssm"))
+	} else if in.ID != "" && (len(in.Tags) > 0 || in.Name != "" || in.SSM != "" || in.Owner != "") {
+		errs = errs.Also(apis.ErrGeneric(`"id" is mutually exclusive, cannot be set with a combination of other fields in`))
 	}
 	return errs
 }

--- a/pkg/apis/v1beta1/suite_test.go
+++ b/pkg/apis/v1beta1/suite_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Validation", func() {
 		It("should succeed with a valid subnet selector on id", func() {
 			nc.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
 				{
-					ID: "sg-12345749",
+					ID: "subnet-12345749",
 				},
 			}
 			Expect(nc.Validate(ctx)).To(Succeed())
@@ -205,6 +205,17 @@ var _ = Describe("Validation", func() {
 				{
 					Tags: map[string]string{
 						"": "testvalue4",
+					},
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when specifying id with tags", func() {
+			nc.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+				{
+					ID: "subnet-12345749",
+					Tags: map[string]string{
+						"test": "testvalue",
 					},
 				},
 			}
@@ -305,6 +316,37 @@ var _ = Describe("Validation", func() {
 			}
 			Expect(nc.Validate(ctx)).ToNot(Succeed())
 		})
+		It("should fail when specifying id with tags", func() {
+			nc.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+				{
+					ID: "sg-12345749",
+					Tags: map[string]string{
+						"test": "testvalue",
+					},
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when specifying id with name", func() {
+			nc.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+				{
+					ID:   "sg-12345749",
+					Name: "my-security-group",
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when specifying name with tags", func() {
+			nc.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
+				{
+					Name: "my-security-group",
+					Tags: map[string]string{
+						"test": "testvalue",
+					},
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
 	})
 	Context("AMISelectorTerms", func() {
 		It("should succeed with a valid ami selector on tags", func() {
@@ -396,6 +438,44 @@ var _ = Describe("Validation", func() {
 					Tags: map[string]string{
 						"": "testvalue4",
 					},
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when specifying id with tags", func() {
+			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
+				{
+					ID: "ami-12345749",
+					Tags: map[string]string{
+						"test": "testvalue",
+					},
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when specifying id with name", func() {
+			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
+				{
+					ID:   "ami-12345749",
+					Name: "my-custom-ami",
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when specifying id with owner", func() {
+			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
+				{
+					ID:    "ami-12345749",
+					Owner: "123456789",
+				},
+			}
+			Expect(nc.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should fail when specifying id with ssm", func() {
+			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
+				{
+					ID:  "ami-12345749",
+					SSM: "/test/ssm/path",
 				},
 			}
 			Expect(nc.Validate(ctx)).ToNot(Succeed())

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -226,24 +226,28 @@ func (p *Provider) minPods(instanceTypes []*cloudprovider.InstanceType, zone str
 }
 
 func getFilters(nodeTemplate *v1alpha1.AWSNodeTemplate) []*ec2.Filter {
-	filters := []*ec2.Filter{}
+	var filters []*ec2.Filter
 	// Filter by subnet
 	for key, value := range nodeTemplate.Spec.SubnetSelector {
-		if key == "aws-ids" {
+		switch key {
+		case "aws-ids", "aws::ids":
 			filters = append(filters, &ec2.Filter{
 				Name:   aws.String("subnet-id"),
 				Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
 			})
-		} else if value == "*" {
-			filters = append(filters, &ec2.Filter{
-				Name:   aws.String("tag-key"),
-				Values: []*string{aws.String(key)},
-			})
-		} else {
-			filters = append(filters, &ec2.Filter{
-				Name:   aws.String(fmt.Sprintf("tag:%s", key)),
-				Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
-			})
+		default:
+			switch value {
+			case "*":
+				filters = append(filters, &ec2.Filter{
+					Name:   aws.String("tag-key"),
+					Values: []*string{aws.String(key)},
+				})
+			default:
+				filters = append(filters, &ec2.Filter{
+					Name:   aws.String(fmt.Sprintf("tag:%s", key)),
+					Values: aws.StringSlice(functional.SplitCommaSeparatedString(value)),
+				})
+			}
 		}
 	}
 	return filters

--- a/test/suites/integration/webhook_test.go
+++ b/test/suites/integration/webhook_test.go
@@ -326,6 +326,84 @@ var _ = Describe("Webhooks", func() {
 				},
 				}))).ToNot(Succeed())
 			})
+			It("should fail when securityGroupSelector has id and other filters", func() {
+				Expect(env.Client.Create(env, awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					AWS: v1alpha1.AWS{
+						SecurityGroupSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+							"aws-ids":                "sg-12345",
+						},
+						SubnetSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+					},
+				}))).ToNot(Succeed())
+				Expect(env.Client.Create(env, awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					AWS: v1alpha1.AWS{
+						SecurityGroupSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+							"aws-ids":                "sg-12345",
+						},
+						SubnetSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+					},
+				}))).ToNot(Succeed())
+			})
+			It("should fail when subnetSelector has id and other filters", func() {
+				Expect(env.Client.Create(env, awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					AWS: v1alpha1.AWS{
+						SecurityGroupSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+						SubnetSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+							"aws-ids":                "subnet-12345",
+						},
+					},
+				}))).ToNot(Succeed())
+				Expect(env.Client.Create(env, awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					AWS: v1alpha1.AWS{
+						SecurityGroupSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+						SubnetSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+							"aws-ids":                "subnet-12345",
+						},
+					},
+				}))).ToNot(Succeed())
+			})
+			It("should fail when amiSelector has id and other filters", func() {
+				Expect(env.Client.Create(env, awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					AWS: v1alpha1.AWS{
+						SecurityGroupSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+						SubnetSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+					},
+					AMISelector: map[string]string{
+						"foo":     "bar",
+						"aws-ids": "ami-12345",
+					},
+				}))).ToNot(Succeed())
+				Expect(env.Client.Create(env, awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{
+					AWS: v1alpha1.AWS{
+						SecurityGroupSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+						SubnetSelector: map[string]string{
+							"karpenter.sh/discovery": settings.FromContext(env.Context).ClusterName,
+						},
+					},
+					AMISelector: map[string]string{
+						"foo":      "bar",
+						"aws::ids": "ami-12345",
+					},
+				}))).ToNot(Succeed())
+			})
 		})
 	})
 })

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -105,6 +105,8 @@ Snapshot releases are tagged with the git commit hash prefixed by the Karpenter 
 ### Upgrading to v0.30.0+
 
 * Karpenter will now [statically drift]({{<ref "./concepts/deprovisioning.md#drift" >}}) on both Provisioner and AWSNodeTemplate Fields. For Provisioner Static Drift, the `karpenter.sh/provisioner-hash` annotation must be present on both the Provisioner and Machine. For AWSNodeTemplate drift, the `karpenter.k8s.aws/nodetemplate-hash` annotation must be present on the AWSNodeTemplate and Machine. Karpenter will not add these annotations to pre-existing nodes, so each of these nodes will need to be recycled one time for the annotations to be added.
+* Karpenter will now fail validation on AWSNodeTemplates and Provisioner `spec.provider` that have `amiSelectors`, `subnetSelectors`, or `securityGroupSelectors` set with a combination of id selectors (`aws-ids`, `aws::ids`) and other selectors. 
+
 ### Upgrading to v0.29.0+
 
 {{% alert title="Warning" color="warning" %}}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds validation to ensure that the `id` field that can be specified in selectors through `aws-ids` and `aws::ids` is mutually exclusive with other fields that can be specified in the selector like `tags`, `owners`, and `names`

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.