### PR TITLE
ci: Enable control plane logging for e2e tests

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -113,6 +113,10 @@ runs:
           - key: CriticalAddonsOnly
             value: "true"
             effect: NoSchedule
+      cloudWatch:
+        clusterLogging:
+          enableTypes: ["*"]
+          logRetentionInDays: 30
       iam:
         serviceRolePermissionsBoundary: "arn:aws:iam::${{ inputs.account_id }}:policy/GithubActionsPermissionsBoundary"
         serviceAccounts:
@@ -152,8 +156,6 @@ runs:
       # We need to call these update iamserviceaccount commands again since the "eksctl upgrade cluster" action
       # doesn't handle updates to IAM serviceaccounts correctly when the roles assigned to them change
       eksctl update iamserviceaccount -f clusterconfig.yaml --approve
-      
-
   - name: tag oidc provider of the cluster
     if: always()
     shell: bash
@@ -162,13 +164,6 @@ runs:
       arn="arn:aws:iam::${{ inputs.account_id }}:oidc-provider/${oidc_id}"
       aws iam tag-open-id-connect-provider --open-id-connect-provider-arn $arn \
          --tags Key=testing/type,Value=e2e  Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  - name: enable control-plane logging for the cluster
-    shell: bash
-    run: |
-      aws eks update-cluster-config \
-        --region ${{ inputs.region }} \
-        --name ${{ inputs.cluster_name }} \
-        --logging '{"clusterLogging":[{"types":["api","audit","authenticator","controllerManager","scheduler"],"enabled":true}]}'
   - name: give KarpenterNodeRole permission to bootstrap
     shell: bash
     run: |

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -162,6 +162,13 @@ runs:
       arn="arn:aws:iam::${{ inputs.account_id }}:oidc-provider/${oidc_id}"
       aws iam tag-open-id-connect-provider --open-id-connect-provider-arn $arn \
          --tags Key=testing/type,Value=e2e  Key=github.com/run-url,Value=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  - name: enable control-plane logging for the cluster
+    shell: bash
+    run: |
+      aws eks update-cluster-config \
+        --region ${{ inputs.region }} \
+        --name ${{ inputs.cluster_name }} \
+        --logging '{"clusterLogging":[{"types":["api","audit","authenticator","controllerManager","scheduler"],"enabled":true}]}'
   - name: give KarpenterNodeRole permission to bootstrap
     shell: bash
     run: |

--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -148,8 +148,7 @@ Resources:
               - eks:ListFargateProfiles
               - eks:TagResource
               - eks:DescribeCluster
-            Resource: 
-              - !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:cluster/*"
+            Resource: !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:cluster/*"
             Condition:
               StringEquals:
                 aws:RequestedRegion: 
@@ -169,16 +168,17 @@ Resources:
               - eks:DeleteNodegroup
               - eks:DescribeNodegroup
               - eks:TagResource
-            Resource: 
-              - !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:nodegroup/*"
+            Resource: !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:nodegroup/*"
             Condition:
               StringEquals:
                 aws:RequestedRegion: 
                   Ref: Regions
           - Effect: Allow
+            Action: logs:PutRetentionPolicy
+            Resource: !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/eks/*"
+          - Effect: Allow
             Action: fis:CreateExperimentTemplate
-            Resource: 
-              - !Sub "arn:${AWS::Partition}:fis:*:${AWS::AccountId}:action/*"
+            Resource: !Sub "arn:${AWS::Partition}:fis:*:${AWS::AccountId}:action/*"
             Condition:
               StringEquals:
                 aws:RequestedRegion: 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates the `create-cluster.yaml` action to create clusters with log retention enabled for 30d.

**How was this change tested?**

`/karepenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.