### PR TITLE
test: Fix E2E test permissions, upgrade, consolidation, and integration tests

### DIFF
--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: run the Upgrade test suite
         run: |
           aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }}
-          CLUSTER_NAME=${{ env.CLUSTER_NAME }} INTERRUPTION_QUEUE=${{ env.CLUSTER_NAME }} CLUSTER_ENDPOINT="$(aws eks describe-cluster --name ${{ env.CLUSTER_NAME }} --query "cluster.endpoint" --output text)" TEST_SUITE="Integration" make e2etests
+          CLUSTER_NAME=${{ env.CLUSTER_NAME }} INTERRUPTION_QUEUE=${{ env.CLUSTER_NAME }} CLUSTER_ENDPOINT="$(aws eks describe-cluster --name ${{ env.CLUSTER_NAME }} --query "cluster.endpoint" --output text)" TEST_SUITE="Beta/Integration" make e2etests
       - name: notify slack of success or failure
         uses: ./.github/actions/e2e/slack/notify
         if: (success() || failure()) && github.event_name != 'workflow_run' && github.event_name != 'conformance'

--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -270,116 +270,7 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              # Tag Permissions
-              - ec2:DescribeTags
-              # Internet Gateway Permissions
-              - ec2:DescribeEgressOnlyInternetGateways
-              - ec2:DescribeInternetGateways
-              # Elastic IP Permissions
-              - ec2:DescribeAddresses
-              # Instance Permissions
-              - ec2:DescribeInstanceTypeOfferings
-              - ec2:DescribeInstanceTypes
-              - ec2:DescribeInstances
-              - ec2:DescribeKeyPairs
-              # Launch Template Permissions
-              - ec2:DescribeLaunchTemplateVersions
-              - ec2:DescribeLaunchTemplates
-              # NAT Gateway Permissions
-              - ec2:DescribeNatGateways
-              # Network Interface Permissions
-              - ec2:DescribeNetworkInterfaces
-              # Route Table Permissions
-              - ec2:DescribeRouteTables
-              # Security Group Permissions
-              - ec2:DescribeSecurityGroups
-              # Subnet Permissions
-              - ec2:DescribeAvailabilityZones
-              - ec2:DescribeSubnets
-              # Volume Permissions
-              - ec2:DescribeVolumes
-              - ec2:DescribeVolumesModifications
-              - ec2:DescribeSnapshots
-              # Network ACL Permissions
-              - ec2:DescribeNetworkAcls
-              # VPC Permissions
-              - ec2:DescribeVpcs
-              # Image Permissions
-              - ec2:DescribeImages
-              # Tag Permissions
-              - ec2:CreateTags
-              - ec2:DeleteTags
-              # Internet Gateway Permissions
-              - ec2:CreateEgressOnlyInternetGateway
-              - ec2:DeleteEgressOnlyInternetGateway
-              # Elastic IP Permissions
-              - ec2:AllocateAddress
-              - ec2:ReleaseAddress
-              # Instance Permissions
-              - ec2:ModifyInstanceAttribute
-              - ec2:DescribeInstanceAttribute
-              - ec2:RunInstances
-              - ec2:StopInstances
-              - ec2:TerminateInstances
-              - ec2:AttachNetworkInterface
-              - ec2:ModifyNetworkInterfaceAttribute
-              - ec2:DetachNetworkInterface
-              # Internet Gateway Permissions
-              - ec2:AttachInternetGateway
-              - ec2:CreateInternetGateway
-              - ec2:DeleteInternetGateway
-              - ec2:DetachInternetGateway
-              # Launch Template Permissions
-              - ec2:CreateLaunchTemplate
-              - ec2:DeleteLaunchTemplate
-              # Fleet Permissions
-              - ec2:CreateFleet
-              # NAT Gateway Permissions
-              - ec2:CreateNatGateway
-              - ec2:DeleteNatGateway
-              # Network Interface Permissions
-              - ec2:AssignPrivateIpAddresses
-              - ec2:UnassignPrivateIpAddresses
-              - ec2:AssignIpv6Addresses
-              - ec2:UnassignIpv6Addresses
-              - ec2:AttachNetworkInterface
-              - ec2:DetachNetworkInterface
-              - ec2:CreateNetworkInterface
-              - ec2:ModifyNetworkInterfaceAttribute
-              - ec2:DeleteNetworkInterface
-              - ec2:CreateNetworkInterfacePermission
-              # Route Table Permissions
-              - ec2:CreateRoute
-              - ec2:CreateRouteTable
-              - ec2:DeleteRoute
-              - ec2:DeleteRouteTable
-              - ec2:AssociateRouteTable
-              - ec2:DisassociateRouteTable
-              # Security Group Permissions
-              - ec2:AuthorizeSecurityGroupIngress
-              - ec2:CreateSecurityGroup
-              - ec2:DeleteSecurityGroup
-              - ec2:RevokeSecurityGroupIngress
-              # Subnet Permissions
-              - ec2:CreateSubnet
-              - ec2:DeleteSubnet
-              - ec2:ModifySubnetAttribute
-              # Volume Permissions
-              - ec2:CreateSnapshot
-              - ec2:DeleteSnapshot
-              - ec2:CreateVolume
-              - ec2:DeleteVolume
-              - ec2:AttachVolume
-              - ec2:ModifyVolume
-              - ec2:DetachVolume
-              # VPC Permissions
-              - ec2:AssociateVpcCidrBlock
-              - ec2:DisassociateVpcCidrBlock
-              - ec2:CreateVpc
-              - ec2:DeleteVpc
-              - ec2:DescribeVpcAttribute
-              - ec2:ModifyVpcAttribute
-              - ec2:RunInstances
+              - ec2:*
               # Read-Only Permissions to pull ECR images needed by the NodeInstanceRole
               - ecr:GetAuthorizationToken
               - ecr:BatchCheckLayerAvailability
@@ -397,75 +288,22 @@ Resources:
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:UpdateAutoScalingGroup
               # EKS ServiceRole permissions needed to handle LoadBalancer
-              - elasticloadbalancing:AddTags
-              - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
-              - elasticloadbalancing:AttachLoadBalancerToSubnets
-              - elasticloadbalancing:ConfigureHealthCheck
-              - elasticloadbalancing:CreateListener
-              - elasticloadbalancing:CreateLoadBalancer
-              - elasticloadbalancing:CreateLoadBalancerListeners
-              - elasticloadbalancing:CreateLoadBalancerPolicy
-              - elasticloadbalancing:CreateTargetGroup
-              - elasticloadbalancing:DeleteListener
-              - elasticloadbalancing:DeleteLoadBalancer
-              - elasticloadbalancing:DeleteLoadBalancerListeners
-              - elasticloadbalancing:DeleteTargetGroup
-              - elasticloadbalancing:DeregisterInstancesFromLoadBalancer
-              - elasticloadbalancing:DeregisterTargets
-              - elasticloadbalancing:DescribeListeners
-              - elasticloadbalancing:DescribeLoadBalancerAttributes
-              - elasticloadbalancing:DescribeLoadBalancerPolicies
-              - elasticloadbalancing:DescribeLoadBalancers
-              - elasticloadbalancing:DescribeTargetGroupAttributes
-              - elasticloadbalancing:DescribeTargetGroups
-              - elasticloadbalancing:DescribeTargetHealth
-              - elasticloadbalancing:DetachLoadBalancerFromSubnets
-              - elasticloadbalancing:ModifyListener
-              - elasticloadbalancing:ModifyLoadBalancerAttributes
-              - elasticloadbalancing:ModifyTargetGroup
-              - elasticloadbalancing:ModifyTargetGroupAttributes
-              - elasticloadbalancing:RegisterInstancesWithLoadBalancer
-              - elasticloadbalancing:RegisterTargets
-              - elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer
-              - elasticloadbalancing:SetLoadBalancerPoliciesOfListener
+              - elasticloadbalancing:*
               - kms:CreateGrant
               - kms:GenerateDataKeyWithoutPlaintext
               - kms:DescribeKey
               # SSM Permissions for AmazonSSMManagedInstanceCore policy applied to the NodeInstanceRole
-              - ssm:DescribeAssociation
-              - ssm:GetDeployablePatchSnapshotForInstance
-              - ssm:GetDocument
-              - ssm:DescribeDocument
-              - ssm:GetManifest
-              - ssm:GetParameter
-              - ssm:GetParameters
-              - ssm:ListAssociations
-              - ssm:ListInstanceAssociations
-              - ssm:PutInventory
-              - ssm:PutComplianceItems
-              - ssm:PutConfigurePackageResult
-              - ssm:UpdateAssociationStatus
-              - ssm:UpdateInstanceAssociationStatus
-              - ssm:UpdateInstanceInformation
+              - ssm:*
               # SSM Permissions for AmazonSSMManagedInstanceCore policy applied to the NodeInstanceRole
-              - ssmmessages:CreateControlChannel
-              - ssmmessages:CreateDataChannel
-              - ssmmessages:OpenControlChannel
-              - ssmmessages:OpenDataChannel
+              - ssmmessages:*
               # SSM Permissions for AmazonSSMManagedInstanceCore policy applied to the NodeInstanceRole
-              - ec2messages:AcknowledgeMessage
-              - ec2messages:DeleteMessage
-              - ec2messages:FailMessage
-              - ec2messages:GetEndpoint
-              - ec2messages:GetMessages
-              - ec2messages:SendReply
+              - ec2messages:*
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
               - sqs:GetQueueUrl
               - sqs:SendMessage
               - sqs:ReceiveMessage
               - pricing:GetProducts
-              - ec2:DescribeSpotPriceHistory
               - eks:DescribeCluster
             Resource: "*"
           - Effect: Allow
@@ -473,6 +311,31 @@ Resources:
             Resource:
               - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-*"
               - !GetAtt FISInterruptionRole.Arn
+          - Effect: Allow
+            Action: iam:CreateInstanceProfile
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/karpenter.k8s.aws/ec2nodeclass: "*"
+          - Effect: Allow
+            Action: iam:TagInstanceProfile
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:RequestTag/karpenter.k8s.aws/ec2nodeclass: "*"
+                aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass: "*"
+          - Effect: Allow
+            Action:
+              - iam:AddRoleToInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
+              - iam:DeleteInstanceProfile
+            Resource: "*"
+            Condition:
+              StringLike:
+                aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass: "*"
+          - Effect: Allow
+            Action: iam:GetInstanceProfile
+            Resource: "*"
           - Effect: Allow
             Action:
               - aps:RemoteWrite

--- a/test/pkg/environment/aws/environment.go
+++ b/test/pkg/environment/aws/environment.go
@@ -42,6 +42,10 @@ import (
 
 const WindowsDefaultImage = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
 
+// ExcludedInstanceFamilies denotes instance families that have issues during resource registration due to compatability
+// issues with versions of the VPR Resource Controller
+var ExcludedInstanceFamilies = []string{"m7a", "r7a", "c7a", "r7i"}
+
 type Environment struct {
 	*common.Environment
 	Region string

--- a/test/pkg/environment/aws/environment.go
+++ b/test/pkg/environment/aws/environment.go
@@ -42,7 +42,7 @@ import (
 
 const WindowsDefaultImage = "mcr.microsoft.com/oss/kubernetes/pause:3.9"
 
-// ExcludedInstanceFamilies denotes instance families that have issues during resource registration due to compatability
+// ExcludedInstanceFamilies denotes instance families that have issues during resource registration due to compatibility
 // issues with versions of the VPR Resource Controller
 var ExcludedInstanceFamilies = []string{"m7a", "r7a", "c7a", "r7i"}
 

--- a/test/pkg/environment/common/monitor.go
+++ b/test/pkg/environment/common/monitor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/utils/resources"
 )
 
@@ -223,7 +224,8 @@ func (m *Monitor) nodeUtilization(resource v1.ResourceName) []float64 {
 	for nodeName, requests := range st.nodeRequests {
 		allocatable := st.nodes[nodeName].Status.Allocatable[resource]
 		// skip any nodes we didn't launch
-		if _, ok := st.nodes[nodeName].Labels[v1alpha5.ProvisionerNameLabelKey]; !ok {
+		if st.nodes[nodeName].Labels[v1alpha5.ProvisionerNameLabelKey] == "" &&
+			st.nodes[nodeName].Labels[v1beta1.NodePoolLabelKey] == "" {
 			continue
 		}
 		if allocatable.IsZero() {

--- a/test/suites/alpha/drift/suite_test.go
+++ b/test/suites/alpha/drift/suite_test.go
@@ -375,7 +375,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			}).Should(Succeed())
 
 			// Expect nodes To get cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Drift should fail and the original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored out
@@ -433,7 +433,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			}).Should(Succeed())
 
 			// Expect nodes To be cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Drift should fail and original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored outr

--- a/test/suites/alpha/drift/suite_test.go
+++ b/test/suites/alpha/drift/suite_test.go
@@ -88,7 +88,6 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			},
 		})
 		env.ExpectSettingsOverriddenLegacy(map[string]string{"featureGates.driftEnabled": "true"})
-		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 	})
 	It("should deprovision nodes that have drifted due to AMIs", func() {
 		// choose an old static image
@@ -122,7 +121,6 @@ var _ = Describe("Drift", Label("AWS"), func() {
 	})
 	It("should not deprovision nodes that have drifted without the featureGate enabled", func() {
 		env.ExpectSettingsOverriddenLegacy(map[string]string{"featureGates.driftEnabled": "false"})
-		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=false"})
 		// choose an old static image
 		parameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
 			Name: awssdk.String("/aws/service/eks/optimized-ami/1.23/amazon-linux-2/amazon-eks-node-1.23-v20230322/image_id"),

--- a/test/suites/alpha/drift/suite_test.go
+++ b/test/suites/alpha/drift/suite_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 			// Drift should fail and the original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored out
-			env.EventuallyExpectNodesUncordonedLegacyWithTimeout(12*time.Minute, cordonedNodes...)
+			env.EventuallyExpectNodesUncordonedLegacyWithTimeout(11*time.Minute, cordonedNodes...)
 
 			Eventually(func(g Gomega) {
 				machines := &v1alpha5.MachineList{}
@@ -433,8 +433,8 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Drift should fail and original node should be uncordoned
-			// TODO: reduce timeouts when deprovisioning waits are factored outr
-			env.EventuallyExpectNodesUncordonedLegacyWithTimeout(12*time.Minute, cordonedNodes...)
+			// TODO: reduce timeouts when deprovisioning waits are factored out
+			env.EventuallyExpectNodesUncordonedLegacyWithTimeout(11*time.Minute, cordonedNodes...)
 
 			// Expect that the new machine/node is kept around after the un-cordon
 			nodeList := &v1.NodeList{}

--- a/test/suites/alpha/drift/suite_test.go
+++ b/test/suites/alpha/drift/suite_test.go
@@ -379,10 +379,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 			// Drift should fail and the original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored out
-			Eventually(func(g Gomega) {
-				g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(cordonedNodes[0]), cordonedNodes[0]))
-				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
-			}).WithTimeout(11 * time.Minute).Should(Succeed())
+			env.EventuallyExpectNodesUncordonedLegacyWithTimeout(12*time.Minute, cordonedNodes...)
 
 			Eventually(func(g Gomega) {
 				machines := &v1alpha5.MachineList{}
@@ -437,10 +434,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 			// Drift should fail and original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored outr
-			Eventually(func(g Gomega) {
-				g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(cordonedNodes[0]), cordonedNodes[0]))
-				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
-			}).WithTimeout(12 * time.Minute).Should(Succeed())
+			env.EventuallyExpectNodesUncordonedLegacyWithTimeout(12*time.Minute, cordonedNodes...)
 
 			// Expect that the new machine/node is kept around after the un-cordon
 			nodeList := &v1.NodeList{}

--- a/test/suites/alpha/expiration/expiration_test.go
+++ b/test/suites/alpha/expiration/expiration_test.go
@@ -237,7 +237,7 @@ var _ = Describe("Expiration", func() {
 			}).Should(Succeed())
 
 			// Expect nodes To get cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Expire should fail and the original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored out
@@ -305,7 +305,7 @@ var _ = Describe("Expiration", func() {
 			}).Should(Succeed())
 
 			// Expect nodes To be cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Expire should fail and original node should be uncordoned and no machines should be removed
 			// TODO: reduce timeouts when deprovisioning waits are factored out

--- a/test/suites/alpha/expiration/expiration_test.go
+++ b/test/suites/alpha/expiration/expiration_test.go
@@ -74,7 +74,6 @@ var _ = Describe("Expiration", func() {
 			TTLSecondsUntilExpired: ptr.Int64(30),
 		})
 		env.ExpectSettingsOverriddenLegacy(map[string]string{"featureGates.driftEnabled": "false"})
-		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 	})
 	It("should expire the node after the TTLSecondsUntilExpired is reached", func() {
 		var numPods int32 = 1

--- a/test/suites/alpha/integration/ami_test.go
+++ b/test/suites/alpha/integration/ami_test.go
@@ -372,7 +372,7 @@ var _ = Describe("AMI", func() {
 					{
 						Key:      v1alpha1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a", "r7a", "c7a"},
+						Values:   awsenv.ExcludedInstanceFamilies,
 					},
 					{
 						Key:      v1alpha1.LabelInstanceCategory,

--- a/test/suites/alpha/integration/extended_resources_test.go
+++ b/test/suites/alpha/integration/extended_resources_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+	awsenv "github.com/aws/karpenter/test/pkg/environment/aws"
 
 	awstest "github.com/aws/karpenter/pkg/test"
 )
@@ -135,7 +136,7 @@ var _ = Describe("Extended Resources", func() {
 				{
 					Key:      v1alpha1.LabelInstanceFamily,
 					Operator: v1.NodeSelectorOpNotIn,
-					Values:   []string{"m7a", "r7a"},
+					Values:   awsenv.ExcludedInstanceFamilies,
 				},
 			},
 		})

--- a/test/suites/alpha/integration/kubelet_config_test.go
+++ b/test/suites/alpha/integration/kubelet_config_test.go
@@ -107,7 +107,7 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 					v1.NodeSelectorRequirement{
 						Key:      v1alpha1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a", "r7a"},
+						Values:   aws.ExcludedInstanceFamilies,
 					})
 				pod := test.Pod(test.PodOptions{
 					NodeSelector: map[string]string{
@@ -145,7 +145,7 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 					v1.NodeSelectorRequirement{
 						Key:      v1alpha1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a", "r7a", "c7a"},
+						Values:   aws.ExcludedInstanceFamilies,
 					},
 					v1.NodeSelectorRequirement{
 						Key:      v1alpha1.LabelInstanceCategory,

--- a/test/suites/alpha/integration/utilization_test.go
+++ b/test/suites/alpha/integration/utilization_test.go
@@ -12,13 +12,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utilization_test
+package integration_test
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,25 +26,7 @@ import (
 	"github.com/aws/karpenter/test/pkg/debug"
 
 	awstest "github.com/aws/karpenter/pkg/test"
-	"github.com/aws/karpenter/test/pkg/environment/aws"
 )
-
-var env *aws.Environment
-
-func TestUtilization(t *testing.T) {
-	RegisterFailHandler(Fail)
-	BeforeSuite(func() {
-		env = aws.NewEnvironment(t)
-	})
-	AfterSuite(func() {
-		env.Stop()
-	})
-	RunSpecs(t, "Alpha/Utilization")
-}
-
-var _ = BeforeEach(func() { env.BeforeEach() })
-var _ = AfterEach(func() { env.Cleanup() })
-var _ = AfterEach(func() { env.AfterEach() })
 
 var _ = Describe("Utilization", Label(debug.NoWatch), Label(debug.NoEvents), func() {
 	It("should provision one pod per node", func() {

--- a/test/suites/alpha/machine/garbage_collection_test.go
+++ b/test/suites/alpha/machine/garbage_collection_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -136,7 +135,6 @@ var _ = Describe("NodeClaimGarbageCollection", func() {
 	It("should succeed to garbage collect a Machine that was deleted without the cluster's knowledge", func() {
 		// Disable the interruption queue for the garbage collection test
 		env.ExpectSettingsOverriddenLegacy(map[string]string{"aws.interruptionQueueName": ""})
-		env.ExpectSettingsOverridden(v1.EnvVar{Name: "INTERRUPTION_QUEUE", Value: ""})
 
 		provider := awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},

--- a/test/suites/alpha/scale/deprovisioning_test.go
+++ b/test/suites/alpha/scale/deprovisioning_test.go
@@ -82,7 +82,6 @@ var _ = Describe("Deprovisioning", Label(debug.NoWatch), Label(debug.NoEvents), 
 
 	BeforeEach(func() {
 		env.ExpectSettingsOverriddenLegacy(map[string]string{"featureGates.driftEnabled": "true"})
-		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 		nodeTemplate = awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},

--- a/test/suites/beta/drift/suite_test.go
+++ b/test/suites/beta/drift/suite_test.go
@@ -433,6 +433,7 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 			// TODO: reduce timeouts when disruption waits are factored out
 			env.EventuallyExpectNodesUncordonedWithTimeout(11*time.Minute, cordonedNodes...)
 
+			// We give another 6 minutes here to handle the deletion at the 15m registration timeout
 			Eventually(func(g Gomega) {
 				nodeClaims := &corev1beta1.NodeClaimList{}
 				g.Expect(env.Client.List(env, nodeClaims, client.HasLabels{test.DiscoveryLabel})).To(Succeed())
@@ -485,8 +486,8 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
 
 			// Drift should fail and original node should be uncordoned
-			// TODO: reduce timeouts when disruption waits are factored outr
-			env.EventuallyExpectNodesUncordonedWithTimeout(12*time.Minute, cordonedNodes...)
+			// TODO: reduce timeouts when disruption waits are factored out
+			env.EventuallyExpectNodesUncordonedWithTimeout(11*time.Minute, cordonedNodes...)
 
 			// Expect that the new nodeClaim/node is kept around after the un-cordon
 			nodeList := &v1.NodeList{}

--- a/test/suites/beta/drift/suite_test.go
+++ b/test/suites/beta/drift/suite_test.go
@@ -103,7 +103,6 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 				},
 			},
 		})
-		env.ExpectSettingsOverriddenLegacy(map[string]string{"featureGates.driftEnabled": "true"})
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 	})
 	It("should disrupt nodes that have drifted due to AMIs", func() {
@@ -137,7 +136,6 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 		env.EventuallyExpectNotFound(pod, nodeClaim, node)
 	})
 	It("should not disrupt nodes that have drifted without the featureGate enabled", func() {
-		env.ExpectSettingsOverriddenLegacy(map[string]string{"featureGates.driftEnabled": "false"})
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=false"})
 		// choose an old static image
 		parameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{

--- a/test/suites/beta/drift/suite_test.go
+++ b/test/suites/beta/drift/suite_test.go
@@ -431,10 +431,7 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 
 			// Drift should fail and the original node should be uncordoned
 			// TODO: reduce timeouts when disruption waits are factored out
-			Eventually(func(g Gomega) {
-				g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(cordonedNodes[0]), cordonedNodes[0]))
-				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
-			}).WithTimeout(11 * time.Minute).Should(Succeed())
+			env.EventuallyExpectNodesUncordonedWithTimeout(11*time.Minute, cordonedNodes...)
 
 			Eventually(func(g Gomega) {
 				nodeClaims := &corev1beta1.NodeClaimList{}
@@ -489,10 +486,7 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 
 			// Drift should fail and original node should be uncordoned
 			// TODO: reduce timeouts when disruption waits are factored outr
-			Eventually(func(g Gomega) {
-				g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(cordonedNodes[0]), cordonedNodes[0]))
-				g.Expect(cordonedNodes[0].Spec.Unschedulable).To(BeFalse())
-			}).WithTimeout(12 * time.Minute).Should(Succeed())
+			env.EventuallyExpectNodesUncordonedWithTimeout(12*time.Minute, cordonedNodes...)
 
 			// Expect that the new nodeClaim/node is kept around after the un-cordon
 			nodeList := &v1.NodeList{}

--- a/test/suites/beta/integration/cni_test.go
+++ b/test/suites/beta/integration/cni_test.go
@@ -52,7 +52,6 @@ var _ = Describe("CNITests", func() {
 		Expect(allocatablePods).To(Equal(eniLimitedPodsFor(node.Labels["node.kubernetes.io/instance-type"])))
 	})
 	It("should set maxPods when reservedENIs is set", func() {
-		env.ExpectSettingsOverriddenLegacy(map[string]string{"aws.reservedENIs": "1"})
 		env.ExpectSettingsOverridden(corev1.EnvVar{Name: "RESERVED_ENIS", Value: "1"})
 		pod := test.Pod()
 		env.ExpectCreated(pod, nodeClass, nodePool)

--- a/test/suites/beta/integration/emptiness_test.go
+++ b/test/suites/beta/integration/emptiness_test.go
@@ -52,7 +52,6 @@ var _ = Describe("Emptiness", func() {
 		By("waiting for the nodeclaim emptiness status condition to propagate")
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(nodeClaim), nodeClaim)).To(Succeed())
-			g.Expect(nodeClaim.StatusConditions().GetCondition(corev1beta1.Empty)).ToNot(BeNil())
 			g.Expect(nodeClaim.StatusConditions().GetCondition(corev1beta1.Empty).IsTrue()).To(BeTrue())
 		}).Should(Succeed())
 

--- a/test/suites/beta/integration/extended_resources_test.go
+++ b/test/suites/beta/integration/extended_resources_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
+	awsenv "github.com/aws/karpenter/test/pkg/environment/aws"
 )
 
 var _ = Describe("Extended Resources", func() {
@@ -95,7 +96,7 @@ var _ = Describe("Extended Resources", func() {
 			{
 				Key:      v1beta1.LabelInstanceFamily,
 				Operator: v1.NodeSelectorOpNotIn,
-				Values:   []string{"m7a", "r7a", "c7a"},
+				Values:   awsenv.ExcludedInstanceFamilies,
 			},
 			{
 				Key:      v1beta1.LabelInstanceCategory,

--- a/test/suites/beta/integration/extended_resources_test.go
+++ b/test/suites/beta/integration/extended_resources_test.go
@@ -90,7 +90,6 @@ var _ = Describe("Extended Resources", func() {
 		DeferCleanup(func() {
 			env.ExpectPodENIDisabled()
 		})
-		env.ExpectSettingsOverriddenLegacy(map[string]string{"aws.enablePodENI": "true"})
 		// TODO: remove this requirement once VPC RC rolls out m7a.*, r7a.* ENI data (https://github.com/aws/karpenter/issues/4472)
 		nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, []v1.NodeSelectorRequirement{
 			{

--- a/test/suites/beta/integration/instance_profile_test.go
+++ b/test/suites/beta/integration/instance_profile_test.go
@@ -23,7 +23,6 @@ import (
 
 	coretest "github.com/aws/karpenter-core/pkg/test"
 	awserrors "github.com/aws/karpenter/pkg/errors"
-	"github.com/aws/karpenter/pkg/providers/instanceprofile"
 )
 
 var _ = Describe("InstanceProfile Generation", func() {
@@ -37,7 +36,7 @@ var _ = Describe("InstanceProfile Generation", func() {
 		Expect(instance.IamInstanceProfile).ToNot(BeNil())
 		Expect(lo.FromPtr(instance.IamInstanceProfile.Arn)).To(ContainSubstring(nodeClass.Status.InstanceProfile))
 
-		instanceProfile := env.ExpectInstanceProfileExists(instanceprofile.GetProfileName(env.Context, env.Region, nodeClass))
+		instanceProfile := env.ExpectInstanceProfileExists(env.GetInstanceProfileName(nodeClass))
 		Expect(instanceProfile.Roles).To(HaveLen(1))
 		Expect(lo.FromPtr(instanceProfile.Roles[0].RoleName)).To(Equal(nodeClass.Spec.Role))
 	})

--- a/test/suites/beta/integration/instance_profile_test.go
+++ b/test/suites/beta/integration/instance_profile_test.go
@@ -35,7 +35,7 @@ var _ = Describe("InstanceProfile Generation", func() {
 
 		instance := env.GetInstance(node.Name)
 		Expect(instance.IamInstanceProfile).ToNot(BeNil())
-		Expect(instance.IamInstanceProfile.Arn).To(ContainSubstring(nodeClass.Spec.Role))
+		Expect(lo.FromPtr(instance.IamInstanceProfile.Arn)).To(ContainSubstring(nodeClass.Status.InstanceProfile))
 
 		instanceProfile := env.ExpectInstanceProfileExists(instanceprofile.GetProfileName(env.Context, env.Region, nodeClass))
 		Expect(instanceProfile.Roles).To(HaveLen(1))
@@ -50,7 +50,7 @@ var _ = Describe("InstanceProfile Generation", func() {
 		env.ExpectDeleted(nodePool, nodeClass)
 		Eventually(func(g Gomega) {
 			_, err := env.IAMAPI.GetInstanceProfileWithContext(env.Context, &iam.GetInstanceProfileInput{
-				InstanceProfileName: aws.String(instanceprofile.GetProfileName(env.Context, env.Region, nodeClass)),
+				InstanceProfileName: aws.String(env.GetInstanceProfileName(nodeClass)),
 			})
 			g.Expect(awserrors.IsNotFound(err)).To(BeTrue())
 		}).Should(Succeed())

--- a/test/suites/beta/integration/kubelet_config_test.go
+++ b/test/suites/beta/integration/kubelet_config_test.go
@@ -259,7 +259,7 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 				Values:   []string{string(v1.Linux)},
 			},
 		}...)
-		nodePool.Spec.Template.Spec.Kubelet.PodsPerCore = ptr.Int32(1)
+		nodePool.Spec.Template.Spec.Kubelet = &corev1beta1.KubeletConfiguration{PodsPerCore: ptr.Int32(1)}
 		numPods := 6
 		dep := test.Deployment(test.DeploymentOptions{
 			Replicas: int32(numPods),

--- a/test/suites/beta/integration/kubelet_config_test.go
+++ b/test/suites/beta/integration/kubelet_config_test.go
@@ -90,7 +90,7 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 					{
 						Key:      v1beta1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a", "r7a", "c7a"},
+						Values:   aws.ExcludedInstanceFamilies,
 					},
 					{
 						Key:      v1beta1.LabelInstanceCategory,
@@ -133,7 +133,7 @@ var _ = Describe("KubeletConfiguration Overrides", func() {
 					{
 						Key:      v1beta1.LabelInstanceFamily,
 						Operator: v1.NodeSelectorOpNotIn,
-						Values:   []string{"m7a", "r7a", "c7a"},
+						Values:   aws.ExcludedInstanceFamilies,
 					},
 					{
 						Key:      v1beta1.LabelInstanceCategory,

--- a/test/suites/beta/integration/scheduling_test.go
+++ b/test/suites/beta/integration/scheduling_test.go
@@ -69,7 +69,6 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 			v1beta1.LabelInstanceCPU:              "2",
 			v1beta1.LabelInstanceMemory:           "4096",
 			v1beta1.LabelInstanceNetworkBandwidth: "750",
-			v1beta1.LabelInstancePods:             "29",
 		}
 		selectors.Insert(lo.Keys(nodeSelector)...) // Add node selector keys to selectors used in testing to ensure we test all labels
 		requirements := lo.MapToSlice(nodeSelector, func(key string, value string) v1.NodeSelectorRequirement {

--- a/test/suites/beta/integration/scheduling_test.go
+++ b/test/suites/beta/integration/scheduling_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 			{
 				Key:      v1beta1.LabelInstanceFamily,
 				Operator: v1.NodeSelectorOpNotIn,
-				Values:   []string{"m7a", "r7a", "c7a"},
+				Values:   aws.ExcludedInstanceFamilies,
 			},
 			{
 				Key:      v1beta1.LabelInstanceCategory,

--- a/test/suites/beta/integration/utilization_test.go
+++ b/test/suites/beta/integration/utilization_test.go
@@ -1,0 +1,43 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/aws/karpenter-core/pkg/test"
+	"github.com/aws/karpenter/test/pkg/debug"
+)
+
+var _ = Describe("Utilization", Label(debug.NoWatch), Label(debug.NoEvents), func() {
+	It("should provision one pod per node", func() {
+		nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, v1.NodeSelectorRequirement{
+			Key:      v1.LabelInstanceTypeStable,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{"t3a.small"},
+		})
+
+		deployment := test.Deployment(test.DeploymentOptions{
+			Replicas:   100,
+			PodOptions: test.PodOptions{ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1.5")}}}})
+
+		env.ExpectCreated(nodeClass, nodePool, deployment)
+		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels), int(*deployment.Spec.Replicas))
+		env.ExpectCreatedNodeCount("==", int(*deployment.Spec.Replicas)) // One pod per node enforced by instance size
+	})
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- This PR updates the IAM Cloudformation permissions used for the permission boundary for the GithubActions role.
- This PR also updates test that is run during the upgrade test to be `Beta/Integration`
- It updates the Monitor to handle watching nodes that are owned by NodePools so consolidation tests work
- It updates bugs in the Integration test cases
- It merges the Utilization test case/suite into the Integration test suite
- The cloudformation policy had to be condensed here to avoid going over the managed instance profile character limit

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.