### PR TITLE
fix: allow user-data mime content-type before mime-version header

### DIFF
--- a/pkg/providers/amifamily/bootstrap/eksbootstrap.go
+++ b/pkg/providers/amifamily/bootstrap/eksbootstrap.go
@@ -123,7 +123,8 @@ func (e EKS) isIPv6() bool {
 // mimeify returns userData in a mime format
 // if the userData passed in is already in a mime format, then the input is returned without modification
 func (e EKS) mimeify(customUserData string) (string, error) {
-	if strings.HasPrefix(strings.TrimSpace(customUserData), "MIME-Version:") {
+	if strings.HasPrefix(strings.TrimSpace(customUserData), "MIME-Version:") ||
+		strings.HasPrefix(strings.TrimSpace(customUserData), "Content-Type:") {
 		return customUserData, nil
 	}
 	var outputBuffer bytes.Buffer

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_content_type_first_input.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_content_type_first_input.golden
@@ -1,0 +1,10 @@
+Content-Type: multipart/mixed; boundary="BOUNDARY"
+MIME-Version: 1.0
+
+--BOUNDARY
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+echo "Running custom user data script"
+
+--BOUNDARY--


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->
https://github.com/aws/karpenter/issues/4581

**Description**
 - Allow a mime formatted user-data to have the Content-Type header before the MIME-Version header since both are valid. 

**How was this change tested?**
 - Added suite test and tested on EKS cluster


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.