### PR TITLE
ci: Set the toolchain kubebuilder install path to be the default one

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -16,7 +16,7 @@ runs:
       id: cache-toolchain
       with:
         path: |
-          ~/.kubebuilder/bin
+          /usr/local/kubebuilder/bin
           ~/go/bin
         key: ${{ runner.os }}-${{ inputs.k8sVersion }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export K8S_VERSION ?= 1.27.x
-export KUBEBUILDER_ASSETS ?= ${HOME}/.kubebuilder/bin
 CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
 
 ## Inject the app version into project.Version

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 K8S_VERSION="${K8S_VERSION:="1.27.x"}"
-KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:="${HOME}/.kubebuilder/bin"}"
+KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
 
 main() {
     tools
@@ -28,7 +28,8 @@ tools() {
 }
 
 kubebuilder() {
-    mkdir -p $KUBEBUILDER_ASSETS
+    sudo mkdir -p ${KUBEBUILDER_ASSETS}
+    sudo chown "${USER}" ${KUBEBUILDER_ASSETS}
     arch=$(go env GOARCH)
     ## Kubebuilder does not support darwin/arm64, so use amd64 through Rosetta instead
     if [[ $(go env GOOS) == "darwin" ]] && [[ $(go env GOARCH) == "arm64" ]]; then


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates the installation path for kubebuilder to change it from a path in your home directory to the default expected installation path `/usr/local/kubebuilder/bin`. This means that you no longer need to set the `KUBEBUILDER_ASSETS` variable in testing

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.