### PR TITLE
Enable scale test running from a PR

### DIFF
--- a/.github/workflows/approval-comment.yaml
+++ b/.github/workflows/approval-comment.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   approval-comment:
-    if: startsWith(github.event.review.body ,'/karpenter snapshot')
+    if: startsWith(github.event.review.body, '/karpenter snapshot') || startsWith(github.event.review.body, '/karpenter scale')
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
@@ -15,7 +15,7 @@ jobs:
       - name: Save info about the review comment as an artifact for other workflows that run on workflow_run to download them
         run: |
           mkdir -p /tmp/artifacts
-          echo ${{ github.event.pull_request.number }} >> /tmp/artifacts/metadata.txt
+          echo ${{ github.event.review.body }} >> /tmp/artifacts/metadata.txt
           echo ${{ github.event.review.commit_id }} >> /tmp/artifacts/metadata.txt
           cat /tmp/artifacts/metadata.txt
       - uses: ./.github/actions/upload-artifact

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -9,30 +9,18 @@ on:
     types: [completed]
   workflow_dispatch:
 jobs:
-  resolve-git-ref:
+  resolve:
     if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    outputs:
-      GIT_REF: ${{ steps.resolve-step.outputs.GIT_REF }}
-    steps:
-      # Download the artifact and resolve the commit if initiated by PR snapshot
-      # Otherwise, use the currently checked-out branch to run the E2E tests against
-      - uses: actions/checkout@v3
-      - if: github.event_name == 'workflow_run'
-        uses: ./.github/actions/download-artifact
-      - id: resolve-step
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            echo GIT_REF=$(tail -n 1 /tmp/artifacts/metadata.txt) >> $GITHUB_OUTPUT
-          else
-            echo GIT_REF="" >> $GITHUB_OUTPUT
-          fi
+    uses: ./.github/workflows/resolve-args.yaml
+    with:
+      allowed_comment: "snapshot"
+      event_name: ${{ github.event_name }}
   e2e-matrix:
-    needs: [resolve-git-ref]
-    if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
+    needs: [resolve]
+    if: needs.resolve.outputs.SHOULD_RUN == 'true'
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       event_name: ${{ github.event_name }}
-      git_ref: ${{ needs.resolve-git-ref.outputs.GIT_REF }}
+      git_ref: ${{ needs.resolve.outputs.GIT_REF }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -2,14 +2,25 @@ name: E2EScaleTrigger
 on:
   schedule:
     - cron: '7 18 * * *'
+  workflow_run:
+    workflows: [ApprovalComment]
+    types: [completed]
   workflow_dispatch:
 jobs:
+  resolve:
+    if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/resolve-args.yaml
+    with:
+      allowed_comment: "scale"
+      event_name: ${{ github.event_name }}
   scale:
-    if: github.repository == 'aws/karpenter' || github.event_name == 'workflow_dispatch'
+    needs: [resolve]
+    if: needs.resolve.outputs.SHOULD_RUN == 'true'
     uses: ./.github/workflows/e2e.yaml
     with:
       suite: Scale
       event_name: ${{ github.event_name }}
+      git_ref: ${{ needs.resolve.outputs.GIT_REF }}
       region: "us-west-2"
       enable_metrics: true
     secrets:

--- a/.github/workflows/resolve-args.yaml
+++ b/.github/workflows/resolve-args.yaml
@@ -1,0 +1,40 @@
+name: ResolveArgs
+on:
+  workflow_call:
+    inputs:
+      event_name:
+        type: string
+        required: true
+      allowed_comment:
+        type: string
+        required: true
+    outputs:
+      SHOULD_RUN:
+        value: ${{ jobs.resolve.outputs.SHOULD_RUN }}
+      GIT_REF:
+        value: ${{ jobs.resolve.outputs.GIT_REF }}
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      SHOULD_RUN: ${{ steps.resolve-step.outputs.SHOULD_RUN }}
+      GIT_REF: ${{ steps.resolve-step.outputs.GIT_REF }}
+    steps:
+      # Download the artifact and resolve the commit if initiated by PR snapshot
+      # Otherwise, use the currently checked-out branch to run the E2E tests against
+      - uses: actions/checkout@v3
+      - if: inputs.event_name == 'workflow_run'
+        uses: ./.github/actions/download-artifact
+      - id: resolve-step
+        run: |
+          if [[ "${{ inputs.event_name }}" == "workflow_run" ]]; then
+            if [[ $(head -n 1 /tmp/artifacts/metadata.txt) == *"${{ inputs.allowed_comment }}"* ]]; then
+               echo SHOULD_RUN=true >> $GITHUB_OUTPUT
+            else
+               echo SHOULD_RUN=false >> $GITHUB_OUTPUT
+            fi
+            echo GIT_REF=$(tail -n 1 /tmp/artifacts/metadata.txt  ) >> $GITHUB_OUTPUT
+          else
+            echo SHOULD_RUN=true >> $GITHUB_OUTPUT
+            echo GIT_REF="" >> $GITHUB_OUTPUT
+          fi


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR allows users to run `/karpenter scale` which will trigger scale testing runs from a PR build.

**How was this change tested?**

`/karpenter snapshot`
`/karpenter scale`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.