### PR TITLE
chore: k8s Version Provider

### DIFF
--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -458,7 +458,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			})
 		})
 		It("should resolve amiSelector AMIs and requirements into status", func() {
-			version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
+			version := lo.Must(awsEnv.VersionProvider.Get(ctx))
 
 			awsEnv.SSMAPI.Parameters = map[string]string{
 				fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version):                                                   "ami-id-123",
@@ -576,7 +576,7 @@ var _ = Describe("AWSNodeTemplateController", func() {
 			}, nodeTemplate.Status.AMIs)
 		})
 		It("should resolve amiSelector AMis and requirements into status when all SSM aliases don't resolve", func() {
-			version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
+			version := lo.Must(awsEnv.VersionProvider.Get(ctx))
 			// This parameter set doesn't include any of the Nvidia AMIs
 			awsEnv.SSMAPI.Parameters = map[string]string{
 				fmt.Sprintf("/aws/service/bottlerocket/aws-k8s-%s/x86_64/latest/image_id", version): "ami-id-123",

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -54,6 +54,7 @@ import (
 	"github.com/aws/karpenter/pkg/providers/pricing"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
+	"github.com/aws/karpenter/pkg/providers/version"
 	"github.com/aws/karpenter/pkg/utils/project"
 )
 
@@ -126,8 +127,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		ec2api,
 		*sess.Config.Region,
 	)
-	amiProvider := amifamily.NewProvider(operator.GetClient(), operator.KubernetesInterface, ssm.New(sess), ec2api,
-		cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval), cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	versionProvider := version.NewProvider(operator.KubernetesInterface, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
+	amiProvider := amifamily.NewProvider(versionProvider, ssm.New(sess), ec2api, cache.New(awscache.DefaultTTL, awscache.DefaultCleanupInterval))
 	amiResolver := amifamily.New(amiProvider)
 	launchTemplateProvider := launchtemplate.NewProvider(
 		ctx,

--- a/pkg/providers/amifamily/ami_test.go
+++ b/pkg/providers/amifamily/ami_test.go
@@ -123,7 +123,7 @@ var _ = AfterSuite(func() {
 var _ = Describe("AMIProvider", func() {
 	var version string
 	BeforeEach(func() {
-		version = lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
+		version = lo.Must(awsEnv.VersionProvider.Get(ctx))
 		nodeClass = test.NodeClass()
 	})
 	It("should succeed to resolve AMIs (AL2)", func() {

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1659,7 +1659,7 @@ var _ = Describe("LaunchTemplates", func() {
 				Expect(awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Len()).To(Equal(0))
 			})
 			It("should choose amis from SSM if no selector specified in AWSNodeTemplate", func() {
-				version := lo.Must(awsEnv.AMIProvider.KubeServerVersion(ctx))
+				version := lo.Must(awsEnv.VersionProvider.Get(ctx))
 				awsEnv.SSMAPI.Parameters = map[string]string{
 					fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", version): "test-ami-123",
 				}

--- a/pkg/providers/version/version.go
+++ b/pkg/providers/version/version.go
@@ -1,0 +1,64 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/patrickmn/go-cache"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/logging"
+
+	"github.com/aws/karpenter-core/pkg/utils/pretty"
+)
+
+const (
+	kubernetesVersionCacheKey = "kubernetesVersion"
+)
+
+// Provider get the APIServer version. This will be initialized at start up and allows karpenter to have an understanding of the cluster version
+// for decision making. The version is cached to help reduce the amount of calls made to the API Server
+
+type Provider struct {
+	cache               *cache.Cache
+	cm                  *pretty.ChangeMonitor
+	kubernetesInterface kubernetes.Interface
+}
+
+func NewProvider(kubernetesInterface kubernetes.Interface, cache *cache.Cache) *Provider {
+	return &Provider{
+		cm:                  pretty.NewChangeMonitor(),
+		cache:               cache,
+		kubernetesInterface: kubernetesInterface,
+	}
+}
+
+func (p *Provider) Get(ctx context.Context) (string, error) {
+	if version, ok := p.cache.Get(kubernetesVersionCacheKey); ok {
+		return version.(string), nil
+	}
+	serverVersion, err := p.kubernetesInterface.Discovery().ServerVersion()
+	if err != nil {
+		return "", err
+	}
+	version := fmt.Sprintf("%s.%s", serverVersion.Major, strings.TrimSuffix(serverVersion.Minor, "+"))
+	p.cache.SetDefault(kubernetesVersionCacheKey, version)
+	if p.cm.HasChanged("kubernetes-version", version) {
+		logging.FromContext(ctx).With("version", version).Debugf("discovered kubernetes version")
+	}
+	return version, nil
+}

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/karpenter/pkg/providers/pricing"
 	"github.com/aws/karpenter/pkg/providers/securitygroup"
 	"github.com/aws/karpenter/pkg/providers/subnet"
+	"github.com/aws/karpenter/pkg/providers/version"
 
 	coretest "github.com/aws/karpenter-core/pkg/test"
 
@@ -60,6 +61,7 @@ type Environment struct {
 	PricingProvider        *pricing.Provider
 	AMIProvider            *amifamily.Provider
 	AMIResolver            *amifamily.Resolver
+	VersionProvider        *version.Provider
 	LaunchTemplateProvider *launchtemplate.Provider
 }
 
@@ -82,7 +84,8 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 	pricingProvider := pricing.NewProvider(ctx, fakePricingAPI, ec2api, "")
 	subnetProvider := subnet.NewProvider(ec2api, subnetCache)
 	securityGroupProvider := securitygroup.NewProvider(ec2api, securityGroupCache)
-	amiProvider := amifamily.NewProvider(env.Client, env.KubernetesInterface, ssmapi, ec2api, ec2Cache, kubernetesVersionCache)
+	versionProvider := version.NewProvider(env.KubernetesInterface, kubernetesVersionCache)
+	amiProvider := amifamily.NewProvider(versionProvider, ssmapi, ec2api, ec2Cache)
 	amiResolver := amifamily.New(amiProvider)
 	instanceTypesProvider := instancetype.NewProvider("", instanceTypeCache, ec2api, subnetProvider, unavailableOfferingsCache, pricingProvider)
 	launchTemplateProvider :=
@@ -128,6 +131,7 @@ func NewEnvironment(ctx context.Context, env *coretest.Environment) *Environment
 		PricingProvider:        pricingProvider,
 		AMIProvider:            amiProvider,
 		AMIResolver:            amiResolver,
+		VersionProvider:        versionProvider,
 		LaunchTemplateProvider: launchTemplateProvider,
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Creating a provider for k8s version to separate it out from the AMI provider to retirve the k8s version without need to define the AMIProvider 

**How was this change tested?**
- `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.