### PR TITLE
chore: Bump `karpenter-core` to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.46.0
-	github.com/aws/karpenter-core v0.31.1-0.20231020162441-e7fbaa291c4e
+	github.com/aws/karpenter-core v0.31.1-0.20231020234031-e0623869f604
 	github.com/aws/karpenter/tools/kompat v0.0.0-20231010173459-62c25a3ea85c
 	github.com/go-logr/zapr v1.2.4
 	github.com/imdario/mergo v0.3.16

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.46.0 h1:Igh7W8P+sA6mXJ9yhreOSweefLapcqekhxQlY1llxcM=
 github.com/aws/aws-sdk-go v1.46.0/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/karpenter-core v0.31.1-0.20231020162441-e7fbaa291c4e h1:7heVq5GV1sMgcFlnD6pNElqmbxKMLHX9kaXm9njZC0Y=
-github.com/aws/karpenter-core v0.31.1-0.20231020162441-e7fbaa291c4e/go.mod h1:rb3kp/3cj38tACF6udfpmIvKoQMwirSVoHNlrd66LyE=
+github.com/aws/karpenter-core v0.31.1-0.20231020234031-e0623869f604 h1:eQFElFqH3K64na70WZBh6FUFonVRKhtyUptWtpO/JdI=
+github.com/aws/karpenter-core v0.31.1-0.20231020234031-e0623869f604/go.mod h1:rb3kp/3cj38tACF6udfpmIvKoQMwirSVoHNlrd66LyE=
 github.com/aws/karpenter/tools/kompat v0.0.0-20231010173459-62c25a3ea85c h1:oXWwIttmjYLbBKhLazG21aQvpJ3NOOr8IXhCJ/p6e/M=
 github.com/aws/karpenter/tools/kompat v0.0.0-20231010173459-62c25a3ea85c/go.mod h1:l/TIBsaCx/IrOr0Xvlj/cHLOf05QzuQKEZ1hx2XWmfU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -216,9 +216,15 @@ spec:
                       effect:
                         description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
                       key:
                         description: Required. The taint key to be applied to a node.
                         type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                       timeAdded:
                         description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
                         format: date-time
@@ -226,6 +232,7 @@ spec:
                       value:
                         description: The taint value corresponding to the taint key.
                         type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                     required:
                       - effect
                       - key
@@ -239,9 +246,15 @@ spec:
                       effect:
                         description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
                       key:
                         description: Required. The taint key to be applied to a node.
                         type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                       timeAdded:
                         description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
                         format: date-time
@@ -249,6 +262,7 @@ spec:
                       value:
                         description: The taint value corresponding to the taint key.
                         type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                     required:
                       - effect
                       - key

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -85,19 +85,13 @@ spec:
                         annotations:
                           additionalProperties:
                             type: string
+                          description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                           type: object
-                        finalizers:
-                          items:
-                            type: string
-                          type: array
                         labels:
                           additionalProperties:
                             type: string
+                          description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                           type: object
-                        name:
-                          type: string
-                        namespace:
-                          type: string
                       type: object
                     spec:
                       description: NodeClaimSpec describes the desired state of the NodeClaim
@@ -258,9 +252,15 @@ spec:
                               effect:
                                 description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
                                 type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
                               key:
                                 description: Required. The taint key to be applied to a node.
                                 type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                               timeAdded:
                                 description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
                                 format: date-time
@@ -268,6 +268,7 @@ spec:
                               value:
                                 description: The taint value corresponding to the taint key.
                                 type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                             required:
                               - effect
                               - key
@@ -281,9 +282,15 @@ spec:
                               effect:
                                 description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
                                 type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
                               key:
                                 description: Required. The taint key to be applied to a node.
                                 type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                               timeAdded:
                                 description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
                                 format: date-time
@@ -291,6 +298,7 @@ spec:
                               value:
                                 description: The taint value corresponding to the taint key.
                                 type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                             required:
                               - effect
                               - key

--- a/pkg/providers/launchtemplate/nodeclass_test.go
+++ b/pkg/providers/launchtemplate/nodeclass_test.go
@@ -56,7 +56,7 @@ var _ = Describe("EC2NodeClass/LaunchTemplates", func() {
 		nodePool = coretest.NodePool(corev1beta1.NodePool{
 			Spec: corev1beta1.NodePoolSpec{
 				Template: corev1beta1.NodeClaimTemplate{
-					ObjectMeta: metav1.ObjectMeta{
+					ObjectMeta: corev1beta1.ObjectMeta{
 						// TODO @joinnis: Move this into the coretest.NodePool function
 						Labels: map[string]string{coretest.DiscoveryLabel: "unspecified"},
 					},

--- a/test/suites/beta/drift/suite_test.go
+++ b/test/suites/beta/drift/suite_test.go
@@ -320,12 +320,12 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 		env.EventuallyExpectNotFound(pod, node)
 	},
 		Entry("Annotation Drift", "Annotation", corev1beta1.NodeClaimTemplate{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: corev1beta1.ObjectMeta{
 				Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"},
 			},
 		}),
 		Entry("Labels Drift", "Labels", corev1beta1.NodeClaimTemplate{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: corev1beta1.ObjectMeta{
 				Labels: map[string]string{"keyLabelTest": "valueLabelTest"},
 			},
 		}),

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -223,11 +223,11 @@ Add `~/go/bin` to your $PATH, if you have not already done so.
     aws iam detach-role-policy --role-name "${ROLE_NAME}" --policy-arn "${POLICY_ARN}"
     ```
 
-    {{% alert title="Note" color="warning" %}}
+{{% alert title="Note" color="warning" %}}
 
-    If you are using some IaC for managing your policy documents attached to the controller role, you may want to attach this new beta policy to the same CloudFormation stack. You can do this by removing the old alpha policy, ensuring that the Karpenter controller continues to work with just the beta policy, and then updating the stack to contain the new beta policy rather than having that policy managed separately.
+If you are using some IaC for managing your policy documents attached to the controller role, you may want to attach this new beta policy to the same CloudFormation stack. You can do this by removing the old alpha policy, ensuring that the Karpenter controller continues to work with just the beta policy, and then updating the stack to contain the new beta policy rather than having that policy managed separately.
 
-    {{% /alert %}}
+{{% /alert %}}
    
 #### Additional Release Notes
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR bumps `karpenter-core` to the latest which also contains validations built-in to the OpenAPI spec as well as a change to the ObjectMeta type for the `v1beta1.NodeClaimTemplate`

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.