### PR TITLE
docs: Make the latest K8s version to a parameter

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -67,6 +67,7 @@ params:
         icon: fab fa-slack
         desc: 'Chat with us on Slack in the #aws-provider channel'
   latest_release_version: v0.31.1
+  latest_k8s_version: 1.28
   versions:
     - v0.31
     - v0.30

--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -176,10 +176,10 @@ Yes, see the [KubeletConfiguration Section in the NodePool docs]({{<ref "./conce
 The difference between the Core and Full variants is that Core is a minimal OS with less components and no graphic user interface (GUI) or desktop experience.
 `Windows2019` and `Windows2022` AMI families use the Windows Server Core option for simplicity, but if required, you can specify a custom AMI to run Windows Server Full.
 
-You can specify the [Amazon EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-windows-ami.html) with Windows Server 2022 Full for Kubernetes 1.28 by configuring an `amiSelector` that references the AMI name.
-```
+You can specify the [Amazon EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-windows-ami.html) with Windows Server 2022 Full for Kubernetes {{< param "latest_k8s_version" >}} by configuring an `amiSelector` that references the AMI name.
+```yaml
 amiSelectorTerms:
-    - name: Windows_Server-2022-English-Full-EKS_Optimized-1.28*
+    - name: Windows_Server-2022-English-Full-EKS_Optimized-{{< param "latest_k8s_version" >}}*
 ```
 
 ## Deprovisioning

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -41,10 +41,11 @@ authenticate properly by running `aws sts get-caller-identity`.
 
 ### 2. Set environment variables
 
-After setting up the tools, set the Karpenter version number:
+After setting up the tools, set the Karpenter and Kubernetes version:
 
 ```bash
 export KARPENTER_VERSION={{< param "latest_release_version" >}}
+export K8S_VERSION={{< param "latest_k8s_version" >}}
 ```
 
 Then set the following environment variable:
@@ -56,7 +57,7 @@ If you open a new shell to run steps in this procedure, you need to set some or 
 To remind yourself of these values, type:
 
 ```bash
-echo $KARPENTER_VERSION $CLUSTER_NAME $AWS_DEFAULT_REGION $AWS_ACCOUNT_ID $TEMPOUT
+echo $KARPENTER_VERSION $K8S_VERSION $CLUSTER_NAME $AWS_DEFAULT_REGION $AWS_ACCOUNT_ID $TEMPOUT
 ```
 
 {{% /alert %}}

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -12,7 +12,7 @@ kind: ClusterConfig
 metadata:
   name: ${CLUSTER_NAME}
   region: ${AWS_DEFAULT_REGION}
-  version: "1.28"
+  version: "${K8S_VERSION}"
   tags:
     karpenter.sh/discovery: ${CLUSTER_NAME}
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This changes makes it so that you just need to update the `latest_k8s_version` parameter inside of the `config.yaml` file to update the latest version of K8s across the docs.

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.