### PR TITLE
test: skip instance profile generation tests

### DIFF
--- a/test/suites/integration/instance_profile_test.go
+++ b/test/suites/integration/instance_profile_test.go
@@ -54,6 +54,7 @@ var _ = Describe("InstanceProfile Generation", func() {
 		})
 	})
 	It("should generate the InstanceProfile when setting the role", func() {
+		Skip("InstanceProfile generation tests disabled until v1beta1")
 		pod := coretest.Pod()
 		env.ExpectCreated(nodePool, nodeClass, pod)
 		env.EventuallyExpectHealthy(pod)
@@ -68,6 +69,7 @@ var _ = Describe("InstanceProfile Generation", func() {
 		Expect(lo.FromPtr(instanceProfile.Roles[0].RoleName)).To(Equal(nodeClass.Spec.Role))
 	})
 	It("should remove the generated InstanceProfile when deleting the NodeClass", func() {
+		Skip("InstanceProfile generation tests disabled until v1beta1")
 		pod := coretest.Pod()
 		env.ExpectCreated(nodePool, nodeClass, pod)
 		env.EventuallyExpectHealthy(pod)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a skip so we don't run tests until v1beta1 is released.

**How was this change tested?**
- make e2etests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.