### PR TITLE
docs: Backport the compatibility matrix

### DIFF
--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with [all currently supported EKS versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html). As with all EKS supported versions, Karpenter will [support a version for 14 months after it is first made available](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#version-deprecation).
+See the [Compatibility Matrix in the Upgrade Guide]({{< ref "./upgrade-guide#compatibility-matrix" >}}) to view the supported Kubernetes versions per Karpenter released version.
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh or existing install of the latest AWS Elastic Kubernetes Service (EKS).

--- a/website/content/en/docs/upgrade-guide.md
+++ b/website/content/en/docs/upgrade-guide.md
@@ -9,7 +9,7 @@ description: >
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
-To make upgrading easier we aim to minimize introduction of breaking changes with the followings:
+To make upgrading easier we aim to minimize introduction of breaking changes with the following:
 
 ## Compatibility Matrix 
 
@@ -29,9 +29,10 @@ Karpenter currently does not support the following [new `topologySpreadConstrain
 
 For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
 {{% /alert %}}
+
 ## Compatibility issues
 
-To make upgrading easier, we aim to minimize the introduction of breaking changes with the followings components:
+To make upgrading easier, we aim to minimize the introduction of breaking changes with the following components:
 
 * Provisioner API
 * Helm Chart

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with [all currently supported EKS versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html). As with all EKS supported versions, Karpenter will [support a version for 14 months after it is first made available](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#version-deprecation).
+See the [Compatibility Matrix in the Upgrade Guide]({{< ref "./upgrade-guide#compatibility-matrix" >}}) to view the supported Kubernetes versions per Karpenter released version.
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh or existing install of the latest AWS Elastic Kubernetes Service (EKS).

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -9,7 +9,7 @@ description: >
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
-To make upgrading easier we aim to minimize introduction of breaking changes with the followings:
+To make upgrading easier we aim to minimize introduction of breaking changes with the following:
 
 ## Compatibility Matrix 
 
@@ -29,9 +29,10 @@ Karpenter currently does not support the following [new `topologySpreadConstrain
 
 For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
 {{% /alert %}}
+
 ## Compatibility issues
 
-To make upgrading easier, we aim to minimize the introduction of breaking changes with the followings components:
+To make upgrading easier, we aim to minimize the introduction of breaking changes with the following components:
 
 * Provisioner API
 * Helm Chart

--- a/website/content/en/v0.27/faq.md
+++ b/website/content/en/v0.27/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with [all currently supported EKS versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html). As with all EKS supported versions, Karpenter will [support a version for 14 months after it is first made available](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#version-deprecation).
+See the [Compatibility Matrix in the Upgrade Guide]({{< ref "./upgrade-guide#compatibility-matrix" >}}) to view the supported Kubernetes versions per Karpenter released version.
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh or existing install of the latest AWS Elastic Kubernetes Service (EKS).

--- a/website/content/en/v0.27/upgrade-guide.md
+++ b/website/content/en/v0.27/upgrade-guide.md
@@ -9,11 +9,21 @@ description: >
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
-To make upgrading easier we aim to minimize introduction of breaking changes with the followings:
+To make upgrading easier we aim to minimize introduction of breaking changes with the following:
 
-# Compatibility issues
+## Compatibility Matrix
 
-To make upgrading easier, we aim to minimize the introduction of breaking changes with the followings components:
+[comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)
+
+| KUBERNETES |  1.23   |  1.24   |  1.25   | 
+|------------|---------|---------|---------|
+| karpenter  | 0.21.x+ | 0.21.x+ | 0.25.x+ |
+
+[comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
+
+## Compatibility issues
+
+To make upgrading easier, we aim to minimize the introduction of breaking changes with the following components:
 
 * Provisioner API
 * Helm Chart

--- a/website/content/en/v0.28/faq.md
+++ b/website/content/en/v0.28/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with [all currently supported EKS versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html). As with all EKS supported versions, Karpenter will [support a version for 14 months after it is first made available](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#version-deprecation).
+See the [Compatibility Matrix in the Upgrade Guide]({{< ref "./upgrade-guide#compatibility-matrix" >}}) to view the supported Kubernetes versions per Karpenter released version.
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh or existing install of the latest AWS Elastic Kubernetes Service (EKS).

--- a/website/content/en/v0.28/upgrade-guide.md
+++ b/website/content/en/v0.28/upgrade-guide.md
@@ -9,7 +9,26 @@ description: >
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
-To make upgrading easier we aim to minimize introduction of breaking changes with the followings:
+To make upgrading easier we aim to minimize introduction of breaking changes with the following:
+
+## Compatibility Matrix
+
+[comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)
+
+| KUBERNETES |  1.23   |  1.24   |  1.25   |  1.26   |  1.27   |
+|------------|---------|---------|---------|---------|---------|
+| karpenter  | 0.21.x+ | 0.21.x+ | 0.25.x+ | 0.28.x+ | 0.28.x+ |
+
+[comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
+
+{{% alert title="Note" color="warning" %}}
+Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
+- `matchLabelKeys`
+- `nodeAffinityPolicy`
+- `nodeTaintsPolicy`
+
+For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
+{{% /alert %}}
 
 ## Compatibility issues
 

--- a/website/content/en/v0.29/faq.md
+++ b/website/content/en/v0.29/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with [all currently supported EKS versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html). As with all EKS supported versions, Karpenter will [support a version for 14 months after it is first made available](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#version-deprecation).
+See the [Compatibility Matrix in the Upgrade Guide]({{< ref "./upgrade-guide#compatibility-matrix" >}}) to view the supported Kubernetes versions per Karpenter released version.
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh or existing install of the latest AWS Elastic Kubernetes Service (EKS).

--- a/website/content/en/v0.29/upgrade-guide.md
+++ b/website/content/en/v0.29/upgrade-guide.md
@@ -9,11 +9,30 @@ description: >
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
-To make upgrading easier we aim to minimize introduction of breaking changes with the followings:
+To make upgrading easier we aim to minimize introduction of breaking changes with the following:
+
+## Compatibility Matrix
+
+[comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)
+
+| KUBERNETES |  1.23   |  1.24   |  1.25   |  1.26   |  1.27   |
+|------------|---------|---------|---------|---------|---------|
+| karpenter  | 0.21.x+ | 0.21.x+ | 0.25.x+ | 0.28.x+ | 0.28.x+ |
+
+[comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
+
+{{% alert title="Note" color="warning" %}}
+Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
+- `matchLabelKeys`
+- `nodeAffinityPolicy`
+- `nodeTaintsPolicy`
+
+For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
+{{% /alert %}}
 
 ## Compatibility issues
 
-To make upgrading easier, we aim to minimize the introduction of breaking changes with the followings components:
+To make upgrading easier, we aim to minimize the introduction of breaking changes with the following components:
 
 * Provisioner API
 * Helm Chart

--- a/website/content/en/v0.30/faq.md
+++ b/website/content/en/v0.30/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with [all currently supported EKS versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html). As with all EKS supported versions, Karpenter will [support a version for 14 months after it is first made available](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#version-deprecation).
+See the [Compatibility Matrix in the Upgrade Guide]({{< ref "./upgrade-guide#compatibility-matrix" >}}) to view the supported Kubernetes versions per Karpenter released version.
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh or existing install of the latest AWS Elastic Kubernetes Service (EKS).

--- a/website/content/en/v0.30/upgrade-guide.md
+++ b/website/content/en/v0.30/upgrade-guide.md
@@ -9,11 +9,30 @@ description: >
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
-To make upgrading easier we aim to minimize introduction of breaking changes with the followings:
+To make upgrading easier we aim to minimize introduction of breaking changes with the following:
+
+## Compatibility Matrix
+
+[comment]: <> (the content below is generated from hack/docs/compataiblitymetrix_gen_docs.go)
+
+| KUBERNETES |  1.23   |  1.24   |  1.25   |  1.26   |  1.27   |
+|------------|---------|---------|---------|---------|---------|
+| karpenter  | 0.21.x+ | 0.21.x+ | 0.25.x+ | 0.28.x+ | 0.28.x+ |
+
+[comment]: <> (end docs generated content from hack/docs/compataiblitymetrix_gen_docs.go)
+
+{{% alert title="Note" color="warning" %}}
+Karpenter currently does not support the following [new `topologySpreadConstraints` keys](https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/), promoted to beta in Kubernetes 1.27:
+- `matchLabelKeys`
+- `nodeAffinityPolicy`
+- `nodeTaintsPolicy`
+
+For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
+{{% /alert %}}
 
 ## Compatibility issues
 
-To make upgrading easier, we aim to minimize the introduction of breaking changes with the followings components:
+To make upgrading easier, we aim to minimize the introduction of breaking changes with the following components:
 
 * Provisioner API
 * Helm Chart

--- a/website/content/en/v0.31/faq.md
+++ b/website/content/en/v0.31/faq.md
@@ -36,7 +36,7 @@ Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?
-Karpenter is tested with [all currently supported EKS versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html). As with all EKS supported versions, Karpenter will [support a version for 14 months after it is first made available](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#version-deprecation).
+See the [Compatibility Matrix in the Upgrade Guide]({{< ref "./upgrade-guide#compatibility-matrix" >}}) to view the supported Kubernetes versions per Karpenter released version.
 
 ### What Kubernetes distributions are supported?
 Karpenter documents integration with a fresh or existing install of the latest AWS Elastic Kubernetes Service (EKS).

--- a/website/content/en/v0.31/upgrade-guide.md
+++ b/website/content/en/v0.31/upgrade-guide.md
@@ -9,7 +9,7 @@ description: >
 Karpenter is a controller that runs in your cluster, but it is not tied to a specific Kubernetes version, as the Cluster Autoscaler is.
 Use your existing upgrade mechanisms to upgrade your core add-ons in Kubernetes and keep Karpenter up to date on bug fixes and new features.
 
-To make upgrading easier we aim to minimize introduction of breaking changes with the followings:
+To make upgrading easier we aim to minimize introduction of breaking changes with the following:
 
 ## Compatibility Matrix 
 
@@ -29,9 +29,10 @@ Karpenter currently does not support the following [new `topologySpreadConstrain
 
 For more information on Karpenter's support for these keys, view [this tracking issue](https://github.com/aws/karpenter-core/issues/430).
 {{% /alert %}}
+
 ## Compatibility issues
 
-To make upgrading easier, we aim to minimize the introduction of breaking changes with the followings components:
+To make upgrading easier, we aim to minimize the introduction of breaking changes with the following components:
 
 * Provisioner API
 * Helm Chart


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4782 

**Description**

This docs change backports the compatibility matrix to older version so it's clear which versions that Karpenter supports.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.