### PR TITLE
chore: Bump upgrade test version

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -58,7 +58,9 @@ jobs:
   e2e-upgrade:
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      from_git_ref: v0.29.1
+      # This version matches the steps of the newest version of the create-cluster action
+      # which will prevent post-run of the create-cluster action not to fail
+      from_git_ref: dc0e340759a6a42f042405cf03347b6f3c328dd6
       to_git_ref: ${{ inputs.git_ref }}
       event_name: ${{ inputs.event_name }}
       region: ${{ inputs.region }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- The E2E Upgrade tests post run action are failing due to GHA step difference. Bumping the older version of the repo to keep the two version of the `create-cluster` to match

**How was this change tested?**
- `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.