### PR TITLE
test: Remove r7a and c7a instance types from scale tests

### DIFF
--- a/test/suites/scale/deprovisioning_test.go
+++ b/test/suites/scale/deprovisioning_test.go
@@ -108,6 +108,12 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{"nitro"},
 				},
+				// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+				{
+					Key:      v1alpha1.LabelInstanceFamily,
+					Operator: v1.NodeSelectorOpNotIn,
+					Values:   []string{"r7a", "c7a"},
+				},
 			},
 			// No limits!!!
 			// https://tenor.com/view/chaos-gif-22919457
@@ -186,6 +192,14 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 				}
 				provisionerOptions.Kubelet = &v1alpha5.KubeletConfiguration{
 					MaxPods: lo.ToPtr[int32](int32(maxPodDensity)),
+				}
+				provisionerOptions.Requirements = []v1.NodeSelectorRequirement{
+					// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+					{
+						Key:      v1alpha1.LabelInstanceFamily,
+						Operator: v1.NodeSelectorOpNotIn,
+						Values:   []string{"r7a", "c7a"},
+					},
 				}
 				provisionerMap[v] = test.Provisioner(provisionerOptions)
 			}

--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -68,6 +68,12 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), fu
 					Operator: v1.NodeSelectorOpIn,
 					Values:   []string{"nitro"},
 				},
+				// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
+				{
+					Key:      v1alpha1.LabelInstanceFamily,
+					Operator: v1.NodeSelectorOpNotIn,
+					Values:   []string{"r7a", "c7a"},
+				},
 			},
 			// No limits!!!
 			// https://tenor.com/view/chaos-gif-22919457


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Remove c7a instance type from scale testing

**How was this change tested?**
- `/karpenter scale`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.