### PR TITLE
docs: Update CloudFormation to handle v1beta1 permissions

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -75,6 +75,10 @@ runs:
           -r \
           aws ec2 delete-security-group \
             --group-id
+    - name: delete-iam-alpha-policy
+      shell: bash
+      run: |
+        aws iam delete-policy --policy-arn "arn:aws:iam::${{ inputs.account_id }}:policy/KarpenterControllerPolicy-Alpha-${{ inputs.cluster_name }}" || true
     - name: delete-iam-policies-stack
       shell: bash
       run: |

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -61,6 +61,18 @@ runs:
         --capabilities CAPABILITY_NAMED_IAM \
         --parameter-overrides "ClusterName=${{ inputs.cluster_name }}" \
         --tags "testing/type=e2e" "github.com/run-url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" "karpenter.sh/discovery=${{ inputs.cluster_name }}"
+  - name: deploy alpha policy
+    shell: bash
+    run: |
+      export AWS_PARTITION=aws
+      export AWS_REGION=${{ inputs.region }}
+      export AWS_ACCOUNT_ID=${{ inputs.account_id }}
+      export CLUSTER_NAME=${{ inputs.cluster_name }}
+      
+      POLICY_DOCUMENT=$(envsubst < .github/actions/e2e/create-cluster/alpha-controller-policy.json)
+      POLICY_NAME="KarpenterControllerPolicy-Alpha-${CLUSTER_NAME}"
+      echo "Creating policy $POLICY_NAME..."
+      aws iam create-policy --policy-name "$POLICY_NAME" --policy-document "$POLICY_DOCUMENT"
   - name: create or upgrade cluster
     shell: bash
     run: |
@@ -104,6 +116,7 @@ runs:
               namespace: karpenter
             attachPolicyARNs:
               - "arn:aws:iam::${{ inputs.account_id }}:policy/KarpenterControllerPolicy-${{ inputs.cluster_name }}"
+              - "arn:aws:iam::${{ inputs.account_id }}:policy/KarpenterControllerPolicy-Alpha-${{ inputs.cluster_name }}"
             permissionsBoundary: "arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"
             roleName: karpenter-irsa-${{ inputs.cluster_name }}
             roleOnly: true

--- a/.github/actions/e2e/create-cluster/alpha-controller-policy.json
+++ b/.github/actions/e2e/create-cluster/alpha-controller-policy.json
@@ -1,0 +1,166 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowScopedEC2InstanceActions",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::image/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}::snapshot/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:spot-instances-request/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:security-group/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:subnet/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+      ],
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateFleet"
+      ]
+    },
+    {
+      "Sid": "AllowScopedEC2InstanceActionsWithTags",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:fleet/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+      ],
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateFleet",
+        "ec2:CreateLaunchTemplate"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/kubernetes.io/cluster/${CLUSTER_NAME}": "owned"
+        },
+        "StringLike": {
+          "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowScopedResourceCreationTagging",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:fleet/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:volume/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:network-interface/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+      ],
+      "Action": "ec2:CreateTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/kubernetes.io/cluster/${CLUSTER_NAME}": "owned",
+          "ec2:CreateAction": [
+            "RunInstances",
+            "CreateFleet",
+            "CreateLaunchTemplate"
+          ]
+        },
+        "StringLike": {
+          "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowMachineMigrationTagging",
+      "Effect": "Allow",
+      "Resource": "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
+      "Action": "ec2:CreateTags",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/kubernetes.io/cluster/${CLUSTER_NAME}": "owned",
+          "aws:RequestTag/karpenter.sh/managed-by": "${CLUSTER_NAME}"
+        },
+        "StringLike": {
+          "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+        },
+        "ForAllValues:StringEquals": {
+          "aws:TagKeys": [
+            "karpenter.sh/provisioner-name",
+            "karpenter.sh/managed-by"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "AllowScopedDeletion",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:instance/*",
+        "arn:${AWS_PARTITION}:ec2:${AWS_REGION}:*:launch-template/*"
+      ],
+      "Action": [
+        "ec2:TerminateInstances",
+        "ec2:DeleteLaunchTemplate"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/kubernetes.io/cluster/${CLUSTER_NAME}": "owned"
+        },
+        "StringLike": {
+          "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowRegionalReadActions",
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeSubnets"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "${AWS_REGION}"
+        }
+      }
+    },
+    {
+      "Sid": "AllowSSMReadActions",
+      "Effect": "Allow",
+      "Resource": "arn:${AWS_PARTITION}:ssm:${AWS_REGION}::parameter/aws/service/*",
+      "Action": "ssm:GetParameter"
+    },
+    {
+      "Sid": "AllowPricingReadActions",
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": "pricing:GetProducts"
+    },
+    {
+      "Sid": "AllowInterruptionQueueActions",
+      "Effect": "Allow",
+      "Resource": "arn:aws:sqs:${AWS_REGION}:${AWS_ACCOUNT_ID}:${CLUSTER_NAME}",
+      "Action": [
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:GetQueueUrl",
+        "sqs:ReceiveMessage"
+      ]
+    },
+    {
+      "Sid": "AllowPassingInstanceRole",
+      "Effect": "Allow",
+      "Resource": "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}",
+      "Action": "iam:PassRole",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    }
+  ]
+}

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -77,7 +77,7 @@ Resources:
                   "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned"
                 },
                 "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  "aws:RequestTag/karpenter.sh/nodepool": "*"
                 }
               }
             },
@@ -102,27 +102,26 @@ Resources:
                   ]
                 },
                 "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  "aws:RequestTag/karpenter.sh/nodepool": "*"
                 }
               }
             },
             {
-              "Sid": "AllowMachineMigrationTagging",
+              "Sid": "AllowScopedResourceTagging",
               "Effect": "Allow",
               "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
                   "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
-                  "aws:RequestTag/karpenter.sh/managed-by": "${ClusterName}"
                 },
                 "StringLike": {
-                  "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                  "aws:ResourceTag/karpenter.sh/nodepool": "*"
                 },
                 "ForAllValues:StringEquals": {
                   "aws:TagKeys": [
-                    "karpenter.sh/provisioner-name",
-                    "karpenter.sh/managed-by"
+                    "karpenter.k8s.aws/nodeclaim",
+                    "Name"
                   ]
                 }
               }
@@ -143,7 +142,7 @@ Resources:
                   "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
                 },
                 "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                  "aws:ResourceTag/karpenter.sh/nodepool": "*"
                 }
               }
             },
@@ -201,6 +200,58 @@ Resources:
                   "iam:PassedToService": "ec2.amazonaws.com"
                 }
               }
+            },
+            {
+              "Sid": "AllowScopedInstanceProfileCreationActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": [
+                "iam:CreateInstanceProfile"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedInstanceProfileTagActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": [
+                "iam:TagInstanceProfile"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedInstanceProfileActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": [
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:DeleteInstanceProfile"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
+                }
+              }
+            },
+            {
+              "Sid": "AllowInstanceProfileReadActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": "iam:GetInstanceProfile"
             },
             {
               "Sid": "AllowAPIServerEndpointDiscovery",

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -113,7 +113,7 @@ Resources:
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
-                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
                 },
                 "StringLike": {
                   "aws:ResourceTag/karpenter.sh/nodepool": "*"
@@ -212,6 +212,9 @@ Resources:
                 "StringEquals": {
                   "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
                   "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.sh/nodeclass": "*"
                 }
               }
             },
@@ -228,6 +231,10 @@ Resources:
                   "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
                   "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
                   "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.sh/nodeclass": "*",
+                  "aws:RequestTag/karpenter.sh/nodeclass": "*"
                 }
               }
             },
@@ -244,6 +251,9 @@ Resources:
                 "StringEquals": {
                   "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
                   "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.sh/nodeclass": "*"
                 }
               }
             },


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Updates the CloudFormation template shipped with the Getting Started guide to use v1beta1 permissions. This also ensures that we are deploying the Karpenter controller IAM permissions with an additional policy that gives the controller the alpha permissions so that we can ensure that scenarios that are testing alpha and beta simultaneously will work.

**How was this change tested?**

`make apply` with the new permissions

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.