### PR TITLE
ci: Fix passing through the `event_name` correctly

### DIFF
--- a/.github/actions/e2e/slack/notify/action.yaml
+++ b/.github/actions/e2e/slack/notify/action.yaml
@@ -11,9 +11,6 @@ inputs:
     required: true
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
-  event_name:
-    description: "Type of event that triggered this test run"
-    required: true
 runs:
   using: "composite"
   steps:
@@ -22,7 +19,7 @@ runs:
         ref: ${{ inputs.git_ref }}
     - shell: bash
       run: |
-        if [[ ${{ inputs.event_name }} == "schedule" ]]; then
+        if [[ ${{ github.event_name }} == "schedule" ]]; then
           RUN_NAME="${{ inputs.suite }}-periodic"
         else
           RUN_NAME="${{ inputs.suite }}-${GITHUB_SHA::7}"

--- a/.github/workflows/e2e-conformance-trigger.yaml
+++ b/.github/workflows/e2e-conformance-trigger.yaml
@@ -13,7 +13,6 @@ jobs:
     uses: ./.github/workflows/resolve-args.yaml
     with:
       allowed_comment: "conformance"
-      event_name: ${{ github.event_name }}
   conformance:
     needs: [resolve]
     if: needs.resolve.outputs.SHOULD_RUN == 'true'
@@ -23,7 +22,6 @@ jobs:
         k8s_version: [ "1.23", "1.24", "1.25", "1.26", "1.27", "1.28" ]
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
-      event_name: ${{ github.event_name }}
       region: "eu-west-1"
       k8s_version: ${{ matrix.k8s_version }}
       workflow_trigger: "conformance"

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -14,13 +14,11 @@ jobs:
     uses: ./.github/workflows/resolve-args.yaml
     with:
       allowed_comment: "snapshot"
-      event_name: ${{ github.event_name }}
   e2e-matrix:
     needs: [resolve]
     if: needs.resolve.outputs.SHOULD_RUN == 'true'
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
-      event_name: ${{ github.event_name }}
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
       workflow_trigger: "matrix"
     secrets:

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -13,11 +13,9 @@ on:
         default: v0.160.0-rc.0
       git_ref:
         type: string
-      event_name:
-        type: string
-        required: true
       workflow_trigger:
         type: string
+        required: true
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
@@ -56,7 +54,6 @@ jobs:
     with:
       suite: ${{ matrix.suite }}
       git_ref: ${{ inputs.git_ref }}
-      event_name: ${{ inputs.event_name }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}
       eksctl_version: ${{ inputs.eksctl_version }}
@@ -70,7 +67,6 @@ jobs:
       # which will take in the eksctl_version into the composite action
       from_git_ref: d29fb004f959d268ecfbddaccee004c99fc8c300
       to_git_ref: ${{ inputs.git_ref }}
-      event_name: ${{ inputs.event_name }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}
       eksctl_version: ${{ inputs.eksctl_version }}

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -12,14 +12,12 @@ jobs:
     uses: ./.github/workflows/resolve-args.yaml
     with:
       allowed_comment: "scale"
-      event_name: ${{ github.event_name }}
   scale:
     needs: [resolve]
     if: needs.resolve.outputs.SHOULD_RUN == 'true'
     uses: ./.github/workflows/e2e.yaml
     with:
       suite: Scale
-      event_name: ${{ github.event_name }}
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
       region: "us-west-2"
       enable_metrics: true

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -36,9 +36,6 @@ on:
       region:
         type: string
         default: "us-east-2"
-      event_name:
-        type: string
-        required: true
       k8s_version:
         type: string
         default: "1.28"
@@ -61,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.to_git_ref }}
-      - if: always() && inputs.event_name == 'workflow_run'
+      - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/start
         with:
           name: ${{ github.workflow }} (${{ inputs.k8s_version }}) / e2e (Upgrade)
@@ -154,12 +151,11 @@ jobs:
           TEST_SUITE="Integration" make e2etests
       - name: notify slack of success or failure
         uses: ./.github/actions/e2e/slack/notify
-        if: (success() || failure()) && inputs.event_name != 'workflow_run' && inputs.event_name != 'conformance'
+        if: (success() || failure()) && github.event_name != 'workflow_run' && github.event_name != 'conformance'
         with:
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
           suite: Upgrade
           k8s_version: ${{ inputs.k8s_version }}
-          event_name: ${{ inputs.event_name }}
           git_ref: ${{ inputs.to_git_ref }}
       - name: dump logs on failure
         uses: ./.github/actions/e2e/dump-logs
@@ -179,7 +175,7 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           git_ref: ${{ inputs.to_git_ref }}
           eksctl_version: ${{ inputs.eksctl_version }}
-      - if: always() && inputs.event_name == 'workflow_run'
+      - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/end
         with:
           name: ${{ github.workflow }} (${{ inputs.k8s_version }}) / e2e (Upgrade)

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,9 +51,6 @@ on:
       suite:
         type: string
         required: true
-      event_name:
-        type: string
-        required: true
       k8s_version:
         type: string
         default: "1.28"
@@ -80,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git_ref }}
-      - if: always() && inputs.event_name == 'workflow_run'
+      - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/start
         with:
           name: ${{ github.workflow }} (${{ inputs.k8s_version }}) / e2e (${{ inputs.suite }})
@@ -135,12 +132,11 @@ jobs:
           TEST_SUITE="${{ inputs.suite }}" ENABLE_METRICS=${{ inputs.enable_metrics }} METRICS_REGION=${{ vars.TIMESTREAM_REGION }} GIT_REF="$(git rev-parse HEAD)" make e2etests
       - name: notify slack of success or failure
         uses: ./.github/actions/e2e/slack/notify
-        if: (success() || failure()) && inputs.event_name != 'workflow_run' && inputs.workflow_trigger != 'conformance'
+        if: (success() || failure()) && github.event_name != 'workflow_run' && inputs.workflow_trigger != 'conformance'
         with:
           url: ${{ secrets.SLACK_WEBHOOK_URL }}
           suite: ${{ inputs.suite }}
           k8s_version: ${{ inputs.k8s_version }}
-          event_name: ${{ inputs.event_name }}
           git_ref: ${{ inputs.git_ref }}
       - name: dump logs on failure
         uses: ./.github/actions/e2e/dump-logs
@@ -160,7 +156,7 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           git_ref: ${{ inputs.git_ref }}
           eksctl_version: ${{ inputs.eksctl_version }}
-      - if: always() && inputs.event_name == 'workflow_run'
+      - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/end
         with:
           name: ${{ github.workflow }} (${{ inputs.k8s_version }}) / e2e (${{ inputs.suite }})

--- a/.github/workflows/resolve-args.yaml
+++ b/.github/workflows/resolve-args.yaml
@@ -2,9 +2,6 @@ name: ResolveArgs
 on:
   workflow_call:
     inputs:
-      event_name:
-        type: string
-        required: true
       allowed_comment:
         type: string
         required: true
@@ -23,11 +20,11 @@ jobs:
       # Download the artifact and resolve the commit if initiated by PR snapshot
       # Otherwise, use the currently checked-out branch to run the E2E tests against
       - uses: actions/checkout@v4
-      - if: inputs.event_name == 'workflow_run'
+      - if: github.event_name == 'workflow_run'
         uses: ./.github/actions/download-artifact
       - id: resolve-step
         run: |
-          if [[ "${{ inputs.event_name }}" == "workflow_run" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             if [[ $(head -n 1 /tmp/artifacts/metadata.txt) == *"${{ inputs.allowed_comment }}"* ]]; then
                echo SHOULD_RUN=true >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Drop passing through the `event_name` through `inputs.event_name` since the `github` context always stores the top-level event in `github.event_name`

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.