### PR TITLE
ci: Pin helm version in action due to `v3.13.0` bug

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -32,7 +32,7 @@ runs:
         ref: ${{ inputs.git_ref }}
     - uses: ./.github/actions/e2e/install-eksctl
       with:
-        eksctl_version: ${{ inputs.eksctl_version }}
+        version: ${{ inputs.eksctl_version }}
     - name: delete-instance-profiles
       shell:
       run: |

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -41,7 +41,7 @@ runs:
       ref: ${{ inputs.git_ref }}
   - uses: ./.github/actions/e2e/install-eksctl
     with:
-      eksctl_version: ${{ inputs.eksctl_version }}
+      version: ${{ inputs.eksctl_version }}
   - name: create iam policies
     shell: bash
     run: |

--- a/.github/actions/e2e/install-eksctl/action.yaml
+++ b/.github/actions/e2e/install-eksctl/action.yaml
@@ -1,7 +1,7 @@
 name: InstallEKSCTL
 description: 'Installs eksctl'
 inputs:
-  eksctl_version:
+  version:
     description: "Version of EKSCTL to use for the launched cluster"
     required: true
 runs:
@@ -12,9 +12,9 @@ runs:
         # for ARM systems, set ARCH to: `arm64`, `armv6` or `armv7`
         ARCH=amd64
         PLATFORM=$(uname -s)_$ARCH
-        curl -sLO "https://github.com/weaveworks/eksctl/releases/download/${{ inputs.eksctl_version }}/eksctl_$PLATFORM.tar.gz"
+        curl -sLO "https://github.com/weaveworks/eksctl/releases/download/${{ inputs.version }}/eksctl_$PLATFORM.tar.gz"
 
         # (Optional) Verify checksum
-        curl -sL "https://github.com/weaveworks/eksctl/releases/download/${{ inputs.eksctl_version }}/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
+        curl -sL "https://github.com/weaveworks/eksctl/releases/download/${{ inputs.version }}/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
         tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
         sudo mv /tmp/eksctl /usr/local/bin

--- a/.github/actions/e2e/install-helm/action.yaml
+++ b/.github/actions/e2e/install-helm/action.yaml
@@ -1,5 +1,9 @@
 name: InstallHelm
 description: 'Installs helm'
+inputs:
+  version:
+    description: "Version of Helm to install"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -8,7 +12,7 @@ runs:
       run: |
         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
         chmod 700 get_helm.sh
-        ./get_helm.sh
+        ./get_helm.sh --version ${{ inputs.version }}
     - name: install helm-diff
       shell: bash
       run: |

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -34,6 +34,7 @@ runs:
     with:
       ref: ${{ inputs.git_ref }}
   - uses: ./.github/actions/e2e/install-helm
+    version: v3.12.3 # Pinned to this version since v3.13.0 has issues with anonymous pulls: https://github.com/helm/helm/issues/12423
   - name: create karpenter namespace
     shell: bash
     run: |

--- a/.github/actions/e2e/install-prometheus/action.yaml
+++ b/.github/actions/e2e/install-prometheus/action.yaml
@@ -25,6 +25,7 @@ runs:
       with:
         ref: ${{ inputs.git_ref }}
     - uses: ./.github/actions/e2e/install-helm
+      version: v3.12.3 # Pinned to this version since v3.13.0 has issues with anonymous pulls: https://github.com/helm/helm/issues/12423
     - name: add prometheus repo
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Helm has a bug in `v3.13.0` here: https://github.com/helm/helm/issues/12423 which prevents anonymous pulling from succeeding. We should be pinning the version anyways versus pulling against latest.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.