### PR TITLE
choreL: Update NodeClassReference to have fieldname 'nodeClassRef'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.45.19
-	github.com/aws/karpenter-core v0.31.0
+	github.com/aws/karpenter-core v0.31.1-0.20231003150228-d494b7d6d54f
 	github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644
 	github.com/imdario/mergo v0.3.16
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.45.19 h1:+4yXWhldhCVXWFOQRF99ZTJ92t4DtoHROZIbN7Ujk/U=
 github.com/aws/aws-sdk-go v1.45.19/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.31.0 h1:3EVFl6luDqMmucaJFPI8dGgwpajxNeIOuB6BymKnTOo=
-github.com/aws/karpenter-core v0.31.0/go.mod h1:gYAB79gHhfCDNa1MnN/6C7TJ9QRgpzcNf8evekHn6Bk=
+github.com/aws/karpenter-core v0.31.1-0.20231003150228-d494b7d6d54f h1:yl73U8hrilKuHnGu1dqSv3H/r+3zXA0z8iJYDGbjGxE=
+github.com/aws/karpenter-core v0.31.1-0.20231003150228-d494b7d6d54f/go.mod h1:4wXCSTj97gOWkWeB4D6LjWQMoqldrI8fo4tUOAhYTDs=
 github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644 h1:M1fxGlOfvSqFYI01HL2zzvomy8e7LiTHk77KDuChWZQ=
 github.com/aws/karpenter/tools/kompat v0.0.0-20230915222222-abfbf5fa3644/go.mod h1:l/TIBsaCx/IrOr0Xvlj/cHLOf05QzuQKEZ1hx2XWmfU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -40,7 +40,7 @@ spec:
       name: NodePool
       priority: 1
       type: string
-    - jsonPath: .spec.nodeClass.name
+    - jsonPath: .spec.nodeClassRef.name
       name: NodeClass
       priority: 1
       type: string
@@ -160,9 +160,9 @@ spec:
                       system daemons and kernel memory.
                     type: object
                 type: object
-              nodeClass:
-                description: NodeClass is a reference to an object that defines provider
-                  specific configuration
+              nodeClassRef:
+                description: NodeClassRef is a reference to an object that defines
+                  provider specific configuration
                 properties:
                   apiVersion:
                     description: API version of the referent
@@ -282,7 +282,7 @@ spec:
                   type: object
                 type: array
             required:
-            - nodeClass
+            - nodeClassRef
             - requirements
             type: object
           status:
@@ -341,6 +341,10 @@ spec:
                   - type
                   type: object
                 type: array
+              imageID:
+                description: ImageID is an identifier for the image that runs on the
+                  node
+                type: string
               nodeName:
                 description: NodeName is the name of the corresponding node object
                 type: string

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -17,7 +17,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.template.spec.nodeClass.name
+    - jsonPath: .spec.template.spec.nodeClassRef.name
       name: NodeClass
       type: string
     - jsonPath: .spec.weight
@@ -219,9 +219,9 @@ spec:
                               for OS system daemons and kernel memory.
                             type: object
                         type: object
-                      nodeClass:
-                        description: NodeClass is a reference to an object that defines
-                          provider specific configuration
+                      nodeClassRef:
+                        description: NodeClassRef is a reference to an object that
+                          defines provider specific configuration
                         properties:
                           apiVersion:
                             description: API version of the referent
@@ -351,7 +351,7 @@ spec:
                           type: object
                         type: array
                     required:
-                    - nodeClass
+                    - nodeClassRef
                     - requirements
                     type: object
                 type: object

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -208,7 +208,7 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *corev1beta1.No
 	if err != nil {
 		return "", client.IgnoreNotFound(fmt.Errorf("resolving owner, %w", err))
 	}
-	if nodePool.Spec.Template.Spec.NodeClass == nil {
+	if nodePool.Spec.Template.Spec.NodeClassRef == nil {
 		return "", nil
 	}
 	nodeClass, err := c.resolveNodeClassFromNodePool(ctx, nodePool)
@@ -235,14 +235,14 @@ func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeC
 	if nodeClaim.IsMachine {
 		nodeTemplate, err := c.resolveNodeTemplate(ctx,
 			[]byte(nodeClaim.Annotations[v1alpha5.ProviderCompatabilityAnnotationKey]),
-			machineutil.NewMachineTemplateRef(nodeClaim.Spec.NodeClass))
+			machineutil.NewMachineTemplateRef(nodeClaim.Spec.NodeClassRef))
 		if err != nil {
 			return nil, fmt.Errorf("resolving node template, %w", err)
 		}
 		return nodeclassutil.New(nodeTemplate), nil
 	}
 	nodeClass := &v1beta1.EC2NodeClass{}
-	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodeClaim.Spec.NodeClass.Name}, nodeClass); err != nil {
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodeClaim.Spec.NodeClassRef.Name}, nodeClass); err != nil {
 		return nil, err
 	}
 	// For the purposes of NodeClass CloudProvider resolution, we treat deleting NodeClasses as NotFound
@@ -259,14 +259,14 @@ func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePo
 		if nodePool.Spec.Template.Spec.Provider != nil {
 			rawProvider = nodePool.Spec.Template.Spec.Provider.Raw
 		}
-		nodeTemplate, err := c.resolveNodeTemplate(ctx, rawProvider, machineutil.NewMachineTemplateRef(nodePool.Spec.Template.Spec.NodeClass))
+		nodeTemplate, err := c.resolveNodeTemplate(ctx, rawProvider, machineutil.NewMachineTemplateRef(nodePool.Spec.Template.Spec.NodeClassRef))
 		if err != nil {
 			return nil, fmt.Errorf("resolving node template, %w", err)
 		}
 		return nodeclassutil.New(nodeTemplate), nil
 	}
 	nodeClass := &v1beta1.EC2NodeClass{}
-	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePool.Spec.Template.Spec.NodeClass.Name}, nodeClass); err != nil {
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePool.Spec.Template.Spec.NodeClassRef.Name}, nodeClass); err != nil {
 		return nil, err
 	}
 	// For the purposes of NodeClass CloudProvider resolution, we treat deleting NodeClasses as NotFound

--- a/pkg/cloudprovider/nodeclaim_test.go
+++ b/pkg/cloudprovider/nodeclaim_test.go
@@ -52,7 +52,7 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 			Spec: corev1beta1.NodePoolSpec{
 				Template: corev1beta1.NodeClaimTemplate{
 					Spec: corev1beta1.NodeClaimSpec{
-						NodeClass: &corev1beta1.NodeClassReference{
+						NodeClassRef: &corev1beta1.NodeClassReference{
 							Name: nodeClass.Name,
 						},
 						Requirements: []v1.NodeSelectorRequirement{
@@ -67,7 +67,7 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 				Labels: map[string]string{corev1beta1.NodePoolLabelKey: nodePool.Name},
 			},
 			Spec: corev1beta1.NodeClaimSpec{
-				NodeClass: &corev1beta1.NodeClassReference{
+				NodeClassRef: &corev1beta1.NodeClassReference{
 					Name: nodeClass.Name,
 				},
 			},
@@ -463,7 +463,7 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 				Spec: corev1beta1.NodePoolSpec{
 					Template: corev1beta1.NodeClaimTemplate{
 						Spec: corev1beta1.NodeClaimSpec{
-							NodeClass: &corev1beta1.NodeClassReference{
+							NodeClassRef: &corev1beta1.NodeClassReference{
 								Name: nodeClass2.Name,
 							},
 						},
@@ -504,7 +504,7 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 				Spec: corev1beta1.NodePoolSpec{
 					Template: corev1beta1.NodeClaimTemplate{
 						Spec: corev1beta1.NodeClaimSpec{
-							NodeClass: &corev1beta1.NodeClassReference{
+							NodeClassRef: &corev1beta1.NodeClassReference{
 								Name: misconfiguredNodeClass.Name,
 							},
 						},

--- a/pkg/controllers/nodeclaim/garbagecollection/nodeclaim_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/nodeclaim_test.go
@@ -52,7 +52,7 @@ var _ = Describe("NodeClaim/GarbageCollection", func() {
 			Spec: corev1beta1.NodePoolSpec{
 				Template: corev1beta1.NodeClaimTemplate{
 					Spec: corev1beta1.NodeClaimSpec{
-						NodeClass: &corev1beta1.NodeClassReference{
+						NodeClassRef: &corev1beta1.NodeClassReference{
 							Name: nodeClass.Name,
 						},
 					},
@@ -208,7 +208,7 @@ var _ = Describe("NodeClaim/GarbageCollection", func() {
 			)
 			nodeClaim := coretest.NodeClaim(corev1beta1.NodeClaim{
 				Spec: corev1beta1.NodeClaimSpec{
-					NodeClass: &corev1beta1.NodeClassReference{
+					NodeClassRef: &corev1beta1.NodeClassReference{
 						Name: nodeClass.Name,
 					},
 				},
@@ -269,7 +269,7 @@ var _ = Describe("NodeClaim/GarbageCollection", func() {
 
 		nodeClaim := coretest.NodeClaim(corev1beta1.NodeClaim{
 			Spec: corev1beta1.NodeClaimSpec{
-				NodeClass: &corev1beta1.NodeClassReference{
+				NodeClassRef: &corev1beta1.NodeClassReference{
 					Name: nodeClass.Name,
 				},
 			},
@@ -325,7 +325,7 @@ var _ = Describe("NodeClaim/GarbageCollection", func() {
 			)
 			nodeClaim := coretest.NodeClaim(corev1beta1.NodeClaim{
 				Spec: corev1beta1.NodeClaimSpec{
-					NodeClass: &corev1beta1.NodeClassReference{
+					NodeClassRef: &corev1beta1.NodeClassReference{
 						Name: nodeClass.Name,
 					},
 				},

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Combined/GarbageCollection", func() {
 			)
 			nodeClaim := coretest.NodeClaim(corev1beta1.NodeClaim{
 				Spec: corev1beta1.NodeClaimSpec{
-					NodeClass: &corev1beta1.NodeClassReference{
+					NodeClassRef: &corev1beta1.NodeClassReference{
 						Name: nodeClass.Name,
 					},
 				},

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -235,10 +235,10 @@ func (c *NodeClassController) Builder(_ context.Context, m manager.Manager) core
 			&source.Kind{Type: &corev1beta1.NodeClaim{}},
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
 				nc := o.(*corev1beta1.NodeClaim)
-				if nc.Spec.NodeClass == nil {
+				if nc.Spec.NodeClassRef == nil {
 					return nil
 				}
-				return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nc.Spec.NodeClass.Name}}}
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nc.Spec.NodeClassRef.Name}}}
 			}),
 			// Watch for NodeClaim deletion events
 			builder.WithPredicates(predicate.Funcs{

--- a/pkg/controllers/nodeclass/nodeclass_test.go
+++ b/pkg/controllers/nodeclass/nodeclass_test.go
@@ -848,7 +848,7 @@ var _ = Describe("NodeClassController", func() {
 			for i := 0; i < 2; i++ {
 				nc := coretest.NodeClaim(corev1beta1.NodeClaim{
 					Spec: corev1beta1.NodeClaimSpec{
-						NodeClass: &corev1beta1.NodeClassReference{
+						NodeClassRef: &corev1beta1.NodeClassReference{
 							Name: nodeClass.Name,
 						},
 					},

--- a/pkg/providers/instance/nodeclass_test.go
+++ b/pkg/providers/instance/nodeclass_test.go
@@ -40,7 +40,7 @@ var _ = Describe("NodeClass/InstanceProvider", func() {
 			Spec: corev1beta1.NodePoolSpec{
 				Template: corev1beta1.NodeClaimTemplate{
 					Spec: corev1beta1.NodeClaimSpec{
-						NodeClass: &corev1beta1.NodeClassReference{
+						NodeClassRef: &corev1beta1.NodeClassReference{
 							Name: nodeClass.Name,
 						},
 					},
@@ -54,7 +54,7 @@ var _ = Describe("NodeClass/InstanceProvider", func() {
 				},
 			},
 			Spec: corev1beta1.NodeClaimSpec{
-				NodeClass: &corev1beta1.NodeClassReference{
+				NodeClassRef: &corev1beta1.NodeClassReference{
 					Name: nodeClass.Name,
 				},
 			},

--- a/pkg/providers/instancetype/nodeclass_test.go
+++ b/pkg/providers/instancetype/nodeclass_test.go
@@ -61,7 +61,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 								Values:   []string{corev1beta1.CapacityTypeOnDemand},
 							},
 						},
-						NodeClass: &corev1beta1.NodeClassReference{
+						NodeClassRef: &corev1beta1.NodeClassReference{
 							Name: nodeClass.Name,
 						},
 					},
@@ -84,7 +84,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 								Values:   []string{corev1beta1.CapacityTypeOnDemand},
 							},
 						},
-						NodeClass: &corev1beta1.NodeClassReference{
+						NodeClassRef: &corev1beta1.NodeClassReference{
 							Name: windowsNodeClass.Name,
 						},
 					},

--- a/pkg/providers/launchtemplate/nodeclass_test.go
+++ b/pkg/providers/launchtemplate/nodeclass_test.go
@@ -67,7 +67,7 @@ var _ = Describe("EC2NodeClass/LaunchTemplates", func() {
 								Values:   []string{corev1beta1.CapacityTypeOnDemand},
 							},
 						},
-						NodeClass: &corev1beta1.NodeClassReference{
+						NodeClassRef: &corev1beta1.NodeClassReference{
 							Name: nodeClass.Name,
 						},
 					},
@@ -1099,7 +1099,7 @@ var _ = Describe("EC2NodeClass/LaunchTemplates", func() {
 					EnableENILimitedPodDensity: lo.ToPtr(false),
 				}))
 
-				nodePool.Spec.Template.Spec.NodeClass = &corev1beta1.NodeClassReference{Name: "doesnotexist"}
+				nodePool.Spec.Template.Spec.NodeClassRef = &corev1beta1.NodeClassReference{Name: "doesnotexist"}
 				ExpectApplied(ctx, env.Client, nodePool)
 				pod := coretest.UnschedulablePod()
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)

--- a/pkg/test/nodeclass.go
+++ b/pkg/test/nodeclass.go
@@ -70,10 +70,10 @@ func EC2NodeClassFieldIndexer(ctx context.Context) func(cache.Cache) error {
 	return func(c cache.Cache) error {
 		return c.IndexField(ctx, &corev1beta1.NodeClaim{}, "spec.nodeClass.name", func(obj client.Object) []string {
 			nc := obj.(*corev1beta1.NodeClaim)
-			if nc.Spec.NodeClass == nil {
+			if nc.Spec.NodeClassRef == nil {
 				return []string{""}
 			}
-			return []string{nc.Spec.NodeClass.Name}
+			return []string{nc.Spec.NodeClassRef.Name}
 		})
 	}
 }

--- a/test/suites/integration/tags_test.go
+++ b/test/suites/integration/tags_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Tags", func() {
 				Spec: corev1beta1.NodePoolSpec{
 					Template: corev1beta1.NodeClaimTemplate{
 						Spec: corev1beta1.NodeClaimSpec{
-							NodeClass: &corev1beta1.NodeClassReference{
+							NodeClassRef: &corev1beta1.NodeClassReference{
 								Name: nodeClass.Name,
 							},
 						},
@@ -144,7 +144,7 @@ var _ = Describe("Tags", func() {
 				Spec: corev1beta1.NodePoolSpec{
 					Template: corev1beta1.NodeClaimTemplate{
 						Spec: corev1beta1.NodeClaimSpec{
-							NodeClass: &corev1beta1.NodeClassReference{Name: nodeClass.Name},
+							NodeClassRef: &corev1beta1.NodeClassReference{Name: nodeClass.Name},
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Update NodeClassReference to have fieldname `nodeClassRef` instead of `nodeClass` to show the field is a reference field

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.