### PR TITLE
docs: Add more userdata examples for node log query

### DIFF
--- a/examples/provisioner/launchtemplates/al2-kubelet-log-query.yaml
+++ b/examples/provisioner/launchtemplates/al2-kubelet-log-query.yaml
@@ -1,0 +1,45 @@
+# This example provisioner will provision instances using the AL2 EKS-Optimized AMI
+# and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: default
+spec:
+  providerRef:
+    name: al2
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: al2
+spec:
+  amiFamily: AL2
+  subnetSelector:
+    karpenter.sh/discovery: my-cluster
+  securityGroupSelector:
+    karpenter.sh/discovery: my-cluster
+  userData: |
+    MIME-Version: 1.0
+    Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+    --BOUNDARY
+    Content-Type: text/x-shellscript; charset="us-ascii"
+
+    #!/bin/bash
+
+    set -e
+
+    # Add additional KUBELET_EXTRA_ARGS to the service
+    # Requires Kubernetes 1.27 (alpha feature)
+    cat << EOF > /etc/systemd/system/kubelet.service.d/90-kubelet-extra-args.conf
+    [Service]
+    Environment="KUBELET_EXTRA_ARGS=--feature-gates=NodeLogQuery=true $KUBELET_EXTRA_ARGS"
+    EOF
+    systemctl daemon-reload
+
+    # Enable log handler and log query to the kubelet configuration
+    echo "$(jq '.enableSystemLogHandler=true' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
+    echo "$(jq '.enableSystemLogQuery=true' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
+
+    --BOUNDARY--

--- a/examples/provisioner/launchtemplates/ubuntu-kubelet-log-query.yaml
+++ b/examples/provisioner/launchtemplates/ubuntu-kubelet-log-query.yaml
@@ -1,0 +1,44 @@
+# This example provisioner will provision instances using the Ubuntu EKS AMI
+# and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: default
+spec:
+  providerRef:
+    name: ubuntu
+---
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  amiFamily: Ubuntu
+  subnetSelector:
+    karpenter.sh/discovery: my-cluster
+  securityGroupSelector:
+    karpenter.sh/discovery: my-cluster
+  userData: |
+    MIME-Version: 1.0
+    Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+    --BOUNDARY
+    Content-Type: text/x-shellscript; charset="us-ascii"
+
+    #!/bin/bash
+    # There is currently a bug with log query and kubelet running inside a snap environment
+    # https://github.com/kubernetes/kubernetes/issues/120618
+    # This example is provided for reference on how to change Ubuntu settings in user data
+
+    set -e
+
+    # This requires Kubernetes 1.27 or above (alpha feature)
+    # This modifies the configuration of the /etc/eks/bootstrap.sh script because /etc/kubernetes/kubelet/kubelet-config.json
+    # doesn't exist before bootstrap.sh is run
+    
+    sed -i 's/args="$KUBELET_EXTRA_ARGS"/args="--feature-gates=NodeLogQuery=true $KUBELET_EXTRA_ARGS"/g' /etc/eks/bootstrap.sh
+    sed -i '/# writes kubeReserved and evictionHard/a echo "$(jq .enableSystemLogHandler=true $KUBELET_CONFIG)" > $KUBELET_CONFIG' /etc/eks/bootstrap.sh
+    sed -i '/# writes kubeReserved and evictionHard/a echo "$(jq .enableSystemLogQuery=true $KUBELET_CONFIG)" > $KUBELET_CONFIG' /etc/eks/bootstrap.sh
+
+    --BOUNDARY--

--- a/examples/provisioner/launchtemplates/ubuntu-kubelet-log-query.yaml
+++ b/examples/provisioner/launchtemplates/ubuntu-kubelet-log-query.yaml
@@ -12,7 +12,7 @@ spec:
 apiVersion: karpenter.k8s.aws/v1alpha1
 kind: AWSNodeTemplate
 metadata:
-  name: default
+  name: ubuntu
 spec:
   amiFamily: Ubuntu
   subnetSelector:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

**Description**
Add additional examples for customizing userdata on AL2 and Ubuntu OS. Shows examples extending KUBELET_EXTRA_ARGS which was undocumented other places.

**How was this change tested?**
Creating multiple clusters with AL2 and Ubuntu provisioners

The Ubuntu example currently doesn't work with the feature I was trying to get working (see https://github.com/kubernetes/kubernetes/issues/120618 ) but I still think it's valuable to have an example of how to do these customizations on Ubuntu as well as AL2.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.