### PR TITLE
docs: Remove `karpenter.sh/voluntary-disruption` annotation from docs

### DIFF
--- a/website/content/en/preview/concepts/deprovisioning.md
+++ b/website/content/en/preview/concepts/deprovisioning.md
@@ -185,13 +185,13 @@ __Behavioral Fields__
 
 To enable the drift feature flag, refer to the [Settings Feature Gates]({{<ref "./settings#feature-gates" >}}).
 
-Karpenter will annotate the nodes with the `karpenter.sh/voluntary-disruption: "drifted"` if the node is drifted, and does not have the annotation,
+Karpenter will add `MachineDrifted` status condition on the machines if the machine is drifted, and does not have the status condition,
 
-Karpenter will remove the  `karpenter.sh/voluntary-disruption: "drifted"` annotation for the following these scenarios:
-1. The `featureGates.driftEnabled` is not enabled but the node is drifted, karpenter will remove the annotation so another disruption controller can annotate the node.
-2. The node isn't drifted, but has the annotation, karpenter will remove it.
+Karpenter will remove the  `MachineDrifted` status condition for the following these scenarios:
+1. The `featureGates.driftEnabled` is not enabled but the machine is drifted, karpenter will remove the status condition.
+2. The machine isn't drifted, but has the status condition, karpenter will remove it.
 
-If the node is marked as voluntarily disrupted by another controller, karpenter will do nothing.
+If the node is marked as drifted by another controller, karpenter will do nothing.
 
 ## Controls
 

--- a/website/content/en/v0.30/concepts/deprovisioning.md
+++ b/website/content/en/v0.30/concepts/deprovisioning.md
@@ -185,13 +185,14 @@ __Behavioral Fields__
 
 To enable the drift feature flag, refer to the [Settings Feature Gates]({{<ref "./settings#feature-gates" >}}).
 
-Karpenter will annotate the nodes with the `karpenter.sh/voluntary-disruption: "drifted"` if the node is drifted, and does not have the annotation,
+Karpenter will add `MachineDrifted` status condition on the machines if the machine is drifted, and does not have the status condition,
 
-Karpenter will remove the  `karpenter.sh/voluntary-disruption: "drifted"` annotation for the following these scenarios:
-1. The `featureGates.driftEnabled` is not enabled but the node is drifted, karpenter will remove the annotation so another disruption controller can annotate the node.
-2. The node isn't drifted, but has the annotation, karpenter will remove it.
+Karpenter will remove the  `MachineDrifted` status condition for the following these scenarios:
+1. The `featureGates.driftEnabled` is not enabled but the machine is drifted, karpenter will remove the status condition.
+2. The machine isn't drifted, but has the status condition, karpenter will remove it.
 
-If the node is marked as voluntarily disrupted by another controller, karpenter will do nothing.
+If the node is marked as drifted by another controller, karpenter will do nothing.
+
 
 ## Controls
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4609 

**Description**
- Remove from docs as this is not true anymore

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.