### PR TITLE
chore: Drop support for tag-based ami requirements with `v1beta1/NodeClass`

### DIFF
--- a/pkg/controllers/nodeclass/nodeclass_test.go
+++ b/pkg/controllers/nodeclass/nodeclass_test.go
@@ -691,49 +691,6 @@ var _ = Describe("NodeClassController", func() {
 				},
 			))
 		})
-		It("should resolve amiSelector AMIs that have well-known tags as AMI requirements into status", func() {
-			awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{
-				Images: []*ec2.Image{
-					{
-						Name:         aws.String("test-ami-4"),
-						ImageId:      aws.String("ami-test4"),
-						CreationDate: aws.String(time.Now().Add(2 * time.Minute).Format(time.RFC3339)),
-						Architecture: aws.String("x86_64"),
-						Tags: []*ec2.Tag{
-							{Key: aws.String("Name"), Value: aws.String("test-ami-3")},
-							{Key: aws.String("foo"), Value: aws.String("bar")},
-							{Key: aws.String("kubernetes.io/os"), Value: aws.String("test-requirement-1")},
-						},
-					},
-				},
-			})
-			ExpectApplied(ctx, env.Client, nodeClass)
-			ExpectReconcileSucceeded(ctx, nodeClassController, client.ObjectKeyFromObject(nodeClass))
-			nodeClass = ExpectExists(ctx, env.Client, nodeClass)
-
-			Expect(nodeClass.Status.AMIs).To(Equal([]v1beta1.AMI{
-				{
-					Name: "test-ami-4",
-					ID:   "ami-test4",
-					Requirements: []v1.NodeSelectorRequirement{
-						{
-							Key:      "kubernetes.io/os",
-							Operator: "In",
-							Values: []string{
-								"test-requirement-1",
-							},
-						},
-						{
-							Key:      "kubernetes.io/arch",
-							Operator: "In",
-							Values: []string{
-								"amd64",
-							},
-						},
-					},
-				},
-			}))
-		})
 	})
 	Context("Static Drift Hash", func() {
 		DescribeTable("should update the static drift hash when static field is updated", func(changes *v1beta1.EC2NodeClass) {

--- a/pkg/providers/launchtemplate/nodeclass_test.go
+++ b/pkg/providers/launchtemplate/nodeclass_test.go
@@ -1435,24 +1435,12 @@ var _ = Describe("EC2NodeClass/LaunchTemplates", func() {
 						Name:         aws.String(coretest.RandomName()),
 						ImageId:      aws.String("ami-123"),
 						Architecture: aws.String("x86_64"),
-						Tags: []*ec2.Tag{
-							{
-								Key:   aws.String(v1.LabelInstanceTypeStable),
-								Value: aws.String("m5.large"),
-							},
-						},
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 					{
 						Name:         aws.String(coretest.RandomName()),
 						ImageId:      aws.String("ami-456"),
-						Architecture: aws.String("x86_64"),
-						Tags: []*ec2.Tag{
-							{
-								Key:   aws.String(v1.LabelInstanceTypeStable),
-								Value: aws.String("m5.xlarge"),
-							},
-						},
+						Architecture: aws.String("arm64"),
 						CreationDate: aws.String("2022-08-10T12:00:00Z"),
 					},
 				}})
@@ -1462,11 +1450,11 @@ var _ = Describe("EC2NodeClass/LaunchTemplates", func() {
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Len()).To(BeNumerically(">=", 2))
-				expectedImageIds := sets.NewString("ami-123", "ami-456")
-				actualImageIds := sets.NewString(
-					*awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
-					*awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
-				)
+				expectedImageIds := sets.New[string]("ami-123", "ami-456")
+				actualImageIds := sets.New[string]()
+				awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
+					actualImageIds.Insert(*ltInput.LaunchTemplateData.ImageId)
+				})
 				Expect(expectedImageIds.Equal(actualImageIds)).To(BeTrue())
 			})
 			It("should create a launch template with the newest compatible AMI when multiple amis are discovered", func() {

--- a/pkg/providers/launchtemplate/nodetemplate_test.go
+++ b/pkg/providers/launchtemplate/nodetemplate_test.go
@@ -1522,11 +1522,11 @@ var _ = Describe("NodeTemplate/LaunchTemplates", func() {
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				ExpectScheduled(ctx, env.Client, pod)
 				Expect(awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Len()).To(BeNumerically(">=", 2))
-				expectedImageIds := sets.NewString("ami-123", "ami-456")
-				actualImageIds := sets.NewString(
-					*awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
-					*awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.Pop().LaunchTemplateData.ImageId,
-				)
+				expectedImageIds := sets.New[string]("ami-123", "ami-456")
+				actualImageIds := sets.New[string]()
+				awsEnv.EC2API.CalledWithCreateLaunchTemplateInput.ForEach(func(ltInput *ec2.CreateLaunchTemplateInput) {
+					actualImageIds.Insert(*ltInput.LaunchTemplateData.ImageId)
+				})
 				Expect(expectedImageIds.Equal(actualImageIds)).To(BeTrue())
 			})
 			It("should create a launch template with the newest compatible AMI when multiple amis are discovered", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR drops support for tag-based AMI requirements for `v1beta1/NodeClass` (as specified in the [v1beta1 proposal design](https://github.com/aws/karpenter/blob/main/designs/v1beta1-api.md))

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.