### PR TITLE
fix: karpenter-convert changes post bug bash

### DIFF
--- a/tools/karpenter-convert/go.mod
+++ b/tools/karpenter-convert/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/karpenter-core v0.31.1-0.20231003200119-b5ccaf30be9c
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.28.0
+	github.com/samber/lo v1.38.1
 	github.com/spf13/cobra v1.7.0
 	k8s.io/apimachinery v0.28.2
 	k8s.io/cli-runtime v0.28.2
@@ -21,6 +22,7 @@ require (
 	github.com/aws/aws-sdk-go v1.45.15 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -68,12 +70,12 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/samber/lo v1.38.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
@@ -90,6 +92,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.28.2 // indirect
 	k8s.io/apiextensions-apiserver v0.26.6 // indirect
+	k8s.io/cloud-provider v0.26.6 // indirect
+	k8s.io/csi-translation-lib v0.26.6 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect

--- a/tools/karpenter-convert/go.sum
+++ b/tools/karpenter-convert/go.sum
@@ -209,8 +209,13 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93VanwNIi5bIKnDrJdEY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
+go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
 go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/tools/karpenter-convert/pkg/convert/convert_test.go
+++ b/tools/karpenter-convert/pkg/convert/convert_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,9 +39,10 @@ func TestConvert(t *testing.T) {
 
 var _ = Describe("ConvertObject", func() {
 	type testcase struct {
-		name       string
-		file       string
-		outputFile string
+		name           string
+		ignoreDefaults bool
+		file           string
+		outputFile     string
 	}
 
 	DescribeTable("conversion tests",
@@ -63,6 +65,9 @@ var _ = Describe("ConvertObject", func() {
 			if err := cmd.Flags().Set("output", "yaml"); err != nil {
 				Expect(err).To(BeNil())
 			}
+			if err := cmd.Flags().Set("ignore-defaults", strconv.FormatBool(tc.ignoreDefaults)); err != nil {
+				Expect(err).To(BeNil())
+			}
 
 			cmd.Run(cmd, []string{})
 
@@ -77,6 +82,24 @@ var _ = Describe("ConvertObject", func() {
 				name:       "provisioner to nodepool",
 				file:       "./testdata/provisioner.yaml",
 				outputFile: "./testdata/nodepool.yaml",
+			},
+		),
+
+		Entry("provisioner (set defaults) to nodepool",
+			testcase{
+				name:           "provisioner to nodepool",
+				file:           "./testdata/provisioner_defaults.yaml",
+				outputFile:     "./testdata/nodepool_defaults.yaml",
+				ignoreDefaults: false,
+			},
+		),
+
+		Entry("provisioner (no set defaults) to nodepool",
+			testcase{
+				name:           "provisioner to nodepool",
+				file:           "./testdata/provisioner_no_defaults.yaml",
+				outputFile:     "./testdata/nodepool_no_defaults.yaml",
+				ignoreDefaults: true,
 			},
 		),
 

--- a/tools/karpenter-convert/pkg/convert/testdata/nodeclass.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodeclass.yaml
@@ -1,7 +1,6 @@
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
-  creationTimestamp: null
   name: default
 spec:
   amiFamily: Bottlerocket
@@ -32,7 +31,7 @@ spec:
       deleteOnTermination: true
       volumeSize: 100Gi
       volumeType: gp3
-  role: <your AWS role here>
+  role: $KARPENTER_NODE_ROLE
   securityGroupSelectorTerms:
   - tags:
       karpenter.sh/discovery: $MY_CLUSTER_NAME
@@ -47,4 +46,3 @@ spec:
     kube-api-qps = 30
     [settings.kubernetes.eviction-hard]
     "memory.available" = "10%"
-status: {}

--- a/tools/karpenter-convert/pkg/convert/testdata/nodeclass_no_amifamily.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodeclass_no_amifamily.yaml
@@ -1,7 +1,6 @@
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
 metadata:
-  creationTimestamp: null
   name: default
 spec:
   amiFamily: AL2
@@ -11,7 +10,7 @@ spec:
       deleteOnTermination: true
       volumeSize: 100Gi
       volumeType: gp3
-  role: <your AWS role here>
+  role: $KARPENTER_NODE_ROLE
   securityGroupSelectorTerms:
   - tags:
       karpenter.sh/discovery: karpenter-demo
@@ -26,4 +25,3 @@ spec:
     kube-api-qps = 30
     [settings.kubernetes.eviction-hard]
     "memory.available" = "10%"
-status: {}

--- a/tools/karpenter-convert/pkg/convert/testdata/nodepool.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodepool.yaml
@@ -1,7 +1,6 @@
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
 metadata:
-  creationTimestamp: null
   name: default
 spec:
   disruption:
@@ -15,7 +14,6 @@ spec:
     metadata:
       annotations:
         example.com/owner: my-team
-      creationTimestamp: null
       labels:
         billing-team: my-team
     spec:
@@ -87,7 +85,10 @@ spec:
         values:
         - spot
         - on-demand
-      resources: {}
+      - key: kubernetes.io/os
+        operator: In
+        values:
+        - linux
       startupTaints:
       - effect: NoSchedule
         key: example.com/another-taint
@@ -95,4 +96,3 @@ spec:
       - effect: NoSchedule
         key: example.com/special-taint
   weight: 10
-status: {}

--- a/tools/karpenter-convert/pkg/convert/testdata/nodepool_defaults.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodepool_defaults.yaml
@@ -1,0 +1,51 @@
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  disruption:
+    consolidateAfter: 30s
+    consolidationPolicy: WhenEmpty
+    expireAfter: 720h0m0s
+  limits:
+    cpu: 1k
+    memory: 1000Gi
+  template:
+    metadata:
+      annotations:
+        example.com/owner: my-team
+      labels:
+        billing-team: my-team
+    spec:
+      nodeClassRef:
+        name: default
+      requirements:
+      - key: kubernetes.io/os
+        operator: In
+        values:
+        - linux
+      - key: kubernetes.io/arch
+        operator: In
+        values:
+        - amd64
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values:
+        - on-demand
+      - key: karpenter.k8s.aws/instance-category
+        operator: In
+        values:
+        - c
+        - m
+        - r
+      - key: karpenter.k8s.aws/instance-generation
+        operator: Gt
+        values:
+        - "2"
+      startupTaints:
+      - effect: NoSchedule
+        key: example.com/another-taint
+      taints:
+      - effect: NoSchedule
+        key: example.com/special-taint
+  weight: 10

--- a/tools/karpenter-convert/pkg/convert/testdata/nodepool_no_defaults.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodepool_no_defaults.yaml
@@ -1,0 +1,29 @@
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  disruption:
+    consolidateAfter: 30s
+    consolidationPolicy: WhenEmpty
+    expireAfter: 720h0m0s
+  limits:
+    cpu: 1k
+    memory: 1000Gi
+  template:
+    metadata:
+      annotations:
+        example.com/owner: my-team
+      labels:
+        billing-team: my-team
+    spec:
+      nodeClassRef:
+        name: default
+      requirements: null
+      startupTaints:
+      - effect: NoSchedule
+        key: example.com/another-taint
+      taints:
+      - effect: NoSchedule
+        key: example.com/special-taint
+  weight: 10

--- a/tools/karpenter-convert/pkg/convert/testdata/provisioner_defaults.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/provisioner_defaults.yaml
@@ -1,0 +1,26 @@
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: default
+spec:
+  providerRef:
+    name: default
+  taints:
+    - key: example.com/special-taint
+      effect: NoSchedule
+  startupTaints:
+    - key: example.com/another-taint
+      effect: NoSchedule
+  labels:
+    billing-team: my-team
+  annotations:
+    example.com/owner: "my-team"
+  limits:
+    resources:
+      cpu: "1000"
+      memory: 1000Gi
+  consolidation:
+    enabled: false
+  ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
+  ttlSecondsAfterEmpty: 30
+  weight: 10

--- a/tools/karpenter-convert/pkg/convert/testdata/provisioner_no_defaults.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/provisioner_no_defaults.yaml
@@ -1,0 +1,26 @@
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: default
+spec:
+  providerRef:
+    name: default
+  taints:
+    - key: example.com/special-taint
+      effect: NoSchedule
+  startupTaints:
+    - key: example.com/another-taint
+      effect: NoSchedule
+  labels:
+    billing-team: my-team
+  annotations:
+    example.com/owner: "my-team"
+  limits:
+    resources:
+      cpu: "1000"
+      memory: 1000Gi
+  consolidation:
+    enabled: false
+  ttlSecondsUntilExpired: 2592000 # 30 Days = 60 * 60 * 24 * 30 Seconds;
+  ttlSecondsAfterEmpty: 30
+  weight: 10


### PR DESCRIPTION
fix: karpenter-convert changes to correctly handle emptyFields, provisioner defaults, nodepool resources and aws ec2 role

Fixes #4821, #4822, #4829

**Description**
* Avoid generation of `.metadata.creationTimestamp` and `.status` fields
* Correctly migrate Provisioner requirements defaults
* Avoid generation of Provisioner `.spec.resources` as an empty field
* The ec2 role placeholder has been changed to `$KARPENTER_NODE_ROLE`

**How was this change tested?**
`go build`
`go test`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [X] Yes, PR in progress: https://github.com/aws/karpenter/pull/4749
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.