### PR TITLE
docs: Add section regarding c1.medium and m1.small swap provisioning failures.

### DIFF
--- a/website/content/en/docs/troubleshooting.md
+++ b/website/content/en/docs/troubleshooting.md
@@ -179,6 +179,17 @@ approach, and now it's much more restrictive.
 
 ## Provisioning
 
+### Instances with swap volumes fail to register with control plane
+
+Some instance types (c1.medium and m1.small) are given limited amount of memory (see [Instance Store swap volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html)). They are subsequently configured to use a swap volume, which will cause the kubelet to fail on launch. The following error can be seen in the systemd logs:
+
+```bash
+"command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap!..."
+```
+
+##### Solutions
+Disabling swap will allow kubelet to join the cluster successfully, however users should be mindful of performance, and consider adjusting the Provisioner requirements to use larger instance types.
+
 ### DaemonSets can result in deployment failures
 
 For Karpenter versions 0.5.3 and earlier, DaemonSets were not properly considered when provisioning nodes.

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -179,6 +179,17 @@ approach, and now it's much more restrictive.
 
 ## Provisioning
 
+### Instances with swap volumes fail to register with control plane
+
+Some instance types (c1.medium and m1.small) are given limited amount of memory (see [Instance Store swap volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html)). They are subsequently configured to use a swap volume, which will cause the kubelet to fail on launch. The following error can be seen in the systemd logs:
+
+```bash
+"command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap!..."
+```
+
+##### Solutions
+Disabling swap will allow kubelet to join the cluster successfully, however users should be mindful of performance, and consider adjusting the Provisioner requirements to use larger instance types.
+
 ### DaemonSets can result in deployment failures
 
 For Karpenter versions 0.5.3 and earlier, DaemonSets were not properly considered when provisioning nodes.

--- a/website/content/en/v0.27/troubleshooting.md
+++ b/website/content/en/v0.27/troubleshooting.md
@@ -194,6 +194,17 @@ If you see this issue happens while using the`extraObjects` key from the values 
 
 ## Provisioning
 
+### Instances with swap volumes fail to register with control plane
+
+Some instance types (c1.medium and m1.small) are given limited amount of memory (see [Instance Store swap volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html)). They are subsequently configured to use a swap volume, which will cause the kubelet to fail on launch. The following error can be seen in the systemd logs:
+
+```bash
+"command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap!..."
+```
+
+##### Solutions
+Disabling swap will allow kubelet to join the cluster successfully, however users should be mindful of performance, and consider adjusting the Provisioner requirements to use larger instance types.
+
 ### DaemonSets can result in deployment failures
 
 For Karpenter versions 0.5.3 and earlier, DaemonSets were not properly considered when provisioning nodes.

--- a/website/content/en/v0.28/troubleshooting.md
+++ b/website/content/en/v0.28/troubleshooting.md
@@ -179,6 +179,17 @@ approach, and now it's much more restrictive.
 
 ## Provisioning
 
+### Instances with swap volumes fail to register with control plane
+
+Some instance types (c1.medium and m1.small) are given limited amount of memory (see [Instance Store swap volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html)). They are subsequently configured to use a swap volume, which will cause the kubelet to fail on launch. The following error can be seen in the systemd logs:
+
+```bash
+"command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap!..."
+```
+
+##### Solutions
+Disabling swap will allow kubelet to join the cluster successfully, however users should be mindful of performance, and consider adjusting the Provisioner requirements to use larger instance types.
+
 ### DaemonSets can result in deployment failures
 
 For Karpenter versions 0.5.3 and earlier, DaemonSets were not properly considered when provisioning nodes.

--- a/website/content/en/v0.29/troubleshooting.md
+++ b/website/content/en/v0.29/troubleshooting.md
@@ -179,6 +179,17 @@ approach, and now it's much more restrictive.
 
 ## Provisioning
 
+### Instances with swap volumes fail to register with control plane
+
+Some instance types (c1.medium and m1.small) are given limited amount of memory (see [Instance Store swap volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html)). They are subsequently configured to use a swap volume, which will cause the kubelet to fail on launch. The following error can be seen in the systemd logs:
+
+```bash
+"command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap!..."
+```
+
+##### Solutions
+Disabling swap will allow kubelet to join the cluster successfully, however users should be mindful of performance, and consider adjusting the Provisioner requirements to use larger instance types.
+
 ### DaemonSets can result in deployment failures
 
 For Karpenter versions 0.5.3 and earlier, DaemonSets were not properly considered when provisioning nodes.

--- a/website/content/en/v0.30/troubleshooting.md
+++ b/website/content/en/v0.30/troubleshooting.md
@@ -179,6 +179,17 @@ approach, and now it's much more restrictive.
 
 ## Provisioning
 
+### Instances with swap volumes fail to register with control plane
+
+Some instance types (c1.medium and m1.small) are given limited amount of memory (see [Instance Store swap volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html)). They are subsequently configured to use a swap volume, which will cause the kubelet to fail on launch. The following error can be seen in the systemd logs:
+
+```bash
+"command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap!..."
+```
+
+##### Solutions
+Disabling swap will allow kubelet to join the cluster successfully, however users should be mindful of performance, and consider adjusting the Provisioner requirements to use larger instance types.
+
 ### DaemonSets can result in deployment failures
 
 For Karpenter versions 0.5.3 and earlier, DaemonSets were not properly considered when provisioning nodes.

--- a/website/content/en/v0.31/troubleshooting.md
+++ b/website/content/en/v0.31/troubleshooting.md
@@ -179,6 +179,17 @@ approach, and now it's much more restrictive.
 
 ## Provisioning
 
+### Instances with swap volumes fail to register with control plane
+
+Some instance types (c1.medium and m1.small) are given limited amount of memory (see [Instance Store swap volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html)). They are subsequently configured to use a swap volume, which will cause the kubelet to fail on launch. The following error can be seen in the systemd logs:
+
+```bash
+"command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap!..."
+```
+
+##### Solutions
+Disabling swap will allow kubelet to join the cluster successfully, however users should be mindful of performance, and consider adjusting the Provisioner requirements to use larger instance types.
+
 ### DaemonSets can result in deployment failures
 
 For Karpenter versions 0.5.3 and earlier, DaemonSets were not properly considered when provisioning nodes.


### PR DESCRIPTION
Fixes #4629 

**Description**
Add section regarding c1.medium and m1.small swap provisioning failures to the troubleshooting doc.

**How was this change tested?**
N/A, just a doc update.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.