### PR TITLE
chore: Support v1beta1 in CloudProvider interface

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -35,7 +35,7 @@ runs:
       run: |
         for name in $(aws iam list-instance-profiles --query "InstanceProfiles[*].{Name:InstanceProfileName}" --output text); do
           tags=$(aws iam list-instance-profile-tags --instance-profile-name $name --output json || true)
-          if [[ $(echo $tags | jq -r '.Tags[] | select(.Key == "testing.karpenter.sh/cluster") | .Value') == "${{ inputs.cluster_name }}" ]]; then 
+          if [[ $(echo $tags | jq -r '.Tags[] | select(.Key == "testing/cluster") | .Value') == "${{ inputs.cluster_name }}" ]]; then 
               roleName=$(aws iam get-instance-profile --instance-profile-name $name --query "InstanceProfile.Roles[*].{Name:RoleName}" --output text)
               aws iam remove-role-from-instance-profile --instance-profile-name $name --role-name $roleName
               aws iam delete-instance-profile --instance-profile-name $name

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -57,7 +57,7 @@ runs:
         --template-file $CLOUDFORMATION_PATH \
         --capabilities CAPABILITY_NAMED_IAM \
         --parameter-overrides "ClusterName=${{ inputs.cluster_name }}" \
-        --tags "testing.karpenter.sh/type=e2e" "github.com/run-url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" "karpenter.sh/discovery=${{ inputs.cluster_name }}"
+        --tags "testing/type=e2e" "github.com/run-url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" "karpenter.sh/discovery=${{ inputs.cluster_name }}"
   - name: create or upgrade cluster
     shell: bash
     run: |
@@ -76,7 +76,7 @@ runs:
         tags:
           karpenter.sh/discovery: ${{ inputs.cluster_name }}
           github.com/run-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          testing.karpenter.sh/type: "e2e"
+          testing/type: "e2e"
       kubernetesNetworkConfig:
         ipFamily: ${{ inputs.ip_family }}
       managedNodeGroups:
@@ -132,7 +132,7 @@ runs:
       oidc_id=$(aws eks describe-cluster --name ${{ inputs.cluster_name }} --query "cluster.identity.oidc.issuer" --output text | cut -d '/' -f 3,4,5)
       arn="arn:aws:iam::${{ inputs.account_id }}:oidc-provider/${oidc_id}"
       aws iam tag-open-id-connect-provider --open-id-connect-provider-arn $arn \
-         --tags Key=testing.karpenter.sh/type,Value=e2e  Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+         --tags Key=testing/type,Value=e2e  Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   - name: give KarpenterNodeRole permission to bootstrap
     shell: bash
     run: |

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.328
-	github.com/aws/karpenter-core v0.30.0
+	github.com/aws/karpenter-core v0.30.1-0.20230908181031-cbc03e98ef14
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.328 h1:WBwlf8ym9SDQ/GTIBO9eXyvwappKJyOetWJKl4mT7ZU=
 github.com/aws/aws-sdk-go v1.44.328/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.30.0 h1:iEn5D/mvaqPeYNix7JPZyuyELf5Qu2Fx2WP8lFByhDo=
-github.com/aws/karpenter-core v0.30.0/go.mod h1:AQl8m8OtgO2N8IlZlzAU6MTrJTJSbe6K4GwdRUNSJVc=
+github.com/aws/karpenter-core v0.30.1-0.20230908181031-cbc03e98ef14 h1:sBNA922mx/1UIq2Y1zI21R3/bGs1q9Mj/9xILbFI6zo=
+github.com/aws/karpenter-core v0.30.1-0.20230908181031-cbc03e98ef14/go.mod h1:AQl8m8OtgO2N8IlZlzAU6MTrJTJSbe6K4GwdRUNSJVc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/hack/docs/instancetypes_gen_docs.go
+++ b/hack/docs/instancetypes_gen_docs.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	coreoperator "github.com/aws/karpenter-core/pkg/operator"
 	coretest "github.com/aws/karpenter-core/pkg/test"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	awscloudprovider "github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/operator"
@@ -111,7 +112,7 @@ func main() {
 			},
 		},
 	}
-	instanceTypes, err := cp.GetInstanceTypes(ctx, prov)
+	instanceTypes, err := cp.GetInstanceTypes(ctx, nodepoolutil.New(prov))
 	if err != nil {
 		log.Fatalf("listing instance types, %s", err)
 	}

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -51,37 +51,37 @@ spec:
               Node properties are determined from a combination of provisioner and
               pod scheduling constraints.
             properties:
-              deprovisioning:
+              disruption:
                 default:
+                  consolidateAfter: 15s
                   consolidationPolicy: WhenUnderutilized
-                  consolidationTTL: 15s
-                  expirationTTL: 90d
-                description: Deprovisioning contains the parameters that relate to
-                  Karpenter's deprovisioning logic
+                  expireAfter: 720h
+                description: Disruption contains the parameters that relate to Karpenter's
+                  disruption logic
                 properties:
+                  consolidateAfter:
+                    default: 15s
+                    description: ConsolidateAfter is the duration the controller will
+                      wait before attempting to terminate nodes that are underutilized.
+                      Refer to ConsolidationPolicy for how underutilization is considered.
+                    pattern: ^(([0-9]+(s|m|h))+)|(Never)$
+                    type: string
                   consolidationPolicy:
                     default: WhenUnderutilized
                     description: ConsolidationPolicy describes which nodes Karpenter
-                      can deprovision through its consolidation algorithm. This policy
+                      can disrupt through its consolidation algorithm. This policy
                       defaults to "WhenUnderutilized" if not specified
                     enum:
-                    - Never
                     - WhenEmpty
                     - WhenUnderutilized
                     type: string
-                  consolidationTTL:
-                    default: 15s
-                    description: ConsolidationTTL is the duration the controller will
-                      wait before attempting to terminate nodes that are underutilized.
-                      Refer to ConsolidationPolicy for how underutilization is considered.
-                    type: string
-                  expirationTTL:
-                    default: 90d
-                    description: ExpirationTTL is the duration the controller will
-                      wait before terminating a node, measured from when the node
-                      is created. This is useful to implement features like eventually
-                      consistent node upgrade, memory leak protection, and disruption
-                      testing.
+                  expireAfter:
+                    default: 720h
+                    description: ExpireAfter is the duration the controller will wait
+                      before terminating a node, measured from when the node is created.
+                      This is useful to implement features like eventually consistent
+                      node upgrade, memory leak protection, and disruption testing.
+                    pattern: ^(([0-9]+(s|m|h))+)|(Never)$
                     type: string
                 type: object
               limits:

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -23,7 +23,6 @@ import (
 
 	corev1beta1 "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
-	provisionerutil "github.com/aws/karpenter-core/pkg/utils/provisioner"
 	"github.com/aws/karpenter-core/pkg/utils/sets"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
@@ -64,7 +63,7 @@ func (c *CloudProvider) isNodeClassDrifted(ctx context.Context, nodeClaim *corev
 
 func (c *CloudProvider) isAMIDrifted(ctx context.Context, nodeClaim *corev1beta1.NodeClaim, nodePool *corev1beta1.NodePool,
 	instance *instance.Instance, nodeClass *v1beta1.NodeClass) (cloudprovider.DriftReason, error) {
-	instanceTypes, err := c.GetInstanceTypes(ctx, provisionerutil.New(nodePool))
+	instanceTypes, err := c.GetInstanceTypes(ctx, nodePool)
 	if err != nil {
 		return "", fmt.Errorf("getting instanceTypes, %w", err)
 	}
@@ -84,7 +83,7 @@ func (c *CloudProvider) isAMIDrifted(ctx context.Context, nodeClaim *corev1beta1
 	if len(amis) == 0 {
 		return "", fmt.Errorf("no amis exist given constraints")
 	}
-	mappedAMIs := amis.MapToInstanceTypes([]*cloudprovider.InstanceType{nodeInstanceType})
+	mappedAMIs := amis.MapToInstanceTypes([]*cloudprovider.InstanceType{nodeInstanceType}, nodeClaim.IsMachine)
 	if len(mappedAMIs) == 0 {
 		return "", fmt.Errorf("no instance types satisfy requirements of amis %v", amis)
 	}

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -37,6 +37,8 @@ import (
 	. "github.com/onsi/gomega"
 	. "knative.dev/pkg/logging/testing"
 
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -160,13 +162,13 @@ var _ = Describe("CloudProvider", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate, machine)
-		cloudProviderMachine, err := cloudProvider.Create(ctx, machine)
+		cloudProviderMachine, err := cloudProvider.Create(ctx, nodeclaimutil.New(machine))
 		Expect(corecloudproivder.IsInsufficientCapacityError(err)).To(BeTrue())
 		Expect(cloudProviderMachine).To(BeNil())
 	})
 	It("should return AWSNodetemplate Hash on the machine", func() {
 		ExpectApplied(ctx, env.Client, provisioner, nodeTemplate, machine)
-		cloudProviderMachine, err := cloudProvider.Create(ctx, machine)
+		cloudProviderMachine, err := cloudProvider.Create(ctx, nodeclaimutil.New(machine))
 		Expect(err).To(BeNil())
 		Expect(cloudProviderMachine).ToNot(BeNil())
 		_, ok := cloudProviderMachine.ObjectMeta.Annotations[v1alpha1.AnnotationNodeTemplateHash]
@@ -265,7 +267,7 @@ var _ = Describe("CloudProvider", func() {
 				},
 			}
 			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodepoolutil.New(provisioner))
 			Expect(err).ToNot(HaveOccurred())
 			selectedInstanceType = instanceTypes[0]
 
@@ -308,44 +310,44 @@ var _ = Describe("CloudProvider", func() {
 		})
 		It("should not fail if node template does not exist", func() {
 			ExpectDeleted(ctx, env.Client, nodeTemplate)
-			drifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			drifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeEmpty())
 		})
 		It("should return false if providerRef is not defined", func() {
 			provisioner.Spec.ProviderRef = nil
 			ExpectApplied(ctx, env.Client, provisioner)
-			drifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			drifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeEmpty())
 		})
 		It("should not fail if provisioner does not exist", func() {
 			ExpectDeleted(ctx, env.Client, provisioner)
-			drifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			drifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(drifted).To(BeEmpty())
 		})
 		It("should return drifted if the AMI is not valid", func() {
 			// Instance is a reference to what we return in the GetInstances call
 			instance.ImageId = aws.String(fake.ImageID())
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(Equal(cloudprovider.AMIDrift))
 		})
 		It("should return drifted if the subnet is not valid", func() {
 			instance.SubnetId = aws.String(fake.SubnetID())
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(Equal(cloudprovider.SubnetDrift))
 		})
 		It("should return an error if AWSNodeTemplate subnets are empty", func() {
 			nodeTemplate.Status.Subnets = []v1alpha1.Subnet{}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
-			_, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			_, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).To(HaveOccurred())
 		})
 		It("should not return drifted if the machine is valid", func() {
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(BeEmpty())
 		})
@@ -354,20 +356,20 @@ var _ = Describe("CloudProvider", func() {
 			ExpectApplied(ctx, env.Client, nodeTemplate)
 			// Instance is a reference to what we return in the GetInstances call
 			instance.SecurityGroups = []*ec2.GroupIdentifier{{GroupId: aws.String(fake.SecurityGroupID())}}
-			_, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			_, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).To(HaveOccurred())
 		})
 		It("should return drifted if the instance securitygroup do not match the AWSNodeTemplateStatus", func() {
 			// Instance is a reference to what we return in the GetInstances call
 			instance.SecurityGroups = []*ec2.GroupIdentifier{{GroupId: aws.String(fake.SecurityGroupID())}}
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(Equal(cloudprovider.SecurityGroupDrift))
 		})
 		It("should return drifted if there are more instance securitygroups are present than AWSNodeTemplate Status", func() {
 			// Instance is a reference to what we return in the GetInstances call
 			instance.SecurityGroups = []*ec2.GroupIdentifier{{GroupId: aws.String(fake.SecurityGroupID())}, {GroupId: aws.String(validSecurityGroup)}}
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(Equal(cloudprovider.SecurityGroupDrift))
 		})
@@ -383,7 +385,7 @@ var _ = Describe("CloudProvider", func() {
 				},
 			}
 			ExpectApplied(ctx, env.Client, nodeTemplate)
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(Equal(cloudprovider.SecurityGroupDrift))
 		})
@@ -391,12 +393,12 @@ var _ = Describe("CloudProvider", func() {
 			nodeTemplate.Spec.LaunchTemplateName = aws.String("validLaunchTemplateName")
 			nodeTemplate.Spec.SecurityGroupSelector = nil
 			nodeTemplate.Status.SecurityGroups = nil
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(BeEmpty())
 		})
 		It("should not return drifted if the securitygroups match", func() {
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isDrifted).To(BeEmpty())
 		})
@@ -404,12 +406,12 @@ var _ = Describe("CloudProvider", func() {
 			machine.Labels = map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 			}
-			_, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			_, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).To(HaveOccurred())
 		})
 		It("should error drift if machine doesn't have provider id", func() {
 			machine.Status = v1alpha5.MachineStatus{}
-			isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).To(HaveOccurred())
 			Expect(isDrifted).To(BeEmpty())
 		})
@@ -417,7 +419,7 @@ var _ = Describe("CloudProvider", func() {
 			awsEnv.EC2API.DescribeInstancesBehavior.Output.Set(&ec2.DescribeInstancesOutput{
 				Reservations: []*ec2.Reservation{{Instances: []*ec2.Instance{}}},
 			})
-			_, err := cloudProvider.IsMachineDrifted(ctx, machine)
+			_, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 			Expect(err).To(HaveOccurred())
 		})
 		Context("Static Drift Detection", func() {
@@ -432,7 +434,7 @@ var _ = Describe("CloudProvider", func() {
 			DescribeTable("should return drifted if the AWSNodeTemplate.Spec is updated",
 				func(awsnodetemplatespec v1alpha1.AWSNodeTemplateSpec) {
 					ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-					isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+					isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(isDrifted).To(BeEmpty())
 
@@ -442,7 +444,7 @@ var _ = Describe("CloudProvider", func() {
 					updatedAWSNodeTemplate.Annotations = map[string]string{v1alpha1.AnnotationNodeTemplateHash: updatedAWSNodeTemplate.Hash()}
 
 					ExpectApplied(ctx, env.Client, updatedAWSNodeTemplate)
-					isDrifted, err = cloudProvider.IsMachineDrifted(ctx, machine)
+					isDrifted, err = cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(isDrifted).To(Equal(cloudprovider.NodeTemplateDrift))
 				},
@@ -458,7 +460,7 @@ var _ = Describe("CloudProvider", func() {
 			DescribeTable("should not return drifted if dynamic fields are updated",
 				func(awsnodetemplatespec v1alpha1.AWSNodeTemplateSpec) {
 					ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-					isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+					isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(isDrifted).To(BeEmpty())
 
@@ -468,7 +470,7 @@ var _ = Describe("CloudProvider", func() {
 					updatedAWSNodeTemplate.Annotations = map[string]string{v1alpha1.AnnotationNodeTemplateHash: updatedAWSNodeTemplate.Hash()}
 
 					ExpectApplied(ctx, env.Client, updatedAWSNodeTemplate)
-					isDrifted, err = cloudProvider.IsMachineDrifted(ctx, machine)
+					isDrifted, err = cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(isDrifted).To(BeEmpty())
 				},
@@ -482,7 +484,7 @@ var _ = Describe("CloudProvider", func() {
 					"Test Key": "Test Value",
 				}
 				ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-				isDrifted, err := cloudProvider.IsMachineDrifted(ctx, machine)
+				isDrifted, err := cloudProvider.IsDrifted(ctx, nodeclaimutil.New(machine))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(isDrifted).To(BeEmpty())
 			})

--- a/pkg/controllers/machine/garbagecollection/controller.go
+++ b/pkg/controllers/machine/garbagecollection/controller.go
@@ -67,8 +67,8 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("listing cloudprovider machines, %w", err)
 	}
-	managedRetrieved := lo.Filter(retrieved, func(m *v1alpha5.Machine, _ int) bool {
-		return m.Annotations[v1alpha5.MachineManagedByAnnotationKey] != "" && m.DeletionTimestamp.IsZero()
+	managedRetrieved := lo.Filter(retrieved, func(nc *v1beta1.NodeClaim, _ int) bool {
+		return nc.Annotations[v1beta1.ManagedByAnnotationKey] != "" && nc.DeletionTimestamp.IsZero()
 	})
 	nodeClaimList, err := nodeclaimutil.List(ctx, c.kubeClient)
 	if err != nil {
@@ -101,16 +101,16 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	return reconcile.Result{RequeueAfter: lo.Ternary(c.successfulCount <= 20, time.Second*10, time.Minute*2)}, multierr.Combine(errs...)
 }
 
-func (c *Controller) garbageCollect(ctx context.Context, machine *v1alpha5.Machine, nodeList *v1.NodeList) error {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", machine.Status.ProviderID))
-	if err := c.cloudProvider.Delete(ctx, machine); err != nil {
-		return corecloudprovider.IgnoreMachineNotFoundError(err)
+func (c *Controller) garbageCollect(ctx context.Context, nodeClaim *v1beta1.NodeClaim, nodeList *v1.NodeList) error {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provider-id", nodeClaim.Status.ProviderID))
+	if err := c.cloudProvider.Delete(ctx, nodeClaim); err != nil {
+		return corecloudprovider.IgnoreNodeClaimNotFoundError(err)
 	}
 	logging.FromContext(ctx).Debugf("garbage collected cloudprovider instance")
 
 	// Go ahead and cleanup the node if we know that it exists to make scheduling go quicker
 	if node, ok := lo.Find(nodeList.Items, func(n v1.Node) bool {
-		return n.Spec.ProviderID == machine.Status.ProviderID
+		return n.Spec.ProviderID == nodeClaim.Status.ProviderID
 	}); ok {
 		if err := c.kubeClient.Delete(ctx, &node); err != nil {
 			return client.IgnoreNotFound(err)

--- a/pkg/controllers/machine/garbagecollection/suite_test.go
+++ b/pkg/controllers/machine/garbagecollection/suite_test.go
@@ -96,7 +96,7 @@ var _ = Describe("MachineGarbageCollection", func() {
 		nodeTemplate := test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{})
 		provisioner := test.Provisioner(coretest.ProvisionerOptions{
 			ProviderRef: &v1alpha5.MachineTemplateRef{
-				APIVersion: v1alpha5.TestingGroup + "v1alpha1",
+				APIVersion: "testing/v1alpha1",
 				Kind:       "NodeTemplate",
 				Name:       nodeTemplate.Name,
 			},
@@ -140,7 +140,7 @@ var _ = Describe("MachineGarbageCollection", func() {
 		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKey{})
 		_, err := cloudProvider.Get(ctx, providerID)
 		Expect(err).To(HaveOccurred())
-		Expect(corecloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(corecloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 	It("should delete an instance along with the node if there is no machine owner (to quicken scheduling)", func() {
 		// Launch time was 10m ago
@@ -155,7 +155,7 @@ var _ = Describe("MachineGarbageCollection", func() {
 		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKey{})
 		_, err := cloudProvider.Get(ctx, providerID)
 		Expect(err).To(HaveOccurred())
-		Expect(corecloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(corecloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 
 		ExpectNotFound(ctx, env.Client, node)
 	})
@@ -207,7 +207,7 @@ var _ = Describe("MachineGarbageCollection", func() {
 
 				_, err := cloudProvider.Get(ctx, fmt.Sprintf("aws:///test-zone-1a/%s", id))
 				Expect(err).To(HaveOccurred())
-				Expect(corecloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+				Expect(corecloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 			}(id)
 		}
 		wg.Wait()

--- a/pkg/controllers/machine/link/suite_test.go
+++ b/pkg/controllers/machine/link/suite_test.go
@@ -92,7 +92,7 @@ var _ = Describe("MachineLink", func() {
 		nodeTemplate = test.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{})
 		provisioner = test.Provisioner(coretest.ProvisionerOptions{
 			ProviderRef: &v1alpha5.MachineTemplateRef{
-				APIVersion: v1alpha5.TestingGroup + "v1alpha1",
+				APIVersion: "testing/v1alpha1",
 				Kind:       "NodeTemplate",
 				Name:       nodeTemplate.Name,
 			},

--- a/pkg/fake/cloudprovider.go
+++ b/pkg/fake/cloudprovider.go
@@ -19,7 +19,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -36,19 +36,19 @@ type CloudProvider struct {
 	ValidAMIs     []string
 }
 
-func (c *CloudProvider) Create(_ context.Context, _ *v1alpha5.Machine) (*v1alpha5.Machine, error) {
+func (c *CloudProvider) Create(_ context.Context, _ *v1beta1.NodeClaim) (*v1beta1.NodeClaim, error) {
 	name := test.RandomName()
-	return &v1alpha5.Machine{
+	return &v1beta1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Status: v1alpha5.MachineStatus{
+		Status: v1beta1.NodeClaimStatus{
 			ProviderID: RandomProviderID(),
 		},
 	}, nil
 }
 
-func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provisioner) ([]*corecloudprovider.InstanceType, error) {
+func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1beta1.NodePool) ([]*corecloudprovider.InstanceType, error) {
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}
@@ -57,8 +57,8 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provisio
 	}, nil
 }
 
-func (c *CloudProvider) IsMachineDrifted(_ context.Context, machine *v1alpha5.Machine) (corecloudprovider.DriftReason, error) {
-	nodeAMI := machine.Labels[v1alpha1.LabelInstanceAMIID]
+func (c *CloudProvider) IsDrifted(_ context.Context, nodeClaim *v1beta1.NodeClaim) (corecloudprovider.DriftReason, error) {
+	nodeAMI := nodeClaim.Labels[v1alpha1.LabelInstanceAMIID]
 	for _, ami := range c.ValidAMIs {
 		if nodeAMI == ami {
 			return "", nil
@@ -67,15 +67,15 @@ func (c *CloudProvider) IsMachineDrifted(_ context.Context, machine *v1alpha5.Ma
 	return "drifted", nil
 }
 
-func (c *CloudProvider) Get(context.Context, string) (*v1alpha5.Machine, error) {
+func (c *CloudProvider) Get(context.Context, string) (*v1beta1.NodeClaim, error) {
 	return nil, nil
 }
 
-func (c *CloudProvider) List(context.Context) ([]*v1alpha5.Machine, error) {
+func (c *CloudProvider) List(context.Context) ([]*v1beta1.NodeClaim, error) {
 	return nil, nil
 }
 
-func (c *CloudProvider) Delete(context.Context, *v1alpha5.Machine) error {
+func (c *CloudProvider) Delete(context.Context, *v1beta1.NodeClaim) error {
 	return nil
 }
 

--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -93,11 +93,11 @@ func (a AMIs) String() string {
 }
 
 // MapToInstanceTypes returns a map of AMIIDs that are the most recent on creationDate to compatible instancetypes
-func (a AMIs) MapToInstanceTypes(instanceTypes []*cloudprovider.InstanceType) map[string][]*cloudprovider.InstanceType {
+func (a AMIs) MapToInstanceTypes(instanceTypes []*cloudprovider.InstanceType, isMachine bool) map[string][]*cloudprovider.InstanceType {
 	amiIDs := map[string][]*cloudprovider.InstanceType{}
 	for _, instanceType := range instanceTypes {
 		for _, ami := range a {
-			if err := instanceType.Requirements.Compatible(ami.Requirements); err == nil {
+			if err := instanceType.Requirements.Compatible(ami.Requirements, lo.Ternary(isMachine, scheduling.AllowUndefinedWellKnownLabelsV1Alpha5, scheduling.AllowUndefinedWellKnownLabelsV1Beta1)); err == nil {
 				amiIDs[ami.AmiID] = append(amiIDs[ami.AmiID], instanceType)
 				break
 			}

--- a/pkg/providers/amifamily/resolver.go
+++ b/pkg/providers/amifamily/resolver.go
@@ -125,7 +125,7 @@ func (r Resolver) Resolve(ctx context.Context, nodeClass *v1beta1.NodeClass, nod
 	if len(amis) == 0 {
 		return nil, fmt.Errorf("no amis exist given constraints")
 	}
-	mappedAMIs := amis.MapToInstanceTypes(instanceTypes)
+	mappedAMIs := amis.MapToInstanceTypes(instanceTypes, nodeClaim.IsMachine)
 	if len(mappedAMIs) == 0 {
 		return nil, fmt.Errorf("no instance types satisfy requirements of amis %v", amis)
 	}

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -37,6 +37,7 @@ import (
 	coretest "github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
@@ -124,7 +125,7 @@ var _ = Describe("InstanceProvider", func() {
 			{CapacityType: v1alpha5.CapacityTypeSpot, InstanceType: "m5.xlarge", Zone: "test-zone-1a"},
 			{CapacityType: v1alpha5.CapacityTypeSpot, InstanceType: "m5.xlarge", Zone: "test-zone-1b"},
 		})
-		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodepoolutil.New(provisioner))
 		Expect(err).ToNot(HaveOccurred())
 
 		// Filter down to a single instance type

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Instance Types", func() {
 		})
 		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 		ExpectScheduled(ctx, env.Client, pod)
-		its, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+		its, err := cloudProvider.GetInstanceTypes(ctx, nodepoolutil.New(provisioner))
 		Expect(err).To(BeNil())
 		// Order all the instances by their price
 		// We need some way to deterministically order them if their prices match
@@ -409,7 +409,7 @@ var _ = Describe("Instance Types", func() {
 		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 		ExpectScheduled(ctx, env.Client, pod)
 
-		its, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+		its, err := cloudProvider.GetInstanceTypes(ctx, nodepoolutil.New(provisioner))
 		Expect(err).To(BeNil())
 		// Order all the instances by their price
 		// We need some way to deterministically order them if their prices match
@@ -1177,7 +1177,7 @@ var _ = Describe("Instance Types", func() {
 			})
 
 			ExpectApplied(ctx, env.Client, provisioner, nodeTemplate)
-			its, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+			its, err := cloudProvider.GetInstanceTypes(ctx, nodepoolutil.New(provisioner))
 			Expect(err).To(BeNil())
 
 			instanceTypes := map[string]*corecloudprovider.InstanceType{}
@@ -1423,7 +1423,7 @@ var _ = Describe("Instance Types", func() {
 			}
 
 			awsEnv.InstanceTypeCache.Flush()
-			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+			instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodepoolutil.New(provisioner))
 			Expect(err).To(BeNil())
 			instanceTypeNames := sets.NewString()
 			for _, it := range instanceTypes {
@@ -1622,7 +1622,7 @@ var _ = Describe("Instance Types", func() {
 // vs the on-demand offering.
 func generateSpotPricing(cp *cloudprovider.CloudProvider, prov *v1alpha5.Provisioner) *ec2.DescribeSpotPriceHistoryOutput {
 	rsp := &ec2.DescribeSpotPriceHistoryOutput{}
-	instanceTypes, err := cp.GetInstanceTypes(ctx, prov)
+	instanceTypes, err := cp.GetInstanceTypes(ctx, nodepoolutil.New(prov))
 	awsEnv.InstanceTypeCache.Flush()
 	Expect(err).To(Succeed())
 	t := fakeClock.Now()

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_merged.golden
@@ -16,5 +16,5 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 --container-runtime containerd \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
---kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110'
+--kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing/cluster=unspecified" --max-pods=110'
 --//--

--- a/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/al2_userdata_unmerged.golden
@@ -10,5 +10,5 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 --container-runtime containerd \
 --dns-cluster-ip '10.0.100.10' \
 --use-max-pods false \
---kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110'
+--kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=%s,testing/cluster=unspecified" --max-pods=110'
 --//--

--- a/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_merged.golden
@@ -11,7 +11,7 @@ max-pods = 110
 custom-node-label = 'custom'
 'karpenter.sh/capacity-type' = 'on-demand'
 'karpenter.sh/provisioner-name' = '%s'
-'testing.karpenter.sh/cluster' = 'unspecified'
+'testing/cluster' = 'unspecified'
 
 [settings.kubernetes.node-taints]
 baz = ['bin:NoExecute']

--- a/pkg/providers/launchtemplate/testdata/br_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/br_userdata_unmerged.golden
@@ -9,7 +9,7 @@ max-pods = 110
 [settings.kubernetes.node-labels]
 'karpenter.sh/capacity-type' = 'on-demand'
 'karpenter.sh/provisioner-name' = '%s'
-'testing.karpenter.sh/cluster' = 'unspecified'
+'testing/cluster' = 'unspecified'
 
 [settings.kubernetes.node-taints]
 baz = ['bin:NoExecute']

--- a/pkg/providers/launchtemplate/testdata/windows_userdata_merged.golden
+++ b/pkg/providers/launchtemplate/testdata/windows_userdata_merged.golden
@@ -2,5 +2,5 @@
 Write-Host "Running custom user data script"
 Write-Host "Finished running custom user data script"
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=%s,testing/cluster=unspecified" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>

--- a/pkg/providers/launchtemplate/testdata/windows_userdata_unmerged.golden
+++ b/pkg/providers/launchtemplate/testdata/windows_userdata_unmerged.golden
@@ -1,4 +1,4 @@
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=%s,testing/cluster=unspecified" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>

--- a/test/hack/cleanup/main.go
+++ b/test/hack/cleanup/main.go
@@ -43,9 +43,11 @@ const (
 	karpenterProvisionerNameTag = "karpenter.sh/provisioner-name"
 	karpenterLaunchTemplateTag  = "karpenter.k8s.aws/cluster"
 	karpenterSecurityGroupTag   = "karpenter.sh/discovery"
-	karpenterTestingTag         = "testing.karpenter.sh/cluster"
-	k8sClusterTag               = "cluster.k8s.amazonaws.com/name"
-	githubRunURLTag             = "github.com/run-url"
+	// TODO @joinnis: Remove this karpenterTestingTagLegacy field after running this cleanup script for a few days
+	karpenterTestingTagLegacy = "testing.karpenter.sh/cluster"
+	karpenterTestingTag       = "testing/cluster"
+	k8sClusterTag             = "cluster.k8s.amazonaws.com/name"
+	githubRunURLTag           = "github.com/run-url"
 )
 
 type CleanableResourceType interface {
@@ -413,7 +415,7 @@ func (ip *instanceProfile) Get(ctx context.Context, expirationTime time.Time) (n
 		}
 
 		for _, t := range profiles.Tags {
-			if lo.FromPtr(t.Key) == karpenterTestingTag && out.InstanceProfiles[i].CreateDate.Before(expirationTime) {
+			if lo.FromPtr(t.Key) == karpenterTestingTag || lo.FromPtr(t.Key) == karpenterTestingTagLegacy && out.InstanceProfiles[i].CreateDate.Before(expirationTime) {
 				names = append(names, lo.FromPtr(out.InstanceProfiles[i].InstanceProfileName))
 			}
 		}

--- a/test/pkg/environment/common/environment.go
+++ b/test/pkg/environment/common/environment.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	coreapis "github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/utils/project"
@@ -92,7 +91,7 @@ func (env *Environment) Stop() {
 
 func NewConfig() *rest.Config {
 	config := controllerruntime.GetConfigOrDie()
-	config.UserAgent = fmt.Sprintf("%s-%s", v1alpha5.TestingGroup, project.Version)
+	config.UserAgent = fmt.Sprintf("testing-%s", project.Version)
 	config.QPS = 1e6
 	config.Burst = 1e6
 	return config

--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -632,7 +632,7 @@ func (env *Environment) GetDaemonSetCount(prov *v1alpha5.Provisioner) int {
 		if err := scheduling.Taints(nodeTemplate.Spec.Taints).Tolerates(p); err != nil {
 			return false
 		}
-		if err := nodeTemplate.Requirements.Compatible(scheduling.NewPodRequirements(p)); err != nil {
+		if err := nodeTemplate.Requirements.Compatible(scheduling.NewPodRequirements(p), scheduling.AllowUndefinedWellKnownLabelsV1Alpha5); err != nil {
 			return false
 		}
 		return true

--- a/test/suites/integration/daemonset_test.go
+++ b/test/suites/integration/daemonset_test.go
@@ -105,7 +105,7 @@ var _ = Describe("DaemonSet", func() {
 		// Eventually expect a single node to exist and both the deployment pod and the daemonset pod to schedule to it
 		Eventually(func(g Gomega) {
 			nodeList := &v1.NodeList{}
-			g.Expect(env.Client.List(env, nodeList, client.HasLabels{"testing.karpenter.sh/cluster"})).To(Succeed())
+			g.Expect(env.Client.List(env, nodeList, client.HasLabels{"testing/cluster"})).To(Succeed())
 			g.Expect(nodeList.Items).To(HaveLen(1))
 
 			deploymentPods := env.Monitor.RunningPods(podSelector)
@@ -136,7 +136,7 @@ var _ = Describe("DaemonSet", func() {
 		// Eventually expect a single node to exist and both the deployment pod and the daemonset pod to schedule to it
 		Eventually(func(g Gomega) {
 			nodeList := &v1.NodeList{}
-			g.Expect(env.Client.List(env, nodeList, client.HasLabels{"testing.karpenter.sh/cluster"})).To(Succeed())
+			g.Expect(env.Client.List(env, nodeList, client.HasLabels{"testing/cluster"})).To(Succeed())
 			g.Expect(nodeList.Items).To(HaveLen(1))
 
 			deploymentPods := env.Monitor.RunningPods(podSelector)

--- a/test/suites/integration/testdata/amd_driver_input.sh
+++ b/test/suites/integration/testdata/amd_driver_input.sh
@@ -40,7 +40,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' --b64-cluster-ca '%s' \
 --use-max-pods false \
 --container-runtime containerd \
---kubelet-extra-args '--node-labels=karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified'
+--kubelet-extra-args '--node-labels=karpenter.sh/provisioner-name=%s,testing/cluster=unspecified'
 
 reboot
 --BOUNDARY-- 

--- a/test/suites/machine/testdata/al2_userdata_custom_labels_input.sh
+++ b/test/suites/machine/testdata/al2_userdata_custom_labels_input.sh
@@ -9,6 +9,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' --b64-cluster-ca '%s' \
 --use-max-pods false \
 --container-runtime containerd \
---kubelet-extra-args '--node-labels=testing.karpenter.sh/cluster=unspecified,custom-label=custom-value,custom-label2=custom-value2'
+--kubelet-extra-args '--node-labels=testing/cluster=unspecified,custom-label=custom-value,custom-label2=custom-value2'
 
 --BOUNDARY--

--- a/test/suites/machine/testdata/al2_userdata_input.sh
+++ b/test/suites/machine/testdata/al2_userdata_input.sh
@@ -9,6 +9,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh '%s' --apiserver-endpoint '%s' --b64-cluster-ca '%s' \
 --use-max-pods false \
 --container-runtime containerd \
---kubelet-extra-args '--node-labels=karpenter.sh/provisioner-name=%s,testing.karpenter.sh/cluster=unspecified'
+--kubelet-extra-args '--node-labels=karpenter.sh/provisioner-name=%s,testing/cluster=unspecified'
 
 --BOUNDARY--

--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	deprovisioningTypeKey = v1alpha5.TestingGroup + "/deprovisioning-type"
+	deprovisioningTypeKey = "testing/deprovisioning-type"
 	consolidationValue    = "consolidation"
 	emptinessValue        = "emptiness"
 	expirationValue       = "expiration"

--- a/tools/allocatable-diff/main.go
+++ b/tools/allocatable-diff/main.go
@@ -32,10 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	coreoperator "github.com/aws/karpenter-core/pkg/operator"
-
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corecloudprovider "github.com/aws/karpenter-core/pkg/cloudprovider"
+	coreoperator "github.com/aws/karpenter-core/pkg/operator"
 	"github.com/aws/karpenter/pkg/apis/settings"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter/pkg/cloudprovider"

--- a/website/content/en/docs/concepts/node-templates.md
+++ b/website/content/en/docs/concepts/node-templates.md
@@ -579,7 +579,7 @@ Final merged UserData -
 <powershell>
 Write-Host "Running custom user data script"
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=windows2022,testing.karpenter.sh/test-id=unspecified" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=windows2022" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>
 ```
 

--- a/website/content/en/preview/concepts/node-templates.md
+++ b/website/content/en/preview/concepts/node-templates.md
@@ -581,7 +581,7 @@ Final merged UserData -
 <powershell>
 Write-Host "Running custom user data script"
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=windows2022,testing.karpenter.sh/test-id=unspecified" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=windows2022" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>
 ```
 

--- a/website/content/en/v0.30/concepts/node-templates.md
+++ b/website/content/en/v0.30/concepts/node-templates.md
@@ -579,7 +579,7 @@ Final merged UserData -
 <powershell>
 Write-Host "Running custom user data script"
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=windows2022,testing.karpenter.sh/test-id=unspecified" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=windows2022" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>
 ```
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR migrates the CloudProvider interface to use the new `v1beta1` APIs. A change will have to be made in `aws/karpenter` to support this breaking change. This change is another one of the changes on the path to fully migrating the repository over to the new v1beta1 APIs.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.