### PR TITLE
chore: Audited and documented permissions for gha

### DIFF
--- a/.github/actions/upload-artifact/action.yaml
+++ b/.github/actions/upload-artifact/action.yaml
@@ -1,9 +1,0 @@
-name: UploadArtifacts
-description: 'Uploads artifacts of a workflow as an archive of a directory so that another workflow that runs on workflow_run can download and use it'
-runs:
-  using: "composite"
-  steps:
-    - uses: actions/upload-artifact@v3
-      with:
-        name: artifacts
-        path: /tmp/artifacts

--- a/.github/workflows/approval-comment.yaml
+++ b/.github/workflows/approval-comment.yaml
@@ -6,7 +6,6 @@ on:
 jobs:
   approval-comment:
     if: startsWith(github.event.review.body, '/karpenter snapshot') || startsWith(github.event.review.body, '/karpenter scale') || startsWith(github.event.review.body, '/karpenter conformance')
-    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,4 +20,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} >> /tmp/artifacts/metadata.txt
           echo ${{ github.event.review.commit_id }} >> /tmp/artifacts/metadata.txt
           cat /tmp/artifacts/metadata.txt
-      - uses: ./.github/actions/upload-artifact
+      - uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: /tmp/artifacts

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -5,9 +5,9 @@ on:
     - cron: '0 13 * * MON'
 
 permissions:
-  id-token: write
-  pull-requests: write
-  contents: write
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+  pull-requests: write # name: Create Pull Request
+  contents: write # name: Create Pull Request
 
 jobs:
   codegen:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -12,9 +12,8 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # github/codeql-action/init@v2
+      security-events: write # github/codeql-action/init@v2
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  id-token: write
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 
 jobs:
   docgen-ci:

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -46,9 +46,8 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-  statuses: write
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+  statuses: write # ./.github/actions/commit-status/start
 jobs:
   run-suite:
     name: suite-upgrade

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -74,9 +74,8 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-  statuses: write
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+  statuses: write # ./.github/actions/commit-status/start
 jobs:
   run-suite:
     name: suite-${{ inputs.suite }}

--- a/.github/workflows/pr-snapshot.yaml
+++ b/.github/workflows/pr-snapshot.yaml
@@ -5,8 +5,6 @@ on:
     types: [completed]
 permissions:
   id-token: write
-  pull-requests: write
-  contents: write
   statuses: write
 jobs:
   release:

--- a/.github/workflows/publish-test-tools.yaml
+++ b/.github/workflows/publish-test-tools.yaml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '0 13 * * MON'
 permissions:
-  id-token: write
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   publish-tools:
     if: github.repository == 'aws/karpenter'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,9 @@ on:
   push:
     tags: [ 'v*.*.*' ]
 permissions:
-  id-token: write
-  pull-requests: write
-  contents: write
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+  contents: write # marvinpinto/action-automatic-releases@latest
+  pull-requests: write # name: Create PR
 jobs:
   release:
     if: github.repository == 'aws/karpenter'

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ main ]
 permissions:
-  id-token: write
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   release:
     if: github.repository == 'aws/karpenter'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,9 +7,8 @@ jobs:
   StaleBot:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      discussions: write
-      pull-requests: write
+      issues: write # actions/stale@v8.0.0
+      pull-requests: write # actions/stale@v8.0.0
     if: github.repository == 'aws/karpenter'
     name: Stale issue bot
     steps:

--- a/.github/workflows/sweeper.yaml
+++ b/.github/workflows/sweeper.yaml
@@ -4,8 +4,7 @@ on:
     - cron: '0 */12 * * *'
   workflow_dispatch:
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   sweeper:
     if: vars.ACCOUNT_ID != '' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

Reading GH doc samples, it appears the read contents is no longer required to check out the repo. 

**How was this change tested?**

I suspect this will break things, as testing these permissions is hard. 

1. Will test the snapshot workflow after merging
1. I'm doing the release there, and will feel the pain myself :) 
2. Other workflows occur on merge/cron, I'll fix in response.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.