### PR TITLE
ci: Add cleanup and region parameters to workflow runs

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
   eksctl_version:
     description: "Version of eksctl to install"
-    default: v0.160.0-rc.0
+    default: v0.163.0
 runs:
   using: "composite"
   steps:

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -19,7 +19,7 @@ inputs:
     default: "1.28"
   eksctl_version:
     description: "Version of eksctl to install"
-    default: v0.160.0-rc.0
+    default: v0.163.0
   ip_family:
     description: "IP Family of the cluster. Valid values are IPv4 or IPv6"
     required: false

--- a/.github/workflows/e2e-cleanup.yaml
+++ b/.github/workflows/e2e-cleanup.yaml
@@ -1,0 +1,30 @@
+name: E2ECleanup
+on:
+  workflow_dispatch:
+    inputs:
+      cluster_name:
+        type: string
+        required: true
+      git_ref:
+        type: string
+      region:
+        type: choice
+        options:
+          - "us-east-1"
+          - "us-east-2"
+          - "us-west-2"
+          - "eu-west-1"
+jobs:
+  cleanup:
+    name: cleanup-${{ inputs.cluster_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: cleanup karpenter and cluster '${{ inputs.cluster-name }}' resources
+        uses: ./.github/actions/e2e/cleanup
+        with:
+          account_id: ${{ vars.ACCOUNT_ID }}
+          role: ${{ vars.ROLE_NAME }}
+          region: ${{ inputs.region }}
+          cluster_name: ${{ inputs.cluster_name }}
+          git_ref: ${{ inputs.git_ref }}
+          eksctl_version: v0.163.0

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -8,6 +8,17 @@ on:
     workflows: [ApprovalComment]
     types: [completed]
   workflow_dispatch:
+    region:
+      required: true
+      default: 'us-west-2'
+      type: choice
+      options:
+        - 'us-west-2'
+        - 'us-east-1'
+    cleanup:
+      required: true
+      default: true
+      type: boolean
 jobs:
   resolve:
     if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
@@ -20,6 +31,8 @@ jobs:
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
+      region: ${{ inputs.region || 'us-west-2' }}
       workflow_trigger: "matrix"
+      cleanup: ${{ inputs.cleanup || true }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -10,11 +10,11 @@ on:
   workflow_dispatch:
     region:
       required: true
-      default: 'us-west-2'
+      default: 'us-east-2'
       type: choice
       options:
-        - 'us-west-2'
-        - 'us-east-1'
+        - "us-east-1"
+        - "us-east-2"
     cleanup:
       required: true
       default: true
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
-      region: ${{ inputs.region || 'us-west-2' }}
+      region: ${{ inputs.region || 'us-east-2' }}
       workflow_trigger: "matrix"
       cleanup: ${{ inputs.cleanup || true }}
     secrets:

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -10,7 +10,11 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.160.0-rc.0
+        default: v0.163.0
+      cleanup:
+        type: boolean
+        required: true
+        default: true
       git_ref:
         type: string
       workflow_trigger:
@@ -39,7 +43,11 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.160.0-rc.0
+        default: v0.163.0
+      cleanup:
+        type: boolean
+        required: true
+        default: true
 # All jobs will run under the following conditions:
 #   1. Upstream Karpenter repo triggered the job by schedule, push, or dispatch
 #   2. Upstream Karpenter repo triggered the job by workflow_run, which requires maintainer check to succeed
@@ -73,6 +81,7 @@ jobs:
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}
       eksctl_version: ${{ inputs.eksctl_version }}
+      cleanup: ${{ inputs.cleanup }}
       workflow_trigger: ${{ inputs.workflow_trigger }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -87,6 +96,7 @@ jobs:
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}
       eksctl_version: ${{ inputs.eksctl_version }}
+      cleanup: ${{ inputs.cleanup }}
       workflow_trigger: ${{ inputs.workflow_trigger }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -8,9 +8,6 @@ on:
       k8s_version:
         type: string
         default: "1.28"
-      eksctl_version:
-        type: string
-        default: v0.163.0
       cleanup:
         type: boolean
         required: true
@@ -28,8 +25,10 @@ on:
       region:
         type: choice
         options:
+          - "us-east-1"
           - "us-east-2"
           - "us-west-2"
+          - "eu-west-1"
         default: "us-east-2"
       k8s_version:
         type: choice
@@ -41,9 +40,6 @@ on:
           - "1.27"
           - "1.28"
         default: "1.28"
-      eksctl_version:
-        type: string
-        default: v0.163.0
       cleanup:
         type: boolean
         required: true
@@ -80,7 +76,6 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}
-      eksctl_version: ${{ inputs.eksctl_version }}
       cleanup: ${{ inputs.cleanup }}
       workflow_trigger: ${{ inputs.workflow_trigger }}
     secrets:
@@ -95,7 +90,6 @@ jobs:
       to_git_ref: ${{ inputs.git_ref }}
       region: ${{ inputs.region }}
       k8s_version: ${{ inputs.k8s_version }}
-      eksctl_version: ${{ inputs.eksctl_version }}
       cleanup: ${{ inputs.cleanup }}
       workflow_trigger: ${{ inputs.workflow_trigger }}
     secrets:

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -12,8 +12,8 @@ on:
         default: 'us-west-2'
         type: choice
         options:
-          - 'us-west-2'
-          - 'us-east-1'
+          - "us-east-1"
+          - "us-west-2"
       cleanup:
         required: true
         default: true

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -6,6 +6,22 @@ on:
     workflows: [ApprovalComment]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      region:
+        required: true
+        default: 'us-west-2'
+        type: choice
+        options:
+          - 'us-west-2'
+          - 'us-east-1'
+      cleanup:
+        required: true
+        default: true
+        type: boolean
+      enable_metrics:
+        required: true
+        default: false
+        type: boolean
 jobs:
   resolve:
     if: (github.repository == 'aws/karpenter' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')) || github.event_name == 'workflow_dispatch'
@@ -19,8 +35,9 @@ jobs:
     with:
       suite: Scale
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
-      region: "us-west-2"
-      enable_metrics: true
+      region: ${{ inputs.region || 'us-west-2' }}
+      enable_metrics: ${{ inputs.enable_metrics || true }}
       workflow_trigger: "scale"
+      cleanup: ${{ inputs.cleanup || true }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -25,7 +25,11 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.160.0-rc.0
+        default: v0.163.0
+      cleanup:
+        required: true
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       from_git_ref:
@@ -41,7 +45,11 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.160.0-rc.0
+        default: v0.163.0
+      cleanup:
+        required: true
+        default: true
+        type: boolean
       workflow_trigger:
         type: string
     secrets:
@@ -172,7 +180,7 @@ jobs:
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
       - name: cleanup karpenter and cluster '${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}' resources
         uses: ./.github/actions/e2e/cleanup
-        if: always()
+        if: always() && inputs.cleanup
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -23,9 +23,6 @@ on:
           - "1.27"
           - "1.28"
         default: "1.28"
-      eksctl_version:
-        type: string
-        default: v0.163.0
       cleanup:
         required: true
         default: true
@@ -43,9 +40,6 @@ on:
       k8s_version:
         type: string
         default: "1.28"
-      eksctl_version:
-        type: string
-        default: v0.163.0
       cleanup:
         required: true
         default: true
@@ -95,7 +89,7 @@ jobs:
           region: ${{ inputs.region }}
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
           k8s_version: ${{ inputs.k8s_version }}
-          eksctl_version: ${{ inputs.eksctl_version }}
+          eksctl_version: v0.163.0
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.from_git_ref }}
       - name: install prometheus
@@ -128,7 +122,7 @@ jobs:
           region: ${{ inputs.region }}
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
           k8s_version: ${{ inputs.k8s_version }}
-          eksctl_version: ${{ inputs.eksctl_version }}
+          eksctl_version: v0.163.0
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.to_git_ref }}
       - name: upgrade prometheus
@@ -187,7 +181,7 @@ jobs:
           region: ${{ inputs.region }}
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
           git_ref: ${{ inputs.to_git_ref }}
-          eksctl_version: ${{ inputs.eksctl_version }}
+          eksctl_version: v0.163.0
       - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/end
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,6 +7,7 @@ on:
       region:
         type: choice
         options:
+          - "us-east-1"
           - "us-east-2"
           - "us-west-2"
           - "eu-west-1"
@@ -43,9 +44,6 @@ on:
           - "1.27"
           - "1.28"
         default: "1.28"
-      eksctl_version:
-        type: string
-        default: v0.163.0
       enable_metrics:
         type: boolean
         default: false
@@ -66,9 +64,6 @@ on:
       k8s_version:
         type: string
         default: "1.28"
-      eksctl_version:
-        type: string
-        default: v0.163.0
       enable_metrics:
         type: boolean
         default: false
@@ -121,7 +116,7 @@ jobs:
           region: ${{ inputs.region }}
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
           k8s_version: ${{ inputs.k8s_version }}
-          eksctl_version: ${{ inputs.eksctl_version }}
+          eksctl_version: v0.163.0
           ip_family: ${{ contains(inputs.suite, 'IPv6') && 'IPv6' || 'IPv4' }} # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.git_ref }}
       - name: install prometheus
@@ -174,7 +169,7 @@ jobs:
           region: ${{ inputs.region }}
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
           git_ref: ${{ inputs.git_ref }}
-          eksctl_version: ${{ inputs.eksctl_version }}
+          eksctl_version: v0.163.0
       - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/end
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,10 +45,14 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.160.0-rc.0
+        default: v0.163.0
       enable_metrics:
         type: boolean
         default: false
+      cleanup:
+        type: boolean
+        required: true
+        default: true
   workflow_call:
     inputs:
       git_ref:
@@ -64,10 +68,14 @@ on:
         default: "1.28"
       eksctl_version:
         type: string
-        default: v0.160.0-rc.0
+        default: v0.163.0
       enable_metrics:
         type: boolean
         default: false
+      cleanup:
+        type: boolean
+        required: true
+        default: true
       workflow_trigger:
         type: string
     secrets:
@@ -159,7 +167,7 @@ jobs:
           cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
       - name: cleanup karpenter and cluster '${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}' resources
         uses: ./.github/actions/e2e/cleanup
-        if: always()
+        if: always() && inputs.cleanup
         with:
           account_id: ${{ vars.ACCOUNT_ID }}
           role: ${{ vars.ROLE_NAME }}

--- a/test/cloudformation/iam_cloudformation.yaml
+++ b/test/cloudformation/iam_cloudformation.yaml
@@ -9,7 +9,7 @@ Parameters:
     Description: "The restrictions on which branches have permission to reach out to the OIDC provider. This is useful for security hardening of your github actions as described in https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
   Regions:
     Type: CommaDelimitedList
-    Default: "us-east-2,us-west-2,eu-west-1"
+    Default: "us-east-1,us-east-2,us-west-2,eu-west-1"
   PrometheusWorkspaceID:
     Type: String
     Description: "Prometheus workspace to forward cluster prometheus metrics to"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Adds the ability to run workflows in different regions as well as a mechanism to disable cluster cleanup for runs

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.