### PR TITLE
test: Disable r7a instance types until supported by vpc-rc

### DIFF
--- a/test/suites/integration/ami_test.go
+++ b/test/suites/integration/ami_test.go
@@ -369,11 +369,11 @@ var _ = Describe("AMI", func() {
 						Operator: v1.NodeSelectorOpIn,
 						Values:   []string{string(v1.Windows)},
 					},
-					// TODO: remove this requirement once VPC RC rolls out m7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+					// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
 					{
 						Key:      v1alpha1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a"},
+						Values:   []string{"m7a", "r7a"},
 					},
 					{
 						Key:      v1alpha1.LabelInstanceCategory,

--- a/test/suites/integration/extended_resources_test.go
+++ b/test/suites/integration/extended_resources_test.go
@@ -134,11 +134,11 @@ var _ = Describe("Extended Resources", func() {
 					Key:      v1alpha1.LabelInstanceCategory,
 					Operator: v1.NodeSelectorOpExists,
 				},
-				// TODO: Remove this once m7a instances are supported by the vpc resource controller
+				// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
 				{
 					Key:      v1alpha1.LabelInstanceFamily,
 					Operator: v1.NodeSelectorOpNotIn,
-					Values:   []string{"m7a"},
+					Values:   []string{"m7a", "r7a"},
 				},
 			},
 		})

--- a/test/suites/integration/kubelet_config_test.go
+++ b/test/suites/integration/kubelet_config_test.go
@@ -104,11 +104,11 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{string(v1.Linux)},
 				},
-					// TODO: remove this requirement once VPC RC rolls out m7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+					// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
 					v1.NodeSelectorRequirement{
 						Key:      v1alpha1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a"},
+						Values:   []string{"m7a", "r7a"},
 					})
 				pod := test.Pod(test.PodOptions{
 					NodeSelector: map[string]string{
@@ -142,11 +142,11 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 						Operator: v1.NodeSelectorOpIn,
 						Values:   []string{string(v1.Windows)},
 					},
-					// TODO: remove this requirement once VPC RC rolls out m7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+					// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
 					v1.NodeSelectorRequirement{
 						Key:      v1alpha1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a"},
+						Values:   []string{"m7a", "r7a"},
 					},
 					v1.NodeSelectorRequirement{
 						Key:      v1alpha1.LabelInstanceCategory,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR disable the `r7a` family instance types in tests that require the `vpc-resource-controller` to be running appropriately until the limits for these instance types is rolled out.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.