### PR TITLE
chore: Handle `v1beta1` labels for requirements and tags

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -61,6 +61,7 @@ import (
 
 func init() {
 	v1alpha5.NormalizedLabels = lo.Assign(v1alpha5.NormalizedLabels, map[string]string{"topology.ebs.csi.aws.com/zone": v1.LabelTopologyZone})
+	corev1beta1.NormalizedLabels = lo.Assign(corev1beta1.NormalizedLabels, map[string]string{"topology.ebs.csi.aws.com/zone": v1.LabelTopologyZone})
 	coreapis.Settings = append(coreapis.Settings, apis.Settings...)
 }
 
@@ -340,12 +341,15 @@ func (c *CloudProvider) instanceToMachine(i *instance.Instance, instanceType *cl
 		machine.Status.Allocatable = functional.FilterMap(instanceType.Allocatable(), func(_ v1.ResourceName, v resource.Quantity) bool { return !resources.IsZero(v) })
 	}
 	labels[v1.LabelTopologyZone] = i.Zone
-	labels[v1alpha5.LabelCapacityType] = i.CapacityType
+	labels[corev1beta1.CapacityTypeLabelKey] = i.CapacityType
 	if v, ok := i.Tags[v1alpha5.ProvisionerNameLabelKey]; ok {
 		labels[v1alpha5.ProvisionerNameLabelKey] = v
 	}
-	if v, ok := i.Tags[v1alpha5.MachineManagedByAnnotationKey]; ok {
-		annotations[v1alpha5.MachineManagedByAnnotationKey] = v
+	if v, ok := i.Tags[corev1beta1.NodePoolLabelKey]; ok {
+		labels[corev1beta1.NodePoolLabelKey] = v
+	}
+	if v, ok := i.Tags[corev1beta1.ManagedByAnnotationKey]; ok {
+		annotations[corev1beta1.ManagedByAnnotationKey] = v
 	}
 	machine.Labels = labels
 	machine.Annotations = annotations

--- a/pkg/providers/amifamily/al2.go
+++ b/pkg/providers/amifamily/al2.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
@@ -36,36 +36,36 @@ type AL2 struct {
 }
 
 // DefaultAMIs returns the AMI name, and Requirements, with an SSM query
-func (a AL2) DefaultAMIs(version string) []DefaultAMIOutput {
+func (a AL2) DefaultAMIs(version string, isNodeTemplate bool) []DefaultAMIOutput {
 	return []DefaultAMIOutput{
 		{
 			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpExists),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpExists),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-gpu/recommended/image_id", version),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpExists),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpExists),
 			),
 		},
 		{
-			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-%s/recommended/image_id", version, v1alpha5.ArchitectureArm64),
+			Query: fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-%s/recommended/image_id", version, corev1beta1.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureArm64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 	}

--- a/pkg/providers/amifamily/bootstrap/bootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/bootstrap.go
@@ -95,7 +95,7 @@ func (o Options) nodeLabelArg() string {
 	keys := lo.Keys(o.Labels)
 	sort.Strings(keys) // ensures this list is deterministic, for easy testing.
 	for _, key := range keys {
-		if v1alpha5.LabelDomainExceptions.Has(key) {
+		if v1alpha5.LabelDomainExceptions.Has(key) || corev1beta1.LabelDomainExceptions.Has(key) {
 			continue
 		}
 		labelStrings = append(labelStrings, fmt.Sprintf("%s=%v", key, o.Labels[key]))

--- a/pkg/providers/amifamily/bottlerocket.go
+++ b/pkg/providers/amifamily/bottlerocket.go
@@ -30,8 +30,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 )
 
@@ -41,50 +39,50 @@ type Bottlerocket struct {
 }
 
 // DefaultAMIs returns the AMI name, and Requirements, with an SSM query
-func (b Bottlerocket) DefaultAMIs(version string) []DefaultAMIOutput {
+func (b Bottlerocket) DefaultAMIs(version string, isNodeTemplate bool) []DefaultAMIOutput {
 	return []DefaultAMIOutput{
 		{
 			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpExists),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpExists),
 			),
 		},
 		{
 			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/x86_64/latest/image_id", version),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpExists),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpExists),
 			),
 		},
 		{
-			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/image_id", version, v1alpha5.ArchitectureArm64),
+			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/%s/latest/image_id", version, corev1beta1.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureArm64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpDoesNotExist),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpDoesNotExist),
 			),
 		},
 		{
-			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/%s/latest/image_id", version, v1alpha5.ArchitectureArm64),
+			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/%s/latest/image_id", version, corev1beta1.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpExists),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureArm64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpExists),
 			),
 		},
 		{
-			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/%s/latest/image_id", version, v1alpha5.ArchitectureArm64),
+			Query: fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s-nvidia/%s/latest/image_id", version, corev1beta1.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
-				scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpExists),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureArm64),
+				scheduling.NewRequirement(lo.Ternary(isNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpExists),
 			),
 		},
 	}

--- a/pkg/providers/amifamily/custom.go
+++ b/pkg/providers/amifamily/custom.go
@@ -38,7 +38,7 @@ func (c Custom) UserData(_ *corev1beta1.KubeletConfiguration, _ []v1.Taint, _ ma
 	}
 }
 
-func (c Custom) DefaultAMIs(_ string) []DefaultAMIOutput {
+func (c Custom) DefaultAMIs(_ string, _ bool) []DefaultAMIOutput {
 	return nil
 }
 

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -54,7 +54,7 @@ type Options struct {
 	InstanceProfile         string
 	CABundle                *string `hash:"ignore"`
 	// Level-triggered fields that may change out of sync.
-	SecurityGroups           []v1alpha1.SecurityGroup
+	SecurityGroups           []v1beta1.SecurityGroup
 	Tags                     map[string]string
 	Labels                   map[string]string `hash:"ignore"`
 	KubeDNSIP                net.IP
@@ -74,7 +74,7 @@ type LaunchTemplate struct {
 
 // AMIFamily can be implemented to override the default logic for generating dynamic launch template parameters
 type AMIFamily interface {
-	DefaultAMIs(version string) []DefaultAMIOutput
+	DefaultAMIs(version string, isNodeTemplate bool) []DefaultAMIOutput
 	UserData(kubeletConfig *corev1beta1.KubeletConfiguration, taints []core.Taint, labels map[string]string, caBundle *string, instanceTypes []*cloudprovider.InstanceType, customUserData *string) bootstrap.Bootstrapper
 	DefaultBlockDeviceMappings() []*v1beta1.BlockDeviceMapping
 	DefaultMetadataOptions() *v1beta1.MetadataOptions

--- a/pkg/providers/amifamily/ubuntu.go
+++ b/pkg/providers/amifamily/ubuntu.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 )
@@ -35,18 +34,18 @@ type Ubuntu struct {
 }
 
 // DefaultAMIs returns the AMI name, and Requirements, with an SSM query
-func (u Ubuntu) DefaultAMIs(version string) []DefaultAMIOutput {
+func (u Ubuntu) DefaultAMIs(version string, _ bool) []DefaultAMIOutput {
 	return []DefaultAMIOutput{
 		{
-			Query: fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/%s/hvm/ebs-gp2/ami-id", version, v1alpha5.ArchitectureAmd64),
+			Query: fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/%s/hvm/ebs-gp2/ami-id", version, corev1beta1.ArchitectureAmd64),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
 			),
 		},
 		{
-			Query: fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/%s/hvm/ebs-gp2/ami-id", version, v1alpha5.ArchitectureArm64),
+			Query: fmt.Sprintf("/aws/service/canonical/ubuntu/eks/20.04/%s/stable/current/%s/hvm/ebs-gp2/ami-id", version, corev1beta1.ArchitectureArm64),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureArm64),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureArm64),
 			),
 		},
 	}

--- a/pkg/providers/amifamily/windows.go
+++ b/pkg/providers/amifamily/windows.go
@@ -30,7 +30,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -43,12 +42,12 @@ type Windows struct {
 	Build   string
 }
 
-func (w Windows) DefaultAMIs(version string) []DefaultAMIOutput {
+func (w Windows) DefaultAMIs(version string, _ bool) []DefaultAMIOutput {
 	return []DefaultAMIOutput{
 		{
 			Query: fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-%s-English-%s-EKS_Optimized-%s/image_id", w.Version, v1alpha1.WindowsCore, version),
 			Requirements: scheduling.NewRequirements(
-				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, v1alpha5.ArchitectureAmd64),
+				scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, corev1beta1.ArchitectureAmd64),
 				scheduling.NewRequirement(v1.LabelOSStable, v1.NodeSelectorOpIn, string(v1.Windows)),
 				scheduling.NewRequirement(v1.LabelWindowsBuild, v1.NodeSelectorOpIn, w.Build),
 			),

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/samber/lo"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 )
 
 // Instance is an internal data representation of either an ec2.Instance or an ec2.FleetInstance
@@ -47,7 +47,7 @@ func NewInstance(out *ec2.Instance) *Instance {
 		ImageID:      aws.StringValue(out.ImageId),
 		Type:         aws.StringValue(out.InstanceType),
 		Zone:         aws.StringValue(out.Placement.AvailabilityZone),
-		CapacityType: lo.Ternary(out.SpotInstanceRequestId != nil, v1alpha5.CapacityTypeSpot, v1alpha5.CapacityTypeOnDemand),
+		CapacityType: lo.Ternary(out.SpotInstanceRequestId != nil, corev1beta1.CapacityTypeSpot, corev1beta1.CapacityTypeOnDemand),
 		SecurityGroupIDs: lo.Map(out.SecurityGroups, func(securitygroup *ec2.GroupIdentifier, _ int) string {
 			return aws.StringValue(securitygroup.GroupId)
 		}),

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -35,7 +35,6 @@ import (
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/utils/resources"
@@ -56,9 +55,9 @@ func NewInstanceType(ctx context.Context, info *ec2.InstanceTypeInfo, kc *corev1
 	amiFamily := amifamily.GetAMIFamily(nodeClass.Spec.AMIFamily, &amifamily.Options{})
 	return &cloudprovider.InstanceType{
 		Name:         aws.StringValue(info.InstanceType),
-		Requirements: computeRequirements(ctx, info, offerings, region, amiFamily, kc),
+		Requirements: computeRequirements(ctx, info, offerings, region, amiFamily, kc, nodeClass),
 		Offerings:    offerings,
-		Capacity:     computeCapacity(ctx, info, amiFamily, nodeClass.Spec.BlockDeviceMappings, kc),
+		Capacity:     computeCapacity(ctx, info, amiFamily, nodeClass.Spec.BlockDeviceMappings, kc, nodeClass),
 		Overhead: &cloudprovider.InstanceTypeOverhead{
 			KubeReserved:      kubeReservedResources(cpu(info), pods(ctx, info, amiFamily, kc), ENILimitedPods(ctx, info), amiFamily, kc),
 			SystemReserved:    systemReservedResources(kc),
@@ -67,8 +66,9 @@ func NewInstanceType(ctx context.Context, info *ec2.InstanceTypeInfo, kc *corev1
 	}
 }
 
+//nolint:gocyclo
 func computeRequirements(ctx context.Context, info *ec2.InstanceTypeInfo, offerings cloudprovider.Offerings, region string,
-	amiFamily amifamily.AMIFamily, kc *corev1beta1.KubeletConfiguration) scheduling.Requirements {
+	amiFamily amifamily.AMIFamily, kc *corev1beta1.KubeletConfiguration, nodeClass *v1beta1.NodeClass) scheduling.Requirements {
 	requirements := scheduling.NewRequirements(
 		// Well Known Upstream
 		scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, aws.StringValue(info.InstanceType)),
@@ -78,82 +78,78 @@ func computeRequirements(ctx context.Context, info *ec2.InstanceTypeInfo, offeri
 		scheduling.NewRequirement(v1.LabelTopologyRegion, v1.NodeSelectorOpIn, region),
 		scheduling.NewRequirement(v1.LabelWindowsBuild, v1.NodeSelectorOpDoesNotExist),
 		// Well Known to Karpenter
-		scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, lo.Map(offerings.Available(), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
+		scheduling.NewRequirement(corev1beta1.CapacityTypeLabelKey, v1.NodeSelectorOpIn, lo.Map(offerings.Available(), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
 		// Well Known to AWS
-		scheduling.NewRequirement(v1alpha1.LabelInstanceCPU, v1.NodeSelectorOpIn, fmt.Sprint(aws.Int64Value(info.VCpuInfo.DefaultVCpus))),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceMemory, v1.NodeSelectorOpIn, fmt.Sprint(aws.Int64Value(info.MemoryInfo.SizeInMiB))),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceNetworkBandwidth, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstancePods, v1.NodeSelectorOpIn, fmt.Sprint(pods(ctx, info, amiFamily, kc))),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceCategory, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceFamily, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceGeneration, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceLocalNVME, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceSize, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceGPUName, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceGPUManufacturer, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceGPUMemory, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorName, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorManufacturer, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceAcceleratorCount, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceHypervisor, v1.NodeSelectorOpIn, aws.StringValue(info.Hypervisor)),
-		scheduling.NewRequirement(v1alpha1.LabelInstanceEncryptionInTransitSupported, v1.NodeSelectorOpIn, fmt.Sprint(aws.BoolValue(info.NetworkInfo.EncryptionInTransitSupported))),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceCPU, v1beta1.LabelInstanceCPU), v1.NodeSelectorOpIn, fmt.Sprint(aws.Int64Value(info.VCpuInfo.DefaultVCpus))),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceMemory, v1beta1.LabelInstanceMemory), v1.NodeSelectorOpIn, fmt.Sprint(aws.Int64Value(info.MemoryInfo.SizeInMiB))),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceNetworkBandwidth, v1beta1.LabelInstanceNetworkBandwidth), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstancePods, v1beta1.LabelInstancePods), v1.NodeSelectorOpIn, fmt.Sprint(pods(ctx, info, amiFamily, kc))),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceCategory, v1beta1.LabelInstanceCategory), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceFamily, v1beta1.LabelInstanceFamily), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGeneration, v1beta1.LabelInstanceGeneration), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceLocalNVME, v1beta1.LabelInstanceLocalNVME), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceSize, v1beta1.LabelInstanceSize), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUName, v1beta1.LabelInstanceGPUName), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUManufacturer, v1beta1.LabelInstanceGPUManufacturer), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUMemory, v1beta1.LabelInstanceGPUMemory), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorName, v1beta1.LabelInstanceAcceleratorName), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorManufacturer, v1beta1.LabelInstanceAcceleratorManufacturer), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount), v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceHypervisor, v1beta1.LabelInstanceHypervisor), v1.NodeSelectorOpIn, aws.StringValue(info.Hypervisor)),
+		scheduling.NewRequirement(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceEncryptionInTransitSupported, v1beta1.LabelInstanceEncryptionInTransitSupported), v1.NodeSelectorOpIn, fmt.Sprint(aws.BoolValue(info.NetworkInfo.EncryptionInTransitSupported))),
 	)
 	// Instance Type Labels
 	instanceFamilyParts := instanceTypeScheme.FindStringSubmatch(aws.StringValue(info.InstanceType))
 	if len(instanceFamilyParts) == 4 {
-		requirements[v1alpha1.LabelInstanceCategory].Insert(instanceFamilyParts[1])
-		requirements[v1alpha1.LabelInstanceGeneration].Insert(instanceFamilyParts[3])
+		requirements[lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceCategory, v1beta1.LabelInstanceCategory)].Insert(instanceFamilyParts[1])
+		requirements[lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGeneration, v1beta1.LabelInstanceGeneration)].Insert(instanceFamilyParts[3])
 	}
 	instanceTypeParts := strings.Split(aws.StringValue(info.InstanceType), ".")
 	if len(instanceTypeParts) == 2 {
-		requirements.Get(v1alpha1.LabelInstanceFamily).Insert(instanceTypeParts[0])
-		requirements.Get(v1alpha1.LabelInstanceSize).Insert(instanceTypeParts[1])
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceFamily, v1beta1.LabelInstanceFamily)).Insert(instanceTypeParts[0])
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceSize, v1beta1.LabelInstanceSize)).Insert(instanceTypeParts[1])
 	}
 	if info.InstanceStorageInfo != nil && aws.StringValue(info.InstanceStorageInfo.NvmeSupport) != ec2.EphemeralNvmeSupportUnsupported {
 		requirements[v1alpha1.LabelInstanceLocalNVME].Insert(fmt.Sprint(aws.Int64Value(info.InstanceStorageInfo.TotalSizeInGB)))
 	}
 	// Network bandwidth
 	if bandwidth, ok := InstanceTypeBandwidthMegabits[aws.StringValue(info.InstanceType)]; ok {
-		requirements[v1alpha1.LabelInstanceNetworkBandwidth].Insert(fmt.Sprint(bandwidth))
+		requirements[lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceNetworkBandwidth, v1beta1.LabelInstanceNetworkBandwidth)].Insert(fmt.Sprint(bandwidth))
 	}
 	// GPU Labels
 	if info.GpuInfo != nil && len(info.GpuInfo.Gpus) == 1 {
 		gpu := info.GpuInfo.Gpus[0]
-		requirements.Get(v1alpha1.LabelInstanceGPUName).Insert(lowerKabobCase(aws.StringValue(gpu.Name)))
-		requirements.Get(v1alpha1.LabelInstanceGPUManufacturer).Insert(lowerKabobCase(aws.StringValue(gpu.Manufacturer)))
-		requirements.Get(v1alpha1.LabelInstanceGPUCount).Insert(fmt.Sprint(aws.Int64Value(gpu.Count)))
-		requirements.Get(v1alpha1.LabelInstanceGPUMemory).Insert(fmt.Sprint(aws.Int64Value(gpu.MemoryInfo.SizeInMiB)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUName, v1beta1.LabelInstanceGPUName)).Insert(lowerKabobCase(aws.StringValue(gpu.Name)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUManufacturer, v1beta1.LabelInstanceGPUManufacturer)).Insert(lowerKabobCase(aws.StringValue(gpu.Manufacturer)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUCount, v1beta1.LabelInstanceGPUCount)).Insert(fmt.Sprint(aws.Int64Value(gpu.Count)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceGPUMemory, v1beta1.LabelInstanceGPUMemory)).Insert(fmt.Sprint(aws.Int64Value(gpu.MemoryInfo.SizeInMiB)))
 	}
 	// Accelerators
 	if info.InferenceAcceleratorInfo != nil && len(info.InferenceAcceleratorInfo.Accelerators) == 1 {
 		accelerator := info.InferenceAcceleratorInfo.Accelerators[0]
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorName).Insert(lowerKabobCase(aws.StringValue(accelerator.Name)))
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorManufacturer).Insert(lowerKabobCase(aws.StringValue(accelerator.Manufacturer)))
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorCount).Insert(fmt.Sprint(aws.Int64Value(accelerator.Count)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorName, v1beta1.LabelInstanceAcceleratorName)).Insert(lowerKabobCase(aws.StringValue(accelerator.Name)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorManufacturer, v1beta1.LabelInstanceAcceleratorManufacturer)).Insert(lowerKabobCase(aws.StringValue(accelerator.Manufacturer)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount)).Insert(fmt.Sprint(aws.Int64Value(accelerator.Count)))
 	}
 	// Windows Build Version Labels
 	if family, ok := amiFamily.(*amifamily.Windows); ok {
 		requirements.Get(v1.LabelWindowsBuild).Insert(family.Build)
 	}
-	return hardcodeNeuron(requirements, info)
-}
-
-// TODO: remove function once DescribeInstanceTypes contains the accelerator data
-// Values found from: https://aws.amazon.com/ec2/instance-types/trn1/
-func hardcodeNeuron(requirements scheduling.Requirements, info *ec2.InstanceTypeInfo) scheduling.Requirements {
 	// Trn1 Accelerators
+	// TODO: remove function once DescribeInstanceTypes contains the accelerator data
+	// Values found from: https://aws.amazon.com/ec2/instance-types/trn1/
 	if strings.HasPrefix(*info.InstanceType, "trn1") {
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorName).Insert(lowerKabobCase("Inferentia"))
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorManufacturer).Insert(lowerKabobCase("AWS"))
-		requirements.Get(v1alpha1.LabelInstanceAcceleratorCount).Insert(fmt.Sprint(awsNeurons(info)))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorName, v1beta1.LabelInstanceAcceleratorName)).Insert(lowerKabobCase("Inferentia"))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorManufacturer, v1beta1.LabelInstanceAcceleratorManufacturer)).Insert(lowerKabobCase("AWS"))
+		requirements.Get(lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.LabelInstanceAcceleratorCount, v1beta1.LabelInstanceAcceleratorCount)).Insert(fmt.Sprint(awsNeurons(info)))
 	}
 	return requirements
 }
 
 func getOS(info *ec2.InstanceTypeInfo, amiFamily amifamily.AMIFamily) []string {
 	if _, ok := amiFamily.(*amifamily.Windows); ok {
-		if getArchitecture(info) == v1alpha5.ArchitectureAmd64 {
+		if getArchitecture(info) == corev1beta1.ArchitectureAmd64 {
 			return []string{string(v1.Windows)}
 		}
 		return []string{}
@@ -163,7 +159,7 @@ func getOS(info *ec2.InstanceTypeInfo, amiFamily amifamily.AMIFamily) []string {
 
 func getArchitecture(info *ec2.InstanceTypeInfo) string {
 	for _, architecture := range info.ProcessorInfo.SupportedArchitectures {
-		if value, ok := v1alpha1.AWSToKubeArchitectures[aws.StringValue(architecture)]; ok {
+		if value, ok := v1beta1.AWSToKubeArchitectures[aws.StringValue(architecture)]; ok {
 			return value
 		}
 	}
@@ -171,22 +167,22 @@ func getArchitecture(info *ec2.InstanceTypeInfo) string {
 }
 
 func computeCapacity(ctx context.Context, info *ec2.InstanceTypeInfo, amiFamily amifamily.AMIFamily,
-	blockDeviceMappings []*v1beta1.BlockDeviceMapping, kc *corev1beta1.KubeletConfiguration) v1.ResourceList {
+	blockDeviceMappings []*v1beta1.BlockDeviceMapping, kc *corev1beta1.KubeletConfiguration, nodeClass *v1beta1.NodeClass) v1.ResourceList {
 
 	resourceList := v1.ResourceList{
-		v1.ResourceCPU:               *cpu(info),
-		v1.ResourceMemory:            *memory(ctx, info),
-		v1.ResourceEphemeralStorage:  *ephemeralStorage(amiFamily, blockDeviceMappings),
-		v1.ResourcePods:              *pods(ctx, info, amiFamily, kc),
-		v1alpha1.ResourceAWSPodENI:   *awsPodENI(ctx, aws.StringValue(info.InstanceType)),
-		v1alpha1.ResourceNVIDIAGPU:   *nvidiaGPUs(info),
-		v1alpha1.ResourceAMDGPU:      *amdGPUs(info),
-		v1alpha1.ResourceAWSNeuron:   *awsNeurons(info),
-		v1alpha1.ResourceHabanaGaudi: *habanaGaudis(info),
+		v1.ResourceCPU:              *cpu(info),
+		v1.ResourceMemory:           *memory(ctx, info),
+		v1.ResourceEphemeralStorage: *ephemeralStorage(amiFamily, blockDeviceMappings),
+		v1.ResourcePods:             *pods(ctx, info, amiFamily, kc),
+		lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.ResourceAWSPodENI, v1beta1.ResourceAWSPodENI):     *awsPodENI(ctx, aws.StringValue(info.InstanceType)),
+		lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.ResourceNVIDIAGPU, v1beta1.ResourceNVIDIAGPU):     *nvidiaGPUs(info),
+		lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.ResourceAMDGPU, v1beta1.ResourceAMDGPU):           *amdGPUs(info),
+		lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.ResourceAWSNeuron, v1beta1.ResourceAWSNeuron):     *awsNeurons(info),
+		lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.ResourceHabanaGaudi, v1beta1.ResourceHabanaGaudi): *habanaGaudis(info),
 	}
 	if _, ok := amiFamily.(*amifamily.Windows); ok {
 		//ResourcePrivateIPv4Address is the same as ENILimitedPods on Windows node
-		resourceList[v1alpha1.ResourcePrivateIPv4Address] = *privateIPv4Address(info)
+		resourceList[lo.Ternary(nodeClass.IsNodeTemplate, v1alpha1.ResourcePrivateIPv4Address, v1beta1.ResourcePrivateIPv4Address)] = *privateIPv4Address(info)
 	}
 	return resourceList
 }

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -37,7 +37,6 @@ import (
 
 	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/apis/settings"
-	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	awserrors "github.com/aws/karpenter/pkg/errors"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
@@ -165,8 +164,8 @@ func (p *Provider) createAMIOptions(ctx context.Context, nodeClass *v1beta1.Node
 		ClusterEndpoint:         p.ClusterEndpoint,
 		AWSENILimitedPodDensity: settings.FromContext(ctx).EnableENILimitedPodDensity,
 		InstanceProfile:         instanceProfile,
-		SecurityGroups: lo.Map(securityGroups, func(s *ec2.SecurityGroup, _ int) v1alpha1.SecurityGroup {
-			return v1alpha1.SecurityGroup{ID: aws.StringValue(s.GroupId), Name: aws.StringValue(s.GroupName)}
+		SecurityGroups: lo.Map(securityGroups, func(s *ec2.SecurityGroup, _ int) v1beta1.SecurityGroup {
+			return v1beta1.SecurityGroup{ID: aws.StringValue(s.GroupId), Name: aws.StringValue(s.GroupName)}
 		}),
 		Tags:      tags,
 		Labels:    labels,
@@ -235,7 +234,7 @@ func (p *Provider) createLaunchTemplate(ctx context.Context, options *amifamily.
 				Enabled: aws.Bool(options.DetailedMonitoring),
 			},
 			// If the network interface is defined, the security groups are defined within it
-			SecurityGroupIds: lo.Ternary(networkInterface != nil, nil, lo.Map(options.SecurityGroups, func(s v1alpha1.SecurityGroup, _ int) *string { return aws.String(s.ID) })),
+			SecurityGroupIds: lo.Ternary(networkInterface != nil, nil, lo.Map(options.SecurityGroups, func(s v1beta1.SecurityGroup, _ int) *string { return aws.String(s.ID) })),
 			UserData:         aws.String(userData),
 			ImageId:          aws.String(options.AMIID),
 			MetadataOptions: &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
@@ -274,7 +273,7 @@ func (p *Provider) generateNetworkInterface(options *amifamily.LaunchTemplate) [
 			{
 				AssociatePublicIpAddress: options.AssociatePublicIPAddress,
 				DeviceIndex:              aws.Int64(0),
-				Groups:                   lo.Map(options.SecurityGroups, func(s v1alpha1.SecurityGroup, _ int) *string { return aws.String(s.ID) }),
+				Groups:                   lo.Map(options.SecurityGroups, func(s v1beta1.SecurityGroup, _ int) *string { return aws.String(s.ID) }),
 			},
 		}
 	}

--- a/pkg/providers/securitygroup/suite_test.go
+++ b/pkg/providers/securitygroup/suite_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
-	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/test"
 
@@ -71,7 +70,7 @@ var _ = BeforeEach(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	nodeClass = test.NodeClass(v1beta1.NodeClass{
 		Spec: v1beta1.NodeClassSpec{
-			AMIFamily: aws.String(v1alpha1.AMIFamilyAL2),
+			AMIFamily: aws.String(v1beta1.AMIFamilyAL2),
 			SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
 				{
 					Tags: map[string]string{

--- a/pkg/providers/subnet/suite_test.go
+++ b/pkg/providers/subnet/suite_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
-	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/test"
 
@@ -71,7 +70,7 @@ var _ = BeforeEach(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	nodeClass = test.NodeClass(v1beta1.NodeClass{
 		Spec: v1beta1.NodeClassSpec{
-			AMIFamily: aws.String(v1alpha1.AMIFamilyAL2),
+			AMIFamily: aws.String(v1beta1.AMIFamilyAL2),
 			SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
 				{
 					Tags: map[string]string{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds handling to return the `v1beta1` API Group as the prefix to all the current `karpenter.k8s.aws` requirements. The new requirements will now be prefixed with `compute.k8s.aws`. This change returns these different requirements based on whether you are launching a Machine (`v1alpha5`) or NodeClaim (`v1beta1`)

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.