### PR TITLE
fix: Pending Karpenter pods when less than 2 non-Karpenter nodes exist

### DIFF
--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -64,7 +64,7 @@ nodeSelector:
 # -- Affinity rules for scheduling the pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
 affinity:
   nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
+    preferredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
             - key: karpenter.sh/provisioner-name


### PR DESCRIPTION
**Description**
This change downgrades the affinity rules that require Karpetner pods to provision to non-karpenter nodes from a requirement to a preference.  In some situations, there may be less than 2 karpenter provisioned nodes.  In this situation, one (or both) Karpenter pods will never be allowed to schedule, and autoscaling in the cluster will break.  With this change, Karpenter pods will schedule on non-karpenter nodes if they must.

**How was this change tested?**
We run a lot of Karpenter enabled EKS clusters.  Our EKS clusters only have one non-karpenter node (to bootstrap the cluster).  These clusters get stuck with one dead Karpenter pod because provisioning any node would not be sufficient for Karpetner to get scheduled.  The requirement was manually changed to a preference, and everything immediately scheduled as expected.

**Does this change impact docs?**
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.