### PR TITLE
chore: Add support for `v1beta1/NodeClaim` to the interruption controller

### DIFF
--- a/pkg/controllers/interruption/events/events.go
+++ b/pkg/controllers/interruption/events/events.go
@@ -15,141 +15,194 @@ limitations under the License.
 package events
 
 import (
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/events"
+	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
 )
 
-func SpotInterrupted(node *v1.Node, machine *v1alpha5.Machine) []events.Event {
-	evts := []events.Event{
-		{
+func SpotInterrupted(node *v1.Node, nodeClaim *v1beta1.NodeClaim) (evts []events.Event) {
+	if nodeClaim.IsMachine {
+		machine := machineutil.NewFromNodeClaim(nodeClaim)
+		evts = append(evts, events.Event{
 			InvolvedObject: machine,
 			Type:           v1.EventTypeWarning,
 			Reason:         "SpotInterrupted",
-			Message:        fmt.Sprintf("Machine %s event: A spot interruption warning was triggered for the machine", machine.Name),
-			DedupeValues:   []string{machine.Name},
-		},
+			Message:        "Spot interruption warning was triggered",
+			DedupeValues:   []string{string(machine.UID)},
+		})
+	} else {
+		evts = append(evts, events.Event{
+			InvolvedObject: nodeClaim,
+			Type:           v1.EventTypeWarning,
+			Reason:         "SpotInterrupted",
+			Message:        "Spot interruption warning was triggered",
+			DedupeValues:   []string{string(nodeClaim.UID)},
+		})
 	}
 	if node != nil {
 		evts = append(evts, events.Event{
 			InvolvedObject: node,
 			Type:           v1.EventTypeWarning,
 			Reason:         "SpotInterrupted",
-			Message:        fmt.Sprintf("Node %s event: A spot interruption warning was triggered for the node", node.Name),
-			DedupeValues:   []string{node.Name},
+			Message:        "Spot interruption warning was triggered",
+			DedupeValues:   []string{string(node.UID)},
 		})
 	}
 	return evts
 }
 
-func RebalanceRecommendation(node *v1.Node, machine *v1alpha5.Machine) []events.Event {
-	evts := []events.Event{
-		{
+func RebalanceRecommendation(node *v1.Node, nodeClaim *v1beta1.NodeClaim) (evts []events.Event) {
+	if nodeClaim.IsMachine {
+		machine := machineutil.NewFromNodeClaim(nodeClaim)
+		evts = append(evts, events.Event{
 			InvolvedObject: machine,
 			Type:           v1.EventTypeNormal,
 			Reason:         "SpotRebalanceRecommendation",
-			Message:        fmt.Sprintf("Machine %s event: A spot rebalance recommendation was triggered for the machine", machine.Name),
-			DedupeValues:   []string{machine.Name},
-		},
+			Message:        "Spot rebalance recommendation was triggered",
+			DedupeValues:   []string{string(machine.UID)},
+		})
+	} else {
+		evts = append(evts, events.Event{
+			InvolvedObject: nodeClaim,
+			Type:           v1.EventTypeNormal,
+			Reason:         "SpotRebalanceRecommendation",
+			Message:        "Spot rebalance recommendation was triggered",
+			DedupeValues:   []string{string(nodeClaim.UID)},
+		})
 	}
 	if node != nil {
 		evts = append(evts, events.Event{
 			InvolvedObject: node,
 			Type:           v1.EventTypeNormal,
 			Reason:         "SpotRebalanceRecommendation",
-			Message:        fmt.Sprintf("Node %s event: A spot rebalance recommendation was triggered for the node", node.Name),
-			DedupeValues:   []string{node.Name},
+			Message:        "Spot rebalance recommendation was triggered",
+			DedupeValues:   []string{string(node.UID)},
 		})
 	}
 	return evts
 }
 
-func Stopping(node *v1.Node, machine *v1alpha5.Machine) []events.Event {
-	evts := []events.Event{
-		{
+func Stopping(node *v1.Node, nodeClaim *v1beta1.NodeClaim) (evts []events.Event) {
+	if nodeClaim.IsMachine {
+		machine := machineutil.NewFromNodeClaim(nodeClaim)
+		evts = append(evts, events.Event{
 			InvolvedObject: machine,
 			Type:           v1.EventTypeWarning,
-			Reason:         "Stopping",
-			Message:        fmt.Sprintf("Machine %s event: Machine is stopping", machine.Name),
-			DedupeValues:   []string{machine.Name},
-		},
+			Reason:         "InstanceStopping",
+			Message:        "Instance is stopping",
+			DedupeValues:   []string{string(machine.UID)},
+		})
+	} else {
+		evts = append(evts, events.Event{
+			InvolvedObject: nodeClaim,
+			Type:           v1.EventTypeWarning,
+			Reason:         "InstanceStopping",
+			Message:        "Instance is stopping",
+			DedupeValues:   []string{string(nodeClaim.UID)},
+		})
 	}
 	if node != nil {
 		evts = append(evts, events.Event{
 			InvolvedObject: node,
 			Type:           v1.EventTypeWarning,
-			Reason:         "Stopping",
-			Message:        fmt.Sprintf("Node %s event: Node is stopping", node.Name),
-			DedupeValues:   []string{node.Name},
+			Reason:         "InstanceStopping",
+			Message:        "Instance is stopping",
+			DedupeValues:   []string{string(node.UID)},
 		})
 	}
 	return evts
 }
 
-func Terminating(node *v1.Node, machine *v1alpha5.Machine) []events.Event {
-	evts := []events.Event{
-		{
+func Terminating(node *v1.Node, nodeClaim *v1beta1.NodeClaim) (evts []events.Event) {
+	if nodeClaim.IsMachine {
+		machine := machineutil.NewFromNodeClaim(nodeClaim)
+		evts = append(evts, events.Event{
 			InvolvedObject: machine,
 			Type:           v1.EventTypeWarning,
-			Reason:         "Terminating",
-			Message:        fmt.Sprintf("Machine %s event: Machine is terminating", machine.Name),
-			DedupeValues:   []string{machine.Name},
-		},
+			Reason:         "InstanceTerminating",
+			Message:        "Instance is terminating",
+			DedupeValues:   []string{string(machine.UID)},
+		})
+	} else {
+		evts = append(evts, events.Event{
+			InvolvedObject: nodeClaim,
+			Type:           v1.EventTypeWarning,
+			Reason:         "InstanceTerminating",
+			Message:        "Instance is terminating",
+			DedupeValues:   []string{string(nodeClaim.UID)},
+		})
 	}
 	if node != nil {
 		evts = append(evts, events.Event{
 			InvolvedObject: node,
 			Type:           v1.EventTypeWarning,
-			Reason:         "Terminating",
-			Message:        fmt.Sprintf("Node %s event: Node is terminating", node.Name),
-			DedupeValues:   []string{node.Name},
+			Reason:         "InstanceTerminating",
+			Message:        "Instance is terminating",
+			DedupeValues:   []string{string(node.UID)},
 		})
 	}
 	return evts
 }
 
-func Unhealthy(node *v1.Node, machine *v1alpha5.Machine) []events.Event {
-	evts := []events.Event{
-		{
+func Unhealthy(node *v1.Node, nodeClaim *v1beta1.NodeClaim) (evts []events.Event) {
+	if nodeClaim.IsMachine {
+		machine := machineutil.NewFromNodeClaim(nodeClaim)
+		evts = append(evts, events.Event{
 			InvolvedObject: machine,
 			Type:           v1.EventTypeWarning,
-			Reason:         "Unhealthy",
-			Message:        fmt.Sprintf("Machine %s event: An unhealthy warning was triggered for the machine", machine.Name),
-			DedupeValues:   []string{machine.Name},
-		},
+			Reason:         "InstanceUnhealthy",
+			Message:        "An unhealthy warning was triggered for the instance",
+			DedupeValues:   []string{string(machine.UID)},
+		})
+	} else {
+		evts = append(evts, events.Event{
+			InvolvedObject: nodeClaim,
+			Type:           v1.EventTypeWarning,
+			Reason:         "InstanceUnhealthy",
+			Message:        "An unhealthy warning was triggered for the instance",
+			DedupeValues:   []string{string(nodeClaim.UID)},
+		})
 	}
 	if node != nil {
 		evts = append(evts, events.Event{
 			InvolvedObject: node,
 			Type:           v1.EventTypeWarning,
-			Reason:         "Unhealthy",
-			Message:        fmt.Sprintf("Node %s event: An unhealthy warning was triggered for the node", node.Name),
-			DedupeValues:   []string{node.Name},
+			Reason:         "InstanceUnhealthy",
+			Message:        "An unhealthy warning was triggered for the instance",
+			DedupeValues:   []string{string(node.UID)},
 		})
 	}
 	return evts
 }
 
-func TerminatingOnInterruption(node *v1.Node, machine *v1alpha5.Machine) []events.Event {
-	evts := []events.Event{
-		{
+func TerminatingOnInterruption(node *v1.Node, nodeClaim *v1beta1.NodeClaim) (evts []events.Event) {
+	if nodeClaim.IsMachine {
+		machine := machineutil.NewFromNodeClaim(nodeClaim)
+		evts = append(evts, events.Event{
 			InvolvedObject: machine,
 			Type:           v1.EventTypeWarning,
 			Reason:         "TerminatingOnInterruption",
-			Message:        fmt.Sprintf("Machine %s event: Interruption triggered termination for the machine", machine.Name),
-			DedupeValues:   []string{machine.Name},
-		},
+			Message:        "Interruption triggered termination for the Machine",
+			DedupeValues:   []string{string(machine.UID)},
+		})
+	} else {
+		evts = append(evts, events.Event{
+			InvolvedObject: nodeClaim,
+			Type:           v1.EventTypeWarning,
+			Reason:         "TerminatingOnInterruption",
+			Message:        "Interruption triggered termination for the NodeClaim",
+			DedupeValues:   []string{string(nodeClaim.UID)},
+		})
 	}
 	if node != nil {
 		evts = append(evts, events.Event{
 			InvolvedObject: node,
 			Type:           v1.EventTypeWarning,
 			Reason:         "TerminatingOnInterruption",
-			Message:        fmt.Sprintf("Node %s event: Interruption triggered termination for the node", node.Name),
-			DedupeValues:   []string{node.Name},
+			Message:        "Interruption triggered termination for the Node",
+			DedupeValues:   []string{string(node.UID)},
 		})
 	}
 	return evts


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds support for the `v1beta1/NodeClaim` in the interruption controller that currently only handles machines. This change stages out the `v1beta1` changes so that the `v1beta1` APIs can be released at a later time.

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.