### PR TITLE
test: disallow m7a instance types for pod-eni test

### DIFF
--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -134,6 +134,12 @@ var _ = Describe("Extended Resources", func() {
 					Key:      v1alpha1.LabelInstanceCategory,
 					Operator: v1.NodeSelectorOpExists,
 				},
+				// TODO: Remove this once m7a instances are supported by the vpc resource controller
+				{
+					Key:      v1alpha1.LabelInstanceFamily,
+					Operator: v1.NodeSelectorOpNotIn,
+					Values:   []string{"m7a"},
+				},
 			},
 		})
 		numPods := 1


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Disallows the `m7a` instance family for the following test: `should provision nodes for a deployment that requests vpc.amazonaws.com/pod-eni (security groups for pods)`. Currently this test will fail if an `m7a` type instance is provisioned due to it not being supported by the vpc resource controller.

**How was this change tested?**
`go test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.