### PR TITLE
fix: Enforce `karpenter.k8s.aws` tags on instance profiles and instances

### DIFF
--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -93,7 +93,7 @@ var (
 	ResourceAWSPodENI          v1.ResourceName = "vpc.amazonaws.com/pod-eni"
 	ResourcePrivateIPv4Address v1.ResourceName = "vpc.amazonaws.com/PrivateIPv4Address"
 
-	LabelNodeClass = Group + "/nodeclass"
+	LabelNodeClass = Group + "/ec2nodeclass"
 
 	LabelInstanceHypervisor                   = Group + "/instance-hypervisor"
 	LabelInstanceEncryptionInTransitSupported = Group + "/instance-encryption-in-transit-supported"
@@ -113,6 +113,6 @@ var (
 	LabelInstanceAcceleratorName              = Group + "/instance-accelerator-name"
 	LabelInstanceAcceleratorManufacturer      = Group + "/instance-accelerator-manufacturer"
 	LabelInstanceAcceleratorCount             = Group + "/instance-accelerator-count"
-	AnnotationNodeClassHash                   = Group + "/nodeclass-hash"
+	AnnotationNodeClassHash                   = Group + "/ec2nodeclass-hash"
 	AnnotationInstanceTagged                  = Group + "/tagged"
 )

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -267,6 +267,7 @@ func getTags(ctx context.Context, nodeClass *v1beta1.EC2NodeClass, nodeClaim *co
 			fmt.Sprintf("kubernetes.io/cluster/%s", options.FromContext(ctx).ClusterName): "owned",
 			corev1beta1.NodePoolLabelKey:       nodeClaim.Labels[corev1beta1.NodePoolLabelKey],
 			corev1beta1.ManagedByAnnotationKey: options.FromContext(ctx).ClusterName,
+			v1beta1.LabelNodeClass:             nodeClass.Name,
 		}
 	}
 	return lo.Assign(overridableTags, settings.FromContext(ctx).Tags, nodeClass.Spec.Tags, staticTags)

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -207,7 +207,7 @@ Resources:
                   "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
                 },
                 "StringLike": {
-                  "aws:RequestTag/karpenter.sh/nodeclass": "*"
+                  "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
                 }
               }
             },
@@ -226,8 +226,8 @@ Resources:
                   "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
                 },
                 "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/nodeclass": "*",
-                  "aws:RequestTag/karpenter.sh/nodeclass": "*"
+                  "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*",
+                  "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
                 }
               }
             },
@@ -246,7 +246,7 @@ Resources:
                   "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
                 },
                 "StringLike": {
-                  "aws:ResourceTag/karpenter.sh/nodeclass": "*"
+                  "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"
                 }
               }
             },

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -352,7 +352,7 @@ This gives EC2 permission explicit permission to use the `KarpenterNodeRole-${Cl
 
 The AllowScopedInstanceProfileCreationActions Sid gives the Karpenter controller permission to create a new instance profile with [`iam:CreateInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html),
 provided that the request is made to a cluster with `kubernetes.io/cluster/${ClusterName` set to owned and is made in the current region.
-Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karpenter can generate instance profiles on your behalf based on roles specified in your `EC2NodeClasses` that you use to configure Karpenter.
+Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures that Karpenter can generate instance profiles on your behalf based on roles specified in your `EC2NodeClasses` that you use to configure Karpenter.
 
 ```json
 {
@@ -368,7 +368,7 @@ Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karp
       "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
     },
     "StringLike": {
-      "aws:RequestTag/karpenter.sh/nodeclass": "*"
+      "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
     }
   }
 }
@@ -377,7 +377,7 @@ Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karp
 #### AllowScopedInstanceProfileTagActions
 
 The AllowScopedInstanceProfileTagActions Sid gives the Karpenter controller permission to tag an instance profile with [`iam:TagInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_TagInstanceProfile.html), based on the values shown below,
-Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karpenter is only able to act on instance profiles that it provisions for this cluster.
+Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This ensures that Karpenter is only able to act on instance profiles that it provisions for this cluster.
 
 ```json
 {
@@ -395,8 +395,8 @@ Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karp
       "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
     },
     "StringLike": {
-      "aws:ResourceTag/karpenter.sh/nodeclass": "*",
-      "aws:RequestTag/karpenter.sh/nodeclass": "*"
+      "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*",
+      "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
     }
   }
 }
@@ -407,7 +407,7 @@ Also, `karpenter.sh/nodeclass` must be set to some value. This ensures that Karp
 
 The AllowScopedInstanceProfileActions Sid gives the Karpenter controller permission to perform [`iam:AddRoleToInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddRoleToInstanceProfile.html), [`iam:RemoveRoleFromInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_RemoveRoleFromInstanceProfile.html), and [`iam:DeleteInstanceProfile`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteInstanceProfile.html) actions, 
 provided that the request is made to a cluster with `kubernetes.io/cluster/${ClusterName` set to owned and is made in the current region.
-Also, `karpenter.sh/nodeclass` must be set to some value. This permission is further enforced by the `iam:PassRole` permission. If Karpenter attempts to add a role to an instance profile that it doesn't have `iam:PassRole` permission on, that call will fail. Therefore, if you configure Karpenter to use a new role through the `EC2NodeClass`, ensure that you also specify that role within your `iam:PassRole` permission.
+Also, `karpenter.k8s.aws/ec2nodeclass` must be set to some value. This permission is further enforced by the `iam:PassRole` permission. If Karpenter attempts to add a role to an instance profile that it doesn't have `iam:PassRole` permission on, that call will fail. Therefore, if you configure Karpenter to use a new role through the `EC2NodeClass`, ensure that you also specify that role within your `iam:PassRole` permission.
 
 ```json
 {
@@ -425,7 +425,7 @@ Also, `karpenter.sh/nodeclass` must be set to some value. This permission is fur
       "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
     },
     "StringLike": {
-      "aws:ResourceTag/karpenter.sh/nodeclass": "*"
+      "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"
     }
   }
 }

--- a/website/content/en/preview/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/preview/upgrading/v1beta1-controller-policy.json
@@ -170,6 +170,9 @@
         "StringEquals": {
           "aws:RequestTag/kubernetes.io/cluster/${CLUSTER_NAME}": "owned",
           "aws:RequestTag/topology.kubernetes.io/region": "${REGION}"
+        },
+        "StringLike": {
+          "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
         }
       }
     },
@@ -184,6 +187,10 @@
           "aws:ResourceTag/topology.kubernetes.io/region": "${REGION}",
           "aws:RequestTag/kubernetes.io/cluster/${CLUSTER_NAME}": "owned",
           "aws:RequestTag/topology.kubernetes.io/region": "${REGION}"
+        },
+        "StringLike": {
+          "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*",
+          "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
         }
       }
     },
@@ -200,6 +207,9 @@
         "StringEquals": {
           "aws:ResourceTag/kubernetes.io/cluster/${CLUSTER_NAME}": "owned",
           "aws:ResourceTag/topology.kubernetes.io/region": "${REGION}"
+        },
+        "StringLike": {
+          "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"
         }
       }
     },


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change enforces that `karpenter.k8s.aws/ec2nodeclass` is the tag that is used for tagging instances and entities provisioned by the AWS cloudprovider's EC2NodeClass

**How was this change tested?**

`make presubmit`
`make apply`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.