### PR TITLE
chore: update supported operators in provisioners docs

### DIFF
--- a/website/content/en/preview/concepts/provisioners.md
+++ b/website/content/en/preview/concepts/provisioners.md
@@ -59,7 +59,8 @@ spec:
 
   # Requirements that constrain the parameters of provisioned nodes.
   # These requirements are combined with pod.spec.affinity.nodeAffinity rules.
-  # Operators { In, NotIn } are supported to enable including or excluding values
+  # Operators { In, NotIn, Exists, DoesNotExist, Gt, and Lt } are supported.
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#operators
   requirements:
     - key: "karpenter.k8s.aws/instance-category"
       operator: In


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->
https://github.com/aws/karpenter/issues/4558

**Description**
 - Update supported operators in provisioners docs and linked upstream k8s docs

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.