### PR TITLE
chore: Add support for `v1beta1/NodeClaim` to the NodeTemplate controller

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -48,7 +48,7 @@ func NewControllers(ctx context.Context, sess *session.Session, clk clock.Clock,
 
 	linkController := machinelink.NewController(kubeClient, cloudProvider)
 	controllers := []controller.Controller{
-		nodetemplate.NewController(kubeClient, subnetProvider, securityGroupProvider, amiProvider),
+		nodetemplate.NewNodeTemplateController(kubeClient, subnetProvider, securityGroupProvider, amiProvider),
 		linkController,
 		machinegarbagecollection.NewController(kubeClient, cloudProvider, linkController),
 	}

--- a/pkg/controllers/nodetemplate/suite_test.go
+++ b/pkg/controllers/nodetemplate/suite_test.go
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	awsEnv = test.NewEnvironment(ctx, env)
 
-	controller = nodetemplate.NewController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider)
+	controller = nodetemplate.NewNodeTemplateController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/utils/nodeclass/nodeclass.go
+++ b/pkg/utils/nodeclass/nodeclass.go
@@ -248,6 +248,24 @@ func Get(ctx context.Context, c client.Client, key Key) (*v1beta1.NodeClass, err
 	return nodeClass, nil
 }
 
+func Patch(ctx context.Context, c client.Client, stored, nodeClass *v1beta1.NodeClass) error {
+	if nodeClass.IsNodeTemplate {
+		storedNodeTemplate := nodetemplateutil.New(stored)
+		nodeTemplate := nodetemplateutil.New(nodeClass)
+		return c.Patch(ctx, nodeTemplate, client.MergeFrom(storedNodeTemplate))
+	}
+	return c.Patch(ctx, nodeClass, client.MergeFrom(stored))
+}
+
+func PatchStatus(ctx context.Context, c client.Client, stored, nodeClass *v1beta1.NodeClass) error {
+	if nodeClass.IsNodeTemplate {
+		storedNodeTemplate := nodetemplateutil.New(stored)
+		nodeTemplate := nodetemplateutil.New(nodeClass)
+		return c.Status().Patch(ctx, nodeTemplate, client.MergeFrom(storedNodeTemplate))
+	}
+	return c.Status().Patch(ctx, nodeClass, client.MergeFrom(stored))
+}
+
 func HashAnnotation(nodeClass *v1beta1.NodeClass) map[string]string {
 	if nodeClass.IsNodeTemplate {
 		nodeTemplate := nodetemplateutil.New(nodeClass)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds support for the `v1beta1/NodeClass` in the nodetemplate controller that currently only handles `v1alpha1/AWSNodeTemplate`. This change stages out the `v1beta1` changes so that the `v1beta1` APIs can be released at a later time.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.