### PR TITLE
test: Fix `ExpectUpdated` passing a single object

### DIFF
--- a/test/pkg/environment/common/expectations.go
+++ b/test/pkg/environment/common/expectations.go
@@ -91,7 +91,7 @@ func (env *Environment) ExpectCreatedOrUpdated(objects ...client.Object) {
 				Fail(fmt.Sprintf("Getting object %s, %v", client.ObjectKeyFromObject(o), err))
 			}
 		} else {
-			env.ExpectUpdated(objects...)
+			env.ExpectUpdated(o)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR fixes a call to `ExpectUpdated` in `ExpectCreatedOrUpdated` which was passing all of the objects to `ExpectUpdated` rather than just passing the single object that we were evaluating

**How was this change tested?**

`make presubmit`
`/karpenter scale`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.