### PR TITLE
chore: Log Incompatible version of the API version

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"github.com/samber/lo"
-	"knative.dev/pkg/logging"
 
 	"github.com/aws/karpenter/pkg/cloudprovider"
 	"github.com/aws/karpenter/pkg/controllers"
@@ -43,10 +42,6 @@ func main() {
 	)
 	lo.Must0(op.AddHealthzCheck("cloud-provider", awsCloudProvider.LivenessProbe))
 	cloudProvider := metrics.Decorate(awsCloudProvider)
-
-	if err := op.ValidateK8sVersion(ctx); err != nil {
-		logging.FromContext(ctx).Error(err)
-	}
 
 	op.
 		WithControllers(ctx, corecontrollers.NewControllers(

--- a/hack/docs/version_compatibility.go
+++ b/hack/docs/version_compatibility.go
@@ -18,10 +18,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"sort"
 	"strings"
 
-	"github.com/aws/karpenter/tools/kompat/pkg/kompat"
+	"github.com/aws/karpenter/pkg/providers/version"
 )
 
 func main() {
@@ -33,24 +32,15 @@ func main() {
 		os.Exit(0)
 	}
 
-	chart, err := kompat.Parse(os.Args[1])
-	if err != nil {
-		log.Fatalf("unable to generate compatibility matrix")
-	}
-
-	sort.Slice(chart[0].Compatibility, func(i int, j int) bool {
-		return chart[0].Compatibility[i].AppVersion < chart[0].Compatibility[j].AppVersion
-	})
-
-	version := strings.TrimPrefix(os.Args[2], "v")
+	v := strings.TrimPrefix(os.Args[2], "v")
 	appendVersion := fmt.Sprintf(
 		`
   - appVersion: %s
     minK8sVersion: %s
     maxK8sVersion: %s`,
-		version,
-		chart[0].Compatibility[len(chart[0].Compatibility)-1].MinK8sVersion,
-		chart[0].Compatibility[len(chart[0].Compatibility)-1].MaxK8sVersion)
+		v,
+		version.MinK8sVersion,
+		version.MaxK8sVersion)
 
 	yamlFile, err := os.ReadFile(os.Args[1])
 	if err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -37,8 +37,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/patrickmn/go-cache"
 
-	utilversion "k8s.io/apimachinery/pkg/util/version"
-
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -60,12 +58,6 @@ import (
 	"github.com/aws/karpenter/pkg/providers/version"
 	"github.com/aws/karpenter/pkg/utils/project"
 )
-
-// Karpenter's supported version of Kubernetes
-// If a user runs a karpenter image on a k8s version outside the min and max,
-// One error message will be fired to notify
-const minK8sVersion = "1.23"
-const maxK8sVersion = "1.27"
 
 // Operator is injected into the AWS CloudProvider's factories
 type Operator struct {
@@ -185,20 +177,6 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		InstanceTypesProvider:     instanceTypeProvider,
 		InstanceProvider:          instanceProvider,
 	}
-}
-
-func (op *Operator) ValidateK8sVersion(ctx context.Context) error {
-	v := lo.Must(op.VersionProvider.Get(ctx))
-	k8sVersion := utilversion.MustParseGeneric(v)
-
-	// We will only error if the user is running karpenter on a k8s version,
-	// that is out of the range of the minK8sVersion and maxK8sVersion
-	if k8sVersion.LessThan(utilversion.MustParseGeneric(minK8sVersion)) ||
-		utilversion.MustParseGeneric(maxK8sVersion).LessThan(k8sVersion) {
-		return fmt.Errorf("karpenter version is not compatible with K8s version %s", k8sVersion)
-	}
-
-	return nil
 }
 
 // withUserAgent adds a karpenter specific user-agent string to AWS session


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Log incompatibility  k8s version every time karpenter retrieves the API version

**How was this change tested?**
- N/A
**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.