### PR TITLE
chore: touch up v1beta1 examples

### DIFF
--- a/examples/v1beta1/100-cpu-limit.yaml
+++ b/examples/v1beta1/100-cpu-limit.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: default
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -27,8 +29,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: default
   limits:
     cpu: 100
 ---
@@ -43,7 +43,7 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/al2-custom-ami.yaml
+++ b/examples/v1beta1/al2-custom-ami.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: al2
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -27,8 +29,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: al2
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -41,10 +41,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   amiSelectorTerms:
     - id: ami-123
     - id: ami-456

--- a/examples/v1beta1/al2-custom-userdata.yaml
+++ b/examples/v1beta1/al2-custom-userdata.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: al2
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -27,8 +29,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: al2
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -41,10 +41,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/examples/v1beta1/al2-kubelet-log-query.yaml
+++ b/examples/v1beta1/al2-kubelet-log-query.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: al2
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -26,8 +28,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: al2
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -40,10 +40,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/examples/v1beta1/bottlerocket.yaml
+++ b/examples/v1beta1/bottlerocket.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: bottlerocket
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -26,8 +28,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: bottlerocket
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -40,10 +40,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:

--- a/examples/v1beta1/br-custom-userdata.yaml
+++ b/examples/v1beta1/br-custom-userdata.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: bottlerocket
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -27,8 +29,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: bottlerocket
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -41,10 +41,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   userData:  |
     [settings.kubernetes]
     kube-api-qps = 30

--- a/examples/v1beta1/custom-family.yaml
+++ b/examples/v1beta1/custom-family.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: custom-family
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -26,8 +28,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: custom-family
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -40,10 +40,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   amiSelectorTerms:
     - id: ami-123
     - id: ami-456

--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: default
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -25,8 +27,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -39,7 +39,7 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/large-instances.yaml
+++ b/examples/v1beta1/large-instances.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: default
       requirements:
           # exclude instances with < 4 cores and < 8GiB memory (8192 mebibytes)
         - key: "karpenter.k8s.aws/instance-cpu"
@@ -17,8 +19,6 @@ spec:
         - key: "karpenter.k8s.aws/instance-memory"
           operator: Gt
           values: ["8191"]
-      nodeClassRef:
-        name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -31,7 +31,7 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/multiple-arch.yaml
+++ b/examples/v1beta1/multiple-arch.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: default
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -27,8 +29,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: default
 ---
 apiVersion: karpenter.sh/v1beta1
 kind: NodePool
@@ -39,6 +39,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: default
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -55,8 +57,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -69,7 +69,7 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/multiple-ebs.yaml
+++ b/examples/v1beta1/multiple-ebs.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: multiple-ebs
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -26,8 +28,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: multiple-ebs
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -40,10 +40,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:

--- a/examples/v1beta1/node-ttls.yaml
+++ b/examples/v1beta1/node-ttls.yaml
@@ -9,8 +9,14 @@ metadata:
   annotations:
     kubernetes.io/description: "General purpose NodePool for generic workloads"
 spec:
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 60s # scale down nodes after 60 seconds without workloads (excluding daemons)
+    expireAfter: 168h # expire nodes after 7 days = 7 * 24h
   template:
     spec:
+      nodeClassRef:
+        name: default
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -27,12 +33,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: default
-  disruption:
-    consolidationPolicy: WhenEmpty
-    consolidateAfter: 60s # scale down nodes after 60 seconds without workloads (excluding daemons)
-    expireAfter: 168h # expire nodes after 7 days = 7 * 24h
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -45,7 +45,7 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/spot.yaml
+++ b/examples/v1beta1/spot.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: default
       requirements:
         - key: karpenter.sh/capacity-type
           operator: In
@@ -26,8 +28,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: default
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -40,7 +40,7 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name

--- a/examples/v1beta1/ubuntu-kubelet-log-query.yaml
+++ b/examples/v1beta1/ubuntu-kubelet-log-query.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: ubuntu
       requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -26,8 +28,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: ubuntu
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -40,10 +40,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/examples/v1beta1/windows-custom-userdata.yaml
+++ b/examples/v1beta1/windows-custom-userdata.yaml
@@ -12,6 +12,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: windows2022
       requirements:
         - key: kubernetes.io/os
           operator: In
@@ -28,8 +30,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: windows2022
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -42,10 +42,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   metadataOptions:
     httpProtocolIPv6: disabled
     httpTokens: required

--- a/examples/v1beta1/windows2019.yaml
+++ b/examples/v1beta1/windows2019.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: windows2019
       requirements:
         - key: kubernetes.io/os
           operator: In
@@ -25,8 +27,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: windows2019
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -39,10 +39,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   metadataOptions:
     httpProtocolIPv6: disabled
     httpTokens: required

--- a/examples/v1beta1/windows2022.yaml
+++ b/examples/v1beta1/windows2022.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        name: windows2022
       requirements:
         - key: kubernetes.io/os
           operator: In
@@ -25,8 +27,6 @@ spec:
         - key: karpenter.k8s.aws/instance-generation
           operator: Gt
           values: ["2"]
-      nodeClassRef:
-        name: windows2022
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass
@@ -39,10 +39,10 @@ spec:
   role: "KarpenterNodeRole-${CLUSTER_NAME}" # replace with your cluster name
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
+      karpenter.sh/discovery: "${CLUSTER_NAME}" # replace with your cluster name
   metadataOptions:
     httpProtocolIPv6: disabled
     httpTokens: required

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -10,7 +10,7 @@ main() {
 }
 
 tools() {
-    go install github.com/google/go-licenses@latest
+    # go install github.com/google/go-licenses@latest
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     go install github.com/google/ko@latest
     go install github.com/mikefarah/yq/v4@latest


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
* Tags were overindented
* Shifted "disruption" forward in the example, since it's the focal point (it's also how the keys will be ordered from kubectl get)
* Shifted "nodeClassRef" forward to make it crystal clear to users that there's another entity in play. This is a question/misunderstanding I get a lot. (it's also how the keys will be ordered from kubectl get)

**How was this change tested?**

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.