### PR TITLE
test: use default instance family / generation for Windows tests

### DIFF
--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -365,13 +365,19 @@ var _ = Describe("AMI", func() {
 				StartupTaints: []v1.Taint{{Key: "example.com", Value: "value", Effect: "NoSchedule"}},
 				Requirements: []v1.NodeSelectorRequirement{
 					{
-						Key:      v1alpha1.LabelInstanceCategory,
-						Operator: v1.NodeSelectorOpExists,
-					},
-					{
 						Key:      v1.LabelOSStable,
 						Operator: v1.NodeSelectorOpIn,
 						Values:   []string{string(v1.Windows)},
+					},
+					{
+						Key:      v1alpha1.LabelInstanceCategory,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"c", "m", "r"},
+					},
+					{
+						Key:      v1alpha1.LabelInstanceGeneration,
+						Operator: v1.NodeSelectorOpGt,
+						Values:   []string{"2"},
 					},
 				},
 			})

--- a/test/suites/integration/kubelet_config_test.go
+++ b/test/suites/integration/kubelet_config_test.go
@@ -135,17 +135,30 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 				// Need to enable provisioner-level OS-scoping for now since DS evaluation is done off of the provisioner
 				// requirements, not off of the instance type options so scheduling can fail if provisioners aren't
 				// properly scoped
-				provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{
-					Key:      v1.LabelOSStable,
-					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{string(v1.Windows)},
-				},
+				provisioner.Spec.Requirements = append(
+					provisioner.Spec.Requirements,
+					v1.NodeSelectorRequirement{
+						Key:      v1.LabelOSStable,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{string(v1.Windows)},
+					},
 					// TODO: remove this requirement once VPC RC rolls out m7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
 					v1.NodeSelectorRequirement{
 						Key:      v1alpha1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
 						Values:   []string{"m7a"},
-					})
+					},
+					v1.NodeSelectorRequirement{
+						Key:      v1alpha1.LabelInstanceCategory,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"c", "m", "r"},
+					},
+					v1.NodeSelectorRequirement{
+						Key:      v1alpha1.LabelInstanceGeneration,
+						Operator: v1.NodeSelectorOpGt,
+						Values:   []string{"2"},
+					},
+				)
 				pod := test.Pod(test.PodOptions{
 					Image: aws.WindowsDefaultImage,
 					NodeSelector: map[string]string{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Windows tests will now use the default instance family and generations as they would have if the provisioners were not configured for Windows. This is to address test flaking caused by provisioning instances with extremely slow boot times (e.g. t2.nano / micro).

**How was this change tested?**
`go test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.