### PR TITLE
fix: Fix bug in drift ami resolution with incompatible requirements

### DIFF
--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -89,9 +89,6 @@ func (c *CloudProvider) isAMIDrifted(ctx context.Context, nodeClaim *corev1beta1
 		return "", fmt.Errorf("no amis exist given constraints")
 	}
 	mappedAMIs := amis.MapToInstanceTypes([]*cloudprovider.InstanceType{nodeInstanceType}, nodeClaim.IsMachine)
-	if len(mappedAMIs) == 0 {
-		return "", fmt.Errorf("no instance types satisfy requirements of amis %v", amis)
-	}
 	if !lo.Contains(lo.Keys(mappedAMIs), instance.ImageID) {
 		return AMIDrift, nil
 	}

--- a/pkg/cloudprovider/nodeclaim_test.go
+++ b/pkg/cloudprovider/nodeclaim_test.go
@@ -124,26 +124,32 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 		})
 	})
 	Context("NodeClaim Drift", func() {
-		var validAMI string
+		var armAMIID, amdAMIID string
 		var validSecurityGroup string
 		var selectedInstanceType *corecloudproivder.InstanceType
 		var instance *ec2.Instance
 		var validSubnet1 string
 		var validSubnet2 string
 		BeforeEach(func() {
-			validAMI = fake.ImageID()
+			armAMIID, amdAMIID = fake.ImageID(), fake.ImageID()
 			validSecurityGroup = fake.SecurityGroupID()
 			validSubnet1 = fake.SubnetID()
 			validSubnet2 = fake.SubnetID()
 			awsEnv.SSMAPI.GetParameterOutput = &ssm.GetParameterOutput{
-				Parameter: &ssm.Parameter{Value: aws.String(validAMI)},
+				Parameter: &ssm.Parameter{Value: aws.String(armAMIID)},
 			}
 			awsEnv.EC2API.DescribeImagesOutput.Set(&ec2.DescribeImagesOutput{
 				Images: []*ec2.Image{
 					{
 						Name:         aws.String(coretest.RandomName()),
-						ImageId:      aws.String(validAMI),
+						ImageId:      aws.String(armAMIID),
 						Architecture: aws.String("arm64"),
+						CreationDate: aws.String("2022-08-15T12:00:00Z"),
+					},
+					{
+						Name:         aws.String(coretest.RandomName()),
+						ImageId:      aws.String(amdAMIID),
+						Architecture: aws.String("x86_64"),
 						CreationDate: aws.String("2022-08-15T12:00:00Z"),
 					},
 				},
@@ -171,7 +177,7 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 
 			// Create the instance we want returned from the EC2 API
 			instance = &ec2.Instance{
-				ImageId:               aws.String(validAMI),
+				ImageId:               aws.String(armAMIID),
 				InstanceType:          aws.String(selectedInstanceType.Name),
 				SubnetId:              aws.String(validSubnet1),
 				SpotInstanceRequestId: aws.String(coretest.RandomName()),
@@ -304,6 +310,13 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 			})
 			_, err := cloudProvider.IsDrifted(ctx, nodeClaim)
 			Expect(err).To(HaveOccurred())
+		})
+		It("should return drifted if the AMI no longer matches the existing machine instance type", func() {
+			nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{{ID: amdAMIID}}
+			ExpectApplied(ctx, env.Client, nodeClass)
+			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isDrifted).To(Equal(cloudprovider.AMIDrift))
 		})
 		Context("Static Drift Detection", func() {
 			DescribeTable("should return drifted if the spec is updated",

--- a/pkg/cloudprovider/nodeclaim_test.go
+++ b/pkg/cloudprovider/nodeclaim_test.go
@@ -311,7 +311,7 @@ var _ = Describe("NodeClaim/CloudProvider", func() {
 			_, err := cloudProvider.IsDrifted(ctx, nodeClaim)
 			Expect(err).To(HaveOccurred())
 		})
-		It("should return drifted if the AMI no longer matches the existing machine instance type", func() {
+		It("should return drifted if the AMI no longer matches the existing NodeClaims instance type", func() {
 			nodeClass.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{{ID: amdAMIID}}
 			ExpectApplied(ctx, env.Client, nodeClass)
 			isDrifted, err := cloudProvider.IsDrifted(ctx, nodeClaim)

--- a/pkg/fake/utils.go
+++ b/pkg/fake/utils.go
@@ -37,7 +37,7 @@ func ProviderID(id string) string {
 }
 
 func ImageID() string {
-	return fmt.Sprintf("ami-%s", randomdata.Alphanumeric(17))
+	return fmt.Sprintf("ami-%s", strings.ToLower(randomdata.Alphanumeric(17)))
 }
 func SecurityGroupID() string {
 	return fmt.Sprintf("sg-%s", randomdata.Alphanumeric(17))

--- a/test/suites/alpha/drift/suite_test.go
+++ b/test/suites/alpha/drift/suite_test.go
@@ -40,12 +40,13 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
 	"github.com/aws/karpenter/pkg/apis/v1alpha1"
+
 	awstest "github.com/aws/karpenter/pkg/test"
 	"github.com/aws/karpenter/test/pkg/environment/aws"
 )
 
 var env *aws.Environment
-var customAMI string
+var amdAMI string
 
 func TestDrift(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -70,7 +71,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 	var nodeTemplate *v1alpha1.AWSNodeTemplate
 	var provisioner *v1alpha5.Provisioner
 	BeforeEach(func() {
-		customAMI = env.GetCustomAMI("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", 1)
+		amdAMI = env.GetCustomAMI("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", 1)
 		nodeTemplate = awstest.AWSNodeTemplate(v1alpha1.AWSNodeTemplateSpec{AWS: v1alpha1.AWS{
 			SecurityGroupSelector: map[string]string{"karpenter.sh/discovery": env.ClusterName},
 			SubnetSelector:        map[string]string{"karpenter.sh/discovery": env.ClusterName},
@@ -106,12 +107,40 @@ var _ = Describe("Drift", Label("AWS"), func() {
 
 		machine := env.EventuallyExpectCreatedMachineCount("==", 1)[0]
 		node := env.EventuallyExpectNodeCount("==", 1)[0]
-		nodeTemplate.Spec.AMISelector = map[string]string{"aws-ids": customAMI}
+		nodeTemplate.Spec.AMISelector = map[string]string{"aws-ids": amdAMI}
 		env.ExpectCreatedOrUpdated(nodeTemplate)
 
 		Eventually(func(g Gomega) {
 			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
 			g.Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).ToNot(BeNil())
+			g.Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue()).To(BeTrue())
+		}).Should(Succeed())
+
+		delete(pod.Annotations, v1alpha5.DoNotEvictPodAnnotationKey)
+		env.ExpectUpdated(pod)
+		env.EventuallyExpectNotFound(pod, machine, node)
+	})
+	It("should return drifted if the AMI no longer matches the existing machine instance type", func() {
+		armParameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
+			Name: awssdk.String("/aws/service/eks/optimized-ami/1.28/amazon-linux-2-arm64/recommended/image_id"),
+		})
+		Expect(err).To(BeNil())
+		armAMI := *armParameter.Parameter.Value
+		nodeTemplate.Spec.AMIFamily = &v1alpha1.AMIFamilyAL2
+		nodeTemplate.Spec.AMISelector = map[string]string{"aws-ids": armAMI}
+		provisioner.Spec.Requirements = append(provisioner.Spec.Requirements, v1.NodeSelectorRequirement{Key: v1.LabelArchStable, Operator: v1.NodeSelectorOpExists})
+
+		env.ExpectCreated(pod, nodeTemplate, provisioner)
+		env.EventuallyExpectHealthy(pod)
+		env.ExpectCreatedNodeCount("==", 1)
+
+		machine := env.EventuallyExpectCreatedMachineCount("==", 1)[0]
+		node := env.EventuallyExpectNodeCount("==", 1)[0]
+		nodeTemplate.Spec.AMISelector = map[string]string{"aws-ids": amdAMI}
+		env.ExpectCreatedOrUpdated(nodeTemplate)
+
+		Eventually(func(g Gomega) {
+			g.Expect(env.Client.Get(env, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
 			g.Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue()).To(BeTrue())
 		}).Should(Succeed())
 
@@ -136,7 +165,7 @@ var _ = Describe("Drift", Label("AWS"), func() {
 		env.ExpectCreatedNodeCount("==", 1)
 
 		node := env.Monitor.CreatedNodes()[0]
-		nodeTemplate.Spec.AMISelector = map[string]string{"aws-ids": customAMI}
+		nodeTemplate.Spec.AMISelector = map[string]string{"aws-ids": amdAMI}
 		env.ExpectUpdated(nodeTemplate)
 
 		// We should consistently get the same node existing for a minute


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Incompatible requirements of instance types on AMIS causing drift not to occur

**How was this change tested?**
- `make test`
- E2E tests are run locally 

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.