### PR TITLE
chore: Add nodepool label to instance if found as tag

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -362,6 +362,9 @@ func (c *CloudProvider) instanceToNodeClaim(i *instance.Instance, instanceType *
 		labels[v1alpha5.ProvisionerNameLabelKey] = v
 		nodeClaim.IsMachine = true
 	}
+	if v, ok := i.Tags[corev1beta1.NodePoolLabelKey]; ok {
+		labels[corev1beta1.NodePoolLabelKey] = v
+	}
 	if v, ok := i.Tags[corev1beta1.ManagedByAnnotationKey]; ok {
 		annotations[corev1beta1.ManagedByAnnotationKey] = v
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds the NodePool label to the NodeClaim that is returned by any cloudprovider call if the nodepool label is found as a tag on the instance.

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.