### PR TITLE
fix: China Pricing Endpoint

### DIFF
--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -90,7 +90,7 @@ func NewAPI(sess *session.Session, region string) pricingiface.PricingAPI {
 	if strings.HasPrefix(region, "ap-") {
 		pricingAPIRegion = "ap-south-1"
 	} else if strings.HasPrefix(region, "cn-") {
-		pricingAPIRegion = "cn-north-1"
+		pricingAPIRegion = "cn-northwest-1"
 	} else if strings.HasPrefix(region, "eu-") {
 		pricingAPIRegion = "eu-central-1"
 	}

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -89,11 +89,9 @@ func NewAPI(sess *session.Session, region string) pricingiface.PricingAPI {
 	pricingAPIRegion := "us-east-1"
 	if strings.HasPrefix(region, "ap-") {
 		pricingAPIRegion = "ap-south-1"
-	} 
-	else if strings.HasPrefix(region, "cn-") {
+	} else if strings.HasPrefix(region, "cn-") {
 		pricingAPIRegion = "cn-north-1"
-	}
-	else if strings.HasPrefix(region, "eu-") {
+	} else if strings.HasPrefix(region, "eu-") {
 		pricingAPIRegion = "eu-central-1"
 	}
 	return pricing.New(sess, &aws.Config{Region: aws.String(pricingAPIRegion)})

--- a/pkg/providers/pricing/pricing.go
+++ b/pkg/providers/pricing/pricing.go
@@ -87,9 +87,13 @@ func NewAPI(sess *session.Session, region string) pricingiface.PricingAPI {
 	}
 	// pricing API doesn't have an endpoint in all regions
 	pricingAPIRegion := "us-east-1"
-	if strings.HasPrefix(region, "ap-") || strings.HasPrefix(region, "cn-") {
+	if strings.HasPrefix(region, "ap-") {
 		pricingAPIRegion = "ap-south-1"
-	} else if strings.HasPrefix(region, "eu-") {
+	} 
+	else if strings.HasPrefix(region, "cn-") {
+		pricingAPIRegion = "cn-north-1"
+	}
+	else if strings.HasPrefix(region, "eu-") {
 		pricingAPIRegion = "eu-central-1"
 	}
 	return pricing.New(sess, &aws.Config{Region: aws.String(pricingAPIRegion)})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4658

**Description**

Pricing endpoint for China was wrong as the generated auth tokens are not valid in the Asia Pacific region. Also it's best to get prices from the same region.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.