### PR TITLE
chore: Add more E2E test fixes for the Beta Suites

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -61,13 +61,11 @@ jobs:
           - Alpha/Integration
           - Alpha/Machine
           - Alpha/Consolidation
-          - Alpha/Utilization
           - Alpha/Interruption
           - Alpha/Drift
           - Alpha/Expiration
           - Alpha/Chaos
           - Alpha/IPv6
-          - Alpha/Scale
     uses: ./.github/workflows/e2e.yaml
     with:
       suite: ${{ matrix.suite }}

--- a/test/suites/beta/expiration/suite_test.go
+++ b/test/suites/beta/expiration/suite_test.go
@@ -128,8 +128,7 @@ var _ = Describe("Expiration", func() {
 
 		// Eventually the node will be set as unschedulable, which means its actively being deprovisioned
 		Eventually(func(g Gomega) {
-			n := &v1.Node{}
-			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), n)).Should(Succeed())
+			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).Should(Succeed())
 			_, ok := lo.Find(node.Spec.Taints, func(t v1.Taint) bool {
 				return corev1beta1.IsDisruptingTaint(t)
 			})
@@ -197,8 +196,7 @@ var _ = Describe("Expiration", func() {
 
 		// Eventually the node will be set as unschedulable, which means its actively being deprovisioned
 		Eventually(func(g Gomega) {
-			n := &v1.Node{}
-			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), n)).Should(Succeed())
+			g.Expect(env.Client.Get(env.Context, client.ObjectKeyFromObject(node), node)).Should(Succeed())
 			_, ok := lo.Find(node.Spec.Taints, func(t v1.Taint) bool {
 				return corev1beta1.IsDisruptingTaint(t)
 			})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change drops the Utilization and Scale test suites from the matrix run and fixes a bug in the Expiration test for Beta.

**How was this change tested?**

`make e2etests`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.