### PR TITLE
fix: configure serviceMonitor condition for monitoring API

### DIFF
--- a/charts/karpenter/templates/servicemonitor.yaml
+++ b/charts/karpenter/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
 {{- if.Values.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -26,4 +27,5 @@ spec:
     {{- with .Values.serviceMonitor.endpointConfig }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Fixes
**Description**
Some installations we configure Karpenter before prometheus-operator and our argo-cd Waves broke and cannot continue the installation we implement the same structure as argocd [helm-chart](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml#L1C1-L1C70) to check if the monitoring API is available.

**How was this change tested?**


**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.