### PR TITLE
chore: bump to EKS 1.28

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -16,7 +16,7 @@ inputs:
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
     required: false
-    default: "1.27"
+    default: "1.28"
   eksctl_version:
     description: "Version of eksctl to install"
     default: v0.159.0
@@ -50,10 +50,10 @@ runs:
       if [ ! -f $CLOUDFORMATION_PATH ]; then
         CLOUDFORMATION_PATH=website/content/en/preview/getting-started/getting-started-with-eksctl/cloudformation.yaml
       fi
-      
+
       # Update the Cloudformation policy to add the permissionBoundary to the NodeRole
       yq -i '.Resources.KarpenterNodeRole.Properties.PermissionsBoundary="arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"' $CLOUDFORMATION_PATH
-      
+
       aws iam create-service-linked-role --aws-service-name spot.amazonaws.com || true
       aws cloudformation deploy \
         --stack-name iam-${{ inputs.cluster_name }} \
@@ -67,7 +67,7 @@ runs:
       # Create or Upgrade the cluster based on whether the cluster already exists
       cmd="create"
       eksctl get cluster --name ${{ inputs.cluster_name }} && cmd="upgrade"
-      
+
       eksctl ${cmd} cluster -f - <<EOF
       ---
       apiVersion: eksctl.io/v1alpha5

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -3,7 +3,7 @@ description: 'Installs Go Downloads and installs Karpenter Dependencies'
 inputs:
   k8sVersion:
     description: Kubernetes version to use when installing the toolchain
-    default: "1.27.x"
+    default: "1.28.x"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          k8sVersion: ["1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x"]
+          k8sVersion: ["1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x", "1.28.x"]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/install-deps

--- a/.github/workflows/e2e-conformance-trigger.yaml
+++ b/.github/workflows/e2e-conformance-trigger.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ "1.23", "1.24", "1.25", "1.26", "1.27" ]
+        k8s_version: [ "1.23", "1.24", "1.25", "1.26", "1.27", "1.28" ]
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       event_name: ${{ github.event_name }}

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -7,7 +7,7 @@ on:
         default: "us-east-2"
       k8s_version:
         type: string
-        default: "1.27"
+        default: "1.28"
       eksctl_version:
         type: string
         default: v0.159.0
@@ -38,7 +38,7 @@ on:
           - "1.26"
           - "1.27"
           - "1.28"
-        default: "1.27"
+        default: "1.28"
       eksctl_version:
         type: string
         default: v0.159.0

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -22,7 +22,7 @@ on:
           - "1.26"
           - "1.27"
           - "1.28"
-        default: "1.27"
+        default: "1.28"
       eksctl_version:
         type: string
         default: v0.159.0
@@ -34,14 +34,14 @@ on:
       to_git_ref:
         type: string
       region:
-        type: string 
+        type: string
         default: "us-east-2"
       event_name:
         type: string
         required: true
       k8s_version:
         type: string
-        default: "1.27"
+        default: "1.28"
       eksctl_version:
         type: string
         default: v0.159.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,7 @@ on:
           - "1.26"
           - "1.27"
           - "1.28"
-        default: "1.27"
+        default: "1.28"
       eksctl_version:
         type: string
         default: v0.159.0
@@ -56,7 +56,7 @@ on:
         required: true
       k8s_version:
         type: string
-        default: "1.27"
+        default: "1.28"
       eksctl_version:
         type: string
         default: v0.159.0
@@ -94,7 +94,7 @@ jobs:
           role-duration-seconds: 21600
       - name: add jitter on cluster creation
         run: |
-          # Creating jitter so that we can stagger cluster creation to avoid throttling 
+          # Creating jitter so that we can stagger cluster creation to avoid throttling
           sleep $(( $RANDOM % 300 + 1 ))
       - name: generate cluster name
         run: |

--- a/pkg/providers/version/version.go
+++ b/pkg/providers/version/version.go
@@ -33,7 +33,7 @@ const (
 	// If a user runs a karpenter image on a k8s version outside the min and max,
 	// One error message will be fired to notify
 	MinK8sVersion = "1.23"
-	MaxK8sVersion = "1.27"
+	MaxK8sVersion = "1.28"
 )
 
 // Provider get the APIServer version. This will be initialized at start up and allows karpenter to have an understanding of the cluster version


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Bumps the GitHub Actions infrastructure to use EKS 1.28 by default. Additionally bumps the max supported kubernetes version to 1.28.

**How was this change tested?**
N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.