### PR TITLE
chore: Add handling for v1beta1 logging configuration migration

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -34,16 +34,15 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"karpenter.sh/provisioner-name","operator":"DoesNotExist"}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity rules for scheduling the pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels. |
 | controller.env | list | `[]` | Additional environment variables for the controller pod. |
 | controller.envFrom | list | `[]` |  |
-| controller.errorOutputPaths | list | `["stderr"]` | Controller errorOutputPaths - default to stderr only |
+| controller.errorOutputPaths | list | `["stderr"]` | Controller errorOutputPaths - defaults to stderr only (Deprecated: Use logConfig.errorOutputPaths instead) |
 | controller.extraVolumeMounts | list | `[]` | Additional volumeMounts for the controller pod. |
 | controller.healthProbe.port | int | `8081` | The container port to use for http health probe. |
 | controller.image.digest | string | `"sha256:d29767fa9c5c0511a3812397c932f5735234f03a7a875575422b712d15e54a77"` | SHA256 digest of the controller image. |
 | controller.image.repository | string | `"public.ecr.aws/karpenter/controller"` | Repository path to the controller image. |
 | controller.image.tag | string | `"v0.31.0"` | Tag of the controller image. |
-| controller.logEncoding | string | `""` | Controller log encoding, defaults to the global log encoding |
-| controller.logLevel | string | `""` | Controller log level, defaults to the global log level |
+| controller.logLevel | string | `""` | Controller log level, defaults to the global log level (Deprecated: Use logConfig.logLevel.controller instead) |
 | controller.metrics.port | int | `8000` | The container port to use for metrics. |
-| controller.outputPaths | list | `["stdout"]` | Controller outputPaths - default to stdout only |
+| controller.outputPaths | list | `["stdout"]` | Controller outputPaths - defaults to stdout only (Deprecated: Use logConfig.outputPaths instead) |
 | controller.resources | object | `{}` | Resources for the controller pod. |
 | controller.sidecarContainer | list | `[]` | Additional sidecarContainer config |
 | controller.sidecarVolumeMounts | list | `[]` | Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts |
@@ -54,7 +53,13 @@ helm upgrade --install --namespace karpenter --create-namespace \
 | hostNetwork | bool | `false` | Bind the pod to the host network. This is required when using a custom CNI. |
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for Docker images. |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images. |
-| logEncoding | string | `"console"` | Global log encoding |
+| logConfig | object | `{"enabled":true,"errorOutputPaths":["stderr"],"logEncoding":"console","logLevel":{"controller":"debug","global":"debug","webhook":"error"},"outputPaths":["stdout"]}` | Log configuration |
+| logConfig.enabled | bool | `true` | Whether to enable provisioning and mounting the log ConfigMap |
+| logConfig.errorOutputPaths | list | `["stderr"]` | Log errorOutputPaths - defaults to stderr only |
+| logConfig.logEncoding | string | `"console"` | Log encoding - defaults to console - must be one of 'json', 'console' |
+| logConfig.logLevel | object | `{"controller":"debug","global":"debug","webhook":"error"}` | Component-based log configuration |
+| logConfig.outputPaths | list | `["stdout"]` | Log outputPaths - defaults to stdout only |
+| logEncoding | string | `"console"` | Global log encoding (Deprecated: Use logConfig.logEncoding instead) |
 | logLevel | string | `"debug"` | Global log level |
 | nameOverride | string | `""` | Overrides the chart's name. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selectors to schedule the pod to nodes with labels. |

--- a/charts/karpenter/templates/_helpers.tpl
+++ b/charts/karpenter/templates/_helpers.tpl
@@ -171,10 +171,17 @@ Flatten Settings Map using "." syntax
 {{/*
 Flatten the stdout logging outputs from args provided
 */}}
-{{- define "karpenter.controller.outputPathsList" -}}
+{{- define "karpenter.outputPathsList" -}}
 {{ $paths := list -}}
 {{- range .Values.controller.outputPaths -}}
-    {{- $paths = printf "%s" . | quote  | append $paths -}}
+    {{- if not (has (printf "%s" . | quote) $paths) -}}
+        {{- $paths = printf "%s" . | quote  | append $paths -}}
+    {{- end -}}
+{{- end -}}
+{{- range .Values.logConfig.outputPaths -}}
+    {{- if not (has (printf "%s" . | quote) $paths) -}}
+        {{- $paths = printf "%s" . | quote  | append $paths -}}
+    {{- end -}}
 {{- end -}}
 {{ $paths | join ", " }}
 {{- end -}}
@@ -182,10 +189,17 @@ Flatten the stdout logging outputs from args provided
 {{/*
 Flatten the stderr logging outputs from args provided
 */}}
-{{- define "karpenter.controller.errorOutputPathsList" -}}
+{{- define "karpenter.errorOutputPathsList" -}}
 {{ $paths := list -}}
 {{- range .Values.controller.errorOutputPaths -}}
-    {{- $paths = printf "%s" . | quote  | append $paths -}}
+    {{- if not (has (printf "%s" . | quote) $paths) -}}
+        {{- $paths = printf "%s" . | quote  | append $paths -}}
+    {{- end -}}
+{{- end -}}
+{{- range .Values.logConfig.errorOutputPaths -}}
+    {{- if not (has (printf "%s" . | quote) $paths) -}}
+        {{- $paths = printf "%s" . | quote  | append $paths -}}
+    {{- end -}}
 {{- end -}}
 {{ $paths | join ", " }}
 {{- end -}}

--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -14,7 +14,7 @@ data:
   # https://github.com/uber-go/zap/blob/aa3e73ec0896f8b066ddf668597a02f89628ee50/config.go
   zap-logger-config: |
     {
-      "level": "{{ or .Values.logLevel .Values.logConfig.logLevel.global }}",
+      "level": "{{ or .Values.logConfig.logLevel.global .Values.logLevel }}",
       "development": false,
       "disableStacktrace": true,
       "disableCaller": true,
@@ -24,7 +24,7 @@ data:
       },
       "outputPaths": [{{ include "karpenter.outputPathsList" . }}],
       "errorOutputPaths": [{{ include "karpenter.errorOutputPathsList" . }}],
-      "encoding": "{{ or .Values.logEncoding .Values.logConfig.logEncoding }}",
+      "encoding": "{{ or .Values.logConfig.logEncoding .Values.logEncoding }}",
       "encoderConfig": {
         "timeKey": "time",
         "levelKey": "level",
@@ -36,6 +36,6 @@ data:
         "timeEncoder": "iso8601"
       }
     }
-  loglevel.controller: {{ or .Values.controller.logLevel .Values.logConfig.logLevel.controller }}
-  loglevel.webhook: {{ or .Values.webhook.logLevel .Values.logConfig.logLevel.webhook }}
+  loglevel.controller: {{ or .Values.logConfig.logLevel.controller .Values.controller.logLevel }}
+  loglevel.webhook: {{ or .Values.logConfig.logLevel.webhook .Values.webhook.logLevel }}
 {{- end }}

--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.logConfig.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,7 +14,7 @@ data:
   # https://github.com/uber-go/zap/blob/aa3e73ec0896f8b066ddf668597a02f89628ee50/config.go
   zap-logger-config: |
     {
-      "level": "{{ .Values.logLevel }}",
+      "level": "{{ or .Values.logLevel .Values.logConfig.logLevel.global }}",
       "development": false,
       "disableStacktrace": true,
       "disableCaller": true,
@@ -21,9 +22,9 @@ data:
         "initial": 100,
         "thereafter": 100
       },
-      "outputPaths": [{{ include "karpenter.controller.outputPathsList" . }}],
-      "errorOutputPaths": [{{ include "karpenter.controller.errorOutputPathsList" . }}],
-      "encoding": "{{ .Values.logEncoding }}",
+      "outputPaths": [{{ include "karpenter.outputPathsList" . }}],
+      "errorOutputPaths": [{{ include "karpenter.errorOutputPathsList" . }}],
+      "encoding": "{{ or .Values.logEncoding .Values.logConfig.logEncoding }}",
       "encoderConfig": {
         "timeKey": "time",
         "levelKey": "level",
@@ -35,9 +36,6 @@ data:
         "timeEncoder": "iso8601"
       }
     }
-{{- with .Values.controller.logLevel }}
-  loglevel.controller: {{ . | quote }}
-{{- end }}
-{{- with .Values.webhook.logLevel }}
-  loglevel.webhook: {{ . | quote }}
+  loglevel.controller: {{ or .Values.controller.logLevel .Values.logConfig.logLevel.controller }}
+  loglevel.webhook: {{ or .Values.webhook.logLevel .Values.logConfig.logLevel.webhook }}
 {{- end }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -82,6 +82,8 @@ spec:
             - name: DISABLE_WEBHOOK
               value: "true"
           {{- end }}
+            - name: LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
             - name: METRICS_PORT
               value: "{{ .Values.controller.metrics.port }}"
             - name: HEALTH_PROBE_PORT
@@ -134,22 +136,28 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.controller.extraVolumeMounts }}
+        {{- if or (.Values.logConfig.enabled) (.Values.controller.extraVolumeMounts) }}
           volumeMounts:
+          {{- if .Values.logConfig.enabled }}
+            - name: config-logging
+              mountPath: /etc/karpenter/logging
+          {{- end }}
+          {{- with .Values.controller.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
         {{- with .Values.controller.sidecarContainer }}
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if and (.Values.controller.sidecarContainer) (or .Values.controller.extraVolumeMounts .Values.controller.sidecarVolumeMounts) }}
           volumeMounts:
           {{- with .Values.controller.extraVolumeMounts }}
-          {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.controller.sidecarVolumeMounts }}
-          {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -170,7 +178,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.extraVolumes }}
       volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging
+      {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -178,10 +178,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- if or (.Values.logConfig.enabled) (.Values.extraVolumes) }}
       volumes:
+      {{- if .Values.logConfig.enabled }}
         - name: config-logging
           configMap:
             name: config-logging
+      {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -117,16 +117,14 @@ controller:
   #    cpu: 1
   #    memory: 1Gi
 
-  # -- Controller outputPaths - default to stdout only
+  # -- Controller outputPaths - defaults to stdout only (Deprecated: Use logConfig.outputPaths instead)
   outputPaths:
     - stdout
-  # -- Controller errorOutputPaths - default to stderr only
+  # -- Controller errorOutputPaths - defaults to stderr only (Deprecated: Use logConfig.errorOutputPaths instead)
   errorOutputPaths:
     - stderr
-  # -- Controller log level, defaults to the global log level
+  # -- Controller log level, defaults to the global log level (Deprecated: Use logConfig.logLevel.controller instead)
   logLevel: ""
-  # -- Controller log encoding, defaults to the global log encoding
-  logEncoding: ""
   # -- Additional volumeMounts for the controller pod.
   extraVolumeMounts: []
   # - name: aws-iam-token
@@ -145,6 +143,7 @@ controller:
 webhook:
   # -- Whether to enable the webhooks and webhook permissions.
   enabled: true
+  # -- Webhook log level (Deprecated: Use logConfig.logLevel.webhook instead)
   logLevel: error
   # -- The container port to use for the webhook.
   port: 8443
@@ -153,8 +152,25 @@ webhook:
     port: 8001
 # -- Global log level
 logLevel: debug
-# -- Global log encoding
+# -- Global log encoding (Deprecated: Use logConfig.logEncoding instead)
 logEncoding: console
+# -- Log configuration
+logConfig:
+  # -- Whether to enable provisioning and mounting the log ConfigMap
+  enabled: true
+  # -- Log outputPaths - defaults to stdout only
+  outputPaths:
+    - stdout
+  # -- Log errorOutputPaths - defaults to stderr only
+  errorOutputPaths:
+    - stderr
+  # -- Log encoding - defaults to console - must be one of 'json', 'console'
+  logEncoding: console
+  # -- Component-based log configuration
+  logLevel:
+    global: debug
+    controller: debug
+    webhook: error
 # -- Global Settings to configure Karpenter
 settings:
   # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds logging configuration values in the helm chart under the `logConfig` values block. You can now selectively disable the `logging-config` ConfigMap with `logConfig.enabled=false`. The global `logLevel` helm value now sets the `LOG_LEVEL` environment variable to configure the Karpenter controller log level. 

Also, with this change, combined with https://github.com/aws/karpenter-core/pull/553, Karpenter will now configure the logging ConfigMap to be mounted as a volumeMount in the container by default.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.