### PR TITLE
feat: Filter custom AMIs by K8s version

### DIFF
--- a/charts/karpenter/templates/configmap.yaml
+++ b/charts/karpenter/templates/configmap.yaml
@@ -55,6 +55,9 @@ data:
 {{- with .Values.settings.aws.reservedENIs }}
   aws.reservedENIs: "{{ . }}"
 {{- end }}
+{{- with .Values.settings.amiK8sVersionTag }}
+  amiK8sVersionTag: "{{ . }}"
+{{- end }}
 {{- with .Values.settings.featureGates.driftEnabled }}
   featureGates.driftEnabled: "${{ . }}"
 {{- end }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -144,6 +144,10 @@ spec:
             - name: RESERVED_ENIS
               value: "{{ . }}"
           {{- end }}
+          {{- with .Values.settings.amiK8sVersionTag }}
+            - name: AMI_K8S_VERSION_TAG
+              value: "{{ . }}"
+          {{- end }}
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -203,3 +203,6 @@ settings:
     # Setting drift to true enables the drift disruption method to watch for drift between currently deployed nodes
     # and the desired state of nodes set in provisioners and node templates
     drift: false
+  # The name of an AMI tag whose value corresponds to the k8s version that the AMI was built for. If set, Karpenter
+  # will only consider AMIs with tags whose value matches the cluster's k8s version.
+  amiK8sVersionTag: ""

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -44,6 +44,7 @@ var defaultSettings = &Settings{
 	InterruptionQueueName:      "",
 	Tags:                       map[string]string{},
 	ReservedENIs:               0,
+	AMIK8sVersionTag:           "",
 }
 
 // +k8s:deepcopy-gen=true
@@ -61,6 +62,7 @@ type Settings struct {
 	InterruptionQueueName      string
 	Tags                       map[string]string
 	ReservedENIs               int
+	AMIK8sVersionTag           string
 }
 
 func (*Settings) ConfigMap() string {
@@ -86,6 +88,7 @@ func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context,
 		configmap.AsBool("aws.isolatedVPC", &s.IsolatedVPC),
 		configmap.AsFloat64("aws.vmMemoryOverheadPercent", &s.VMMemoryOverheadPercent),
 		configmap.AsString("aws.interruptionQueueName", &s.InterruptionQueueName),
+		configmap.AsString("amiK8sVersionTag", &s.AMIK8sVersionTag),
 		AsStringMap("aws.tags", &s.Tags),
 		configmap.AsInt("aws.reservedENIs", &s.ReservedENIs),
 	); err != nil {

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	VMMemoryOverheadPercent float64
 	InterruptionQueue       string
 	ReservedENIs            int
+	AMIK8sVersionTag        string
 
 	setFlags map[string]bool
 }
@@ -60,6 +61,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent", env.WithDefaultFloat64("VM_MEMORY_OVERHEAD_PERCENT", 0.075), "The VM memory overhead as a percent that will be subtracted from the total memory for all instance types.")
 	fs.StringVar(&o.InterruptionQueue, "interruption-queue", env.WithDefaultString("INTERRUPTION_QUEUE", ""), "Interruption queue is disabled if not specified. Enabling interruption handling may require additional permissions on the controller service account. Additional permissions are outlined in the docs.")
 	fs.IntVar(&o.ReservedENIs, "reserved-enis", env.WithDefaultInt("RESERVED_ENIS", 0), "Reserved ENIs are not included in the calculations for max-pods or kube-reserved. This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.")
+	fs.StringVar(&o.AMIK8sVersionTag, "ami-k8s-version-tag", env.WithDefaultString("AMI_K8S_VERSION_TAG", ""), "The name of an AMI tag whose value corresponds to the k8s version that the AMI was built for. If set, Karpenter will only consider AMIs with tags whose value matches the cluster's k8s version.")
 }
 
 func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {
@@ -105,6 +107,7 @@ func (o *Options) MergeSettings(ctx context.Context) {
 	mergeField(&o.VMMemoryOverheadPercent, s.VMMemoryOverheadPercent, o.setFlags["vm-memory-overhead-percent"])
 	mergeField(&o.InterruptionQueue, s.InterruptionQueueName, o.setFlags["interruption-queue"])
 	mergeField(&o.ReservedENIs, s.ReservedENIs, o.setFlags["reserved-enis"])
+	mergeField(&o.AMIK8sVersionTag, s.AMIK8sVersionTag, o.setFlags["ami-k8s-version-tag"])
 	if err := o.validateRequiredFields(); err != nil {
 		panic(fmt.Errorf("checking required fields, %w", err))
 	}


### PR DESCRIPTION
Fixes #4769

**Description**

This PR adds a new Helm chart value, `amiK8sVersionTag`, that enables custom AMIs to be filtered by K8s version.

The value of `amiK8sVersionTag` should be the name of an AMI tag whose value corresponds to the k8s version that the AMI was built for. If set, Karpenter, will only consider AMIs with tags whose value matches the cluster's k8s version.

As mentioned in #4769, this is useful so that users who are utilizing custom AMIs do not have to manually maintain consistency between their Kubernetes cluster version and their node templates.

**How was this change tested?**

It wasn't.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] Yes. I will push subsequent commits with documentation updates if the change is accepted.
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.