### PR TITLE
ci: Bump to a version that uses `eksctl` version

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -66,9 +66,9 @@ jobs:
   e2e-upgrade:
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      # This version matches the steps of the newest version of the create-cluster action
-      # which will prevent post-run of the create-cluster action not to fail
-      from_git_ref: dc0e340759a6a42f042405cf03347b6f3c328dd6
+      # This version matches the steps of the newest version of the install-eksctl action
+      # which will take in the eksctl_version into the composite action
+      from_git_ref: d29fb004f959d268ecfbddaccee004c99fc8c300
       to_git_ref: ${{ inputs.git_ref }}
       event_name: ${{ inputs.event_name }}
       region: ${{ inputs.region }}

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -120,6 +120,7 @@ jobs:
           region: ${{ inputs.region }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           k8s_version: ${{ inputs.k8s_version }}
+          eksctl_version: ${{ inputs.eksctl_version }}
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.to_git_ref }}
       - name: upgrade prometheus


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR bumps the `from_git_ref` to the latest version that has the `eksctl_version` as the passthrough for setting the version. 

The long-term fix for having to do this in the `e2e-upgrade` is handle the checkouts to the old version in the action in a way that doesn't override the actions directory.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.