### PR TITLE
chore: remove context from karpenter-core controllers

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,7 +45,6 @@ func main() {
 
 	op.
 		WithControllers(ctx, corecontrollers.NewControllers(
-			ctx,
 			op.Clock,
 			op.GetClient(),
 			op.KubernetesInterface,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- As of https://github.com/aws/karpenter-core/pull/572, we need to remove `ctx` value when creating karpenter-core controllers

**How was this change tested?**
- N/A
- 
**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.