### PR TITLE
docs: Add contribution info

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -7,6 +7,8 @@ docs:            <-- Documentation changes that do not impact code
 test:            <-- Test changes that do not impact behavior
 ci:              <-- Changes that affect test or rollout automation
 !${type}:        <-- Include ! if your change includes a backwards incompatible change.
+
+Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
 -->
 
 Fixes #N/A <!-- issue number -->

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Karpenter improves the efficiency and cost of running workloads on Kubernetes cl
 * **Provisioning** nodes that meet the requirements of the pods
 * **Removing** the nodes when the nodes are no longer needed
 
-Come discuss Karpenter in the [#karpenter](https://kubernetes.slack.com/archives/C02SFFZSA2K) channel, in the [Kubernetes slack](https://slack.k8s.io/) or join the [Karpenter working group](https://karpenter.sh/docs/contributing/working-group/) bi-weekly calls.
+Come discuss Karpenter in the [#karpenter](https://kubernetes.slack.com/archives/C02SFFZSA2K) channel, in the [Kubernetes slack](https://slack.k8s.io/) or join the [Karpenter working group](https://karpenter.sh/docs/contributing/working-group/) bi-weekly calls. If you want to contribute to the Karpenter project, please refer to the Karpenter docs.
 
 Check out the [Docs](https://karpenter.sh/docs/) to learn more.
 


### PR DESCRIPTION
**Description**
As the project doesn't include the CONTRIBUTING.md, a clear guide on where to find the contribution guidelines would make it easy for developers who want to get involved with the Karpenter project. 

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.