### PR TITLE
test: Wait for a second on cleanup to let the caches catch-up

### DIFF
--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -271,7 +271,8 @@ var _ = Describe("Extended Resources", func() {
 })
 
 func ExpectNvidiaDevicePluginCreated() {
-	env.ExpectCreatedWithOffset(1, &appsv1.DaemonSet{
+	GinkgoHelper()
+	env.ExpectCreated(&appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nvidia-device-plugin-daemonset",
 			Namespace: "kube-system",
@@ -341,7 +342,8 @@ func ExpectNvidiaDevicePluginCreated() {
 }
 
 func ExpectAMDDevicePluginCreated() {
-	env.ExpectCreatedWithOffset(1, &appsv1.DaemonSet{
+	GinkgoHelper()
+	env.ExpectCreated(&appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "amdgpu-device-plugin-daemonset",
 			Namespace: "kube-system",
@@ -414,13 +416,13 @@ func ExpectAMDDevicePluginCreated() {
 }
 
 func ExpectHabanaDevicePluginCreated() {
-	env.ExpectCreatedWithOffset(1, &v1.Namespace{
+	GinkgoHelper()
+	env.ExpectCreated(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "habana-system",
 		},
 	})
-
-	env.ExpectCreatedWithOffset(1, &appsv1.DaemonSet{
+	env.ExpectCreated(&appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "habanalabs-device-plugin-daemonset",
 			Namespace: "habana-system",


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Wait for a second on cleanup of the E2E test to let the caches catch-up for the cleanup stage.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.