### PR TITLE
fix(kube-node-lease): remove objects created for kube-node-lease

### DIFF
--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -69,24 +69,3 @@ rules:
     resources: ["services"]
     resourceNames: ["kube-dns"]
     verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "karpenter.fullname" . }}-lease
-  namespace: kube-node-lease
-  labels:
-    {{- include "karpenter.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-rules:
-  # Read
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "list", "watch"]
-  # Write
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["delete"]

--- a/charts/karpenter/templates/rolebinding.yaml
+++ b/charts/karpenter/templates/rolebinding.yaml
@@ -37,23 +37,3 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "karpenter.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
---- 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "karpenter.fullname" . }}-lease
-  namespace: kube-node-lease
-  labels:
-    {{- include "karpenter.labels" . | nindent 4 }}
-  {{- with .Values.additionalAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "karpenter.fullname" . }}-lease
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "karpenter.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION

Fixes #4547

Hey,
It looks like about 2 months ago, resources for `kube-node-lease` were added to karpenter:
https://github.com/aws/karpenter/pull/4453

Those changes are causing karpenter not to work on clusters without a namespace called `kube-node-lease`

as i see, this namespace is used for test, as it appers only in those files:

```shell
karpenter/test/suites/beta/integration/lease_garbagecollection_test.go
karpenter/test/suites/beta/integration/lease_garbagecollection_test.go
```




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.