### PR TITLE
chore: Exclude APICodeGen in community-contributors.sh

### DIFF
--- a/hack/github/community-contributors.sh
+++ b/hack/github/community-contributors.sh
@@ -79,7 +79,8 @@ COMMUNITY_CONTRIBUTIONS=$(
         .author != "suket22" and
         .author != "StableRelease" and
         .author != "dependabot[bot]" and
-        .author != "github-actions[bot]"
+        .author != "github-actions[bot]" and
+        .author != "APICodeGen"
     )
 ' | jq -s
 )


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Exclude APICodeGen in community-contributors.sh so it's not counted as an external contributor.

**How was this change tested?**

Ran community-contributors.sh.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.