### PR TITLE
feat(crds): Migrate from a webhook to CEL validation for aws nodetemplates

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
@@ -46,6 +46,9 @@ spec:
                   type: string
                 description: AMISelector discovers AMIs to be used by Amazon EC2 tags.
                 type: object
+                x-kubernetes-validations:
+                - message: Only one of UserData and AMISelector can be provided
+                  rule: '!has(self.AMISelector) || has(self.AMISelector) != has(self.UserData)'
               apiVersion:
                 description: 'APIVersion defines the versioned schema of this representation
                   of an object. Servers should convert recognized schemas to the latest
@@ -215,7 +218,27 @@ spec:
                   will merge certain fields into this UserData to ensure nodes are
                   being provisioned with the correct configuration.
                 type: string
+                x-kubernetes-validations:
+                - message: Only one of UserData and AMISelector can be provided
+                  rule: '!has(self.AMISelector) || has(self.AMISelector) != has(self.UserData)'
             type: object
+            x-kubernetes-validations:
+            - message: If AMIFamily is Custom then AMI Selector must be set
+              rule: '!has(self.AMIFamily) || !self.AMIFamily == "Custom" || has(self.AMISelector)'
+            - message: Only one of AMISelector and LaunchTemplate can be provided
+              rule: '!has(self.AMISelector) || has(self.AMISelector) != has(self.LaunchTemplateName)'
+            - message: AMI ID must be a valid ami-id
+              rule: '!has(self.AMISelector) || !has(self.AMISelector["aws-ids"]) ||
+                self.AMISelector["aws-ids"].matches("^ami-[a-f0-9]{8,17}$")'
+            - message: AMI ID must be a valid ami-id
+              rule: '!has(self.AMISelector) || !has(self.AMISelector["aws::ids"])
+                || self.AMISelector["aws::ids"].matches("^ami-[a-f0-9]{8,17}$")'
+            - message: Tags must not match kubernetes patterns
+              rule: '!has(self.Tags) || !self.Tags.all(e, e.key.matches(''^kubernetes.io/cluster/[0-9A-Za-z][A-Za-z0-9\-_]*$''))'
+            - message: Tags must not match karpenter provisioner label
+              rule: '!has(self.Tags) || !self.Tags.all(e, e.key.matches(^karpenter.k8s.aws/provisioner-name$))'
+            - message: Tags must not match karpenter managed by tag
+              rule: '!has(self.Tags) || !self.Tags.all(e, e.key.matches(^karpenter.k8s.aws/machine-managed-by$))'
           status:
             description: AWSNodeTemplateStatus contains the resolved state of the
               AWSNodeTemplate


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4563 <!-- issue number -->

**Description**

Adds support for CEL validation of the AWS Templates

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.