### PR TITLE
fix: Ensure a consistent ordering for all NodeTemplate status fields

### DIFF
--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -65,14 +65,17 @@ type AMIs []AMI
 // If creation date is nil or two AMIs have the same creation date, the AMIs will be sorted by name in ascending order.
 func (a AMIs) Sort() {
 	sort.Slice(a, func(i, j int) bool {
-		if a[i].CreationDate != "" || a[j].CreationDate != "" {
-			itime, _ := time.Parse(time.RFC3339, a[i].CreationDate)
-			jtime, _ := time.Parse(time.RFC3339, a[j].CreationDate)
-			if itime.Unix() != jtime.Unix() {
-				return itime.Unix() >= jtime.Unix()
-			}
+		itime, _ := time.Parse(time.RFC3339, a[i].CreationDate)
+		jtime, _ := time.Parse(time.RFC3339, a[j].CreationDate)
+		if itime.Unix() != jtime.Unix() {
+			return itime.Unix() > jtime.Unix()
 		}
-		return a[i].Name >= a[j].Name
+		if a[i].Name != a[j].Name {
+			return a[i].Name < a[j].Name
+		}
+		iHash, _ := hashstructure.Hash(a[i].Requirements, hashstructure.FormatV2, &hashstructure.HashOptions{})
+		jHash, _ := hashstructure.Hash(a[i].Requirements, hashstructure.FormatV2, &hashstructure.HashOptions{})
+		return iHash < jHash
 	})
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR ensures that all pieces of the `NodeTemplate` output are sorted so that it always has a consistent output and doesn't perform additional `Patch` operations. Previously, it was possible that the `SecurityGroup` ordering or the AMI requirements ordering could change because they were stored in a map.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.