### PR TITLE
test: use legacy taint logic for disruption

### DIFF
--- a/test/suites/alpha/drift/suite_test.go
+++ b/test/suites/alpha/drift/suite_test.go
@@ -377,7 +377,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			}).Should(Succeed())
 
 			// Expect nodes To get cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Drift should fail and the original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored out
@@ -435,7 +435,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 			}).Should(Succeed())
 
 			// Expect nodes To be cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Drift should fail and original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored outr

--- a/test/suites/alpha/expiration/expiration_test.go
+++ b/test/suites/alpha/expiration/expiration_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Expiration", func() {
 			}).Should(Succeed())
 
 			// Expect nodes To get cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Expire should fail and the original node should be uncordoned
 			// TODO: reduce timeouts when deprovisioning waits are factored out
@@ -306,7 +306,7 @@ var _ = Describe("Expiration", func() {
 			}).Should(Succeed())
 
 			// Expect nodes To be cordoned
-			cordonedNodes := env.EventuallyExpectCordonedNodeCount("==", 1)
+			cordonedNodes := env.EventuallyExpectCordonedNodeCountLegacy("==", 1)
 
 			// Expire should fail and original node should be uncordoned and no machines should be removed
 			// TODO: reduce timeouts when deprovisioning waits are factored out


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Fixes an inconsistency in logic where we were using the new v1beta1 taint logic with v1alpha APIs.

**How was this change tested?**
make presubmit, test with e2e

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.