### PR TITLE
test: Use delegating client in E2E testing

### DIFF
--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -17,12 +17,15 @@ package common
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/onsi/gomega"
 	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -30,6 +33,7 @@ import (
 	loggingtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/system"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	coreapis "github.com/aws/karpenter-core/pkg/apis"
@@ -47,6 +51,7 @@ const (
 
 type Environment struct {
 	context.Context
+	cancel context.CancelFunc
 
 	Client     client.Client
 	Config     *rest.Config
@@ -58,8 +63,9 @@ type Environment struct {
 
 func NewEnvironment(t *testing.T) *Environment {
 	ctx := loggingtesting.TestContextWithLogger(t)
+	ctx, cancel := context.WithCancel(ctx)
 	config := NewConfig()
-	client := lo.Must(NewClient(config))
+	client := NewClient(ctx, config)
 
 	lo.Must0(os.Setenv(system.NamespaceEnvKey, "karpenter"))
 	kubernetesInterface := kubernetes.NewForConfigOrDie(config)
@@ -72,11 +78,16 @@ func NewEnvironment(t *testing.T) *Environment {
 	gomega.SetDefaultEventuallyPollingInterval(1 * time.Second)
 	return &Environment{
 		Context:    ctx,
+		cancel:     cancel,
 		Config:     config,
 		Client:     client,
 		KubeClient: kubernetes.NewForConfigOrDie(config),
 		Monitor:    NewMonitor(ctx, client),
 	}
+}
+
+func (env *Environment) Stop() {
+	env.cancel()
 }
 
 func NewConfig() *rest.Config {
@@ -87,16 +98,34 @@ func NewConfig() *rest.Config {
 	return config
 }
 
-func NewClient(config *rest.Config) (client.Client, error) {
+func NewClient(ctx context.Context, config *rest.Config) client.Client {
 	scheme := runtime.NewScheme()
-	if err := clientgoscheme.AddToScheme(scheme); err != nil {
-		return nil, err
+	lo.Must0(clientgoscheme.AddToScheme(scheme))
+	lo.Must0(apis.AddToScheme(scheme))
+	lo.Must0(coreapis.AddToScheme(scheme))
+
+	cache := lo.Must(cache.New(config, cache.Options{Scheme: scheme}))
+	lo.Must0(cache.IndexField(ctx, &v1.Pod{}, "spec.nodeName", func(o client.Object) []string {
+		pod := o.(*v1.Pod)
+		return []string{pod.Spec.NodeName}
+	}))
+	lo.Must0(cache.IndexField(ctx, &v1.Event{}, "involvedObject.kind", func(o client.Object) []string {
+		evt := o.(*v1.Event)
+		return []string{evt.InvolvedObject.Kind}
+	}))
+	lo.Must0(cache.IndexField(ctx, &v1.Node{}, "spec.unschedulable", func(o client.Object) []string {
+		node := o.(*v1.Node)
+		return []string{strconv.FormatBool(node.Spec.Unschedulable)}
+	}))
+	c := lo.Must(client.NewDelegatingClient(client.NewDelegatingClientInput{
+		CacheReader: cache,
+		Client:      lo.Must(client.New(config, client.Options{Scheme: scheme})),
+	}))
+	go func() {
+		lo.Must0(cache.Start(ctx))
+	}()
+	if !cache.WaitForCacheSync(ctx) {
+		log.Fatalf("cache failed to sync")
 	}
-	if err := apis.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := coreapis.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	return client.New(config, client.Options{Scheme: scheme})
+	return c
 }

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -196,7 +196,10 @@ func (env *Environment) ExpectPrefixDelegationDisabled() {
 }
 
 func (env *Environment) ExpectExists(obj client.Object) {
-	ExpectWithOffset(1, env.Client.Get(env, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+	}).WithTimeout(time.Second * 5).Should(Succeed())
 }
 
 func (env *Environment) EventuallyExpectHealthy(pods ...*v1.Pod) {

--- a/test/suites/chaos/suite_test.go
+++ b/test/suites/chaos/suite_test.go
@@ -52,6 +52,9 @@ func TestChaos(t *testing.T) {
 	BeforeSuite(func() {
 		env = common.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Chaos")
 }
 

--- a/test/suites/consolidation/suite_test.go
+++ b/test/suites/consolidation/suite_test.go
@@ -47,6 +47,9 @@ func TestConsolidation(t *testing.T) {
 	BeforeSuite(func() {
 		env = environmentaws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Consolidation")
 }
 

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -53,6 +53,9 @@ func TestDrift(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Drift")
 }
 

--- a/test/suites/expiration/expiration_test.go
+++ b/test/suites/expiration/expiration_test.go
@@ -49,6 +49,9 @@ func TestExpiration(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Expiration")
 }
 

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -30,6 +30,9 @@ func TestIntegration(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Integration")
 }
 

--- a/test/suites/interruption/suite_test.go
+++ b/test/suites/interruption/suite_test.go
@@ -46,6 +46,9 @@ func TestInterruption(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Interruption")
 }
 

--- a/test/suites/ipv6/suite_test.go
+++ b/test/suites/ipv6/suite_test.go
@@ -38,6 +38,9 @@ func TestIPv6(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "IPv6")
 }
 

--- a/test/suites/machine/suite_test.go
+++ b/test/suites/machine/suite_test.go
@@ -30,6 +30,9 @@ func TestMachine(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Machine")
 }
 

--- a/test/suites/scale/suite_test.go
+++ b/test/suites/scale/suite_test.go
@@ -32,6 +32,9 @@ func TestScale(t *testing.T) {
 		env = aws.NewEnvironment(t)
 		SetDefaultEventuallyTimeout(time.Hour)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Scale")
 }
 

--- a/test/suites/utilization/suite_test.go
+++ b/test/suites/utilization/suite_test.go
@@ -40,6 +40,9 @@ func TestUtilization(t *testing.T) {
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
 	})
+	AfterSuite(func() {
+		env.Stop()
+	})
 	RunSpecs(t, "Utilization")
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR replaces the direct client in the E2E testing code to use the `client.DelegatingClient`. This reduces the load on the APIServer for the large number of LIST calls that we make as we are trying to validate whether test conditions are met. 

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.