### PR TITLE
test: Fix Windows UserData test flakes by removing m7a family

### DIFF
--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -369,6 +369,12 @@ var _ = Describe("AMI", func() {
 						Operator: v1.NodeSelectorOpIn,
 						Values:   []string{string(v1.Windows)},
 					},
+					// TODO: remove this requirement once VPC RC rolls out m7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+					{
+						Key:      v1alpha1.LabelInstanceFamily,
+						Operator: v1.NodeSelectorOpNotIn,
+						Values:   []string{"m7a"},
+					},
 					{
 						Key:      v1alpha1.LabelInstanceCategory,
 						Operator: v1.NodeSelectorOpIn,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR fixes the Windows UserData test flakes by removing the `m7a` family from the Windows UserData test until the `vpc-resource-controller` supports this family

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.