### PR TITLE
ci: Enable conformance test running from a PR

### DIFF
--- a/.github/workflows/approval-comment.yaml
+++ b/.github/workflows/approval-comment.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   approval-comment:
-    if: startsWith(github.event.review.body, '/karpenter snapshot') || startsWith(github.event.review.body, '/karpenter scale')
+    if: startsWith(github.event.review.body, '/karpenter snapshot') || startsWith(github.event.review.body, '/karpenter scale') || startsWith(github.event.review.body, '/karpenter conformance')
     permissions: write-all
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-conformance-trigger.yaml
+++ b/.github/workflows/e2e-conformance-trigger.yaml
@@ -3,10 +3,20 @@ on:
   schedule:
     # The test will run every Monday at 12:07 AM UTC
     - cron: '7 0 * * 1'
+  workflow_run:
+    workflows: [ApprovalComment]
+    types: [completed]
   workflow_dispatch:
 jobs:
+  resolve:
+    if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/resolve-args.yaml
+    with:
+      allowed_comment: "conformance"
+      event_name: ${{ github.event_name }}
   conformance:
-    if: github.repository == 'aws/karpenter' || github.event_name == 'workflow_dispatch'
+    needs: [resolve]
+    if: needs.resolve.outputs.SHOULD_RUN == 'true'
     strategy:
       max-parallel: 1
       fail-fast: false


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- This PR allows users to run /karpenter conformance which will trigger scale testing runs from a PR build.

**How was this change tested?**
- `/karpenter conformance`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.