### PR TITLE
docs: Update conceptual index doc to v1beta1 APIs and concepts

### DIFF
--- a/website/content/en/preview/concepts/_index.md
+++ b/website/content/en/preview/concepts/_index.md
@@ -6,87 +6,61 @@ description: >
   Understand key concepts of Karpenter
 ---
 
-Users fall under two basic roles: Kubernetes cluster administrators and application developers.
-This document describes Karpenter concepts through the lens of those two types of users.
+Users fall under two basic roles: [Kubernetes cluster administrators]({{<ref "#cluster-administrator" >}}) and [application developers]({{<ref "#application-developers" >}}). This document describes Karpenter concepts through the lens of those two types of users.
 
-## Cluster administrator
+## Cluster Administrator
 
 As a Kubernetes cluster administrator, you can engage with Karpenter to:
 
 * Install Karpenter
-* Configure provisioners to set constraints and other features for managing nodes
-* Deprovision nodes
-* Upgrade nodes
+* Configure NodePools to set constraints and other features for managing nodes
+* Disrupting nodes
 
 Concepts associated with this role are described below.
 
 
 ### Installing Karpenter
 
-Karpenter is designed to run on a node in your Kubernetes cluster.
-As part of the installation process, you need credentials from the underlying cloud provider to allow nodes to be started up and added to the cluster as they are needed.
+Karpenter is designed to run on a node in your Kubernetes cluster. As part of the installation process, you need credentials from the underlying cloud provider to allow nodes to be started up and added to the cluster as they are needed.
 
-[Getting Started with Karpenter on AWS](../getting-started)
-describes the process of installing Karpenter on an AWS cloud provider.
-Because requests to add and delete nodes and schedule pods are made through Kubernetes, AWS IAM Roles for Service Accounts (IRSA) are needed by your Kubernetes cluster to make privileged requests to AWS.
-For example, Karpenter uses AWS IRSA roles to grant the permissions needed to describe EC2 instance types and create EC2 instances.
+[Getting Started with Karpenter]({{<ref "../getting-started/getting-started-with-karpenter" >}}) describes the process of installing Karpenter. Because requests to add and delete nodes and schedule pods are made through Kubernetes, AWS IAM Roles for Service Accounts (IRSA) are needed by your Kubernetes cluster to make privileged requests to AWS. For example, Karpenter uses AWS IRSA roles to grant the permissions needed to describe EC2 instance types and create EC2 instances.
 
 Once privileges are in place, Karpenter is deployed with a Helm chart.
 
-### Configuring provisioners
+### Configuring NodePools
 
-Karpenter's job is to add nodes to handle unschedulable pods, schedule pods on those nodes, and remove the nodes when they are not needed.
-To configure Karpenter, you create *provisioners* that define how Karpenter manages unschedulable pods and expires nodes.
-Here are some things to know about the Karpenter provisioner:
+Karpenter's job is to add nodes to handle unschedulable pods, schedule pods on those nodes, and remove the nodes when they are not needed. To configure Karpenter, you create [NodePools]({{<ref "nodepools" >}}) that define how Karpenter manages unschedulable pods and configures nodes. You will also define behaviors for your NodePools, capturing details like how Karpenter handles disruption of nodes and setting limits and weights for each NodePool
+
+Here are some things to know about Karpenter's NodePools:
 
 * **Unschedulable pods**: Karpenter only attempts to schedule pods that have a status condition `Unschedulable=True`, which the kube scheduler sets when it fails to schedule the pod to existing capacity.
 
-* **Provisioner CR**: Karpenter defines a Custom Resource called a Provisioner to specify provisioning configuration.
-Each provisioner manages a distinct set of nodes, but pods can be scheduled to any provisioner that supports its scheduling constraints.
-A provisioner contains constraints that impact the nodes that can be provisioned and attributes of those nodes (such timers for removing nodes).
-See [Provisioning]({{<ref "./nodepools" >}}) docs for a description of settings and provisioner examples.
+* [**Defining Constraints**]({{<ref "nodepools" >}}): Karpenter defines a Custom Resource called a NodePool to specify configuration. Each NodePool manages a distinct set of nodes, but pods can be scheduled to any NodePool that supports its scheduling constraints. A NodePool contains constraints that impact the nodes that can be provisioned and attributes of those nodes. See the [NodePools Documentation]({{<ref "nodepools" >}}) docs for a description of configuration and NodePool examples.
 
-* **Well-known labels**: The provisioner can use well-known Kubernetes labels to allow pods to request only certain instance types, architectures, operating systems, or other attributes when creating nodes.
-See [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) for details.
-Keep in mind that only a subset of these labels are supported in Karpenter, as described later.
+* [**Defining Disruption**]({{<ref "disruption" >}}): A NodePool can also include values to indicate when nodes should be disrupted. This includes configuration around concepts like [Consolidation]({{<ref "disruption#consolidation" >}}) and [Expiration]({{<ref "disruption" >}}).
 
-* **Deprovisioning nodes**: A provisioner can also include time-to-live values to indicate when nodes should be deprovisioned after a set amount of time from when they were created or after they becomes empty of deployed pods.
+* **Well-known labels**: The NodePool can use well-known Kubernetes labels to allow pods to request only certain instance types, architectures, operating systems, or other attributes when creating nodes. See [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) for details. Keep in mind that only a subset of these labels are supported in Karpenter, as described later.
 
-* **Multiple provisioners**: Multiple provisioners can be configured on the same cluster.
-For example, you might want to configure different teams on the same cluster to run on completely separate capacity.
-One team could run on nodes using BottleRocket, while another uses EKSOptimizedAMI.
+* **Multiple NodePools**: Multiple NodePools can be configured on the same cluster. For example, you might want to configure different teams on the same cluster to run on completely separate capacity. One team could run on nodes using BottleRocket, while another uses EKSOptimizedAMI.
 
-Although most use cases are addressed with a single provisioner for multiple teams, multiple provisioners are useful to isolate nodes for billing, use different node constraints (such as no GPUs for a team), or use different deprovisioning settings.
+Although most use cases are addressed with a single NodePool for multiple teams, multiple NodePools are useful to isolate nodes for billing, use different node constraints (such as no GPUs for a team), or use different disruption settings.
 
-### Deprovisioning nodes
+### Disrupting nodes
 
 Karpenter deletes nodes when they are no longer needed.
 
-* **Finalizer**: Karpenter places a finalizer bit on each node it creates.
+* [**Finalizer**]({{<ref "disruption#manual-methods" >}}): Karpenter places a finalizer bit on each node it creates.
 When a request comes in to delete one of those nodes (such as a TTL or a manual `kubectl delete node`), Karpenter will cordon the node, drain all the pods, terminate the EC2 instance, and delete the node object.
 Karpenter handles all clean-up work needed to properly delete the node.
-* **Node Expiry**: If a node expiry time-to-live value (`ttlSecondsUntilExpired`) is reached, that node is drained of pods and deleted (even if it is still running workloads).
-* **Empty nodes**: When the last workload pod running on a Karpenter-managed node is gone, the node is annotated with an emptiness timestamp.
-Once that "node empty" time-to-live (`ttlSecondsAfterEmpty`) is reached, finalization is triggered.
-* **Consolidation**: If enabled, Karpenter will work to actively reduce cluster cost by identifying when nodes can be removed as their workloads will run on other nodes in the cluster and when nodes can be replaced with cheaper variants due to a change in the workloads.
-* **Interruption**: If enabled, Karpenter will watch for upcoming involuntary interruption events that could affect your nodes (health events, spot interruption, etc.) and will cordon, drain, and terminate the node(s) ahead of the event to reduce workload disruption.
+* [**Expiration**]({{<ref "disruption" >}}): Karpenter will mark nodes as expired and disrupt them after they have lived a set number of seconds, based on the NodePool's `spec.disruption.expireAfter` value. You can use node expiry to periodically recycle nodes due to security concerns.
+* [**Consolidation**]({{<ref "disruption#consolidation" >}}): Karpenter works to actively reduce cluster cost by identifying when:
+  * Nodes can be removed because the node is empty
+  * Nodes can be removed as their workloads will run on other nodes in the cluster.
+  * Nodes can be replaced with cheaper variants due to a change in the workloads.
+* [**Drift**]({{<ref "disruption#drift" >}}): Karpenter will mark nodes as drifted and disrupt nodes that have drifted from their desired specification. See [Drift]({{<ref "#drift" >}}) to see which fields are considered.
+* [**Interruption**]({{<ref "disruption#interruption" >}}): Karpenter will watch for upcoming interruption events that could affect your nodes (health events, spot interruption, etc.) and will cordon, drain, and terminate the node(s) ahead of the event to reduce workload disruption.
 
-For more details on how Karpenter deletes nodes, see [Deprovisioning nodes](./deprovisioning) for details.
-
-### Upgrading nodes
-
-A straight-forward way to upgrade nodes is to set `ttlSecondsUntilExpired`.
-Nodes will be terminated after a set period of time and will be replaced with newer nodes using the latest discovered AMI.
-See more in [AWSNodeTemplate](./node-templates).
-
-### Constraints
-
-The concept of layered constraints is key to using Karpenter.
-With no constraints defined in provisioners and none requested from pods being deployed, Karpenter chooses from the entire universe of features available to your cloud provider.
-Nodes can be created using any instance type and run in any zones.
-
-An application developer can tighten the constraints defined in a provisioner by the cluster administrator by defining additional scheduling constraints in their pod spec.
-Refer to the description of Karpenter constraints in the Application Developer section below for details.
+For more details on how Karpenter deletes nodes, see the [Disruption Documentation]({{<ref "disruption" >}}).
 
 ### Scheduling
 
@@ -94,81 +68,43 @@ Karpenter launches nodes in response to pods that the Kubernetes scheduler has m
 
 Once Karpenter brings up a node, that node is available for the Kubernetes scheduler to schedule pods on it as well.
 
-### Cloud provider
-Karpenter makes requests to provision new nodes to the associated cloud provider.
-The first supported cloud provider is AWS, although Karpenter is designed to work with other cloud providers.
-Separating Kubernetes and AWS-specific settings allows Karpenter a clean path to integrating with other cloud providers.
+#### Constraints
 
-While using Kubernetes well-known labels, the provisioner can set some values that are specific to the cloud provider.
-So, for example, to include a certain instance type, you could use the Kubernetes label `node.kubernetes.io/instance-type`, but set its value to an AWS instance type (such as `m5.large` or `m5.2xlarge`).
+The concept of layered constraints is key to using Karpenter. With no constraints defined in NodePools and none requested from pods being deployed, Karpenter chooses from the entire universe of features available to your cloud provider. Nodes can be created using any instance type and run in any zones.
 
-### Consolidation
+An application developer can tighten the constraints defined in a NodePool by the cluster administrator by defining additional scheduling constraints in their pod spec. Refer to the description of Karpenter constraints in the Application Developer section below for details.
 
-If consolidation is enabled for a provisioner, Karpenter attempts to reduce the overall cost of the nodes launched by that provisioner if workloads have changed in two ways:
-- Node Deletion
-- Node Replacement
+### Cloud Provider
 
-To perform these actions, Karpenter simulates all pods being evicted from a candidate node and then looks at the results of the scheduling simulation to determine if those pods can run on a combination of existing nodes in the cluster and a new cheaper node.  This operation takes into consideration all scheduling constraints placed on your workloads and provisioners (e.g. taints, tolerations, node selectors, inter-pod affinity, etc).
+Karpenter makes requests to provision new nodes to the associated cloud provider. The first supported cloud provider is AWS, although Karpenter is designed to work with other cloud providers. Separating Kubernetes and AWS-specific settings allows Karpenter a clean path to integrating with other cloud providers.
 
-If as a result of the scheduling simulation all pods can run on existing nodes, the candidate node is simply deleted.  If all pods can run on a combination of existing nodes and a cheaper node, we launch the cheaper node and delete the candidate node which causes the pods to be evicted and re-created by their controllers in order to be rescheduled.
+While using Kubernetes well-known labels, the NodePool can set some values that are specific to the cloud provider. So, for example, to include a certain instance type, you could use the Kubernetes label `node.kubernetes.io/instance-type`, but set its value to an AWS instance type (such as `m5.large` or `m5.2xlarge`).
 
-For Node Replacement to work well, your provisioner must allow selecting from a variety of instance types with varying amounts of allocatable resources.  Consolidation will only consider launching nodes using instance types which are allowed by your provisioner.
+### Kubernetes Cluster Autoscaler
 
-### Interruption
+Like Karpenter, [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) is designed to add nodes when requests come in to run pods that cannot be met by current capacity. Cluster autoscaler is part of the Kubernetes project, with implementations by most major Kubernetes cloud providers. By taking a fresh look at provisioning, Karpenter offers the following improvements:
 
-If interruption-handling is enabled for the controller, Karpenter will watch for upcoming involuntary interruption events that would cause disruption to your workloads. These interruption events include:
+* **Designed to handle the full flexibility of the cloud**: Karpenter has the ability to efficiently address the full range of instance types available through AWS. Cluster autoscaler was not originally built with the flexibility to handle hundreds of instance types, zones, and purchase options.
 
-* Spot Interruption Warnings
-* Scheduled Change Health Events (Maintenance Events)
-* Instance Terminating Events
-* Instance Stopping Events
+* **Group-less node provisioning**: Karpenter manages each instance directly, without use of additional orchestration mechanisms like node groups. This enables it to retry in milliseconds instead of minutes when capacity is unavailable. It also allows Karpenter to leverage diverse instance types, availability zones, and purchase options without the creation of hundreds of node groups.
 
-When Karpenter detects one of these events will occur to your nodes, it automatically cordons, drains, and terminates the node(s) ahead of the interruption event to give the maximum amount of time for workload cleanup prior to compute disruption. This enables scenarios where the `terminationGracePeriod` for your workloads may be long or cleanup for your workloads is critical, and you want enough time to be able to gracefully clean-up your pods.
+## Application Developer
 
-{{% alert title="Note" color="warning" %}}
-Karpenter publishes Kubernetes events to the node for all events listed above in addition to __Spot Rebalance Recommendations__. Karpenter does not currently support cordon, drain, and terminate logic for Spot Rebalance Recommendations.
-{{% /alert %}}
+As someone deploying pods that might be evaluated by Karpenter, you should know how to request the properties that your pods need of its compute resources. Karpenter's job is to efficiently assess and choose compute assets based on requests from pod deployments. These can include basic Kubernetes features or features that are specific to the cloud provider (such as AWS).
 
-### Kubernetes cluster autoscaler
-Like Karpenter, [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) is
-designed to add nodes when requests come in to run pods that cannot be met by current capacity.
-Cluster autoscaler is part of the Kubernetes project, with implementations by most major Kubernetes cloud providers.
-By taking a fresh look at provisioning, Karpenter offers the following improvements:
-
-* **Designed to handle the full flexibility of the cloud**:
-Karpenter has the ability to efficiently address the full range of instance types available through AWS.
-Cluster autoscaler was not originally built with the flexibility to handle hundreds of instance types, zones, and purchase options.
-
-* **Group-less node provisioning**: Karpenter manages each instance directly, without use of additional orchestration mechanisms like node groups.
-This enables it to retry in milliseconds instead of minutes when capacity is unavailable.
-It also allows Karpenter to leverage diverse instance types, availability zones, and purchase options without the creation of hundreds of node groups.
-
-## Application developer
-
-As someone deploying pods that might be evaluated by Karpenter, you should know how to request the properties that your pods need of its compute resources.
-Karpenter's job is to efficiently assess and choose compute assets based on requests from pod deployments.
-These can include basic Kubernetes features or features that are specific to the cloud provider (such as AWS).
-
-Layered *constraints* are applied when a pod makes requests for compute resources that cannot be met by current capacity.
-A pod can specify `nodeAffinity` (to run in a particular zone or instance type) or a `topologySpreadConstraints` spread (to cause a set of pods to be balanced across multiple nodes).
+Layered *constraints* are applied when a pod makes requests for compute resources that cannot be met by current capacity. A pod can specify `nodeAffinity` (to run in a particular zone or instance type) or a `topologySpreadConstraints` spread (to cause a set of pods to be balanced across multiple nodes).
 The pod can specify a `nodeSelector` to run only on nodes with a particular label and  `resource.requests` to ensure that the node has enough available memory.
 
-The Kubernetes scheduler tries to match those constraints with available nodes.
-If the pod is unschedulable, Karpenter creates compute resources that match its needs.
-When Karpenter tries to provision a node, it analyzes scheduling constraints before choosing the node to create.
+The Kubernetes scheduler tries to match those constraints with available nodes. If the pod is unschedulable, Karpenter creates compute resources that match its needs. When Karpenter tries to provision a node, it analyzes scheduling constraints before choosing the node to create.
 
-As long as the requests are not outside of the provisioner's constraints,
-Karpenter will look to best match the request, comparing the same well-known labels defined by the pod's scheduling constraints.
-Note that if the constraints are such that a match is not possible, the pod will remain unscheduled.
+As long as the requests are not outside the NodePool's constraints, Karpenter will look to best match the request, comparing the same well-known labels defined by the pod's scheduling constraints. Note that if the constraints are such that a match is not possible, the pod will remain unscheduled.
 
 So, what constraints can you use as an application developer deploying pods that could be managed by Karpenter?
 
 Kubernetes features that Karpenter supports for scheduling pods include nodeAffinity and [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
 It also supports [PodDisruptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/), [topologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/), and [inter-pod affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity).
 
-From the Kubernetes [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) page,
-you can see a full list of Kubernetes labels, annotations and taints that determine scheduling.
-Those that are implemented in Karpenter include:
+From the Kubernetes [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) page, you can see a full list of Kubernetes labels, annotations and taints that determine scheduling. Those that are implemented in Karpenter include:
 
 * **kubernetes.io/arch**: For example, kubernetes.io/arch=amd64
 * **node.kubernetes.io/instance-type**: For example, node.kubernetes.io/instance-type=m3.medium

--- a/website/content/en/preview/concepts/_index.md
+++ b/website/content/en/preview/concepts/_index.md
@@ -6,7 +6,7 @@ description: >
   Understand key concepts of Karpenter
 ---
 
-Users fall under two basic roles: [Kubernetes cluster administrators]({{<ref "#cluster-administrator" >}}) and [application developers]({{<ref "#application-developers" >}}). This document describes Karpenter concepts through the lens of those two types of users.
+Users fall under two basic roles: [Kubernetes cluster administrators]({{<ref "#cluster-administrator" >}}) and [application developers]({{<ref "#application-developer" >}}). This document describes Karpenter concepts through the lens of those two types of users.
 
 ## Cluster Administrator
 
@@ -37,7 +37,7 @@ Here are some things to know about Karpenter's NodePools:
 
 * [**Defining Constraints**]({{<ref "nodepools" >}}): Karpenter defines a Custom Resource called a NodePool to specify configuration. Each NodePool manages a distinct set of nodes, but pods can be scheduled to any NodePool that supports its scheduling constraints. A NodePool contains constraints that impact the nodes that can be provisioned and attributes of those nodes. See the [NodePools Documentation]({{<ref "nodepools" >}}) docs for a description of configuration and NodePool examples.
 
-* [**Defining Disruption**]({{<ref "disruption" >}}): A NodePool can also include values to indicate when nodes should be disrupted. This includes configuration around concepts like [Consolidation]({{<ref "disruption#consolidation" >}}) and [Expiration]({{<ref "disruption" >}}).
+* [**Defining Disruption**]({{<ref "disruption" >}}): A NodePool can also include values to indicate when nodes should be disrupted. This includes configuration around concepts like [Consolidation]({{<ref "disruption#consolidation" >}}), [Drift]({{<ref "disruption#drift" >}}), and [Expiration]({{<ref "disruption#automated-methods" >}}).
 
 * **Well-known labels**: The NodePool can use well-known Kubernetes labels to allow pods to request only certain instance types, architectures, operating systems, or other attributes when creating nodes. See [Well-Known Labels, Annotations and Taints](https://kubernetes.io/docs/reference/labels-annotations-taints/) for details. Keep in mind that only a subset of these labels are supported in Karpenter, as described later.
 
@@ -78,7 +78,7 @@ An application developer can tighten the constraints defined in a NodePool by th
 
 Karpenter makes requests to provision new nodes to the associated cloud provider. The first supported cloud provider is AWS, although Karpenter is designed to work with other cloud providers. Separating Kubernetes and AWS-specific settings allows Karpenter a clean path to integrating with other cloud providers.
 
-While using Kubernetes well-known labels, the NodePool can set some values that are specific to the cloud provider. So, for example, to include a certain instance type, you could use the Kubernetes label `node.kubernetes.io/instance-type`, but set its value to an AWS instance type (such as `m5.large` or `m5.2xlarge`).
+While using Kubernetes well-known labels, the NodePool can set some values that are specific to the cloud provider. For example, to include a certain instance type, you could use the Kubernetes label `node.kubernetes.io/instance-type`, but set its value to an AWS instance type (such as `m5.large` or `m5.2xlarge`).
 
 ### Kubernetes Cluster Autoscaler
 
@@ -86,7 +86,7 @@ Like Karpenter, [Kubernetes Cluster Autoscaler](https://github.com/kubernetes/au
 
 * **Designed to handle the full flexibility of the cloud**: Karpenter has the ability to efficiently address the full range of instance types available through AWS. Cluster autoscaler was not originally built with the flexibility to handle hundreds of instance types, zones, and purchase options.
 
-* **Group-less node provisioning**: Karpenter manages each instance directly, without use of additional orchestration mechanisms like node groups. This enables it to retry in milliseconds instead of minutes when capacity is unavailable. It also allows Karpenter to leverage diverse instance types, availability zones, and purchase options without the creation of hundreds of node groups.
+* **Quick node provisioning**: Karpenter manages each instance directly, without use of additional orchestration mechanisms like node groups. This enables it to retry in milliseconds instead of minutes when capacity is unavailable. It also allows Karpenter to leverage diverse instance types, availability zones, and purchase options without the creation of hundreds of node groups.
 
 ## Application Developer
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -144,7 +144,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 --dns-cluster-ip '10.100.0.10' \
 --use-max-pods false \
 --container-runtime containerd \
---kubelet-extra-args '--node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=test  --max-pods=110'
+--kubelet-extra-args '--node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=test  --max-pods=110'
 --//--
 ```
 
@@ -161,7 +161,7 @@ max-pods = 110
 
 [settings.kubernetes.node-labels]
 'karpenter.sh/capacity-type' = 'on-demand'
-'karpenter.sh/provisioner-name' = 'test'
+'karpenter.sh/nodepool' = 'test'
 ```
 
 ### Ubuntu
@@ -178,7 +178,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
 --dns-cluster-ip '10.100.0.10' \
 --use-max-pods false \
---kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=test" --max-pods=110'
+--kubelet-extra-args '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=test" --max-pods=110'
 --//--
 ```
 
@@ -187,7 +187,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 ```powershell
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=test" --max-pods=110' -DNSClusterIP '10.100.0.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=test" --max-pods=110' -DNSClusterIP '10.100.0.10'
 </powershell>
 ```
 
@@ -196,7 +196,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 ```powershell
 <powershell>
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=test" --max-pods=110' -DNSClusterIP '10.100.0.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=test" --max-pods=110' -DNSClusterIP '10.100.0.10'
 </powershell>
 ```
 
@@ -444,7 +444,7 @@ Control the exposure of [Instance Metadata Service](https://docs.aws.amazon.com/
 
 Refer to [recommended, security best practices](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node) for limiting exposure of Instance Metadata and User Data to pods.
 
-If metadataOptions are omitted from this provisioner, the following default settings are applied to the `EC2NodeClass`.
+If metadataOptions are omitted from this NodePool, the following default settings are applied to the `EC2NodeClass`.
 
 ```yaml
 spec:
@@ -578,7 +578,7 @@ spec:
     chown -R ec2-user ~ec2-user/.ssh
 ```
 
-For more examples on configuring fields for different AMI families, see the [examples here](https://github.com/aws/karpenter/blob/main/examples/provisioner/launchtemplates).
+For more examples on configuring fields for different AMI families, see the [examples here](https://github.com/aws/karpenter/blob/main/examples/v1beta1).
 
 Karpenter will merge the userData you specify with the default userData for that AMIFamily. See the [AMIFamily]({{< ref "#specamifamily" >}}) section for more details on these defaults. View the sections below to understand the different merge strategies for each AMIFamily.
 
@@ -632,7 +632,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /etc/eks/bootstrap.sh 'test-cluster' --apiserver-endpoint 'https://test-cluster' --b64-cluster-ca 'ca-bundle' \
 --use-max-pods false \
 --container-runtime containerd \
---kubelet-extra-args '--node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/provisioner-name=test  --max-pods=110'
+--kubelet-extra-args '--node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=test  --max-pods=110'
 --//--
 ```
 
@@ -686,7 +686,7 @@ cluster-name = 'cluster'
 
 [settings.kubernetes.node-labels]
 'karpenter.sh/capacity-type' = 'on-demand'
-'karpenter.sh/provisioner-name' = 'provisioner'
+'karpenter.sh/nodepool' = 'default'
 
 [settings.kubernetes.node-taints]
 
@@ -714,7 +714,7 @@ Write-Host "Running custom user data script"
 <powershell>
 Write-Host "Running custom user data script"
 [string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/provisioner-name=windows2022" --max-pods=110' -DNSClusterIP '10.0.100.10'
+& $EKSBootstrapScriptFile -EKSClusterName 'test-cluster' -APIServerEndpoint 'https://test-cluster' -Base64ClusterCA 'ca-bundle' -KubeletExtraArgs '--node-labels="karpenter.sh/capacity-type=spot,karpenter.sh/nodepool=windows2022" --max-pods=110' -DNSClusterIP '10.0.100.10'
 </powershell>
 ```
 

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -440,11 +440,11 @@ Karpenter allows overrides of the default "Name" tag but does not allow override
 
 ## spec.metadataOptions
 
-Control the exposure of [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) on EC2 Instances launched by this NodePool using a generated launch template.
+Control the exposure of [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) on EC2 Instances launched by this EC2NodeClass using a generated launch template.
 
 Refer to [recommended, security best practices](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node) for limiting exposure of Instance Metadata and User Data to pods.
 
-If metadataOptions are omitted from this NodePool, the following default settings are applied to the `EC2NodeClass`.
+If metadataOptions are omitted from this EC2NodeClass, the following default settings are applied:
 
 ```yaml
 spec:

--- a/website/content/en/preview/upgrade-guide.md
+++ b/website/content/en/preview/upgrade-guide.md
@@ -34,7 +34,8 @@ For more information on Karpenter's support for these keys, view [this tracking 
 
 To make upgrading easier, we aim to minimize the introduction of breaking changes with the following components:
 
-* Provisioner API
+* NodePool API
+* EC2NodeClass API
 * Helm Chart
 
 We try to maintain compatibility with:
@@ -70,9 +71,9 @@ If you get the error `invalid ownership metadata; label validation error:` while
 In general, you can reapply the CRDs in the `crds` directory of the Karpenter helm chart:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}pkg/apis/crds/karpenter.sh_provisioners.yaml
-kubectl apply -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}pkg/apis/crds/karpenter.sh_machines.yaml
-kubectl apply -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}pkg/apis/crds/karpenter.k8s.aws_awsnodetemplates.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}pkg/apis/crds/karpenter.sh_nodepols.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef >}}pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
 ```
 
 ### How Do We Break Incompatibility?


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates the documentation for the conceptual section index to align with v1beta1 APIs and concepts. This also re-organizes the doc and drops other details that are duplication in other places in the documentation

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.