### PR TITLE
docs: Fix docs redirects

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -5,6 +5,8 @@
 /v0.26/getting-started/getting-started-with-karpenter/*  /v0.26/getting-started/getting-started-with-eksctl/:splat
 /v0.27/getting-started/getting-started-with-eksctl/* /v0.27/getting-started/getting-started-with-karpenter/:splat
 /v0.28/getting-started/getting-started-with-eksctl/* /v0.28/getting-started/getting-started-with-karpenter/:splat
+
+# Redirect all preview documentation to the new routes
 /preview/concepts/provisioners /preview/concepts/nodepools
 /preview/concepts/node-templates /preview/concepts/nodeclasses
 /preview/concepts/deprovisioning /preview/concepts/disruption
@@ -13,3 +15,15 @@
 /preview/concepts/metrics /preview/reference/metrics
 /preview/concepts/settings /preview/reference/settings
 /preview/concepts/threat-model /preview/reference/threat-model
+
+# Redirect all v0.32 documentation to the new routes
+/v0.32/concepts/provisioners /v0.32/concepts/nodepools
+/v0.32/concepts/node-templates /v0.32/concepts/nodeclasses
+/v0.32/concepts/deprovisioning /v0.32/concepts/disruption
+/v0.32/upgrade-guide /v0.32/upgrading/upgrade-guide
+/v0.32/concepts/instance-types /v0.32/reference/instance-types
+/v0.32/concepts/metrics /v0.32/reference/metrics
+/v0.32/concepts/settings /v0.32/reference/settings
+/v0.32/concepts/threat-model /v0.32/reference/threat-model
+
+# TODO @joinnis: Add redirects for the "docs" version and future versions after v0.32 release

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -8,7 +8,7 @@
 /preview/concepts/provisioners /preview/concepts/nodepools
 /preview/concepts/node-templates /preview/concepts/nodeclasses
 /preview/concepts/deprovisioning /preview/concepts/disruption
-/preview/upgrade/* /preview/upgrading/*
+/preview/upgrade-guide /preview/upgrading/upgrade-guide
 /preview/concepts/instance-types /preview/reference/instance-types
 /preview/concepts/metrics /preview/reference/metrics
 /preview/concepts/settings /preview/reference/settings


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change fixes the docs redirects so that the previous route of "Upgrade Guide" gets routed appropriately. This change also adds the redirects for the `v0.32` version of the docs

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.