### PR TITLE
docs: Update examples to v1beta1

### DIFF
--- a/examples/v1beta1/100-cpu-limit.yaml
+++ b/examples/v1beta1/100-cpu-limit.yaml
@@ -1,0 +1,28 @@
+# This example NodePool limits the amount of compute
+# NodePool by Karpenter to 100 CPU cores
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  spec:
+    template:
+      spec:
+        nodeClassRef:
+          name: default
+  limits:
+    cpu: 100
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/100-cpu-limit.yaml
+++ b/examples/v1beta1/100-cpu-limit.yaml
@@ -1,15 +1,34 @@
-# This example NodePool limits the amount of compute
-# NodePool by Karpenter to 100 CPU cores
+# This example NodePool limits the amount of compute managed by
+# Karpenter for this NodePool. Karpenter will not provision compute that
+# takes the pool over a total of 100 (virtual or physical) CPU cores.
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: default
+  name: limitcpu100
+  annotations:
+    kubernetes.io/description: "NodePool to restrict the number of cpus provisioned to 100"
 spec:
-  spec:
-    template:
-      spec:
-        nodeClassRef:
-          name: default
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+      nodeClassRef:
+        name: default
   limits:
     cpu: 100
 ---
@@ -17,8 +36,10 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose EC2NodeClass for running Amazon Linux 2 nodes"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:

--- a/examples/v1beta1/al2-custom-ami.yaml
+++ b/examples/v1beta1/al2-custom-ami.yaml
@@ -1,0 +1,40 @@
+# This example NodePool will provision instances using a custom EKS-Optimized AMI that belongs to the
+# AL2 AMIFamily. If your AMIs are built off https://github.com/awslabs/amazon-eks-ami and can be bootstrapped
+# by Karpenter, this may be a good fit for you.
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: al2
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: al2
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  amiSelectorTerms:
+    - id: ami-123
+    - id: ami-456
+  userData: |
+    MIME-Version: 1.0
+    Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+    --BOUNDARY
+    Content-Type: text/x-shellscript; charset="us-ascii"
+
+    #!/bin/bash
+    echo "Running a custom user data script"
+
+    --BOUNDARY--

--- a/examples/v1beta1/al2-custom-ami.yaml
+++ b/examples/v1beta1/al2-custom-ami.yaml
@@ -1,13 +1,32 @@
 # This example NodePool will provision instances using a custom EKS-Optimized AMI that belongs to the
 # AL2 AMIFamily. If your AMIs are built off https://github.com/awslabs/amazon-eks-ami and can be bootstrapped
 # by Karpenter, this may be a good fit for you.
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: al2
 ---
@@ -15,8 +34,10 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: al2
+  annotations:
+    kubernetes.io/description: "EC2NodeClass for running Amazon Linux 2 nodes with a custom AMI"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
@@ -29,12 +50,12 @@ spec:
     - id: ami-456
   userData: |
     MIME-Version: 1.0
-    Content-Type: multipart/mixed; boundary="BOUNDARY"
+    Content-Type: multipart/mixed; boundary="EXAMPLEBOUNDARY"
 
-    --BOUNDARY
+    --EXAMPLEBOUNDARY
     Content-Type: text/x-shellscript; charset="us-ascii"
 
     #!/bin/bash
     echo "Running a custom user data script"
 
-    --BOUNDARY--
+    --EXAMPLEBOUNDARY--

--- a/examples/v1beta1/al2-custom-userdata.yaml
+++ b/examples/v1beta1/al2-custom-userdata.yaml
@@ -1,0 +1,37 @@
+# This example NodePool will provision instances using the AL2 EKS-Optimized AMI.
+# The UserData defined in spec.UserData needs to be in the MIME-multipart format,
+# and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: al2
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: al2
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  userData: |
+    MIME-Version: 1.0
+    Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+    --BOUNDARY
+    Content-Type: text/x-shellscript; charset="us-ascii"
+
+    #!/bin/bash
+    echo "Running a custom user data script"
+
+    --BOUNDARY--

--- a/examples/v1beta1/al2-custom-userdata.yaml
+++ b/examples/v1beta1/al2-custom-userdata.yaml
@@ -1,13 +1,32 @@
 # This example NodePool will provision instances using the AL2 EKS-Optimized AMI.
 # The UserData defined in spec.UserData needs to be in the MIME-multipart format,
 # and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: al2
 ---
@@ -15,8 +34,10 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: al2
+  annotations:
+    kubernetes.io/description: "EC2NodeClass for running Amazon Linux 2 nodes with custom user data"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:

--- a/examples/v1beta1/al2-kubelet-log-query.yaml
+++ b/examples/v1beta1/al2-kubelet-log-query.yaml
@@ -1,12 +1,31 @@
 # This example NodePool will provision instances using the AL2 EKS-Optimized AMI
 # and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: al2
 ---
@@ -14,8 +33,10 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: al2
+  annotations:
+    kubernetes.io/description: "EC2NodeClass for running Amazon Linux 2 nodes with user data that enables the NodeLogQuery feature gate"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
@@ -40,7 +61,6 @@ spec:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--feature-gates=NodeLogQuery=true $KUBELET_EXTRA_ARGS"
     EOF
-    systemctl daemon-reload
 
     # Enable log handler and log query to the kubelet configuration
     echo "$(jq '.enableSystemLogHandler=true' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json

--- a/examples/v1beta1/al2-kubelet-log-query.yaml
+++ b/examples/v1beta1/al2-kubelet-log-query.yaml
@@ -1,0 +1,49 @@
+# This example NodePool will provision instances using the AL2 EKS-Optimized AMI
+# and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: al2
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: al2
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  userData: |
+    MIME-Version: 1.0
+    Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+    --BOUNDARY
+    Content-Type: text/x-shellscript; charset="us-ascii"
+
+    #!/bin/bash
+
+    set -e
+
+    # Add additional KUBELET_EXTRA_ARGS to the service
+    # Requires Kubernetes 1.27 (alpha feature)
+    cat << EOF > /etc/systemd/system/kubelet.service.d/90-kubelet-extra-args.conf
+    [Service]
+    Environment="KUBELET_EXTRA_ARGS=--feature-gates=NodeLogQuery=true $KUBELET_EXTRA_ARGS"
+    EOF
+    systemctl daemon-reload
+
+    # Enable log handler and log query to the kubelet configuration
+    echo "$(jq '.enableSystemLogHandler=true' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
+    echo "$(jq '.enableSystemLogQuery=true' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
+
+    --BOUNDARY--

--- a/examples/v1beta1/bottlerocket.yaml
+++ b/examples/v1beta1/bottlerocket.yaml
@@ -1,0 +1,36 @@
+# This example NodePool will provision instances
+# running Bottlerocket OS
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: bottlerocket
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: bottlerocket
+spec:
+  amiFamily: Bottlerocket
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeType: gp3
+        volumeSize: 4Gi
+        deleteOnTermination: true
+    - deviceName: /dev/xvdb
+      ebs:
+        volumeType: gp3
+        volumeSize: 20Gi # replace with your required disk size
+        deleteOnTermination: true

--- a/examples/v1beta1/bottlerocket.yaml
+++ b/examples/v1beta1/bottlerocket.yaml
@@ -1,12 +1,31 @@
 # This example NodePool will provision instances
 # running Bottlerocket OS
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: bottlerocket
 ---
@@ -14,6 +33,8 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: bottlerocket
+  annotations:
+    kubernetes.io/description: "EC2NodeClass for running Bottlerocket nodes"
 spec:
   amiFamily: Bottlerocket
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
@@ -29,6 +50,7 @@ spec:
         volumeType: gp3
         volumeSize: 4Gi
         deleteOnTermination: true
+    # Bottlerocket data volume
     - deviceName: /dev/xvdb
       ebs:
         volumeType: gp3

--- a/examples/v1beta1/br-custom-userdata.yaml
+++ b/examples/v1beta1/br-custom-userdata.yaml
@@ -1,0 +1,29 @@
+# This example NodePool will provision instances
+# running Bottlerocket OS and the userData settings specified in ths AWSNodeTemplate
+# CRD will be merged into Karpenter defaults.
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: bottlerocket
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: bottlerocket
+spec:
+  amiFamily: Bottlerocket
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  userData:  |
+    [settings.kubernetes]
+    kube-api-qps = 30

--- a/examples/v1beta1/br-custom-userdata.yaml
+++ b/examples/v1beta1/br-custom-userdata.yaml
@@ -1,13 +1,32 @@
 # This example NodePool will provision instances
-# running Bottlerocket OS and the userData settings specified in ths AWSNodeTemplate
-# CRD will be merged into Karpenter defaults.
+# running Bottlerocket OS and the user data settings specified in
+# this EC2NodeClass will be merged into Karpenter defaults.
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: bottlerocket
 ---
@@ -15,6 +34,8 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: bottlerocket
+  annotations:
+    kubernetes.io/description: "EC2NodeClass for running Bottlerocket nodes with custom user data"
 spec:
   amiFamily: Bottlerocket
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/custom-family.yaml
+++ b/examples/v1beta1/custom-family.yaml
@@ -1,0 +1,42 @@
+# This example provisioner will provision instances using an AMI that belongs to a custom AMIFamily
+# Keep in mind, that you're in charge of bootstrapping your worker nodes.
+
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: custom-family
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: custom-family
+spec:
+  amiFamily: Custom
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  amiSelectorTerms:
+    - id: ami-123
+    - id: ami-456
+  userData: |
+    MIME-Version: 1.0
+    Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+    --BOUNDARY
+    Content-Type: text/x-shellscript; charset="us-ascii"
+
+    #!/bin/bash
+    echo "Running my custom set-up"
+
+    /etc/eks/bootstrap.sh my-cluster --kubelet-extra-args='--node-labels=foo=bar'
+
+    --BOUNDARY

--- a/examples/v1beta1/custom-family.yaml
+++ b/examples/v1beta1/custom-family.yaml
@@ -1,13 +1,31 @@
-# This example provisioner will provision instances using an AMI that belongs to a custom AMIFamily
+# This example NodePool provisions instances using an AMI that belongs to a custom AMIFamily
 # Keep in mind, that you're in charge of bootstrapping your worker nodes.
-
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: custom-family
 ---
@@ -15,6 +33,8 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: custom-family
+  annotations:
+    kubernetes.io/description: "EC2NodeClass for running Custom AMIFamily with custom user data that doesn't conform to the other AMIFamilies"
 spec:
   amiFamily: Custom
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
@@ -36,7 +56,8 @@ spec:
 
     #!/bin/bash
     echo "Running my custom set-up"
-
+    
+    # Have the kubelet label the node
     /etc/eks/bootstrap.sh my-cluster --kubelet-extra-args='--node-labels=foo=bar'
 
     --BOUNDARY

--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -1,0 +1,33 @@
+# This example NodePool will provision general purpose instances
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        # Include general purpose instance families
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: [c5, m5, r5]
+        # Exclude small instance sizes
+        - key: karpenter.k8s.aws/instance-size
+          operator: NotIn
+          values: [nano, micro, small, large]
+      nodeClassRef:
+        name: default
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/large-instances.yaml
+++ b/examples/v1beta1/large-instances.yaml
@@ -1,0 +1,32 @@
+# This example NodePool will avoid small instance types in the cluster
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+          # exclude instances with < 4 cores and < 8GiB memory (8192 mebibytes)
+        - key: "karpenter.k8s.aws/instance-cpu"
+          operator: Gt
+          values: ["3"]
+        - key: "karpenter.k8s.aws/instance-memory"
+          operator: Gt
+          values: ["8191"]
+      nodeClassRef:
+        name: default
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/large-instances.yaml
+++ b/examples/v1beta1/large-instances.yaml
@@ -1,8 +1,11 @@
 # This example NodePool will avoid small instance types in the cluster
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: default
+  name: large-instances
+  annotations:
+    kubernetes.io/description: "NodePool for provisioning larger instances using Gt/Lt requirements"
 spec:
   template:
     spec:
@@ -21,8 +24,10 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose EC2NodeClass for running Amazon Linux 2 nodes"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:

--- a/examples/v1beta1/multiple-arch.yaml
+++ b/examples/v1beta1/multiple-arch.yaml
@@ -1,11 +1,13 @@
-# This example NodePool will provision general purpose instances
+# This example allows you to create arm64 AND amd64 workloads
+# Karpenter will choose the NodePool that suits the workload requirements and
+# find an AMI automatically that matches the architecture requirements
 ---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: general-purpose
+  name: amd64
   annotations:
-    kubernetes.io/description: "General purpose NodePool for generic workloads"
+    kubernetes.io/description: "NodePool for amd64 workloads"
 spec:
   template:
     spec:
@@ -22,6 +24,34 @@ spec:
         - key: karpenter.k8s.aws/instance-category
           operator: In
           values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+      nodeClassRef:
+        name: default
+---
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: arm64
+  annotations:
+    kubernetes.io/description: "NodePool for arm64 workloads"
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["arm64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "a"]
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]

--- a/examples/v1beta1/multiple-ebs.yaml
+++ b/examples/v1beta1/multiple-ebs.yaml
@@ -1,0 +1,50 @@
+# This example NodePool will provision instances
+# with multiple EBS attached
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        # Include general purpose instance families
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: [c6g, c7g, c6a, c6i, m6a, m6g, m6i, r6a, r6g, r6i]
+        # Exclude small instance sizes
+        - key: karpenter.k8s.aws/instance-size
+          operator: In
+          values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge]
+      nodeClassRef:
+        name: default
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeType: gp3
+        volumeSize: 20Gi
+        deleteOnTermination: true
+    - deviceName: /dev/xvdb
+      ebs:
+        volumeType: gp3
+        volumeSize: 100Gi
+        deleteOnTermination: true
+    - deviceName: /dev/xvdc
+      ebs:
+        volumeType: gp3
+        volumeSize: 2000Gi
+        deleteOnTermination: true

--- a/examples/v1beta1/multiple-ebs.yaml
+++ b/examples/v1beta1/multiple-ebs.yaml
@@ -1,30 +1,42 @@
 # This example NodePool will provision instances
-# with multiple EBS attached
+# with multiple EBS volumes attached
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
       requirements:
-        # Include general purpose instance families
-        - key: karpenter.k8s.aws/instance-family
+        - key: kubernetes.io/arch
           operator: In
-          values: [c6g, c7g, c6a, c6i, m6a, m6g, m6i, r6a, r6g, r6i]
-        # Exclude small instance sizes
-        - key: karpenter.k8s.aws/instance-size
+          values: ["amd64"]
+        - key: kubernetes.io/os
           operator: In
-          values: [medium, large, xlarge, xlarge, 2xlarge, 4xlarge]
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
-        name: default
+        name: multiple-ebs
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
-  name: default
+  name: multiple-ebs
+  annotations:
+    kubernetes.io/description: "EC2NodeClass to provision multiple EBS volumes to attach to new nodes"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:

--- a/examples/v1beta1/node-ttls.yaml
+++ b/examples/v1beta1/node-ttls.yaml
@@ -1,13 +1,32 @@
 # This example NodePool will provision instances
 # that are replaced every 7 days and drain after 1 minute
 # with no workloads
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: default
   disruption:
@@ -19,8 +38,10 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose EC2NodeClass for running Amazon Linux 2 nodes"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:

--- a/examples/v1beta1/node-ttls.yaml
+++ b/examples/v1beta1/node-ttls.yaml
@@ -1,0 +1,30 @@
+# This example NodePool will provision instances
+# that are replaced every 7 days and drain after 1 minute
+# with no workloads
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: default
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 60s # scale down nodes after 60 seconds without workloads (excluding daemons)
+    expireAfter: 168h # expire nodes after 7 days = 7 * 24h
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/spot.yaml
+++ b/examples/v1beta1/spot.yaml
@@ -1,0 +1,30 @@
+# This example will use spot instance type for all
+# provisioned instances
+
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
+      nodeClassRef:
+        name: default
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/spot.yaml
+++ b/examples/v1beta1/spot.yaml
@@ -1,10 +1,12 @@
 # This example will use spot instance type for all
 # provisioned instances
-
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: default
+  name: spot
+  annotations:
+    kubernetes.io/description: "NodePool for provisioning spot capacity"
 spec:
   template:
     spec:
@@ -12,6 +14,18 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values: ["spot"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: default
 ---
@@ -19,8 +33,10 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: default
+  annotations:
+    kubernetes.io/description: "General purpose EC2NodeClass for running Amazon Linux 2 nodes"
 spec:
-  amiFamily: AL2
+  amiFamily: AL2 # Amazon Linux 2
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:

--- a/examples/v1beta1/ubuntu-kubelet-log-query.yaml
+++ b/examples/v1beta1/ubuntu-kubelet-log-query.yaml
@@ -1,13 +1,31 @@
-# This example provisioner will provision instances using the Ubuntu EKS AMI
+# This example NodePool provisions instances using the Ubuntu EKS AMI
 # and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
-
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  name: default
+  name: ubuntu
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
   template:
     spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: ubuntu
 ---
@@ -15,6 +33,8 @@ apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
   name: ubuntu
+  annotations:
+    kubernetes.io/description: "EC2NodeClass for running Ubuntu nodes with user data that enables the NodeLogQuery feature gate"
 spec:
   amiFamily: Ubuntu
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/ubuntu-kubelet-log-query.yaml
+++ b/examples/v1beta1/ubuntu-kubelet-log-query.yaml
@@ -1,0 +1,49 @@
+# This example provisioner will provision instances using the Ubuntu EKS AMI
+# and will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: ubuntu
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: ubuntu
+spec:
+  amiFamily: Ubuntu
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  userData: |
+    MIME-Version: 1.0
+    Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+    --BOUNDARY
+    Content-Type: text/x-shellscript; charset="us-ascii"
+
+    #!/bin/bash
+    # There is currently a bug with log query and kubelet running inside a snap environment
+    # https://github.com/kubernetes/kubernetes/issues/120618
+    # This example is provided for reference on how to change Ubuntu settings in user data
+
+    set -e
+
+    # This requires Kubernetes 1.27 or above (alpha feature)
+    # This modifies the configuration of the /etc/eks/bootstrap.sh script because /etc/kubernetes/kubelet/kubelet-config.json
+    # doesn't exist before bootstrap.sh is run
+    
+    sed -i 's/args="$KUBELET_EXTRA_ARGS"/args="--feature-gates=NodeLogQuery=true $KUBELET_EXTRA_ARGS"/g' /etc/eks/bootstrap.sh
+    sed -i '/# writes kubeReserved and evictionHard/a echo "$(jq .enableSystemLogHandler=true $KUBELET_CONFIG)" > $KUBELET_CONFIG' /etc/eks/bootstrap.sh
+    sed -i '/# writes kubeReserved and evictionHard/a echo "$(jq .enableSystemLogQuery=true $KUBELET_CONFIG)" > $KUBELET_CONFIG' /etc/eks/bootstrap.sh
+
+    --BOUNDARY--

--- a/examples/v1beta1/windows-custom-userdata.yaml
+++ b/examples/v1beta1/windows-custom-userdata.yaml
@@ -1,19 +1,33 @@
-# This example provisioner will provision instances using the Windows 2022 EKS-Optimized AMI.
+# This example NodePool provisions instances using the Windows 2022 EKS-Optimized AMI.
 # The UserData defined in spec.UserData should be PowerShell commands
 # and they will be prepended to a Karpenter managed section that will bootstrap the kubelet.
 # This example also applies to the Windows 2019 EKS-Optimized AMI.
-
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: windows2022
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for Windows workloads"
 spec:
   template:
     spec:
       requirements:
         - key: kubernetes.io/os
           operator: In
-          values: [ "windows" ]
+          values: ["windows"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: windows2022
 ---

--- a/examples/v1beta1/windows-custom-userdata.yaml
+++ b/examples/v1beta1/windows-custom-userdata.yaml
@@ -1,0 +1,40 @@
+# This example provisioner will provision instances using the Windows 2022 EKS-Optimized AMI.
+# The UserData defined in spec.UserData should be PowerShell commands
+# and they will be prepended to a Karpenter managed section that will bootstrap the kubelet.
+# This example also applies to the Windows 2019 EKS-Optimized AMI.
+
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: windows2022
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/os
+          operator: In
+          values: [ "windows" ]
+      nodeClassRef:
+        name: windows2022
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: windows2022
+  annotations:
+    kubernetes.io/description: "Nodes running Windows Server 2022"
+spec:
+  amiFamily: Windows2022
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  metadataOptions:
+    httpProtocolIPv6: disabled
+    httpTokens: required
+  userData: |
+    New-Item -Path 'C:\temp\' -ItemType Directory
+    New-Item -Path 'C:\temp\sample.txt' -ItemType File

--- a/examples/v1beta1/windows2019.yaml
+++ b/examples/v1beta1/windows2019.yaml
@@ -1,0 +1,33 @@
+# This example NodePool will provision instances running Windows Server 2019
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: windows2019
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/os
+          operator: In
+          values: ["windows"]
+      nodeClassRef:
+        name: windows2019
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: windows2019
+  annotations:
+    kubernetes.io/description: "Nodes running Windows Server 2019"
+spec:
+  amiFamily: Windows2019
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  metadataOptions:
+    httpProtocolIPv6: disabled
+    httpTokens: required

--- a/examples/v1beta1/windows2019.yaml
+++ b/examples/v1beta1/windows2019.yaml
@@ -1,8 +1,11 @@
 # This example NodePool will provision instances running Windows Server 2019
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: windows2019
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for Windows workloads"
 spec:
   template:
     spec:
@@ -10,6 +13,18 @@ spec:
         - key: kubernetes.io/os
           operator: In
           values: ["windows"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: windows2019
 ---

--- a/examples/v1beta1/windows2022.yaml
+++ b/examples/v1beta1/windows2022.yaml
@@ -1,0 +1,33 @@
+# This example NodePool will provision instances running Windows Server 2022
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: windows2022
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/os
+          operator: In
+          values: ["windows"]
+      nodeClassRef:
+        name: windows2022
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: windows2022
+  annotations:
+    kubernetes.io/description: "Nodes running Windows Server 2022"
+spec:
+  amiFamily: Windows2022
+  role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+  metadataOptions:
+    httpProtocolIPv6: disabled
+    httpTokens: required

--- a/examples/v1beta1/windows2022.yaml
+++ b/examples/v1beta1/windows2022.yaml
@@ -1,8 +1,11 @@
 # This example NodePool will provision instances running Windows Server 2022
+---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
   name: windows2022
+  annotations:
+    kubernetes.io/description: "General purpose NodePool for Windows workloads"
 spec:
   template:
     spec:
@@ -10,6 +13,18 @@ spec:
         - key: kubernetes.io/os
           operator: In
           values: ["windows"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
       nodeClassRef:
         name: windows2022
 ---

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -123,7 +123,7 @@ status:
   # generated instance profile name
   instanceProfile: "${CLUSTER_NAME}-0123456778901234567789"
 ```
-Refer to the [NodePool docs]({{<ref "./nodepools" >}}) for settings applicable to all providers. To explore various `EC2NodeClass` configurations, refer to the examples provided [in the Karpenter Github repository](https://github.com/aws/karpenter/blob/main/examples/nodepool/).
+Refer to the [NodePool docs]({{<ref "./nodepools" >}}) for settings applicable to all providers. To explore various `EC2NodeClass` configurations, refer to the examples provided [in the Karpenter Github repository](https://github.com/aws/karpenter/blob/main/examples/v1beta1/).
 
 ## spec.amiFamily
 

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -24,7 +24,7 @@ Here are things you should know about NodePools:
 * If Karpenter encounters a startup taint in the NodePool it will be applied to nodes that are provisioned, but pods do not need to tolerate the taint.  Karpenter assumes that the taint is temporary and some other system will remove the taint.
 * It is recommended to create NodePools that are mutually exclusive. So no Pod should match multiple NodePools. If multiple NodePools are matched, Karpenter will use the NodePool with the highest [weight](#specweight).
 
-For some example `NodePool` configurations, see the [examples in the Karpenter GitHub repository](https://github.com/aws/karpenter/blob/main/examples/nodepool/).
+For some example `NodePool` configurations, see the [examples in the Karpenter GitHub repository](https://github.com/aws/karpenter/blob/main/examples/v1beta1/).
 
 ```yaml
 apiVersion: karpenter.sh/v1beta1


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates all of the files in the `examples/provisioner` directory to be v1beta1 examples. It also collapses the two separate directories into a single directory called `v1beta1`

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.