### PR TITLE
feat: Add instance profile generation for `v1beta1/NodeClass`

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -64,6 +64,7 @@ func main() {
 			awsCloudProvider,
 			op.SubnetProvider,
 			op.SecurityGroupProvider,
+			op.InstanceProfileProvider,
 			op.PricingProvider,
 			op.AMIProvider,
 		)...).

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.45.12
-	github.com/aws/karpenter-core v0.30.1-0.20230919163305-847fa5b2e74e
+	github.com/aws/karpenter-core v0.30.1-0.20230921014718-c6fb5c1c5322
 	github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.45.12
-	github.com/aws/karpenter-core v0.30.1-0.20230921014718-c6fb5c1c5322
+	github.com/aws/karpenter-core v0.30.1-0.20230921184727-4dbd382251d3
 	github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.45.12 h1:+bKbbesGNPp+TeGrcqfrWuZoqcIEhjwKyBMHQPp80Jo=
 github.com/aws/aws-sdk-go v1.45.12/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.30.1-0.20230919163305-847fa5b2e74e h1:KkjLabXp+syE0ax63shGVQTtUsgLBi/30HgjEks1hUo=
-github.com/aws/karpenter-core v0.30.1-0.20230919163305-847fa5b2e74e/go.mod h1:SlwFUtchMljQlD5oWFBo3B7voGIa1q4XTwDyTJqJ2h0=
+github.com/aws/karpenter-core v0.30.1-0.20230921014718-c6fb5c1c5322 h1:P6twY4o4lkASx3bhXQf8P/lrsrkGFi/DLpyV/7xU2Ko=
+github.com/aws/karpenter-core v0.30.1-0.20230921014718-c6fb5c1c5322/go.mod h1:SlwFUtchMljQlD5oWFBo3B7voGIa1q4XTwDyTJqJ2h0=
 github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644 h1:M1fxGlOfvSqFYI01HL2zzvomy8e7LiTHk77KDuChWZQ=
 github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644/go.mod h1:l/TIBsaCx/IrOr0Xvlj/cHLOf05QzuQKEZ1hx2XWmfU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.45.12 h1:+bKbbesGNPp+TeGrcqfrWuZoqcIEhjwKyBMHQPp80Jo=
 github.com/aws/aws-sdk-go v1.45.12/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.30.1-0.20230921014718-c6fb5c1c5322 h1:P6twY4o4lkASx3bhXQf8P/lrsrkGFi/DLpyV/7xU2Ko=
-github.com/aws/karpenter-core v0.30.1-0.20230921014718-c6fb5c1c5322/go.mod h1:SlwFUtchMljQlD5oWFBo3B7voGIa1q4XTwDyTJqJ2h0=
+github.com/aws/karpenter-core v0.30.1-0.20230921184727-4dbd382251d3 h1:ObVEjXuIOLYyaDzGtrm6+AGVM4nA91K5oD6a1ByfhXk=
+github.com/aws/karpenter-core v0.30.1-0.20230921184727-4dbd382251d3/go.mod h1:SlwFUtchMljQlD5oWFBo3B7voGIa1q4XTwDyTJqJ2h0=
 github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644 h1:M1fxGlOfvSqFYI01HL2zzvomy8e7LiTHk77KDuChWZQ=
 github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644/go.mod h1:l/TIBsaCx/IrOr0Xvlj/cHLOf05QzuQKEZ1hx2XWmfU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -341,6 +341,10 @@ spec:
                   - requirements
                   type: object
                 type: array
+              instanceProfile:
+                description: InstanceProfile contains the resolved instance profile
+                  for the role
+                type: string
               securityGroups:
                 description: SecurityGroups contains the current Security Groups values
                   that are available to the cluster under the SecurityGroups selectors.

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -223,7 +223,10 @@ spec:
               role:
                 description: Role is the AWS identity that nodes use. This field is
                   immutable. Marking this field as immutable avoids concerns around
-                  terminating managed instance profiles from running instances.
+                  terminating managed instance profiles from running instances. This
+                  field may be made mutable in the future, assuming the correct garbage
+                  collection and drift handling is implemented for the old instance
+                  profiles on an update.
                 type: string
               securityGroupSelectorTerms:
                 description: SecurityGroupSelectorTerms is a list of or security group

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -221,7 +221,8 @@ spec:
                     type: string
                 type: object
               role:
-                description: Role is the AWS identity that nodes use.
+                description: Role is the AWS identity that nodes use. This field is
+                  immutable.
                 type: string
               securityGroupSelectorTerms:
                 description: SecurityGroupSelectorTerms is a list of or security group

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -222,7 +222,8 @@ spec:
                 type: object
               role:
                 description: Role is the AWS identity that nodes use. This field is
-                  immutable.
+                  immutable. Marking this field as immutable avoids concerns around
+                  terminating managed instance profiles from running instances.
                 type: string
               securityGroupSelectorTerms:
                 description: SecurityGroupSelectorTerms is a list of or security group

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -13,9 +13,6 @@ spec:
     kind: NodeClaim
     listKind: NodeClaimList
     plural: nodeclaims
-    shortNames:
-    - nc
-    - ncs
     singular: nodeclaim
   scope: Cluster
   versions:
@@ -79,10 +76,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  containerRuntime:
-                    description: ContainerRuntime is the container runtime to be used
-                      with your worker nodes.
-                    type: string
                   cpuCFSQuota:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits.

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -76,6 +76,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  containerRuntime:
+                    description: ContainerRuntime is the container runtime to be used
+                      with your worker nodes.
+                    type: string
                   cpuCFSQuota:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits.

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -76,10 +76,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  containerRuntime:
-                    description: ContainerRuntime is the container runtime to be used
-                      with your worker nodes.
-                    type: string
                   cpuCFSQuota:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits.

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -13,9 +13,6 @@ spec:
     kind: NodePool
     listKind: NodePoolList
     plural: nodepools
-    shortNames:
-    - np
-    - nps
     singular: nodepool
   scope: Cluster
   versions:
@@ -30,7 +27,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: NodePool is the Schema for the Provisioners API
+        description: NodePool is the Schema for the NodePools API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -134,10 +131,6 @@ spec:
                             items:
                               type: string
                             type: array
-                          containerRuntime:
-                            description: ContainerRuntime is the container runtime
-                              to be used with your worker nodes.
-                            type: string
                           cpuCFSQuota:
                             description: CPUCFSQuota enables CPU CFS quota enforcement
                               for containers that specify CPU limits.

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -131,6 +131,10 @@ spec:
                             items:
                               type: string
                             type: array
+                          containerRuntime:
+                            description: ContainerRuntime is the container runtime
+                              to be used with your worker nodes.
+                            type: string
                           cpuCFSQuota:
                             description: CPUCFSQuota enables CPU CFS quota enforcement
                               for containers that specify CPU limits.

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -131,10 +131,6 @@ spec:
                             items:
                               type: string
                             type: array
-                          containerRuntime:
-                            description: ContainerRuntime is the container runtime
-                              to be used with your worker nodes.
-                            type: string
                           cpuCFSQuota:
                             description: CPUCFSQuota enables CPU CFS quota enforcement
                               for containers that specify CPU limits.

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -45,6 +45,7 @@ type EC2NodeClassSpec struct {
 	// +optional
 	UserData *string `json:"userData,omitempty"`
 	// Role is the AWS identity that nodes use.
+	// This field is immutable.
 	// +required
 	Role string `json:"role"`
 	// Tags to be applied on ec2 resources like instances and launch templates.
@@ -288,8 +289,8 @@ type EC2NodeClass struct {
 	IsNodeTemplate bool `json:"-" hash:"ignore"`
 }
 
-func (a *EC2NodeClass) Hash() string {
-	return fmt.Sprint(lo.Must(hashstructure.Hash(a.Spec, hashstructure.FormatV2, &hashstructure.HashOptions{
+func (in *EC2NodeClass) Hash() string {
+	return fmt.Sprint(lo.Must(hashstructure.Hash(in.Spec, hashstructure.FormatV2, &hashstructure.HashOptions{
 		SlicesAsSets:    true,
 		IgnoreZeroValue: true,
 		ZeroNil:         true,

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -44,8 +44,8 @@ type EC2NodeClassSpec struct {
 	// this UserData to ensure nodes are being provisioned with the correct configuration.
 	// +optional
 	UserData *string `json:"userData,omitempty"`
-	// Role is the AWS identity that nodes use.
-	// This field is immutable.
+	// Role is the AWS identity that nodes use. This field is immutable.
+	// Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
 	// +required
 	Role string `json:"role"`
 	// Tags to be applied on ec2 resources like instances and launch templates.

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -46,6 +46,8 @@ type EC2NodeClassSpec struct {
 	UserData *string `json:"userData,omitempty"`
 	// Role is the AWS identity that nodes use. This field is immutable.
 	// Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
+	// This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
+	// for the old instance profiles on an update.
 	// +required
 	Role string `json:"role"`
 	// Tags to be applied on ec2 resources like instances and launch templates.

--- a/pkg/apis/v1beta1/ec2nodeclass_defaults.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_defaults.go
@@ -19,4 +19,4 @@ import (
 )
 
 // SetDefaults for the EC2NodeClass
-func (a *EC2NodeClass) SetDefaults(_ context.Context) {}
+func (in *EC2NodeClass) SetDefaults(_ context.Context) {}

--- a/pkg/apis/v1beta1/ec2nodeclass_status.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_status.go
@@ -63,4 +63,7 @@ type EC2NodeClassStatus struct {
 	// cluster under the AMI selectors.
 	// +optional
 	AMIs []AMI `json:"amis,omitempty"`
+	// InstanceProfile contains the resolved instance profile for the role
+	// +optional
+	InstanceProfile string `json:"instanceProfile,omitempty"`
 }

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -51,6 +51,10 @@ func init() {
 	)
 }
 
+const (
+	TerminationFinalizer = Group + "/termination"
+)
+
 var (
 	CapacityTypeSpot       = ec2.DefaultTargetCapacityTypeSpot
 	CapacityTypeOnDemand   = ec2.DefaultTargetCapacityTypeOnDemand
@@ -99,6 +103,8 @@ var (
 	ResourceHabanaGaudi        v1.ResourceName = "habana.ai/gaudi"
 	ResourceAWSPodENI          v1.ResourceName = "vpc.amazonaws.com/pod-eni"
 	ResourcePrivateIPv4Address v1.ResourceName = "vpc.amazonaws.com/PrivateIPv4Address"
+
+	LabelNodeClass = Group + "/nodeclass"
 
 	LabelInstanceHypervisor                   = Group + "/instance-hypervisor"
 	LabelInstanceEncryptionInTransitSupported = Group + "/instance-encryption-in-transit-supported"

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -29,6 +29,8 @@ const (
 	UnavailableOfferingsTTL = 3 * time.Minute
 	// InstanceTypesAndZonesTTL is the time before we refresh instance types and zones at EC2
 	InstanceTypesAndZonesTTL = 5 * time.Minute
+	// InstanceProfileTTL is the time before we refresh checking instance profile existence at IAM
+	InstanceProfileTTL = 15 * time.Minute
 )
 
 const (

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -32,6 +32,7 @@ import (
 	nodeclaimlink "github.com/aws/karpenter/pkg/controllers/nodeclaim/link"
 	"github.com/aws/karpenter/pkg/controllers/nodeclass"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
+	"github.com/aws/karpenter/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter/pkg/providers/pricing"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
@@ -42,13 +43,14 @@ import (
 
 func NewControllers(ctx context.Context, sess *session.Session, clk clock.Clock, kubeClient client.Client, recorder events.Recorder,
 	unavailableOfferings *cache.UnavailableOfferings, cloudProvider *cloudprovider.CloudProvider, subnetProvider *subnet.Provider,
-	securityGroupProvider *securitygroup.Provider, pricingProvider *pricing.Provider, amiProvider *amifamily.Provider) []controller.Controller {
+	securityGroupProvider *securitygroup.Provider, instanceProfileProvider *instanceprofile.Provider, pricingProvider *pricing.Provider,
+	amiProvider *amifamily.Provider) []controller.Controller {
 
 	logging.FromContext(ctx).With("version", project.Version).Debugf("discovered version")
 
 	linkController := nodeclaimlink.NewController(kubeClient, cloudProvider)
 	controllers := []controller.Controller{
-		nodeclass.NewNodeTemplateController(kubeClient, subnetProvider, securityGroupProvider, amiProvider),
+		nodeclass.NewNodeTemplateController(kubeClient, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider),
 		linkController,
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider, linkController),
 	}

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -50,7 +50,7 @@ func NewControllers(ctx context.Context, sess *session.Session, clk clock.Clock,
 
 	linkController := nodeclaimlink.NewController(kubeClient, cloudProvider)
 	controllers := []controller.Controller{
-		nodeclass.NewNodeTemplateController(kubeClient, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider),
+		nodeclass.NewNodeTemplateController(kubeClient, recorder, subnetProvider, securityGroupProvider, amiProvider, instanceProfileProvider),
 		linkController,
 		nodeclaimgarbagecollection.NewController(kubeClient, cloudProvider, linkController),
 	}

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) Finalize(ctx context.Context, nodeClass *v1beta1.EC2NodeCla
 	}
 	if len(ids) > 0 {
 		c.recorder.Publish(WaitingOnInstanceTerminationEvent(nodeClass, instanceprofile.GetProfileName(ctx, nodeClass), ids))
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: time.Second * 10}, nil
 	}
 	if err = c.instanceProfileProvider.Delete(ctx, nodeClass); err != nil {
 		return reconcile.Result{}, fmt.Errorf("terminating instance profile, %w", err)

--- a/pkg/controllers/nodeclass/events.go
+++ b/pkg/controllers/nodeclass/events.go
@@ -24,12 +24,12 @@ import (
 	"github.com/aws/karpenter/pkg/utils"
 )
 
-func WaitingOnInstanceTerminationEvent(nodeClass *v1beta1.EC2NodeClass, profileName string, ids []string) events.Event {
+func WaitingOnNodeClaimTerminationEvent(nodeClass *v1beta1.EC2NodeClass, names []string) events.Event {
 	return events.Event{
 		InvolvedObject: nodeClass,
 		Type:           v1.EventTypeNormal,
-		Reason:         "WaitingOnInstanceTermination",
-		Message:        fmt.Sprintf("Waiting on instance termination for instances %s using profile %q", utils.PrettySlice(ids, 5), profileName),
+		Reason:         "WaitingOnNodeClaimTermination",
+		Message:        fmt.Sprintf("Waiting on NodeClaim termination for %s", utils.PrettySlice(names, 5)),
 		DedupeValues:   []string{string(nodeClass.UID)},
 	}
 }

--- a/pkg/controllers/nodeclass/events.go
+++ b/pkg/controllers/nodeclass/events.go
@@ -1,0 +1,35 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeclass
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter-core/pkg/events"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
+	"github.com/aws/karpenter/pkg/utils"
+)
+
+func WaitingOnInstanceTerminationEvent(nodeClass *v1beta1.EC2NodeClass, profileName string, ids []string) events.Event {
+	return events.Event{
+		InvolvedObject: nodeClass,
+		Type:           v1.EventTypeNormal,
+		Reason:         "WaitingOnInstanceTermination",
+		Message:        fmt.Sprintf("Waiting on instance termination for instances %s using profile %q", utils.PrettySlice(ids, 5), profileName),
+		DedupeValues:   []string{string(nodeClass.UID)},
+	}
+}

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -55,8 +55,8 @@ var _ = BeforeSuite(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	awsEnv = test.NewEnvironment(ctx, env)
 
-	nodeTemplateController = nodeclass.NewNodeTemplateController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider)
-	nodeClassController = nodeclass.NewNodeClassController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider)
+	nodeTemplateController = nodeclass.NewNodeTemplateController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider)
+	nodeClassController = nodeclass.NewNodeClassController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -52,7 +52,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...))
+	env = coretest.NewEnvironment(scheme.Scheme, coretest.WithCRDs(apis.CRDs...), coretest.WithFieldIndexers(test.EC2NodeClassFieldIndexer(ctx)))
 	ctx = coresettings.ToContext(ctx, coretest.Settings())
 	ctx = settings.ToContext(ctx, test.Settings())
 	awsEnv = test.NewEnvironment(ctx, env)

--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -20,10 +20,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
 	. "knative.dev/pkg/logging/testing"
 	_ "knative.dev/pkg/system/testing"
 
 	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/events"
 	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter-core/pkg/operator/options"
@@ -55,8 +57,8 @@ var _ = BeforeSuite(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	awsEnv = test.NewEnvironment(ctx, env)
 
-	nodeTemplateController = nodeclass.NewNodeTemplateController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider)
-	nodeClassController = nodeclass.NewNodeClassController(env.Client, awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider)
+	nodeTemplateController = nodeclass.NewNodeTemplateController(env.Client, events.NewRecorder(&record.FakeRecorder{}), awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider)
+	nodeClassController = nodeclass.NewNodeClassController(env.Client, events.NewRecorder(&record.FakeRecorder{}), awsEnv.SubnetProvider, awsEnv.SecurityGroupProvider, awsEnv.AMIProvider, awsEnv.InstanceProfileProvider)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/fake/cloudprovider.go
+++ b/pkg/fake/cloudprovider.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	DefaultRegion = "us-west-2"
+	DefaultRegion  = "us-west-2"
+	DefaultAccount = "123456789"
 )
 
 var _ corecloudprovider.CloudProvider = (*CloudProvider)(nil)

--- a/pkg/fake/ec2api.go
+++ b/pkg/fake/ec2api.go
@@ -72,6 +72,10 @@ type EC2API struct {
 	EC2Behavior
 }
 
+func NewEC2API() *EC2API {
+	return &EC2API{}
+}
+
 // DefaultSupportedUsageClasses is a var because []*string can't be a const
 var DefaultSupportedUsageClasses = aws.StringSlice([]string{"on-demand", "spot"})
 

--- a/pkg/fake/eksapi.go
+++ b/pkg/fake/eksapi.go
@@ -15,6 +15,9 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 )
@@ -24,7 +27,7 @@ const ()
 // EKSAPIBehavior must be reset between tests otherwise tests will
 // pollute each other.
 type EKSAPIBehavior struct {
-	DescribeClusterBehaviour MockedFunction[eks.DescribeClusterInput, eks.DescribeClusterOutput]
+	DescribeClusterBehavior MockedFunction[eks.DescribeClusterInput, eks.DescribeClusterOutput]
 }
 
 type EKSAPI struct {
@@ -35,11 +38,11 @@ type EKSAPI struct {
 // Reset must be called between tests otherwise tests will pollute
 // each other.
 func (s *EKSAPI) Reset() {
-	s.DescribeClusterBehaviour.Reset()
+	s.DescribeClusterBehavior.Reset()
 }
 
-func (s *EKSAPI) DescribeCluster(input *eks.DescribeClusterInput) (*eks.DescribeClusterOutput, error) {
-	return s.DescribeClusterBehaviour.Invoke(input, func(*eks.DescribeClusterInput) (*eks.DescribeClusterOutput, error) {
+func (s *EKSAPI) DescribeClusterWithContext(_ context.Context, input *eks.DescribeClusterInput, _ ...request.Option) (*eks.DescribeClusterOutput, error) {
+	return s.DescribeClusterBehavior.Invoke(input, func(*eks.DescribeClusterInput) (*eks.DescribeClusterOutput, error) {
 		return nil, nil
 	})
 }

--- a/pkg/fake/iamapi.go
+++ b/pkg/fake/iamapi.go
@@ -1,0 +1,146 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+)
+
+const ()
+
+// IAMAPIBehavior must be reset between tests otherwise tests will
+// pollute each other.
+type IAMAPIBehavior struct {
+	GetInstanceProfileBehavior            MockedFunction[iam.GetInstanceProfileInput, iam.GetInstanceProfileOutput]
+	CreateInstanceProfileBehavior         MockedFunction[iam.CreateInstanceProfileInput, iam.CreateInstanceProfileOutput]
+	DeleteInstanceProfileBehavior         MockedFunction[iam.DeleteInstanceProfileInput, iam.DeleteInstanceProfileOutput]
+	AddRoleToInstanceProfileBehavior      MockedFunction[iam.AddRoleToInstanceProfileInput, iam.AddRoleToInstanceProfileOutput]
+	RemoveRoleFromInstanceProfileBehavior MockedFunction[iam.RemoveRoleFromInstanceProfileInput, iam.RemoveRoleFromInstanceProfileOutput]
+}
+
+type IAMAPI struct {
+	sync.Mutex
+
+	iamiface.IAMAPI
+	IAMAPIBehavior
+
+	InstanceProfiles map[string]*iam.InstanceProfile
+}
+
+func NewIAMAPI() *IAMAPI {
+	return &IAMAPI{InstanceProfiles: map[string]*iam.InstanceProfile{}}
+}
+
+// Reset must be called between tests otherwise tests will pollute
+// each other.
+func (s *IAMAPI) Reset() {
+	s.GetInstanceProfileBehavior.Reset()
+	s.InstanceProfiles = map[string]*iam.InstanceProfile{}
+}
+
+func (s *IAMAPI) GetInstanceProfileWithContext(_ context.Context, input *iam.GetInstanceProfileInput, _ ...request.Option) (*iam.GetInstanceProfileOutput, error) {
+	return s.GetInstanceProfileBehavior.Invoke(input, func(*iam.GetInstanceProfileInput) (*iam.GetInstanceProfileOutput, error) {
+		s.Lock()
+		defer s.Unlock()
+
+		if i, ok := s.InstanceProfiles[aws.StringValue(input.InstanceProfileName)]; ok {
+			return &iam.GetInstanceProfileOutput{InstanceProfile: i}, nil
+		}
+		return nil, awserr.New(iam.ErrCodeNoSuchEntityException, fmt.Sprintf("Instance Profile %s cannot be found", aws.StringValue(input.InstanceProfileName)), nil)
+	})
+}
+
+func (s *IAMAPI) CreateInstanceProfileWithContext(_ context.Context, input *iam.CreateInstanceProfileInput, _ ...request.Option) (*iam.CreateInstanceProfileOutput, error) {
+	return s.CreateInstanceProfileBehavior.Invoke(input, func(output *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
+		s.Lock()
+		defer s.Unlock()
+
+		if _, ok := s.InstanceProfiles[aws.StringValue(input.InstanceProfileName)]; ok {
+			return nil, awserr.New(iam.ErrCodeEntityAlreadyExistsException, fmt.Sprintf("Instance Profile %s already exists", aws.StringValue(input.InstanceProfileName)), nil)
+		}
+		instanceProfile := &iam.InstanceProfile{
+			CreateDate:          aws.Time(time.Now()),
+			InstanceProfileId:   aws.String(InstanceProfileID()),
+			InstanceProfileName: input.InstanceProfileName,
+			Path:                input.Path,
+			Tags:                input.Tags,
+		}
+		s.InstanceProfiles[aws.StringValue(input.InstanceProfileName)] = instanceProfile
+		return &iam.CreateInstanceProfileOutput{InstanceProfile: instanceProfile}, nil
+	})
+}
+
+func (s *IAMAPI) DeleteInstanceProfileWithContext(_ context.Context, input *iam.DeleteInstanceProfileInput, _ ...request.Option) (*iam.DeleteInstanceProfileOutput, error) {
+	return s.DeleteInstanceProfileBehavior.Invoke(input, func(output *iam.DeleteInstanceProfileInput) (*iam.DeleteInstanceProfileOutput, error) {
+		s.Lock()
+		defer s.Unlock()
+
+		if i, ok := s.InstanceProfiles[aws.StringValue(input.InstanceProfileName)]; ok {
+			if len(i.Roles) > 0 {
+				return nil, awserr.New(iam.ErrCodeDeleteConflictException, "Cannot delete entity, must remove roles from instance profile first.", nil)
+			}
+			delete(s.InstanceProfiles, aws.StringValue(input.InstanceProfileName))
+			return &iam.DeleteInstanceProfileOutput{}, nil
+		}
+		return nil, awserr.New(iam.ErrCodeNoSuchEntityException, fmt.Sprintf("Instance Profile %s cannot be found", aws.StringValue(input.InstanceProfileName)), nil)
+	})
+}
+
+func (s *IAMAPI) AddRoleToInstanceProfileWithContext(_ context.Context, input *iam.AddRoleToInstanceProfileInput, _ ...request.Option) (*iam.AddRoleToInstanceProfileOutput, error) {
+	return s.AddRoleToInstanceProfileBehavior.Invoke(input, func(output *iam.AddRoleToInstanceProfileInput) (*iam.AddRoleToInstanceProfileOutput, error) {
+		s.Lock()
+		defer s.Unlock()
+
+		if i, ok := s.InstanceProfiles[aws.StringValue(input.InstanceProfileName)]; ok {
+			if len(i.Roles) > 0 {
+				return nil, awserr.New(iam.ErrCodeLimitExceededException, "Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1", nil)
+			}
+			i.Roles = append(i.Roles, &iam.Role{RoleId: aws.String(RoleID()), RoleName: input.RoleName})
+			return nil, nil
+		}
+		return nil, awserr.New(iam.ErrCodeNoSuchEntityException, fmt.Sprintf("Instance Profile %s cannot be found", aws.StringValue(input.InstanceProfileName)), nil)
+	})
+}
+
+func (s *IAMAPI) RemoveRoleFromInstanceProfileWithContext(_ context.Context, input *iam.RemoveRoleFromInstanceProfileInput, _ ...request.Option) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	return s.RemoveRoleFromInstanceProfileBehavior.Invoke(input, func(output *iam.RemoveRoleFromInstanceProfileInput) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+		s.Lock()
+		defer s.Unlock()
+
+		if i, ok := s.InstanceProfiles[aws.StringValue(input.InstanceProfileName)]; ok {
+			var newRoles []*iam.Role
+			for _, role := range i.Roles {
+				if aws.StringValue(role.RoleName) != aws.StringValue(input.RoleName) {
+					newRoles = append(newRoles, role)
+				}
+			}
+			if len(i.Roles) == len(newRoles) {
+				return nil, awserr.New(iam.ErrCodeNoSuchEntityException, fmt.Sprintf("The role with name %s cannot be found", aws.StringValue(input.RoleName)), nil)
+			}
+			i.Roles = newRoles
+			return nil, nil
+		}
+		return nil, awserr.New(iam.ErrCodeNoSuchEntityException, fmt.Sprintf("Instance Profile %s cannot be found", aws.StringValue(input.InstanceProfileName)), nil)
+	})
+}

--- a/pkg/fake/iamapi.go
+++ b/pkg/fake/iamapi.go
@@ -56,6 +56,10 @@ func NewIAMAPI() *IAMAPI {
 // each other.
 func (s *IAMAPI) Reset() {
 	s.GetInstanceProfileBehavior.Reset()
+	s.CreateInstanceProfileBehavior.Reset()
+	s.DeleteInstanceProfileBehavior.Reset()
+	s.AddRoleToInstanceProfileBehavior.Reset()
+	s.RemoveRoleFromInstanceProfileBehavior.Reset()
 	s.InstanceProfiles = map[string]*iam.InstanceProfile{}
 }
 

--- a/pkg/fake/ssmapi.go
+++ b/pkg/fake/ssmapi.go
@@ -34,6 +34,10 @@ type SSMAPI struct {
 	WantErr            error
 }
 
+func NewSSMAPI() *SSMAPI {
+	return &SSMAPI{}
+}
+
 func (a SSMAPI) GetParameterWithContext(_ context.Context, input *ssm.GetParameterInput, _ ...request.Option) (*ssm.GetParameterOutput, error) {
 	if a.WantErr != nil {
 		return nil, a.WantErr

--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -47,6 +47,14 @@ func SubnetID() string {
 	return fmt.Sprintf("subnet-%s", randomdata.Alphanumeric(17))
 }
 
+func InstanceProfileID() string {
+	return fmt.Sprintf("instanceprofile-%s", randomdata.Alphanumeric(17))
+}
+
+func RoleID() string {
+	return fmt.Sprintf("role-%s", randomdata.Alphanumeric(17))
+}
+
 func PrivateDNSName() string {
 	return fmt.Sprintf("ip-192-168-%d-%d.%s.compute.internal", randomdata.Number(0, 256), randomdata.Number(0, 256), DefaultRegion)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -34,6 +34,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/patrickmn/go-cache"
 
@@ -50,6 +51,7 @@ import (
 	awscache "github.com/aws/karpenter/pkg/cache"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
 	"github.com/aws/karpenter/pkg/providers/instance"
+	"github.com/aws/karpenter/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter/pkg/providers/instancetype"
 	"github.com/aws/karpenter/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter/pkg/providers/pricing"
@@ -68,6 +70,7 @@ type Operator struct {
 	EC2API                    ec2iface.EC2API
 	SubnetProvider            *subnet.Provider
 	SecurityGroupProvider     *securitygroup.Provider
+	InstanceProfileProvider   *instanceprofile.Provider
 	AMIProvider               *amifamily.Provider
 	AMIResolver               *amifamily.Resolver
 	LaunchTemplateProvider    *launchtemplate.Provider
@@ -123,6 +126,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	unavailableOfferingsCache := awscache.NewUnavailableOfferings()
 	subnetProvider := subnet.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	securityGroupProvider := securitygroup.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	instanceProfileProvider := instanceprofile.NewProvider(*sess.Config.Region, iam.New(sess), ec2api, cache.New(awscache.InstanceProfileTTL, awscache.DefaultCleanupInterval))
 	pricingProvider := pricing.NewProvider(
 		ctx,
 		pricing.NewAPI(sess, *sess.Config.Region),
@@ -139,6 +143,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		amiResolver,
 		securityGroupProvider,
 		subnetProvider,
+		instanceProfileProvider,
 		lo.Must(getCABundle(ctx, operator.GetConfig())),
 		operator.Elected(),
 		kubeDNSIP,
@@ -169,6 +174,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		EC2API:                    ec2api,
 		SubnetProvider:            subnetProvider,
 		SecurityGroupProvider:     securityGroupProvider,
+		InstanceProfileProvider:   instanceProfileProvider,
 		AMIProvider:               amiProvider,
 		AMIResolver:               amiResolver,
 		VersionProvider:           versionProvider,
@@ -202,7 +208,7 @@ func ResolveClusterEndpoint(ctx context.Context, eksAPI eksiface.EKSAPI) (string
 	if clusterEndpointFromSettings != "" {
 		return clusterEndpointFromSettings, nil // cluster endpoint is explicitly set
 	}
-	out, err := eksAPI.DescribeCluster(&eks.DescribeClusterInput{
+	out, err := eksAPI.DescribeClusterWithContext(ctx, &eks.DescribeClusterInput{
 		Name: aws.String(settings.FromContext(ctx).ClusterName),
 	})
 	if err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -126,7 +126,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	unavailableOfferingsCache := awscache.NewUnavailableOfferings()
 	subnetProvider := subnet.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	securityGroupProvider := securitygroup.NewProvider(ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
-	instanceProfileProvider := instanceprofile.NewProvider(*sess.Config.Region, iam.New(sess), ec2api, cache.New(awscache.InstanceProfileTTL, awscache.DefaultCleanupInterval))
+	instanceProfileProvider := instanceprofile.NewProvider(*sess.Config.Region, iam.New(sess), cache.New(awscache.InstanceProfileTTL, awscache.DefaultCleanupInterval))
 	pricingProvider := pricing.NewProvider(
 		ctx,
 		pricing.NewAPI(sess, *sess.Config.Region),

--- a/pkg/operator/suite_test.go
+++ b/pkg/operator/suite_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Operator", func() {
 		ctx = settings.ToContext(ctx, test.Settings(test.SettingOptions{
 			ClusterEndpoint: lo.ToPtr(""),
 		}))
-		fakeEKSAPI.DescribeClusterBehaviour.Output.Set(
+		fakeEKSAPI.DescribeClusterBehavior.Output.Set(
 			&eks.DescribeClusterOutput{
 				Cluster: &eks.Cluster{
 					Endpoint: lo.ToPtr("https://cluster-endpoint.test-cluster.k8s.local"),
@@ -99,7 +99,7 @@ var _ = Describe("Operator", func() {
 		ctx = settings.ToContext(ctx, test.Settings(test.SettingOptions{
 			ClusterEndpoint: lo.ToPtr(""),
 		}))
-		fakeEKSAPI.DescribeClusterBehaviour.Error.Set(errors.New("test error"))
+		fakeEKSAPI.DescribeClusterBehavior.Error.Set(errors.New("test error"))
 
 		_, err := awscontext.ResolveClusterEndpoint(ctx, fakeEKSAPI)
 		Expect(err).To(HaveOccurred())

--- a/pkg/providers/instanceprofile/instanceprofile.go
+++ b/pkg/providers/instanceprofile/instanceprofile.go
@@ -106,14 +106,12 @@ func (p *Provider) Delete(ctx context.Context, nodeClass *v1beta1.EC2NodeClass) 
 	if err != nil {
 		return awserrors.IgnoreNotFound(fmt.Errorf("getting instance profile %q, %w", profileName, err))
 	}
-	if len(out.InstanceProfile.Roles) > 0 {
-		for _, role := range out.InstanceProfile.Roles {
-			if _, err = p.iamapi.RemoveRoleFromInstanceProfileWithContext(ctx, &iam.RemoveRoleFromInstanceProfileInput{
-				InstanceProfileName: aws.String(profileName),
-				RoleName:            role.RoleName,
-			}); err != nil {
-				return fmt.Errorf("removing role %q from instance profile %q, %w", aws.StringValue(role.RoleName), profileName, err)
-			}
+	for _, role := range out.InstanceProfile.Roles {
+		if _, err = p.iamapi.RemoveRoleFromInstanceProfileWithContext(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+			RoleName:            role.RoleName,
+		}); err != nil {
+			return fmt.Errorf("removing role %q from instance profile %q, %w", aws.StringValue(role.RoleName), profileName, err)
 		}
 	}
 	if _, err = p.iamapi.DeleteInstanceProfileWithContext(ctx, &iam.DeleteInstanceProfileInput{

--- a/pkg/providers/instanceprofile/instanceprofile.go
+++ b/pkg/providers/instanceprofile/instanceprofile.go
@@ -1,0 +1,154 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instanceprofile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/patrickmn/go-cache"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter/pkg/apis/settings"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
+	awserrors "github.com/aws/karpenter/pkg/errors"
+)
+
+var (
+	instanceStateFilter = &ec2.Filter{
+		Name:   aws.String("instance-state-name"),
+		Values: aws.StringSlice([]string{ec2.InstanceStateNamePending, ec2.InstanceStateNameRunning, ec2.InstanceStateNameStopping, ec2.InstanceStateNameStopped, ec2.InstanceStateNameShuttingDown}),
+	}
+)
+
+type Provider struct {
+	region string
+	iamapi iamiface.IAMAPI
+	ec2api ec2iface.EC2API
+	cache  *cache.Cache
+}
+
+func NewProvider(region string, iamapi iamiface.IAMAPI, ec2api ec2iface.EC2API, cache *cache.Cache) *Provider {
+	return &Provider{
+		region: region,
+		iamapi: iamapi,
+		ec2api: ec2api,
+		cache:  cache,
+	}
+}
+
+func (p *Provider) Create(ctx context.Context, nodeClass *v1beta1.EC2NodeClass, tags map[string]string) (string, error) {
+	localTags := lo.Assign(tags, map[string]string{v1beta1.LabelNodeClass: nodeClass.Name, v1.LabelTopologyRegion: p.region})
+	profileName := GetProfileName(ctx, p.region, nodeClass)
+	delete(localTags, corev1beta1.NodePoolLabelKey)
+
+	// An instance profile exists for this NodeClass
+	if _, ok := p.cache.Get(string(nodeClass.UID)); ok {
+		return profileName, nil
+	}
+	// Validate if the instance profile exists and has the correct role assigned to it
+	var instanceProfile *iam.InstanceProfile
+	out, err := p.iamapi.GetInstanceProfileWithContext(ctx, &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)})
+	if err != nil {
+		if !awserrors.IsNotFound(err) {
+			return "", fmt.Errorf("getting instance profile %q, %w", profileName, err)
+		}
+		o, err := p.iamapi.CreateInstanceProfileWithContext(ctx, &iam.CreateInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+			Tags:                lo.MapToSlice(tags, func(k, v string) *iam.Tag { return &iam.Tag{Key: aws.String(k), Value: aws.String(v)} }),
+		})
+		if err != nil {
+			return "", fmt.Errorf("creating instance profile %q, %w", profileName, err)
+		}
+		instanceProfile = o.InstanceProfile
+	} else {
+		instanceProfile = out.InstanceProfile
+	}
+	if len(instanceProfile.Roles) == 1 {
+		return profileName, nil
+	}
+	if _, err = p.iamapi.AddRoleToInstanceProfileWithContext(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+		RoleName:            aws.String(nodeClass.Spec.Role),
+	}); err != nil {
+		return "", fmt.Errorf("adding role %q to instance profile %q, %w", nodeClass.Spec.Role, profileName, err)
+	}
+	p.cache.SetDefault(string(nodeClass.UID), nil)
+	return profileName, nil
+}
+
+func (p *Provider) AssociatedInstances(ctx context.Context, nodeClass *v1beta1.EC2NodeClass) ([]string, error) {
+	profileName := GetProfileName(ctx, p.region, nodeClass)
+
+	// Get all instances that are using our instance profile name and are not yet terminated
+	var ids []string
+	if err := p.ec2api.DescribeInstancesPagesWithContext(ctx, &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("iam-instance-profile.name"),
+				Values: aws.StringSlice([]string{profileName}),
+			},
+			instanceStateFilter,
+		},
+	}, func(page *ec2.DescribeInstancesOutput, _ bool) bool {
+		for _, res := range page.Reservations {
+			ids = append(ids, lo.Map(res.Instances, func(i *ec2.Instance, _ int) string {
+				return aws.StringValue(i.InstanceId)
+			})...)
+		}
+		return true
+	}); err != nil {
+		return nil, fmt.Errorf("getting associated instances for instance profile %q, %w", profileName, err)
+	}
+	return ids, nil
+}
+
+func (p *Provider) Delete(ctx context.Context, nodeClass *v1beta1.EC2NodeClass) error {
+	profileName := GetProfileName(ctx, p.region, nodeClass)
+	out, err := p.iamapi.GetInstanceProfileWithContext(ctx, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	})
+	if err != nil {
+		return awserrors.IgnoreNotFound(fmt.Errorf("getting instance profile %q, %w", profileName, err))
+	}
+	if len(out.InstanceProfile.Roles) > 0 {
+		for _, role := range out.InstanceProfile.Roles {
+			if _, err = p.iamapi.RemoveRoleFromInstanceProfileWithContext(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+				InstanceProfileName: aws.String(profileName),
+				RoleName:            role.RoleName,
+			}); err != nil {
+				return fmt.Errorf("removing role %q from instance profile %q, %w", aws.StringValue(role.RoleName), profileName, err)
+			}
+		}
+	}
+	if _, err = p.iamapi.DeleteInstanceProfileWithContext(ctx, &iam.DeleteInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	}); err != nil {
+		return awserrors.IgnoreNotFound(fmt.Errorf("deleting instance profile %q, %w", profileName, err))
+	}
+	return nil
+}
+
+func GetProfileName(ctx context.Context, region string, nodeClass *v1beta1.EC2NodeClass) string {
+	return fmt.Sprintf("%s/%d", settings.FromContext(ctx).ClusterName, lo.Must(hashstructure.Hash(fmt.Sprintf("%s/%s", nodeClass.Name, region), hashstructure.FormatV2, &hashstructure.HashOptions{})))
+}

--- a/pkg/providers/instancetype/nodeclass_test.go
+++ b/pkg/providers/instancetype/nodeclass_test.go
@@ -99,7 +99,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		nodeSelector := map[string]string{
 			// Well known
 			corev1beta1.NodePoolLabelKey:     nodePool.Name,
-			v1.LabelTopologyRegion:           "",
+			v1.LabelTopologyRegion:           fake.DefaultRegion,
 			v1.LabelTopologyZone:             "test-zone-1a",
 			v1.LabelInstanceTypeStable:       "g4dn.8xlarge",
 			v1.LabelOSStable:                 "linux",
@@ -125,7 +125,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 			v1beta1.LabelInstanceAcceleratorManufacturer:      "aws",
 			v1beta1.LabelInstanceAcceleratorCount:             "1",
 			// Deprecated Labels
-			v1.LabelFailureDomainBetaRegion: "",
+			v1.LabelFailureDomainBetaRegion: fake.DefaultRegion,
 			v1.LabelFailureDomainBetaZone:   "test-zone-1a",
 			"beta.kubernetes.io/arch":       "amd64",
 			"beta.kubernetes.io/os":         "linux",
@@ -152,7 +152,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		nodeSelector := map[string]string{
 			// Well known
 			corev1beta1.NodePoolLabelKey:     nodePool.Name,
-			v1.LabelTopologyRegion:           "",
+			v1.LabelTopologyRegion:           fake.DefaultRegion,
 			v1.LabelTopologyZone:             "test-zone-1a",
 			v1.LabelInstanceTypeStable:       "g4dn.8xlarge",
 			v1.LabelOSStable:                 "linux",
@@ -175,7 +175,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 			v1beta1.LabelInstanceGPUMemory:                    "16384",
 			v1beta1.LabelInstanceLocalNVME:                    "900",
 			// Deprecated Labels
-			v1.LabelFailureDomainBetaRegion: "",
+			v1.LabelFailureDomainBetaRegion: fake.DefaultRegion,
 			v1.LabelFailureDomainBetaZone:   "test-zone-1a",
 			"beta.kubernetes.io/arch":       "amd64",
 			"beta.kubernetes.io/os":         "linux",
@@ -203,7 +203,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		nodeSelector := map[string]string{
 			// Well known
 			corev1beta1.NodePoolLabelKey:     nodePool.Name,
-			v1.LabelTopologyRegion:           "",
+			v1.LabelTopologyRegion:           fake.DefaultRegion,
 			v1.LabelTopologyZone:             "test-zone-1a",
 			v1.LabelInstanceTypeStable:       "inf1.2xlarge",
 			v1.LabelOSStable:                 "linux",
@@ -224,7 +224,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 			v1beta1.LabelInstanceAcceleratorManufacturer:      "aws",
 			v1beta1.LabelInstanceAcceleratorCount:             "1",
 			// Deprecated Labels
-			v1.LabelFailureDomainBetaRegion: "",
+			v1.LabelFailureDomainBetaRegion: fake.DefaultRegion,
 			v1.LabelFailureDomainBetaZone:   "test-zone-1a",
 			"beta.kubernetes.io/arch":       "amd64",
 			"beta.kubernetes.io/os":         "linux",
@@ -588,7 +588,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		instanceInfo, err := awsEnv.InstanceTypesProvider.GetInstanceTypes(ctx)
 		Expect(err).To(BeNil())
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 			Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 		}
 	})
@@ -596,7 +596,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		instanceInfo, err := awsEnv.InstanceTypesProvider.GetInstanceTypes(ctx)
 		Expect(err).To(BeNil())
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 			Expect(it.Capacity.Pods().Value()).ToNot(BeNumerically("==", 110))
 		}
 	})
@@ -608,7 +608,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 			EnableENILimitedPodDensity: lo.ToPtr(true),
 		}))
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", windowsNodeClass, nil)
+			it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, windowsNodeClass, nil)
 			Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 		}
 	})
@@ -667,7 +667,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		})
 		Context("System Reserved Resources", func() {
 			It("should use defaults when no kubelet is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &corev1beta1.KubeletConfiguration{}, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, &corev1beta1.KubeletConfiguration{}, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.SystemReserved.Cpu().String()).To(Equal("0"))
 				Expect(it.Overhead.SystemReserved.Memory().String()).To(Equal("0"))
 				Expect(it.Overhead.SystemReserved.StorageEphemeral().String()).To(Equal("0"))
@@ -680,7 +680,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 						v1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
 					},
 				}
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.SystemReserved.Cpu().String()).To(Equal("2"))
 				Expect(it.Overhead.SystemReserved.Memory().String()).To(Equal("20Gi"))
 				Expect(it.Overhead.SystemReserved.StorageEphemeral().String()).To(Equal("10Gi"))
@@ -688,7 +688,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		})
 		Context("Kube Reserved Resources", func() {
 			It("should use defaults when no kubelet is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &corev1beta1.KubeletConfiguration{}, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, &corev1beta1.KubeletConfiguration{}, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.KubeReserved.Cpu().String()).To(Equal("80m"))
 				Expect(it.Overhead.KubeReserved.Memory().String()).To(Equal("893Mi"))
 				Expect(it.Overhead.KubeReserved.StorageEphemeral().String()).To(Equal("1Gi"))
@@ -705,7 +705,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 						v1.ResourceMemory:           resource.MustParse("10Gi"),
 						v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
-				}, "", nodeClass, nil)
+				}, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.KubeReserved.Cpu().String()).To(Equal("2"))
 				Expect(it.Overhead.KubeReserved.Memory().String()).To(Equal("10Gi"))
 				Expect(it.Overhead.KubeReserved.StorageEphemeral().String()).To(Equal("2Gi"))
@@ -730,7 +730,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "500Mi",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
 				})
 				It("should override eviction threshold when specified as a percentage value", func() {
@@ -745,7 +745,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "10%",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 				})
 				It("should consider the eviction threshold disabled when specified as 100%", func() {
@@ -760,7 +760,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "100%",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("0"))
 				})
 				It("should used default eviction threshold for memory when evictionHard not specified", func() {
@@ -775,7 +775,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "50Mi",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("50Mi"))
 				})
 			})
@@ -792,7 +792,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "500Mi",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
 				})
 				It("should override eviction threshold when specified as a percentage value", func() {
@@ -810,7 +810,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "10%",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 				})
 				It("should consider the eviction threshold disabled when specified as 100%", func() {
@@ -825,7 +825,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "100%",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("0"))
 				})
 				It("should ignore eviction threshold when using Bottlerocket AMI", func() {
@@ -844,12 +844,12 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 							instancetype.MemoryAvailable: "10Gi",
 						},
 					}
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("1Gi"))
 				})
 			})
 			It("should take the default eviction threshold when none is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &corev1beta1.KubeletConfiguration{}, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, &corev1beta1.KubeletConfiguration{}, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.EvictionThreshold.Cpu().String()).To(Equal("0"))
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				Expect(it.Overhead.EvictionThreshold.StorageEphemeral().AsApproximateFloat64()).To(BeNumerically("~", resources.Quantity("2Gi").AsApproximateFloat64()))
@@ -869,7 +869,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 						instancetype.MemoryAvailable: "1Gi",
 					},
 				}
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("3Gi"))
 			})
 			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
@@ -887,7 +887,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 						instancetype.MemoryAvailable: "5%",
 					},
 				}
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.05, 10))
 			})
 			It("should take the greater of evictionHard and evictionSoft for overhead with mixed percentage/value", func() {
@@ -905,7 +905,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 						instancetype.MemoryAvailable: "1Gi",
 					},
 				}
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 			})
 		})
@@ -914,11 +914,11 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 			Expect(err).To(BeNil())
 			for _, info := range instanceInfo {
 				if *info.InstanceType == "t3.large" {
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 35))
 				}
 				if *info.InstanceType == "m6idn.32xlarge" {
-					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+					it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 					Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 345))
 				}
 			}
@@ -930,7 +930,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				MaxPods: ptr.Int32(10),
 			}
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 10))
 			}
 		})
@@ -945,7 +945,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				MaxPods: ptr.Int32(10),
 			}
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 10))
 			}
 		})
@@ -960,7 +960,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				return *info.InstanceType == "t3.large"
 			})
 			Expect(ok).To(Equal(true))
-			it := instancetype.NewInstanceType(ctx, t3Large, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+			it := instancetype.NewInstanceType(ctx, t3Large, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 			// t3.large
 			// maxInterfaces = 3
 			// maxIPv4PerInterface = 12
@@ -980,7 +980,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				return *info.InstanceType == "t3.large"
 			})
 			Expect(ok).To(Equal(true))
-			it := instancetype.NewInstanceType(ctx, t3Large, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+			it := instancetype.NewInstanceType(ctx, t3Large, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 			// t3.large
 			// maxInterfaces = 3
 			// maxIPv4PerInterface = 12
@@ -997,7 +997,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				PodsPerCore: ptr.Int32(1),
 			}
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", ptr.Int64Value(info.VCpuInfo.DefaultVCpus)))
 			}
 		})
@@ -1009,7 +1009,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				MaxPods:     ptr.Int32(20),
 			}
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", lo.Min([]int64{20, ptr.Int64Value(info.VCpuInfo.DefaultVCpus) * 4})))
 			}
 		})
@@ -1021,7 +1021,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				PodsPerCore: ptr.Int32(1),
 			}
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				limitedPods := instancetype.ENILimitedPods(ctx, info)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", limitedPods.Value()))
 			}
@@ -1037,7 +1037,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 				PodsPerCore: ptr.Int32(0),
 			}
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, "", nodeClass, nil)
+				it := instancetype.NewInstanceType(ctx, info, nodePool.Spec.Template.Spec.Kubelet, fake.DefaultRegion, nodeClass, nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 			}
 		})

--- a/pkg/providers/instancetype/nodetemplate_test.go
+++ b/pkg/providers/instancetype/nodetemplate_test.go
@@ -106,7 +106,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		nodeSelector := map[string]string{
 			// Well known
 			v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-			v1.LabelTopologyRegion:           "",
+			v1.LabelTopologyRegion:           fake.DefaultRegion,
 			v1.LabelTopologyZone:             "test-zone-1a",
 			v1.LabelInstanceTypeStable:       "g4dn.8xlarge",
 			v1.LabelOSStable:                 "linux",
@@ -132,7 +132,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			v1alpha1.LabelInstanceAcceleratorManufacturer:      "aws",
 			v1alpha1.LabelInstanceAcceleratorCount:             "1",
 			// Deprecated Labels
-			v1.LabelFailureDomainBetaRegion: "",
+			v1.LabelFailureDomainBetaRegion: fake.DefaultRegion,
 			v1.LabelFailureDomainBetaZone:   "test-zone-1a",
 			"beta.kubernetes.io/arch":       "amd64",
 			"beta.kubernetes.io/os":         "linux",
@@ -159,7 +159,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		nodeSelector := map[string]string{
 			// Well known
 			v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-			v1.LabelTopologyRegion:           "",
+			v1.LabelTopologyRegion:           fake.DefaultRegion,
 			v1.LabelTopologyZone:             "test-zone-1a",
 			v1.LabelInstanceTypeStable:       "g4dn.8xlarge",
 			v1.LabelOSStable:                 "linux",
@@ -182,7 +182,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			v1alpha1.LabelInstanceGPUMemory:                    "16384",
 			v1alpha1.LabelInstanceLocalNVME:                    "900",
 			// Deprecated Labels
-			v1.LabelFailureDomainBetaRegion: "",
+			v1.LabelFailureDomainBetaRegion: fake.DefaultRegion,
 			v1.LabelFailureDomainBetaZone:   "test-zone-1a",
 			"beta.kubernetes.io/arch":       "amd64",
 			"beta.kubernetes.io/os":         "linux",
@@ -210,7 +210,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		nodeSelector := map[string]string{
 			// Well known
 			v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-			v1.LabelTopologyRegion:           "",
+			v1.LabelTopologyRegion:           fake.DefaultRegion,
 			v1.LabelTopologyZone:             "test-zone-1a",
 			v1.LabelInstanceTypeStable:       "inf1.2xlarge",
 			v1.LabelOSStable:                 "linux",
@@ -231,7 +231,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			v1alpha1.LabelInstanceAcceleratorManufacturer:      "aws",
 			v1alpha1.LabelInstanceAcceleratorCount:             "1",
 			// Deprecated Labels
-			v1.LabelFailureDomainBetaRegion: "",
+			v1.LabelFailureDomainBetaRegion: fake.DefaultRegion,
 			v1.LabelFailureDomainBetaZone:   "test-zone-1a",
 			"beta.kubernetes.io/arch":       "amd64",
 			"beta.kubernetes.io/os":         "linux",
@@ -595,7 +595,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		instanceInfo, err := awsEnv.InstanceTypesProvider.GetInstanceTypes(ctx)
 		Expect(err).To(BeNil())
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 			Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 		}
 	})
@@ -603,7 +603,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		instanceInfo, err := awsEnv.InstanceTypesProvider.GetInstanceTypes(ctx)
 		Expect(err).To(BeNil())
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 			Expect(it.Capacity.Pods().Value()).ToNot(BeNumerically("==", 110))
 		}
 	})
@@ -627,7 +627,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			EnableENILimitedPodDensity: lo.ToPtr(true),
 		}))
 		for _, info := range instanceInfo {
-			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(windowsNodeTemplate), nil)
+			it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(windowsNodeTemplate), nil)
 			Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 		}
 	})
@@ -686,7 +686,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		})
 		Context("System Reserved Resources", func() {
 			It("should use defaults when no kubelet is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.SystemReserved.Cpu().String()).To(Equal("0"))
 				Expect(it.Overhead.SystemReserved.Memory().String()).To(Equal("0"))
 				Expect(it.Overhead.SystemReserved.StorageEphemeral().String()).To(Equal("0"))
@@ -701,7 +701,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.SystemReserved.Cpu().String()).To(Equal("2"))
 				Expect(it.Overhead.SystemReserved.Memory().String()).To(Equal("20Gi"))
 				Expect(it.Overhead.SystemReserved.StorageEphemeral().String()).To(Equal("10Gi"))
@@ -709,7 +709,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		})
 		Context("Kube Reserved Resources", func() {
 			It("should use defaults when no kubelet is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.KubeReserved.Cpu().String()).To(Equal("80m"))
 				Expect(it.Overhead.KubeReserved.Memory().String()).To(Equal("893Mi"))
 				Expect(it.Overhead.KubeReserved.StorageEphemeral().String()).To(Equal("1Gi"))
@@ -726,7 +726,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 						v1.ResourceMemory:           resource.MustParse("10Gi"),
 						v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
-				}), "", nodeclassutil.New(nodeTemplate), nil)
+				}), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.KubeReserved.Cpu().String()).To(Equal("2"))
 				Expect(it.Overhead.KubeReserved.Memory().String()).To(Equal("10Gi"))
 				Expect(it.Overhead.KubeReserved.StorageEphemeral().String()).To(Equal("2Gi"))
@@ -753,7 +753,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
 				})
 				It("should override eviction threshold when specified as a percentage value", func() {
@@ -770,7 +770,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 				})
 				It("should consider the eviction threshold disabled when specified as 100%", func() {
@@ -787,7 +787,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("0"))
 				})
 				It("should used default eviction threshold for memory when evictionHard not specified", func() {
@@ -804,7 +804,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("50Mi"))
 				})
 			})
@@ -823,7 +823,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("500Mi"))
 				})
 				It("should override eviction threshold when specified as a percentage value", func() {
@@ -843,7 +843,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 				})
 				It("should consider the eviction threshold disabled when specified as 100%", func() {
@@ -860,7 +860,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("0"))
 				})
 				It("should ignore eviction threshold when using Bottlerocket AMI", func() {
@@ -881,12 +881,12 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 							},
 						},
 					})
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("1Gi"))
 				})
 			})
 			It("should take the default eviction threshold when none is specified", func() {
-				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, &v1beta1.KubeletConfiguration{}, fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Cpu().String()).To(Equal("0"))
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("100Mi"))
 				Expect(it.Overhead.EvictionThreshold.StorageEphemeral().AsApproximateFloat64()).To(BeNumerically("~", resources.Quantity("2Gi").AsApproximateFloat64()))
@@ -908,7 +908,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().String()).To(Equal("3Gi"))
 			})
 			It("should take the greater of evictionHard and evictionSoft for overhead as a value", func() {
@@ -928,7 +928,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.05, 10))
 			})
 			It("should take the greater of evictionHard and evictionSoft for overhead with mixed percentage/value", func() {
@@ -948,7 +948,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 						},
 					},
 				})
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Overhead.EvictionThreshold.Memory().Value()).To(BeNumerically("~", float64(it.Capacity.Memory().Value())*0.1, 10))
 			})
 		})
@@ -958,11 +958,11 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{})
 			for _, info := range instanceInfo {
 				if *info.InstanceType == "t3.large" {
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 35))
 				}
 				if *info.InstanceType == "m6idn.32xlarge" {
-					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+					it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 					Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 345))
 				}
 			}
@@ -972,7 +972,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{MaxPods: ptr.Int32(10)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 10))
 			}
 		})
@@ -985,7 +985,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{MaxPods: ptr.Int32(10)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 10))
 			}
 		})
@@ -1000,7 +1000,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 				return *info.InstanceType == "t3.large"
 			})
 			Expect(ok).To(Equal(true))
-			it := instancetype.NewInstanceType(ctx, t3Large, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+			it := instancetype.NewInstanceType(ctx, t3Large, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 			// t3.large
 			// maxInterfaces = 3
 			// maxIPv4PerInterface = 12
@@ -1020,7 +1020,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 				return *info.InstanceType == "t3.large"
 			})
 			Expect(ok).To(Equal(true))
-			it := instancetype.NewInstanceType(ctx, t3Large, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+			it := instancetype.NewInstanceType(ctx, t3Large, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 			// t3.large
 			// maxInterfaces = 3
 			// maxIPv4PerInterface = 12
@@ -1035,7 +1035,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(1)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", ptr.Int64Value(info.VCpuInfo.DefaultVCpus)))
 			}
 		})
@@ -1044,7 +1044,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(4), MaxPods: ptr.Int32(20)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", lo.Min([]int64{20, ptr.Int64Value(info.VCpuInfo.DefaultVCpus) * 4})))
 			}
 		})
@@ -1054,7 +1054,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyBottlerocket
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(1)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				limitedPods := instancetype.ENILimitedPods(ctx, info)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", limitedPods.Value()))
 			}
@@ -1068,7 +1068,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 			Expect(err).To(BeNil())
 			provisioner = test.Provisioner(coretest.ProvisionerOptions{Kubelet: &v1alpha5.KubeletConfiguration{PodsPerCore: ptr.Int32(0)}})
 			for _, info := range instanceInfo {
-				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), "", nodeclassutil.New(nodeTemplate), nil)
+				it := instancetype.NewInstanceType(ctx, info, nodepoolutil.NewKubeletConfiguration(provisioner.Spec.KubeletConfiguration), fake.DefaultRegion, nodeclassutil.New(nodeTemplate), nil)
 				Expect(it.Capacity.Pods().Value()).To(BeNumerically("==", 110))
 			}
 		})

--- a/pkg/providers/launchtemplate/nodeclass_test.go
+++ b/pkg/providers/launchtemplate/nodeclass_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 	"github.com/aws/karpenter/pkg/fake"
 	"github.com/aws/karpenter/pkg/providers/amifamily/bootstrap"
-	"github.com/aws/karpenter/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter/pkg/providers/instancetype"
 	"github.com/aws/karpenter/pkg/test"
 )
@@ -1660,7 +1659,8 @@ var _ = Describe("EC2NodeClass/LaunchTemplates", func() {
 	Context("Instance Profile Generation", func() {
 		var profileName string
 		BeforeEach(func() {
-			profileName = instanceprofile.GetProfileName(ctx, fake.DefaultRegion, nodeClass)
+			ExpectApplied(ctx, env.Client, nodeClass)
+			profileName = awsEnv.InstanceProfileProvider.GetProfileName(ctx, nodeClass)
 		})
 		It("should create the instance profile when it doesn't exist", func() {
 			nodeClass.Spec.Role = "test-role"

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -30,8 +30,6 @@ import (
 	clock "k8s.io/utils/clock/testing"
 	. "knative.dev/pkg/logging/testing"
 
-	. "github.com/aws/karpenter-core/pkg/test/expectations"
-
 	coresettings "github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
@@ -40,6 +38,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	coretest "github.com/aws/karpenter-core/pkg/test"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/cloudprovider"

--- a/pkg/providers/pricing/suite_test.go
+++ b/pkg/providers/pricing/suite_test.go
@@ -266,7 +266,7 @@ func getPricingEstimateMetricValue(instanceType string, capacityType string, zon
 	metric, ok := FindMetricWithLabelValues("karpenter_cloudprovider_instance_type_price_estimate", map[string]string{
 		pricing.InstanceTypeLabel: instanceType,
 		pricing.CapacityTypeLabel: capacityType,
-		pricing.RegionLabel:       "",
+		pricing.RegionLabel:       fake.DefaultRegion,
 		pricing.TopologyLabel:     zone,
 	})
 	Expect(ok).To(BeTrue())

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/karpenter/pkg/fake"
 	"github.com/aws/karpenter/pkg/providers/amifamily"
 	"github.com/aws/karpenter/pkg/providers/instance"
+	"github.com/aws/karpenter/pkg/providers/instanceprofile"
 	"github.com/aws/karpenter/pkg/providers/instancetype"
 	"github.com/aws/karpenter/pkg/providers/launchtemplate"
 	"github.com/aws/karpenter/pkg/providers/pricing"
@@ -42,6 +43,7 @@ type Environment struct {
 	// API
 	EC2API     *fake.EC2API
 	SSMAPI     *fake.SSMAPI
+	IAMAPI     *fake.IAMAPI
 	PricingAPI *fake.PricingAPI
 
 	// Cache
@@ -52,23 +54,26 @@ type Environment struct {
 	LaunchTemplateCache       *cache.Cache
 	SubnetCache               *cache.Cache
 	SecurityGroupCache        *cache.Cache
+	InstanceProfileCache      *cache.Cache
 
 	// Providers
-	InstanceTypesProvider  *instancetype.Provider
-	InstanceProvider       *instance.Provider
-	SubnetProvider         *subnet.Provider
-	SecurityGroupProvider  *securitygroup.Provider
-	PricingProvider        *pricing.Provider
-	AMIProvider            *amifamily.Provider
-	AMIResolver            *amifamily.Resolver
-	VersionProvider        *version.Provider
-	LaunchTemplateProvider *launchtemplate.Provider
+	InstanceTypesProvider   *instancetype.Provider
+	InstanceProvider        *instance.Provider
+	SubnetProvider          *subnet.Provider
+	SecurityGroupProvider   *securitygroup.Provider
+	InstanceProfileProvider *instanceprofile.Provider
+	PricingProvider         *pricing.Provider
+	AMIProvider             *amifamily.Provider
+	AMIResolver             *amifamily.Resolver
+	VersionProvider         *version.Provider
+	LaunchTemplateProvider  *launchtemplate.Provider
 }
 
 func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment {
 	// API
-	ec2api := &fake.EC2API{}
-	ssmapi := &fake.SSMAPI{}
+	ec2api := fake.NewEC2API()
+	ssmapi := fake.NewSSMAPI()
+	iamapi := fake.NewIAMAPI()
 
 	// cache
 	ec2Cache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
@@ -78,16 +83,18 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	launchTemplateCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	subnetCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	securityGroupCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
+	instanceProfileCache := cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval)
 	fakePricingAPI := &fake.PricingAPI{}
 
 	// Providers
-	pricingProvider := pricing.NewProvider(ctx, fakePricingAPI, ec2api, "")
+	pricingProvider := pricing.NewProvider(ctx, fakePricingAPI, ec2api, fake.DefaultRegion)
 	subnetProvider := subnet.NewProvider(ec2api, subnetCache)
 	securityGroupProvider := securitygroup.NewProvider(ec2api, securityGroupCache)
 	versionProvider := version.NewProvider(env.KubernetesInterface, kubernetesVersionCache)
+	instanceProfileProvider := instanceprofile.NewProvider(fake.DefaultRegion, iamapi, ec2api, instanceProfileCache)
 	amiProvider := amifamily.NewProvider(versionProvider, ssmapi, ec2api, ec2Cache)
 	amiResolver := amifamily.New(amiProvider)
-	instanceTypesProvider := instancetype.NewProvider("", instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)
+	instanceTypesProvider := instancetype.NewProvider(fake.DefaultRegion, instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)
 	launchTemplateProvider :=
 		launchtemplate.NewProvider(
 			ctx,
@@ -96,6 +103,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 			amiResolver,
 			securityGroupProvider,
 			subnetProvider,
+			instanceProfileProvider,
 			ptr.String("ca-bundle"),
 			make(chan struct{}),
 			net.ParseIP("10.0.100.10"),
@@ -114,6 +122,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	return &Environment{
 		EC2API:     ec2api,
 		SSMAPI:     ssmapi,
+		IAMAPI:     iamapi,
 		PricingAPI: fakePricingAPI,
 
 		EC2Cache:                  ec2Cache,
@@ -122,23 +131,26 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		LaunchTemplateCache:       launchTemplateCache,
 		SubnetCache:               subnetCache,
 		SecurityGroupCache:        securityGroupCache,
+		InstanceProfileCache:      instanceProfileCache,
 		UnavailableOfferingsCache: unavailableOfferingsCache,
 
-		InstanceTypesProvider:  instanceTypesProvider,
-		InstanceProvider:       instanceProvider,
-		SubnetProvider:         subnetProvider,
-		SecurityGroupProvider:  securityGroupProvider,
-		PricingProvider:        pricingProvider,
-		AMIProvider:            amiProvider,
-		AMIResolver:            amiResolver,
-		VersionProvider:        versionProvider,
-		LaunchTemplateProvider: launchTemplateProvider,
+		InstanceTypesProvider:   instanceTypesProvider,
+		InstanceProvider:        instanceProvider,
+		SubnetProvider:          subnetProvider,
+		SecurityGroupProvider:   securityGroupProvider,
+		LaunchTemplateProvider:  launchTemplateProvider,
+		InstanceProfileProvider: instanceProfileProvider,
+		PricingProvider:         pricingProvider,
+		AMIProvider:             amiProvider,
+		AMIResolver:             amiResolver,
+		VersionProvider:         versionProvider,
 	}
 }
 
 func (env *Environment) Reset() {
 	env.EC2API.Reset()
 	env.SSMAPI.Reset()
+	env.IAMAPI.Reset()
 	env.PricingAPI.Reset()
 	env.PricingProvider.Reset()
 
@@ -149,6 +161,7 @@ func (env *Environment) Reset() {
 	env.LaunchTemplateCache.Flush()
 	env.SubnetCache.Flush()
 	env.SecurityGroupCache.Flush()
+	env.InstanceProfileCache.Flush()
 
 	mfs, err := crmetrics.Registry.Gather()
 	if err != nil {

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -91,7 +91,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	subnetProvider := subnet.NewProvider(ec2api, subnetCache)
 	securityGroupProvider := securitygroup.NewProvider(ec2api, securityGroupCache)
 	versionProvider := version.NewProvider(env.KubernetesInterface, kubernetesVersionCache)
-	instanceProfileProvider := instanceprofile.NewProvider(fake.DefaultRegion, iamapi, ec2api, instanceProfileCache)
+	instanceProfileProvider := instanceprofile.NewProvider(fake.DefaultRegion, iamapi, instanceProfileCache)
 	amiProvider := amifamily.NewProvider(versionProvider, ssmapi, ec2api, ec2Cache)
 	amiResolver := amifamily.New(amiProvider)
 	instanceTypesProvider := instancetype.NewProvider(fake.DefaultRegion, instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -35,6 +35,7 @@ func EC2NodeClass(overrides ...v1beta1.EC2NodeClass) *v1beta1.EC2NodeClass {
 	}
 	if options.Spec.Role == "" {
 		options.Spec.Role = "test-role"
+		options.Status.InstanceProfile = "test-profile"
 	}
 	if len(options.Spec.SecurityGroupSelectorTerms) == 0 {
 		options.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
@@ -57,5 +58,6 @@ func EC2NodeClass(overrides ...v1beta1.EC2NodeClass) *v1beta1.EC2NodeClass {
 	return &v1beta1.EC2NodeClass{
 		ObjectMeta: test.ObjectMeta(options.ObjectMeta),
 		Spec:       options.Spec,
+		Status:     options.Status,
 	}
 }

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -15,10 +15,14 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/imdario/mergo"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 )
@@ -59,5 +63,17 @@ func EC2NodeClass(overrides ...v1beta1.EC2NodeClass) *v1beta1.EC2NodeClass {
 		ObjectMeta: test.ObjectMeta(options.ObjectMeta),
 		Spec:       options.Spec,
 		Status:     options.Status,
+	}
+}
+
+func EC2NodeClassFieldIndexer(ctx context.Context) func(cache.Cache) error {
+	return func(c cache.Cache) error {
+		return c.IndexField(ctx, &corev1beta1.NodeClaim{}, "spec.nodeClass.name", func(obj client.Object) []string {
+			nc := obj.(*corev1beta1.NodeClaim)
+			if nc.Spec.NodeClass == nil {
+				return []string{""}
+			}
+			return []string{nc.Spec.NodeClass.Name}
+		})
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -51,15 +51,6 @@ func MergeTags(tags ...map[string]string) []*ec2.Tag {
 	})
 }
 
-// Truncate truncates a string after a certain number of max chars to ensure
-// that the String isn't too long
-func Truncate(s string, maxChars int) string {
-	if len(s) < maxChars {
-		return s
-	}
-	return s[:maxChars]
-}
-
 // PrettySlice truncates a slice after a certain number of max items to ensure
 // that the Slice isn't too long
 func PrettySlice[T any](s []T, maxItems int) string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -48,4 +49,29 @@ func MergeTags(tags ...map[string]string) []*ec2.Tag {
 	return lo.MapToSlice(lo.Assign(tags...), func(k, v string) *ec2.Tag {
 		return &ec2.Tag{Key: aws.String(k), Value: aws.String(v)}
 	})
+}
+
+// Truncate truncates a string after a certain number of max chars to ensure
+// that the String isn't too long
+func Truncate(s string, maxChars int) string {
+	if len(s) < maxChars {
+		return s
+	}
+	return s[:maxChars]
+}
+
+// PrettySlice truncates a slice after a certain number of max items to ensure
+// that the Slice isn't too long
+func PrettySlice[T any](s []T, maxItems int) string {
+	var sb strings.Builder
+	for i, elem := range s {
+		if i > maxItems-1 {
+			fmt.Fprintf(&sb, " and %d other(s)", len(s)-i)
+			break
+		} else if i > 0 {
+			fmt.Fprint(&sb, ", ")
+		}
+		fmt.Fprint(&sb, elem)
+	}
+	return sb.String()
 }

--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -111,6 +111,16 @@ func (env *Environment) ExpectExperimentTemplateDeleted(id string) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
+func (env *Environment) ExpectInstanceProfileExists(profileName string) iam.InstanceProfile {
+	GinkgoHelper()
+	out, err := env.IAMAPI.GetInstanceProfileWithContext(env.Context, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out.InstanceProfile).ToNot(BeNil())
+	return lo.FromPtr(out.InstanceProfile)
+}
+
 func (env *Environment) GetInstance(nodeName string) ec2.Instance {
 	node := env.Environment.GetNode(nodeName)
 	return env.GetInstanceByIDWithOffset(1, env.ExpectParsedProviderID(node.Spec.ProviderID))

--- a/test/suites/integration/instance_profile_test.go
+++ b/test/suites/integration/instance_profile_test.go
@@ -63,7 +63,7 @@ var _ = Describe("InstanceProfile Generation", func() {
 		Expect(instance.IamInstanceProfile).ToNot(BeNil())
 		Expect(instance.IamInstanceProfile.Arn).To(ContainSubstring(nodeClass.Spec.Role))
 
-		instanceProfile := env.ExpectInstanceProfileExists(instanceprofile.GetProfileName(env.Context, nodeClass))
+		instanceProfile := env.ExpectInstanceProfileExists(instanceprofile.GetProfileName(env.Context, env.Region, nodeClass))
 		Expect(instanceProfile.Roles).To(HaveLen(1))
 		Expect(lo.FromPtr(instanceProfile.Roles[0].RoleName)).To(Equal(nodeClass.Spec.Role))
 	})
@@ -76,7 +76,7 @@ var _ = Describe("InstanceProfile Generation", func() {
 		env.ExpectDeleted(nodePool, nodeClass)
 		Eventually(func(g Gomega) {
 			_, err := env.IAMAPI.GetInstanceProfileWithContext(env.Context, &iam.GetInstanceProfileInput{
-				InstanceProfileName: aws.String(instanceprofile.GetProfileName(env.Context, nodeClass)),
+				InstanceProfileName: aws.String(instanceprofile.GetProfileName(env.Context, env.Region, nodeClass)),
 			})
 			g.Expect(awserrors.IsNotFound(err)).To(BeTrue())
 		}).Should(Succeed())

--- a/test/suites/integration/instance_profile_test.go
+++ b/test/suites/integration/instance_profile_test.go
@@ -1,0 +1,89 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/mitchellh/hashstructure/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+
+	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	coretest "github.com/aws/karpenter-core/pkg/test"
+	"github.com/aws/karpenter/pkg/apis/settings"
+	"github.com/aws/karpenter/pkg/apis/v1beta1"
+	awserrors "github.com/aws/karpenter/pkg/errors"
+	"github.com/aws/karpenter/pkg/test"
+)
+
+var _ = Describe("InstanceProfile Generation", func() {
+	var nodePool *corev1beta1.NodePool
+	var nodeClass *v1beta1.EC2NodeClass
+	BeforeEach(func() {
+		nodePool = coretest.NodePool()
+		nodeClass = test.EC2NodeClass(v1beta1.EC2NodeClass{
+			Spec: v1beta1.EC2NodeClassSpec{
+				SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
+					{
+						Tags: map[string]string{"*": "*"},
+					},
+				},
+				SecurityGroupSelectorTerms: []v1beta1.SecurityGroupSelectorTerm{
+					{
+						Tags: map[string]string{"*": "*"},
+					},
+				},
+				Role: fmt.Sprintf("KarpenterNodeRole-%s", settings.FromContext(env.Context).ClusterName),
+			},
+		})
+	})
+	It("should generate the InstanceProfile when setting the role", func() {
+		pod := coretest.Pod()
+		env.ExpectCreated(nodePool, nodeClass, pod)
+		env.EventuallyExpectHealthy(pod)
+		node := env.ExpectCreatedNodeCount("==", 1)[0]
+
+		instance := env.GetInstance(node.Name)
+		Expect(instance.IamInstanceProfile).ToNot(BeNil())
+		Expect(instance.IamInstanceProfile.Arn).To(ContainSubstring(nodeClass.Spec.Role))
+
+		instanceProfile := env.ExpectInstanceProfileExists(GetInstanceProfileName(env.Context, nodeClass))
+		Expect(instanceProfile.Roles).To(HaveLen(1))
+		Expect(lo.FromPtr(instanceProfile.Roles[0].RoleName)).To(Equal(nodeClass.Spec.Role))
+	})
+	It("should remove the generated InstanceProfile when deleting the NodeClass", func() {
+		pod := coretest.Pod()
+		env.ExpectCreated(nodePool, nodeClass, pod)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		env.ExpectDeleted(nodePool, nodeClass)
+		Eventually(func(g Gomega) {
+			_, err := env.IAMAPI.GetInstanceProfileWithContext(env.Context, &iam.GetInstanceProfileInput{
+				InstanceProfileName: aws.String(GetInstanceProfileName(env.Context, nodeClass)),
+			})
+			g.Expect(awserrors.IsNotFound(err)).To(BeTrue())
+		}).Should(Succeed())
+	})
+})
+
+func GetInstanceProfileName(ctx context.Context, nodeClass *v1beta1.EC2NodeClass) string {
+	return fmt.Sprintf("%s/%d", settings.FromContext(ctx).ClusterName, lo.Must(hashstructure.Hash(nodeClass.Name, hashstructure.FormatV2, &hashstructure.HashOptions{})))
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds instance profile generation when specifying a role in the `v1beta1/NodeClass`. This will not change the ways that instance profiles can be specified with the `v1alpha5/Provisioner`.

Starting in `v1beta1`, you will be required to specify a role in your `EC2NodeClass` like

```yaml
apiVersion: karpenter.k8s.aws/v1beta1
kind: EC2NodeClass
metadata:
  name: default
spec:
  role: KarpenterNodeRole-karpenter-test
...
```

Karpenter will provision an instance profile that uses this role and propagate that profile into the `EC2NodeClass` status

```yaml
apiVersion: karpenter.k8s.aws/v1beta1
kind: EC2NodeClass
metadata:
  name: default
spec:
  role: KarpenterNodeRole-karpenter-test
...
status:
  instanceProfile: karpenter-test_1234567890123456789
```

To ensure that instances that are using this instance profile are able to safely terminate, we now enforce that any `v1beta1/NodeClaim` that is using the `EC2NodeClass` must be removed before the `EC2NodeClass` will remove the instance profile and terminate. You can view this through the eventing logic like

```console
➜  karpenter git:(v1beta1-testing) k describe ec2nodeclasses default
...
Events:
  Type    Reason                        Age   From       Message
  ----    ------                        ----  ----       -------
  Normal  WaitingOnNodeClaimTermination  18s   karpenter  Waiting on NodeClaim termination for default-8l2tz, default-frz5j, default-bfwnx, default-kzwhq, default-jp8dn and 5 other(s)
```

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.