### PR TITLE
chore: Hydrate AMIFamily with AL2 when using nil in Provisioner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ clean-run: ## Clean resources deployed by the run target
 
 test: ## Run tests
 	go test -v ./pkg/$(shell echo $(TEST_SUITE) | tr A-Z a-z)/... --ginkgo.focus="${FOCUS}" --ginkgo.vv
+	cd tools/karpenter-convert && go test -v ./pkg/... --ginkgo.focus="${FOCUS}" --ginkgo.vv
 
 battletest: ## Run randomized, racing, code-covered tests
 	go test -v ./pkg/... \

--- a/tools/karpenter-convert/pkg/convert/convert.go
+++ b/tools/karpenter-convert/pkg/convert/convert.go
@@ -155,6 +155,10 @@ func Process(resource runtime.Object) (runtime.Object, error) {
 
 func processNodeTemplate(resource runtime.Object) runtime.Object {
 	nodetemplate := resource.(*v1alpha1.AWSNodeTemplate)
+	// If the AMIFamily wasn't specified, then we know that it should be AL2 for the conversion
+	if nodetemplate.Spec.AMIFamily == nil {
+		nodetemplate.Spec.AMIFamily = &v1beta1.AMIFamilyAL2
+	}
 
 	nodeclass := nodeclassutil.New(nodetemplate)
 	nodeclass.TypeMeta = metav1.TypeMeta{
@@ -162,18 +166,15 @@ func processNodeTemplate(resource runtime.Object) runtime.Object {
 		APIVersion: v1beta1.SchemeGroupVersion.String(),
 	}
 	nodeclass.Spec.Role = "<your AWS role here>"
-
 	return nodeclass
 }
 
 func processProvisioner(resource runtime.Object) runtime.Object {
 	provisioner := resource.(*v1alpha5.Provisioner)
-
 	nodepool := nodepoolutil.New(provisioner)
 	nodepool.TypeMeta = metav1.TypeMeta{
 		Kind:       "NodePool",
 		APIVersion: corev1beta1.SchemeGroupVersion.String(),
 	}
-
 	return nodepool
 }

--- a/tools/karpenter-convert/pkg/convert/convert_test.go
+++ b/tools/karpenter-convert/pkg/convert/convert_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ConvertObject", func() {
 			bytes, _ := os.ReadFile(tc.outputFile)
 			content := string(bytes)
 
-			Expect(buf.String()).To(ContainSubstring(content), fmt.Sprintf("unexpected output when converting %s to %q, expected: %q, but got %q", tc.file, tc.outputFile, content, buf.String()))
+			Expect(buf.String()).To(Equal(content), fmt.Sprintf("unexpected output when converting %s to %q, expected: %q, but got %q", tc.file, tc.outputFile, content, buf.String()))
 		},
 
 		Entry("provisioner to nodepool",
@@ -85,6 +85,13 @@ var _ = Describe("ConvertObject", func() {
 				name:       "nodetemplate to nodeclass",
 				file:       "./testdata/nodetemplate.yaml",
 				outputFile: "./testdata/nodeclass.yaml",
+			},
+		),
+		Entry("nodetemplate (empty amifamily) to nodeclass",
+			testcase{
+				name:       "nodetemplate (empty amifamily) to nodeclass",
+				file:       "./testdata/nodetemplate_no_amifamily.yaml",
+				outputFile: "./testdata/nodeclass_no_amifamily.yaml",
 			},
 		),
 	)

--- a/tools/karpenter-convert/pkg/convert/testdata/nodeclass_no_amifamily.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodeclass_no_amifamily.yaml
@@ -1,0 +1,29 @@
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  creationTimestamp: null
+  name: default
+spec:
+  amiFamily: AL2
+  blockDeviceMappings:
+  - deviceName: /dev/xvdb
+    ebs:
+      deleteOnTermination: true
+      volumeSize: 100Gi
+      volumeType: gp3
+  role: <your AWS role here>
+  securityGroupSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: karpenter-demo
+  subnetSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: karpenter-demo
+  tags:
+    MyBackupTag: "yes"
+    MyTag: "1234"
+  userData: |
+    [settings.kubernetes]
+    kube-api-qps = 30
+    [settings.kubernetes.eviction-hard]
+    "memory.available" = "10%"
+status: {}

--- a/tools/karpenter-convert/pkg/convert/testdata/nodetemplate_no_amifamily.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodetemplate_no_amifamily.yaml
@@ -1,0 +1,23 @@
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: karpenter-demo
+  securityGroupSelector:
+    karpenter.sh/discovery: karpenter-demo
+  blockDeviceMappings:
+    - deviceName: /dev/xvdb
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        deleteOnTermination: true
+  tags:
+    MyTag: "1234"
+    MyBackupTag: "yes"
+  userData:  |
+    [settings.kubernetes]
+    kube-api-qps = 30
+    [settings.kubernetes.eviction-hard]
+    "memory.available" = "10%"

--- a/tools/karpenter-convert/pkg/convert/testdata/provisioner.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/provisioner.yaml
@@ -3,35 +3,18 @@ kind: Provisioner
 metadata:
   name: default
 spec:
-  # References cloud provider-specific custom resource, see your cloud provider specific documentation
   providerRef:
     name: default
-
-  # Provisioned nodes will have these taints
-  # Taints may prevent pods from scheduling if they are not tolerated by the pod.
   taints:
     - key: example.com/special-taint
       effect: NoSchedule
-
-  # Provisioned nodes will have these taints, but pods do not need to tolerate these taints to be provisioned by this
-  # provisioner. These taints are expected to be temporary and some other entity (e.g. a DaemonSet) is responsible for
-  # removing the taint after it has finished initializing the node.
   startupTaints:
     - key: example.com/another-taint
       effect: NoSchedule
-
-  # Labels are arbitrary key-values that are applied to all nodes
   labels:
     billing-team: my-team
-
-  # Annotations are arbitrary key-values that are applied to all nodes
   annotations:
     example.com/owner: "my-team"
-
-  # Requirements that constrain the parameters of provisioned nodes.
-  # These requirements are combined with pod.spec.affinity.nodeAffinity rules.
-  # Operators { In, NotIn, Exists, DoesNotExist, Gt, and Lt } are supported.
-  # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#operators
   requirements:
     - key: "karpenter.k8s.aws/instance-category"
       operator: In
@@ -54,9 +37,6 @@ spec:
     - key: "karpenter.sh/capacity-type" # If not included, the webhook for the AWS cloud provider will default to on-demand
       operator: In
       values: ["spot", "on-demand"]
-
-  # Karpenter provides the ability to specify a few additional Kubelet args.
-  # These are all optional and provide support for additional customization and use cases.
   kubeletConfiguration:
     clusterDNS: ["10.0.1.100"]
     containerRuntime: containerd
@@ -86,28 +66,12 @@ spec:
     cpuCFSQuota: true
     podsPerCore: 2
     maxPods: 20
-
-
-  # Resource limits constrain the total size of the cluster.
-  # Limits prevent Karpenter from creating new instances once the limit is exceeded.
   limits:
     resources:
       cpu: "1000"
       memory: 1000Gi
-
-  # Enables consolidation which attempts to reduce cluster cost by both removing un-needed nodes and down-sizing those
-  # that can't be removed.  Mutually exclusive with the ttlSecondsAfterEmpty parameter.
   consolidation:
     enabled: false
-
-  # If omitted, the feature is disabled and nodes will never expire.  If set to less time than it requires for a node
-  # to become ready, the node may expire before any pods successfully start.
   ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
-
-  # If omitted, the feature is disabled, nodes will never scale down due to low utilization
   ttlSecondsAfterEmpty: 30
-
-  # Priority given to the provisioner when the scheduler considers which provisioner
-  # to select. Higher weights indicate higher priority when comparing provisioners.
-  # Specifying no weight is equivalent to specifying a weight of 0.
   weight: 10


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change sets the `amiFamily` in the NodeClass to be `AL2` if its undefined in the previous `Provisioner`

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.