### PR TITLE
docs: Collapse CloudFormation permissions

### DIFF
--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -58,31 +58,19 @@ Resources:
               ]
             },
             {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                }
-              }
-            },
-            {
               "Sid": "AllowScopedEC2InstanceActionsWithTags",
               "Effect": "Allow",
               "Resource": [
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
               ],
               "Action": [
                 "ec2:RunInstances",
-                "ec2:CreateFleet"
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate"
               ],
               "Condition": {
                 "StringEquals": {
@@ -181,13 +169,16 @@ Resources:
               }
             },
             {
-              "Sid": "AllowGlobalReadActions",
+              "Sid": "AllowSSMReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
               "Effect": "Allow",
               "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
+              "Action": "pricing:GetProducts"
             },
             {
               "Sid": "AllowInterruptionQueueActions",

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -58,31 +58,19 @@ Resources:
               ]
             },
             {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                }
-              }
-            },
-            {
               "Sid": "AllowScopedEC2InstanceActionsWithTags",
               "Effect": "Allow",
               "Resource": [
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
               ],
               "Action": [
                 "ec2:RunInstances",
-                "ec2:CreateFleet"
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate"
               ],
               "Condition": {
                 "StringEquals": {
@@ -181,13 +169,16 @@ Resources:
               }
             },
             {
-              "Sid": "AllowGlobalReadActions",
+              "Sid": "AllowSSMReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
               "Effect": "Allow",
               "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
+              "Action": "pricing:GetProducts"
             },
             {
               "Sid": "AllowInterruptionQueueActions",

--- a/website/content/en/v0.27/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.27/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -58,31 +58,19 @@ Resources:
               ]
             },
             {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                }
-              }
-            },
-            {
               "Sid": "AllowScopedEC2InstanceActionsWithTags",
               "Effect": "Allow",
               "Resource": [
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
               ],
               "Action": [
                 "ec2:RunInstances",
-                "ec2:CreateFleet"
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate"
               ],
               "Condition": {
                 "StringEquals": {
@@ -181,13 +169,16 @@ Resources:
               }
             },
             {
-              "Sid": "AllowGlobalReadActions",
+              "Sid": "AllowSSMReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
               "Effect": "Allow",
               "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
+              "Action": "pricing:GetProducts"
             },
             {
               "Sid": "AllowInterruptionQueueActions",

--- a/website/content/en/v0.28/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.28/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -58,31 +58,19 @@ Resources:
               ]
             },
             {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                }
-              }
-            },
-            {
               "Sid": "AllowScopedEC2InstanceActionsWithTags",
               "Effect": "Allow",
               "Resource": [
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
               ],
               "Action": [
                 "ec2:RunInstances",
-                "ec2:CreateFleet"
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate"
               ],
               "Condition": {
                 "StringEquals": {
@@ -181,13 +169,16 @@ Resources:
               }
             },
             {
-              "Sid": "AllowGlobalReadActions",
+              "Sid": "AllowSSMReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
               "Effect": "Allow",
               "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
+              "Action": "pricing:GetProducts"
             },
             {
               "Sid": "AllowInterruptionQueueActions",

--- a/website/content/en/v0.29/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.29/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -58,31 +58,19 @@ Resources:
               ]
             },
             {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                }
-              }
-            },
-            {
               "Sid": "AllowScopedEC2InstanceActionsWithTags",
               "Effect": "Allow",
               "Resource": [
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
               ],
               "Action": [
                 "ec2:RunInstances",
-                "ec2:CreateFleet"
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate"
               ],
               "Condition": {
                 "StringEquals": {
@@ -181,13 +169,16 @@ Resources:
               }
             },
             {
-              "Sid": "AllowGlobalReadActions",
+              "Sid": "AllowSSMReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
               "Effect": "Allow",
               "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
+              "Action": "pricing:GetProducts"
             },
             {
               "Sid": "AllowInterruptionQueueActions",

--- a/website/content/en/v0.30/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.30/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -58,31 +58,19 @@ Resources:
               ]
             },
             {
-              "Sid": "AllowScopedEC2LaunchTemplateActions",
-              "Effect": "Allow",
-              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
-              "Action": "ec2:CreateLaunchTemplate",
-              "Condition": {
-                "StringEquals": {
-                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
-                },
-                "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
-                }
-              }
-            },
-            {
               "Sid": "AllowScopedEC2InstanceActionsWithTags",
               "Effect": "Allow",
               "Resource": [
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
                 "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
-                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*"
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
               ],
               "Action": [
                 "ec2:RunInstances",
-                "ec2:CreateFleet"
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate"
               ],
               "Condition": {
                 "StringEquals": {
@@ -181,13 +169,16 @@ Resources:
               }
             },
             {
-              "Sid": "AllowGlobalReadActions",
+              "Sid": "AllowSSMReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
               "Effect": "Allow",
               "Resource": "*",
-              "Action": [
-                "pricing:GetProducts",
-                "ssm:GetParameter"
-              ]
+              "Action": "pricing:GetProducts"
             },
             {
               "Sid": "AllowInterruptionQueueActions",


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR collapses the CloudFormation permissions that are shipping as part of the Getting Started down into less statements and makes the `SSM:GetParameter` permission to be more restrictive by only allowing it to read SSM parameters from the same region that are AWS service managed paths

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.