### PR TITLE
chore: Not allowing empty role to be set on EC2NodeClass

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -272,6 +272,8 @@ spec:
                   profiles on an update.
                 type: string
                 x-kubernetes-validations:
+                - message: role cannot be empty
+                  rule: self != ''
                 - message: immutable field changed
                   rule: self == oldSelf
               securityGroupSelectorTerms:

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -61,6 +61,7 @@ type EC2NodeClassSpec struct {
 	// Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
 	// This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
 	// for the old instance profiles on an update.
+	// +kubebuilder:validation:XValidation:rule="self != ''",message="role cannot be empty"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="immutable field changed"
 	// +required
 	Role string `json:"role"`

--- a/pkg/apis/v1beta1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation_cel_test.go
@@ -41,6 +41,7 @@ var _ = Describe("CEL/Validation", func() {
 		nc = &v1beta1.EC2NodeClass{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
 			Spec: v1beta1.EC2NodeClassSpec{
+				Role:      "test-role",
 				AMIFamily: &v1beta1.AMIFamilyAL2,
 				SubnetSelectorTerms: []v1beta1.SubnetSelectorTerm{
 					{
@@ -703,6 +704,10 @@ var _ = Describe("CEL/Validation", func() {
 		})
 	})
 	Context("Role Immutability", func() {
+		It("should fail if role is not defined", func() {
+			nc.Spec.Role = ""
+			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
+		})
 		It("should fail when updating the role", func() {
 			nc.Spec.Role = "test-role"
 			Expect(env.Client.Create(ctx, nc)).To(Succeed())


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Should not allow empty role to be set on a EC2NodeClass

**How was this change tested?**
- `make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.