### PR TITLE
test: Provide IAM permission to `cloudformation:DescribeStackResources`

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -85,7 +85,7 @@ runs:
       cmd="create"
       eksctl get cluster --name ${{ inputs.cluster_name }} && cmd="upgrade"
 
-      eksctl ${cmd} cluster -f - <<EOF
+      cat << EOF >> clusterconfig.yaml
       ---
       apiVersion: eksctl.io/v1alpha5
       kind: ClusterConfig
@@ -146,6 +146,14 @@ runs:
         wellKnownPolicies:
           ebsCSIController: true
       EOF
+      
+      eksctl ${cmd} cluster -f clusterconfig.yaml
+      
+      # We need to call these update iamserviceaccount commands again since the "eksctl upgrade cluster" action
+      # doesn't handle updates to IAM serviceaccounts correctly when the roles assigned to them change
+      eksctl update iamserviceaccount -f clusterconfig.yaml --approve
+      
+
   - name: tag oidc provider of the cluster
     if: always()
     shell: bash

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -63,9 +63,10 @@ jobs:
   e2e-upgrade:
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
-      # This version matches the steps of the newest version of the install-eksctl action
-      # which will take in the eksctl_version into the composite action
-      from_git_ref: 3519331035579ac0caf66a7f5a5282a2fef9b409
+      # This version matches the steps of the newest version that contains the additional step
+      # of deploying the instance profile so that the pre-upgrade and post-upgrade create-cluster
+      # actions have the same number of steps and don't fail during post-cleanup
+      from_git_ref: 62c25a3ea85c7d00165e60a913fff1ec7c1f29fd
       to_git_ref: ${{ inputs.git_ref }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}

--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -123,6 +123,7 @@ Resources:
               - cloudformation:DeleteStack
               - cloudformation:DescribeChangeSet
               - cloudformation:DescribeStackEvents
+              - cloudformation:DescribeStackResources
               - cloudformation:ExecuteChangeSet
               - cloudformation:GetTemplate
               - cloudformation:GetTemplateSummary


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds the `cloudformation:DescribeStackResources` IAM permission to the CI policy so that the upgrade `create-cluster` action can succeed to update permissions.

**How was this change tested?**

`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.