### PR TITLE
perf: Reduce memory by using `DescribeImages` paginated call

### DIFF
--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -84,9 +84,9 @@ func (c *CloudProvider) isAMIDrifted(ctx context.Context, nodeClaim *corev1beta1
 	if len(amis) == 0 {
 		return "", fmt.Errorf("no amis exist given constraints")
 	}
-	mappedAMIs := amifamily.MapInstanceTypes(amis, []*cloudprovider.InstanceType{nodeInstanceType})
+	mappedAMIs := amis.MapToInstanceTypes([]*cloudprovider.InstanceType{nodeInstanceType})
 	if len(mappedAMIs) == 0 {
-		return "", fmt.Errorf("no instance types satisfy requirements of amis %v,", amis)
+		return "", fmt.Errorf("no instance types satisfy requirements of amis %v", amis)
 	}
 	if !lo.Contains(lo.Keys(mappedAMIs), instance.ImageID) {
 		return AMIDrift, nil

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -343,6 +343,15 @@ func (e *EC2API) DescribeImagesWithContext(_ context.Context, input *ec2.Describ
 	}, nil
 }
 
+func (e *EC2API) DescribeImagesPagesWithContext(ctx context.Context, input *ec2.DescribeImagesInput, fn func(*ec2.DescribeImagesOutput, bool) bool, _ ...request.Option) error {
+	out, err := e.DescribeImagesWithContext(ctx, input)
+	if err != nil {
+		return err
+	}
+	fn(out, false)
+	return nil
+}
+
 func (e *EC2API) DescribeLaunchTemplatesWithContext(_ context.Context, input *ec2.DescribeLaunchTemplatesInput, _ ...request.Option) (*ec2.DescribeLaunchTemplatesOutput, error) {
 	if !e.NextError.IsNil() {
 		defer e.NextError.Reset()
@@ -471,29 +480,35 @@ func (e *EC2API) DescribeAvailabilityZonesWithContext(context.Context, *ec2.Desc
 	}}, nil
 }
 
-func (e *EC2API) DescribeInstanceTypesPagesWithContext(_ context.Context, _ *ec2.DescribeInstanceTypesInput, fn func(*ec2.DescribeInstanceTypesOutput, bool) bool, _ ...request.Option) error {
+func (e *EC2API) DescribeInstanceTypesWithContext(_ context.Context, _ *ec2.DescribeInstanceTypesInput, _ ...request.Option) (*ec2.DescribeInstanceTypesOutput, error) {
 	if !e.NextError.IsNil() {
 		defer e.NextError.Reset()
-		return e.NextError.Get()
+		return nil, e.NextError.Get()
 	}
 	if !e.DescribeInstanceTypesOutput.IsNil() {
-		fn(e.DescribeInstanceTypesOutput.Clone(), false)
-		return nil
+		return e.DescribeInstanceTypesOutput.Clone(), nil
 	}
-	fn(defaultDescribeInstanceTypesOutput, false)
+	return defaultDescribeInstanceTypesOutput, nil
+}
+
+func (e *EC2API) DescribeInstanceTypesPagesWithContext(ctx context.Context, input *ec2.DescribeInstanceTypesInput, fn func(*ec2.DescribeInstanceTypesOutput, bool) bool, _ ...request.Option) error {
+	out, err := e.DescribeInstanceTypesWithContext(ctx, input)
+	if err != nil {
+		return err
+	}
+	fn(out, false)
 	return nil
 }
 
-func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context, _ *ec2.DescribeInstanceTypeOfferingsInput, fn func(*ec2.DescribeInstanceTypeOfferingsOutput, bool) bool, _ ...request.Option) error {
+func (e *EC2API) DescribeInstanceTypeOfferingsWithContext(_ context.Context, _ *ec2.DescribeInstanceTypeOfferingsInput, _ ...request.Option) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
 	if !e.NextError.IsNil() {
 		defer e.NextError.Reset()
-		return e.NextError.Get()
+		return nil, e.NextError.Get()
 	}
 	if !e.DescribeInstanceTypeOfferingsOutput.IsNil() {
-		fn(e.DescribeInstanceTypeOfferingsOutput.Clone(), false)
-		return nil
+		return e.DescribeInstanceTypeOfferingsOutput.Clone(), nil
 	}
-	fn(&ec2.DescribeInstanceTypeOfferingsOutput{
+	return &ec2.DescribeInstanceTypeOfferingsOutput{
 		InstanceTypeOfferings: []*ec2.InstanceTypeOffering{
 			{
 				InstanceType: aws.String("m5.large"),
@@ -588,20 +603,36 @@ func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(_ context.Context
 				Location:     aws.String("test-zone-1c"),
 			},
 		},
-	}, false)
+	}, nil
+}
+
+func (e *EC2API) DescribeInstanceTypeOfferingsPagesWithContext(ctx context.Context, input *ec2.DescribeInstanceTypeOfferingsInput, fn func(*ec2.DescribeInstanceTypeOfferingsOutput, bool) bool, _ ...request.Option) error {
+	out, err := e.DescribeInstanceTypeOfferingsWithContext(ctx, input)
+	if err != nil {
+		return err
+	}
+	fn(out, false)
 	return nil
 }
 
-func (e *EC2API) DescribeSpotPriceHistoryPagesWithContext(_ aws.Context, in *ec2.DescribeSpotPriceHistoryInput, fn func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool, _ ...request.Option) error {
-	e.DescribeSpotPriceHistoryInput.Set(in)
+func (e *EC2API) DescribeSpotPriceHistoryWithContext(_ aws.Context, input *ec2.DescribeSpotPriceHistoryInput, _ ...request.Option) (*ec2.DescribeSpotPriceHistoryOutput, error) {
+	e.DescribeSpotPriceHistoryInput.Set(input)
 	if !e.NextError.IsNil() {
 		defer e.NextError.Reset()
-		return e.NextError.Get()
+		return nil, e.NextError.Get()
 	}
 	if !e.DescribeSpotPriceHistoryOutput.IsNil() {
-		fn(e.DescribeSpotPriceHistoryOutput.Clone(), false)
-		return nil
+		return e.DescribeSpotPriceHistoryOutput.Clone(), nil
 	}
 	// fail if the test doesn't provide specific data which causes our pricing provider to use its static price list
-	return errors.New("no pricing data provided")
+	return nil, errors.New("no pricing data provided")
+}
+
+func (e *EC2API) DescribeSpotPriceHistoryPagesWithContext(ctx aws.Context, input *ec2.DescribeSpotPriceHistoryInput, fn func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool, _ ...request.Option) error {
+	out, err := e.DescribeSpotPriceHistoryWithContext(ctx, input)
+	if err != nil {
+		return err
+	}
+	fn(out, false)
+	return nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -127,7 +127,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		*sess.Config.Region,
 	)
 	amiProvider := amifamily.NewProvider(operator.GetClient(), operator.KubernetesInterface, ssm.New(sess), ec2api,
-		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval), cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval), cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval), cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	amiResolver := amifamily.New(amiProvider)
 	launchTemplateProvider := launchtemplate.NewProvider(
 		ctx,

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -43,12 +43,10 @@ import (
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/utils/functional"
 	"github.com/aws/karpenter-core/pkg/utils/pretty"
-	"github.com/aws/karpenter-core/pkg/utils/sets"
 )
 
 type Provider struct {
-	ssmCache               *cache.Cache
-	ec2Cache               *cache.Cache
+	cache                  *cache.Cache
 	kubernetesVersionCache *cache.Cache
 	ssm                    ssmiface.SSMAPI
 	kubeClient             client.Client
@@ -64,15 +62,57 @@ type AMI struct {
 	Requirements scheduling.Requirements
 }
 
+type AMIs []AMI
+
+// Sort orders the AMIs by creation date in descending order.
+// If creation date is nil or two AMIs have the same creation date, the AMIs will be sorted by name in ascending order.
+func (a AMIs) Sort() {
+	sort.Slice(a, func(i, j int) bool {
+		if a[i].CreationDate != "" || a[j].CreationDate != "" {
+			itime, _ := time.Parse(time.RFC3339, a[i].CreationDate)
+			jtime, _ := time.Parse(time.RFC3339, a[j].CreationDate)
+			if itime.Unix() != jtime.Unix() {
+				return itime.Unix() >= jtime.Unix()
+			}
+		}
+		return a[i].Name >= a[j].Name
+	})
+}
+
+func (a AMIs) String() string {
+	var sb strings.Builder
+	ids := lo.Map(a, func(a AMI, _ int) string { return a.AmiID })
+	if len(a) > 25 {
+		sb.WriteString(strings.Join(ids[:25], ", "))
+		sb.WriteString(fmt.Sprintf(" and %d other(s)", len(a)-25))
+	} else {
+		sb.WriteString(strings.Join(ids, ", "))
+	}
+	return sb.String()
+}
+
+// MapToInstanceTypes returns a map of AMIIDs that are the most recent on creationDate to compatible instancetypes
+func (a AMIs) MapToInstanceTypes(instanceTypes []*cloudprovider.InstanceType) map[string][]*cloudprovider.InstanceType {
+	amiIDs := map[string][]*cloudprovider.InstanceType{}
+	for _, instanceType := range instanceTypes {
+		for _, ami := range a {
+			if err := instanceType.Requirements.Compatible(ami.Requirements); err == nil {
+				amiIDs[ami.AmiID] = append(amiIDs[ami.AmiID], instanceType)
+				break
+			}
+		}
+	}
+	return amiIDs
+}
+
 const (
 	kubernetesVersionCacheKey = "kubernetesVersion"
 )
 
 func NewProvider(kubeClient client.Client, kubernetesInterface kubernetes.Interface, ssm ssmiface.SSMAPI, ec2api ec2iface.EC2API,
-	ssmCache, ec2Cache, kubernetesVersionCache *cache.Cache) *Provider {
+	cache, kubernetesVersionCache *cache.Cache) *Provider {
 	return &Provider{
-		ssmCache:               ssmCache,
-		ec2Cache:               ec2Cache,
+		cache:                  cache,
 		kubernetesVersionCache: kubernetesVersionCache,
 		ssm:                    ssm,
 		kubeClient:             kubeClient,
@@ -98,27 +138,12 @@ func (p *Provider) KubeServerVersion(ctx context.Context) (string, error) {
 	return version, nil
 }
 
-// MapInstanceTypes returns a map of AMIIDs that are the most recent on creationDate to compatible instancetypes
-func MapInstanceTypes(amis []AMI, instanceTypes []*cloudprovider.InstanceType) map[string][]*cloudprovider.InstanceType {
-	amiIDs := map[string][]*cloudprovider.InstanceType{}
-
-	for _, instanceType := range instanceTypes {
-		for _, ami := range amis {
-			if err := instanceType.Requirements.Compatible(ami.Requirements); err == nil {
-				amiIDs[ami.AmiID] = append(amiIDs[ami.AmiID], instanceType)
-				break
-			}
-		}
-	}
-	return amiIDs
-}
-
 // Get Returning a list of AMIs with its associated requirements
-func (p *Provider) Get(ctx context.Context, nodeClass *v1beta1.NodeClass, options *Options) ([]AMI, error) {
+func (p *Provider) Get(ctx context.Context, nodeClass *v1beta1.NodeClass, options *Options) (AMIs, error) {
 	var err error
-	var amis []AMI
+	var amis AMIs
 	if len(nodeClass.Spec.AMISelectorTerms) == 0 {
-		amis, err = p.getDefaultAMIsFromSSM(ctx, nodeClass, options)
+		amis, err = p.getDefaultAMIs(ctx, nodeClass, options)
 		if err != nil {
 			return nil, err
 		}
@@ -128,131 +153,108 @@ func (p *Provider) Get(ctx context.Context, nodeClass *v1beta1.NodeClass, option
 			return nil, err
 		}
 	}
-	amis = groupAMIsByRequirements(SortAMIsByCreationDate(amis))
+	amis.Sort()
 	if p.cm.HasChanged(fmt.Sprintf("amis/%t/%s", nodeClass.IsNodeTemplate, nodeClass.Name), amis) {
-		logging.FromContext(ctx).With("ids", amiList(amis), "count", len(amis)).Debugf("discovered amis")
+		logging.FromContext(ctx).With("ids", amis, "count", len(amis)).Debugf("discovered amis")
 	}
 	return amis, nil
 }
 
-// groupAMIsByRequirements gets the most recent AMIs, by creation date, that have a unique set of requirements
-func groupAMIsByRequirements(amis []AMI) []AMI {
-	var result []AMI
-	requirementsHash := sets.New[uint64]()
-	for _, ami := range amis {
-		hash := lo.Must(hashstructure.Hash(ami.Requirements.NodeSelectorRequirements(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true}))
-		if !requirementsHash.Has(hash) {
-			result = append(result, ami)
-		}
-		requirementsHash.Insert(hash)
+func (p *Provider) getDefaultAMIs(ctx context.Context, nodeClass *v1beta1.NodeClass, options *Options) (res AMIs, err error) {
+	if images, ok := p.cache.Get(lo.FromPtr(nodeClass.Spec.AMIFamily)); ok {
+		return images.(AMIs), nil
 	}
-	return result
-}
-
-func (p *Provider) getDefaultAMIsFromSSM(ctx context.Context, nodeClass *v1beta1.NodeClass, options *Options) ([]AMI, error) {
-	var res []AMI
-
 	amiFamily := GetAMIFamily(nodeClass.Spec.AMIFamily, options)
 	kubernetesVersion, err := p.KubeServerVersion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting kubernetes version %w", err)
 	}
 	defaultAMIs := amiFamily.DefaultAMIs(kubernetesVersion)
-
 	for _, ami := range defaultAMIs {
-		if id, err := p.getAMIsFromSSM(ctx, ami.Query); err != nil {
+		if id, err := p.resolveSSMParameter(ctx, ami.Query); err != nil {
 			logging.FromContext(ctx).With("query", ami.Query).Errorf("discovering amis from ssm, %s", err)
 		} else {
 			res = append(res, AMI{AmiID: id, Requirements: ami.Requirements})
 		}
 	}
-	images, err := p.getAMIs(ctx, lo.Map(res, func(a AMI, _ int) v1beta1.AMISelectorTerm {
-		return v1beta1.AMISelectorTerm{
-			ID: a.AmiID,
+	// Resolve Name and CreationDate information into the DefaultAMIs
+	if err = p.ec2api.DescribeImagesPagesWithContext(ctx, &ec2.DescribeImagesInput{
+		Filters:    []*ec2.Filter{{Name: aws.String("image-id"), Values: aws.StringSlice(lo.Map(res, func(a AMI, _ int) string { return a.AmiID }))}},
+		MaxResults: aws.Int64(500),
+	}, func(page *ec2.DescribeImagesOutput, _ bool) bool {
+		for i := range page.Images {
+			for j := range res {
+				if res[j].AmiID == aws.StringValue(page.Images[i].ImageId) {
+					res[j].Name = aws.StringValue(page.Images[i].Name)
+					res[j].CreationDate = aws.StringValue(page.Images[i].CreationDate)
+				}
+			}
 		}
-	}))
-	if err != nil {
-		return nil, fmt.Errorf("discovering amis, %w", err)
+		return true
+	}); err != nil {
+		return nil, fmt.Errorf("describing images, %w", err)
 	}
-	// Resolve additional information from the set of default AMIs
-	for i := range res {
-		if image, ok := lo.Find(images, func(a AMI) bool {
-			return res[i].AmiID == a.AmiID
-		}); ok {
-			res[i].Name = image.Name
-			res[i].CreationDate = image.CreationDate
-		}
-	}
+	p.cache.SetDefault(lo.FromPtr(nodeClass.Spec.AMIFamily), res)
 	return res, nil
 }
 
-func (p *Provider) getAMIsFromSSM(ctx context.Context, ssmQuery string) (string, error) {
-	if id, ok := p.ssmCache.Get(ssmQuery); ok {
-		return id.(string), nil
-	}
+func (p *Provider) resolveSSMParameter(ctx context.Context, ssmQuery string) (string, error) {
 	output, err := p.ssm.GetParameterWithContext(ctx, &ssm.GetParameterInput{Name: aws.String(ssmQuery)})
 	if err != nil {
 		return "", fmt.Errorf("getting ssm parameter %q, %w", ssmQuery, err)
 	}
 	ami := aws.StringValue(output.Parameter.Value)
-	p.ssmCache.SetDefault(ssmQuery, ami)
 	return ami, nil
 }
 
-func (p *Provider) getAMIs(ctx context.Context, terms []v1beta1.AMISelectorTerm) ([]AMI, error) {
-	ec2AMIs, err := p.getAMIsFromEC2(ctx, terms)
-	if err != nil {
-		return nil, err
-	}
-	return lo.FilterMap(ec2AMIs, func(i *ec2.Image, _ int) (AMI, bool) {
-		reqs := p.getRequirementsFromImage(i)
-		return AMI{
-			Name:         lo.FromPtr(i.Name),
-			AmiID:        lo.FromPtr(i.ImageId),
-			CreationDate: lo.FromPtr(i.CreationDate),
-			Requirements: reqs,
-		}, v1beta1.WellKnownArchitectures.Has(reqs.Get(v1.LabelArchStable).Any())
-	}), nil
-}
-
-func (p *Provider) getAMIsFromEC2(ctx context.Context, terms []v1beta1.AMISelectorTerm) ([]*ec2.Image, error) {
+func (p *Provider) getAMIs(ctx context.Context, terms []v1beta1.AMISelectorTerm) (AMIs, error) {
 	filterAndOwnerSets := GetFilterAndOwnerSets(terms)
 	hash, err := hashstructure.Hash(filterAndOwnerSets, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	if err != nil {
 		return nil, err
 	}
-	if images, ok := p.ec2Cache.Get(fmt.Sprint(hash)); ok {
-		return images.([]*ec2.Image), nil
+	if images, ok := p.cache.Get(fmt.Sprint(hash)); ok {
+		return images.(AMIs), nil
 	}
-	images := map[string]*ec2.Image{}
+	images := map[uint64]AMI{}
 	for _, filtersAndOwners := range filterAndOwnerSets {
-		// This API is not paginated, so a single call suffices.
-		output, err := p.ec2api.DescribeImagesWithContext(ctx, &ec2.DescribeImagesInput{
+		if err = p.ec2api.DescribeImagesPagesWithContext(ctx, &ec2.DescribeImagesInput{
 			// Don't include filters in the Describe Images call as EC2 API doesn't allow empty filters.
-			Filters: lo.Ternary(len(filtersAndOwners.Filters) > 0, filtersAndOwners.Filters, nil),
-			Owners:  lo.Ternary(len(filtersAndOwners.Owners) > 0, aws.StringSlice(filtersAndOwners.Owners), nil),
-		})
-		if err != nil {
+			Filters:    lo.Ternary(len(filtersAndOwners.Filters) > 0, filtersAndOwners.Filters, nil),
+			Owners:     lo.Ternary(len(filtersAndOwners.Owners) > 0, aws.StringSlice(filtersAndOwners.Owners), nil),
+			MaxResults: aws.Int64(500),
+		}, func(page *ec2.DescribeImagesOutput, _ bool) bool {
+			for i := range page.Images {
+				reqs := p.getRequirementsFromImage(page.Images[i])
+				if !v1beta1.WellKnownArchitectures.Has(reqs.Get(v1.LabelArchStable).Any()) {
+					continue
+				}
+				reqsHash := lo.Must(hashstructure.Hash(reqs.NodeSelectorRequirements(), hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true}))
+				// If the proposed image is newer, store it so that we can return it
+				if v, ok := images[reqsHash]; ok {
+					candidateCreationTime, _ := time.Parse(time.RFC3339, lo.FromPtr(page.Images[i].CreationDate))
+					existingCreationTime, _ := time.Parse(time.RFC3339, v.CreationDate)
+					if existingCreationTime == candidateCreationTime && lo.FromPtr(page.Images[i].Name) < v.Name {
+						continue
+					}
+					if candidateCreationTime.Unix() < existingCreationTime.Unix() {
+						continue
+					}
+				}
+				images[reqsHash] = AMI{
+					Name:         lo.FromPtr(page.Images[i].Name),
+					AmiID:        lo.FromPtr(page.Images[i].ImageId),
+					CreationDate: lo.FromPtr(page.Images[i].CreationDate),
+					Requirements: reqs,
+				}
+			}
+			return true
+		}); err != nil {
 			return nil, fmt.Errorf("describing images, %w", err)
 		}
-		for i := range output.Images {
-			images[lo.FromPtr(output.Images[i].ImageId)] = output.Images[i]
-		}
 	}
-	p.ec2Cache.SetDefault(fmt.Sprint(hash), lo.Values(images))
+	p.cache.SetDefault(fmt.Sprint(hash), AMIs(lo.Values(images)))
 	return lo.Values(images), nil
-}
-
-func amiList(amis []AMI) string {
-	var sb strings.Builder
-	ids := lo.Map(amis, func(a AMI, _ int) string { return a.AmiID })
-	if len(amis) > 25 {
-		sb.WriteString(strings.Join(ids[:25], ", "))
-		sb.WriteString(fmt.Sprintf(" and %d other(s)", len(amis)-25))
-	} else {
-		sb.WriteString(strings.Join(ids, ", "))
-	}
-	return sb.String()
 }
 
 type FiltersAndOwners struct {
@@ -296,23 +298,6 @@ func GetFilterAndOwnerSets(terms []v1beta1.AMISelectorTerm) (res []FiltersAndOwn
 		res = append(res, FiltersAndOwners{Filters: []*ec2.Filter{idFilter}})
 	}
 	return res
-}
-
-// SortAMIsByCreationDate the AMIs are sorted by creation date in descending order.
-// If creation date is nil or two AMIs have the same creation date, the AMIs will be sorted by name in ascending order.
-func SortAMIsByCreationDate(amis []AMI) []AMI {
-	sort.Slice(amis, func(i, j int) bool {
-		if amis[i].CreationDate != "" || amis[j].CreationDate != "" {
-			itime, _ := time.Parse(time.RFC3339, amis[i].CreationDate)
-			jtime, _ := time.Parse(time.RFC3339, amis[j].CreationDate)
-			if itime.Unix() != jtime.Unix() {
-				return itime.Unix() >= jtime.Unix()
-			}
-		}
-		return amis[i].Name >= amis[j].Name
-	})
-
-	return amis
 }
 
 func (p *Provider) getRequirementsFromImage(ec2Image *ec2.Image) scheduling.Requirements {

--- a/pkg/providers/amifamily/ami_test.go
+++ b/pkg/providers/amifamily/ami_test.go
@@ -341,7 +341,7 @@ var _ = Describe("AMIProvider", func() {
 			}, filterAndOwnersSets)
 		})
 		It("should sort amis by creationDate", func() {
-			amis := []amifamily.AMI{
+			amis := amifamily.AMIs{
 				{
 					Name:         "test-ami-1",
 					AmiID:        "test-ami-1-id",
@@ -367,9 +367,9 @@ var _ = Describe("AMIProvider", func() {
 					Requirements: scheduling.NewRequirements(),
 				},
 			}
-			amifamily.SortAMIsByCreationDate(amis)
+			amis.Sort()
 			Expect(amis).To(Equal(
-				[]amifamily.AMI{
+				amifamily.AMIs{
 					{
 						Name:         "test-ami-2",
 						AmiID:        "test-ami-2-id",

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -125,9 +125,9 @@ func (r Resolver) Resolve(ctx context.Context, nodeClass *v1beta1.NodeClass, nod
 	if len(amis) == 0 {
 		return nil, fmt.Errorf("no amis exist given constraints")
 	}
-	mappedAMIs := MapInstanceTypes(amis, instanceTypes)
+	mappedAMIs := amis.MapToInstanceTypes(instanceTypes)
 	if len(mappedAMIs) == 0 {
-		return nil, fmt.Errorf("no instance types satisfy requirements of amis %v,", amis)
+		return nil, fmt.Errorf("no instance types satisfy requirements of amis %v", amis)
 	}
 	var resolvedTemplates []*LaunchTemplate
 	for amiID, instanceTypes := range mappedAMIs {

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -44,7 +44,6 @@ type Environment struct {
 	PricingAPI *fake.PricingAPI
 
 	// Cache
-	SSMCache                  *cache.Cache
 	EC2Cache                  *cache.Cache
 	KubernetesVersionCache    *cache.Cache
 	InstanceTypeCache         *cache.Cache
@@ -70,7 +69,6 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	ssmapi := &fake.SSMAPI{}
 
 	// cache
-	ssmCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	ec2Cache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	kubernetesVersionCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	instanceTypeCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
@@ -84,7 +82,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	pricingProvider := pricing.NewProvider(ctx, fakePricingAPI, ec2api, "")
 	subnetProvider := subnet.NewProvider(ec2api, subnetCache)
 	securityGroupProvider := securitygroup.NewProvider(ec2api, securityGroupCache)
-	amiProvider := amifamily.NewProvider(env.Client, env.KubernetesInterface, ssmapi, ec2api, ssmCache, ec2Cache, kubernetesVersionCache)
+	amiProvider := amifamily.NewProvider(env.Client, env.KubernetesInterface, ssmapi, ec2api, ec2Cache, kubernetesVersionCache)
 	amiResolver := amifamily.New(amiProvider)
 	instanceTypesProvider := instancetype.NewProvider("", instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)
 	launchTemplateProvider :=
@@ -115,7 +113,6 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		SSMAPI:     ssmapi,
 		PricingAPI: fakePricingAPI,
 
-		SSMCache:                  ssmCache,
 		EC2Cache:                  ec2Cache,
 		KubernetesVersionCache:    kubernetesVersionCache,
 		InstanceTypeCache:         instanceTypeCache,
@@ -141,7 +138,6 @@ func (env *Environment) Reset() {
 	env.PricingAPI.Reset()
 	env.PricingProvider.Reset()
 
-	env.SSMCache.Flush()
 	env.EC2Cache.Flush()
 	env.KubernetesVersionCache.Flush()
 	env.InstanceTypeCache.Flush()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR reduces the memory utilization from the `DescribeImages` call for calls that are wide-open and grab an extremely high number of images from the API >> 1000 images. This changes the call to be paginated and to cap the number of results in a page at 500 images. Each page only stores an image if the set of requirements for the image is different from the existing set of image requirements OR if the requirements already exist but the image is newer. This reduces the amount of things that are stored in the cache for a request.

**How was this change tested?**

`make presubmit`

For the following test `AWSNodeTemplate`, these are the memory footprints before and after the PR

```yaml
apiVersion: karpenter.k8s.aws/v1alpha1
kind: AWSNodeTemplate
metadata:
  name: default
spec:
  subnetSelector:                             
    karpenter.sh/discovery: <>
  securityGroupSelector:          
    karpenter.sh/discovery: <>
  amiSelector:
    aws::owners: self,amazon
```

#### Before PR

<img width="735" alt="Screenshot 2023-09-03 at 12 24 33 AM" src="https://github.com/aws/karpenter/assets/26334334/2554dea8-2795-429d-850d-f41ca5d6c351">

#### After PR

<img width="719" alt="Screenshot 2023-09-03 at 3 08 58 PM" src="https://github.com/aws/karpenter/assets/26334334/de0963b1-df94-4f52-a767-d70b60ad8720">

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.