### PR TITLE
chore: Expose webhooks on port 8001 and enable disabling webhooks

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -93,6 +93,8 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Tolerations to allow the pod to be scheduled to nodes with taints. |
 | topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}]` | Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels. |
+| webhook.enabled | bool | `true` | Whether to enable the webhooks and webhook permissions. |
 | webhook.logLevel | string | `"error"` |  |
+| webhook.metrics.port | int | `8001` | The container port to use for webhook metrics. |
 | webhook.port | int | `8443` | The container port to use for the webhook. |
 

--- a/charts/karpenter/templates/clusterrole-core.yaml
+++ b/charts/karpenter/templates/clusterrole-core.yaml
@@ -41,12 +41,14 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
     verbs: ["list", "watch"]
+{{- if .Values.webhook.enabled }}
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["get", "watch", "list"]
-  - apiGroups: [ "policy" ]
-    resources: [ "poddisruptionbudgets" ]
-    verbs: [ "get", "list", "watch" ]
+{{- end }}
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
   # Write
   - apiGroups: ["karpenter.sh"]
     resources: ["machines", "machines/status"]
@@ -63,10 +65,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods/eviction"]
     verbs: ["create"]
+{{- if .Values.webhook.enabled }}
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["validation.webhook.karpenter.sh", "validation.webhook.config.karpenter.sh"]
+{{- end }}
   {{- with .Values.additionalClusterRoleRules -}}
   {{ toYaml . | nindent 2 }}
   {{- end -}}

--- a/charts/karpenter/templates/clusterrole.yaml
+++ b/charts/karpenter/templates/clusterrole.yaml
@@ -32,6 +32,11 @@ rules:
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["awsnodetemplates"]
     verbs: ["get", "list", "watch"]
+  # Write
+  - apiGroups: ["karpenter.k8s.aws"]
+    resources: ["awsnodetemplates", "awsnodetemplates/status"]
+    verbs: ["patch", "update"]
+{{- if .Values.webhook.enabled }}
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
@@ -40,7 +45,4 @@ rules:
     resources: ["mutatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["defaulting.webhook.karpenter.k8s.aws"]
-  # Write
-  - apiGroups: ["karpenter.k8s.aws"]
-    resources: ["awsnodetemplates", "awsnodetemplates/status"]
-    verbs: ["patch", "update"]
+{{- end }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -73,12 +73,17 @@ spec:
               value: "1.19.0-0"
             - name: KARPENTER_SERVICE
               value: {{ include "karpenter.fullname" . }}
+          {{- if .Values.webhook.enabled }}
             - name: WEBHOOK_PORT
               value: "{{ .Values.webhook.port }}"
-            - name: METRICS_PORT
-              value: "{{ .Values.controller.metrics.port }}"
             - name: WEBHOOK_METRICS_PORT
               value: "{{ .Values.webhook.metrics.port }}"
+          {{- else }}
+            - name: DISABLE_WEBHOOK
+              value: "true"
+          {{- end }}
+            - name: METRICS_PORT
+              value: "{{ .Values.controller.metrics.port }}"
             - name: HEALTH_PROBE_PORT
               value: "{{ .Values.controller.healthProbe.port }}"
             - name: SYSTEM_NAMESPACE
@@ -102,8 +107,10 @@ spec:
             - name: http-metrics
               containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
-            - name: http-webhook-metrics
+          {{- if .Values.webhook.enabled }}
+            - name: webhook-metrics
               containerPort: {{ .Values.webhook.metrics.port }}
+          {{- end }}
               protocol: TCP
             - name: http
               containerPort: {{ .Values.controller.healthProbe.port }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "{{ .Values.webhook.port }}"
             - name: METRICS_PORT
               value: "{{ .Values.controller.metrics.port }}"
+            - name: WEBHOOK_METRICS_PORT
+              value: "{{ .Values.webhook.metrics.port }}"
             - name: HEALTH_PROBE_PORT
               value: "{{ .Values.controller.healthProbe.port }}"
             - name: SYSTEM_NAMESPACE
@@ -99,6 +101,9 @@ spec:
           ports:
             - name: http-metrics
               containerPort: {{ .Values.controller.metrics.port }}
+              protocol: TCP
+            - name: http-webhook-metrics
+              containerPort: {{ .Values.webhook.metrics.port }}
               protocol: TCP
             - name: http
               containerPort: {{ .Values.controller.healthProbe.port }}

--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -33,10 +33,16 @@ rules:
     verbs: ["patch", "update"]
     resourceNames:
       - "karpenter-leader-election"
+{{- if .Values.webhook.enabled }}
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["patch", "update"]
+    resourceNames:
       - "webhook.configmapwebhook.00-of-01"
       - "webhook.defaultingwebhook.00-of-01"
       - "webhook.validationwebhook.00-of-01"
       - "webhook.webhookcertificates.00-of-01"
+{{- end }}
   # Cannot specify resourceNames on create
   # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
   - apiGroups: ["coordination.k8s.io"]

--- a/charts/karpenter/templates/service.yaml
+++ b/charts/karpenter/templates/service.yaml
@@ -16,6 +16,12 @@ spec:
       port: {{ .Values.controller.metrics.port }}
       targetPort: http-metrics
       protocol: TCP
+  {{- if .Values.webhook.enabled }}
+    - name: webhook-metrics
+      port: {{ .Values.webhook.metrics.port }}
+      targetPort: webhook-metrics
+      protocol: TCP
+  {{- end }}
     - name: https-webhook
       port: {{ .Values.webhook.port }}
       targetPort: https-webhook

--- a/charts/karpenter/templates/webhooks-core.yaml
+++ b/charts/karpenter/templates/webhooks-core.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -53,3 +54,4 @@ webhooks:
     objectSelector:
       matchLabels:
         app.kubernetes.io/part-of: {{ template "karpenter.name" . }}
+{{- end }}

--- a/charts/karpenter/templates/webhooks.yaml
+++ b/charts/karpenter/templates/webhooks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -83,3 +84,4 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+{{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -146,6 +146,9 @@ webhook:
   logLevel: error
   # -- The container port to use for the webhook.
   port: 8443
+  metrics:
+    # -- The container port to use for webhook metrics.
+    port: 8001
 # -- Global log level
 logLevel: debug
 # -- Global log encoding

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -143,6 +143,8 @@ controller:
     # -- The container port to use for http health probe.
     port: 8081
 webhook:
+  # -- Whether to enable the webhooks and webhook permissions.
+  enabled: true
   logLevel: error
   # -- The container port to use for the webhook.
   port: 8443

--- a/website/content/en/preview/concepts/settings.md
+++ b/website/content/en/preview/concepts/settings.md
@@ -23,6 +23,7 @@ There are two main configuration mechanisms that can be used to configure Karpen
 | LEADER_ELECT | \-\-leader-elect | Start leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability. (default = true)|
 | MEMORY_LIMIT | \-\-memory-limit | Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value. (default = -1)|
 | METRICS_PORT | \-\-metrics-port | The port the metric endpoint binds to for operating metrics about the controller itself (default = 8000)|
+| WEBHOOK_METRICS_PORT | \-\-webhook-metrics-port | The port the webhook metric endpoing binds to for operating metrics about the webhook (default = 8001)|
 | WEBHOOK_PORT | \-\-webhook-port | The port the webhook endpoint binds to for validation and mutation of resources (default = 8443)|
 
 [comment]: <> (end docs generated content from hack/docs/configuration_gen_docs.go)

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -120,6 +120,10 @@ Snapshot releases are tagged with the git commit hash prefixed by the Karpenter 
 
 ## Released Upgrade Notes
 
+### Upgrading to v0.32.0+
+
+* Karpenter now serves the webhook prometheus metrics server on port `8001`. If this port is already in-use on the pod or you are running in `hostNetworking` mode, you may need to change this port value. You can configure this port value through the `WEBHOOK_METRICS_PORT` environment variable or the `--set webhook.metrics.port` value if installing via Helm.
+
 ### Upgrading to v0.31.0+
 
 * Karpenter moved its `securityContext` constraints from pod-wide to only applying to the Karpenter container exclusively. If you were previously relying on the pod-wide `securityContext` for your sidecar containers, you will now need to set these values explicitly in your sidecar container configuration.

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -122,7 +122,8 @@ Snapshot releases are tagged with the git commit hash prefixed by the Karpenter 
 
 ### Upgrading to v0.32.0+
 
-* Karpenter now serves the webhook prometheus metrics server on port `8001`. If this port is already in-use on the pod or you are running in `hostNetworking` mode, you may need to change this port value. You can configure this port value through the `WEBHOOK_METRICS_PORT` environment variable or the `--set webhook.metrics.port` value if installing via Helm.
+* Karpenter now serves the webhook prometheus metrics server on port `8001`. If this port is already in-use on the pod or you are running in `hostNetworking` mode, you may need to change this port value. You can configure this port value through the `WEBHOOK_METRICS_PORT` environment variable or the `webhook.metrics.port` value if installing via Helm.
+* Karpenter now exposes the ability to disable webhooks through the `webhook.enabled=false` value. This value will disable the webhook server and will prevent any permissions, mutating or validating webhook configurations from being deployed to the cluster.
 
 ### Upgrading to v0.31.0+
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This enables webhook metrics to be exposed on port 8001 and allows this port to be configured through the `webhook.metrics.port` and to allow disabling the webhooks through the `webhook.enabled` chart value

**How was this change tested?**

`make presubmit`
`make apply` (manual validation)

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.