### PR TITLE
chore: bump eksctl version

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
   eksctl_version:
     description: "Version of eksctl to install"
-    default: v0.159.0
+    default: v0.160.0-rc.0
 runs:
   using: "composite"
   steps:
@@ -38,7 +38,7 @@ runs:
       run: |
         for name in $(aws iam list-instance-profiles --query "InstanceProfiles[*].{Name:InstanceProfileName}" --output text); do
           tags=$(aws iam list-instance-profile-tags --instance-profile-name $name --output json || true)
-          if [[ $(echo $tags | jq -r '.Tags[] | select(.Key == "testing/cluster") | .Value') == "${{ inputs.cluster_name }}" ]]; then 
+          if [[ $(echo $tags | jq -r '.Tags[] | select(.Key == "testing/cluster") | .Value') == "${{ inputs.cluster_name }}" ]]; then
               roleName=$(aws iam get-instance-profile --instance-profile-name $name --query "InstanceProfile.Roles[*].{Name:RoleName}" --output text)
               aws iam remove-role-from-instance-profile --instance-profile-name $name --role-name $roleName
               aws iam delete-instance-profile --instance-profile-name $name
@@ -63,9 +63,9 @@ runs:
             --network-interface-id
     - name: delete-security-group
       shell: bash
-      # For drift testing, we create a security group and need to clean it up here 
+      # For drift testing, we create a security group and need to clean it up here
       # to avoid leaks if the tests is not fully completed
-      run: | 
+      run: |
         aws ec2 describe-security-groups \
           --filters Name=group-name,Values=security-group-drift Name=tag:karpenter.sh/discovery,Values=${{ inputs.cluster_name }} \
           --query "SecurityGroups[*].{ID:GroupId}" \

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -19,7 +19,7 @@ inputs:
     default: "1.28"
   eksctl_version:
     description: "Version of eksctl to install"
-    default: v0.159.0
+    default: v0.160.0-rc.0
   ip_family:
     description: "IP Family of the cluster. Valid values are IPv4 or IPv6"
     required: false

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -10,7 +10,7 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.159.0
+        default: v0.160.0-rc.0
       git_ref:
         type: string
       event_name:
@@ -41,7 +41,7 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.159.0
+        default: v0.160.0-rc.0
 # All jobs will run under the following conditions:
 #   1. Upstream Karpenter repo triggered the job by schedule, push, or dispatch
 #   2. Upstream Karpenter repo triggered the job by workflow_run, which requires maintainer check to succeed

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -25,7 +25,7 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.159.0
+        default: v0.160.0-rc.0
   workflow_call:
     inputs:
       from_git_ref:
@@ -44,7 +44,7 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.159.0
+        default: v0.160.0-rc.0
     secrets:
       SLACK_WEBHOOK_URL:
         required: true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,7 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.159.0
+        default: v0.160.0-rc.0
       enable_metrics:
         type: boolean
         default: false
@@ -59,7 +59,7 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.159.0
+        default: v0.160.0-rc.0
       enable_metrics:
         type: boolean
         default: false


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Bumps eksctl version for GHA to support EKS 1.28.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.