### PR TITLE
ci: Increase`WARM_ENI_TARGET` to avoid timeouts for binding pods on E2E scale tests

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -114,8 +114,12 @@ runs:
             roleOnly: true
         withOIDC: true
       addons:
+      # For our scale testing, warm ENIs to help prevent timeouts on binding pods 
+      # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html 
       - name: vpc-cni
         permissionsBoundary: "arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"
+        configurationValues: |-
+          {"env":{"WARM_ENI_TARGET":"30"}}
       - name: coredns
         permissionsBoundary: "arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"
       - name: kube-proxy


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Increase the the ENI allocated to k8s VPC CNI to prevent long wait on binding pods to nodes on the E2E scale tests 

**How was this change tested?**
- Forked repo 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.