### PR TITLE
BREAKING: Fix helm ordering of values and set default log encoding to `json`

### DIFF
--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -14,7 +14,7 @@ data:
   # https://github.com/uber-go/zap/blob/aa3e73ec0896f8b066ddf668597a02f89628ee50/config.go
   zap-logger-config: |
     {
-      "level": "{{ or .Values.logConfig.logLevel.global .Values.logLevel }}",
+      "level": "{{ .Values.logConfig.logLevel.global }}",
       "development": false,
       "disableStacktrace": true,
       "disableCaller": true,
@@ -24,7 +24,7 @@ data:
       },
       "outputPaths": [{{ include "karpenter.outputPathsList" . }}],
       "errorOutputPaths": [{{ include "karpenter.errorOutputPathsList" . }}],
-      "encoding": "{{ or .Values.logConfig.logEncoding .Values.logEncoding }}",
+      "encoding": "{{ or .Values.logEncoding .Values.logConfig.logEncoding }}",
       "encoderConfig": {
         "timeKey": "time",
         "levelKey": "level",
@@ -36,6 +36,6 @@ data:
         "timeEncoder": "iso8601"
       }
     }
-  loglevel.controller: {{ or .Values.logConfig.logLevel.controller .Values.controller.logLevel }}
-  loglevel.webhook: {{ or .Values.logConfig.logLevel.webhook .Values.webhook.logLevel }}
+  loglevel.controller: {{ or .Values.controller.logLevel .Values.logConfig.logLevel.controller }}
+  loglevel.webhook: {{ or .Values.webhook.logLevel .Values.logConfig.logLevel.webhook }}
 {{- end }}

--- a/charts/karpenter/templates/configmap.yaml
+++ b/charts/karpenter/templates/configmap.yaml
@@ -56,6 +56,6 @@ data:
   aws.reservedENIs: "{{ . }}"
 {{- end }}
 {{- with .Values.settings.featureGates.driftEnabled }}
-  featureGates.driftEnabled: "${{ . }}"
+  featureGates.driftEnabled: "{{ . }}"
 {{- end }}
 

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -82,8 +82,10 @@ spec:
             - name: DISABLE_WEBHOOK
               value: "true"
           {{- end }}
+          {{- with .Values.logLevel }}
             - name: LOG_LEVEL
-              value: "{{ .Values.logLevel }}"
+              value: "{{ . }}"
+          {{- end }}
             - name: METRICS_PORT
               value: "{{ .Values.controller.metrics.port }}"
             - name: HEALTH_PROBE_PORT
@@ -99,7 +101,7 @@ spec:
                   divisor: "0"
                   resource: limits.memory
             - name: FEATURE_GATES
-              value: "Drift={{ or .Values.settings.featureGates.drift .Values.settings.featureGates.driftEnabled }}"
+              value: "Drift={{ or .Values.settings.featureGates.driftEnabled .Values.settings.featureGates.drift }}"
           {{- with .Values.settings.batchMaxDuration }}
             - name: BATCH_MAX_DURATION
               value: "{{ . }}"
@@ -108,39 +110,39 @@ spec:
             - name: BATCH_IDLE_DURATION
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.assumeRoleARN .Values.settings.aws.assumeRoleARN }}
+          {{- with or .Values.settings.aws.assumeRoleARN .Values.settings.assumeRoleARN }}
             - name: ASSUME_ROLE_ARN
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.assumeRoleDuration .Values.settings.aws.assumeRoleDuration }}
+          {{- with or .Values.settings.aws.assumeRoleDuration .Values.settings.assumeRoleDuration }}
             - name: ASSUME_ROLE_DURATION
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.clusterCABundle .Values.settings.aws.clusterCABundle }}
+          {{- with or .Values.settings.aws.clusterCABundle .Values.settings.clusterCABundle }}
             - name: CLUSTER_CA_BUNDLE
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.clusterName .Values.settings.aws.clusterName }}
+          {{- with or .Values.settings.aws.clusterName .Values.settings.clusterName }}
             - name: CLUSTER_NAME
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.clusterEndpoint .Values.settings.aws.clusterEndpoint }}
+          {{- with or .Values.settings.aws.clusterEndpoint .Values.settings.clusterEndpoint }}
             - name: CLUSTER_ENDPOINT
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.isolatedVPC .Values.settings.aws.isolatedVPC }}
+          {{- with or .Values.settings.aws.isolatedVPC .Values.settings.isolatedVPC }}
             - name: ISOLATED_VPC
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.vmMemoryOverheadPercent .Values.settings.aws.vmMemoryOverheadPercent }}
+          {{- with or .Values.settings.aws.vmMemoryOverheadPercent .Values.settings.vmMemoryOverheadPercent }}
             - name: VM_MEMORY_OVERHEAD_PERCENT
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.interruptionQueue .Values.settings.aws.interruptionQueueName }}
+          {{- with or .Values.settings.aws.interruptionQueueName .Values.settings.interruptionQueue }}
             - name: INTERRUPTION_QUEUE
               value: "{{ . }}"
           {{- end }}
-          {{- with or .Values.settings.reservedENIs .Values.settings.aws.reservedENIs }}
+          {{- with or .Values.settings.aws.reservedENIs .Values.settings.reservedENIs }}
             - name: RESERVED_ENIS
               value: "{{ . }}"
           {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -154,8 +154,8 @@ logConfig:
   # -- Log errorOutputPaths - defaults to stderr only
   errorOutputPaths:
     - stderr
-  # -- Log encoding - defaults to console - must be one of 'json', 'console'
-  logEncoding: console
+  # -- Log encoding - defaults to json - must be one of 'json', 'console'
+  logEncoding: json
   # -- Component-based log configuration
   logLevel:
     # -- Global log level, defaults to 'debug'

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -226,6 +226,7 @@ If you are using some IaC for managing your policy documents attached to the con
 * Karpenter now serves the webhook prometheus metrics server on port `8001`. If this port is already in-use on the pod or you are running in `hostNetworking` mode, you may need to change this port value. You can configure this port value through the `WEBHOOK_METRICS_PORT` environment variable or the `webhook.metrics.port` value if installing via Helm.
 * Karpenter now exposes the ability to disable webhooks through the `webhook.enabled=false` value. This value will disable the webhook server and will prevent any permissions, mutating or validating webhook configurations from being deployed to the cluster.
 * Karpenter now moves all logging configuration for the Zap logger into the `logConfig` values block. Configuring Karpenter logging with this mechanism _is_ deprecated and will be dropped at v1. Karpenter now only surfaces logLevel through the `logLevel` helm value. If you need more advanced configuration due to log parsing constraints, we recommend configuring your log parser to handle Karpenter's Zap JSON logging.
+* The default log encoding changed from `console` to `json`. If you were previously not setting the type of log encoding, this default will change with the helm chart. If you were setting the value through `logEncoding`, this value will continue to work until v0.33.x but it is deprecated in favor of `logConfig.logEncoding`
 
 ### Upgrading to v0.31.0+
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the ordering of helm values for evaluation in the chart to ensure that the old values are always considered first. This ensures that the defaults that are specified in the default `values.yaml` file do not override any existing values were set by the user on a previous version.

Note that this PR also contains a breaking change to defaults for log encoding. If you did not previously set the log encoding for Karpenter and relied on the default log encoding of `console`, this will now be changed in the helm chart to `json`, unless this value is updated by specifying the `logConfig.logEncoding` value like `--set logConfig.logEncoding=console`

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.