### PR TITLE
ci: Fix cleanup permissions and configure credentials

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -21,12 +21,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v4.0.1
-      with:
-        role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.role }}
-        aws-region: ${{ inputs.region }}
-        role-duration-seconds: 21600
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.git_ref }}

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -30,12 +30,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: configure aws credentials
-    uses: aws-actions/configure-aws-credentials@v4.0.1
-    with:
-      role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.role }}
-      aws-region: ${{ inputs.region }}
-      role-duration-seconds: 21600
   - uses: actions/checkout@v4
     with:
       ref: ${{ inputs.git_ref }}

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -24,12 +24,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: configure aws credentials
-    uses: aws-actions/configure-aws-credentials@v4.0.1
-    with:
-      role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/${{ inputs.role }}
-      aws-region: ${{ inputs.region }}
-      role-duration-seconds: 21600
   - uses: actions/checkout@v4
     with:
       ref: ${{ inputs.git_ref }}

--- a/.github/workflows/e2e-cleanup.yaml
+++ b/.github/workflows/e2e-cleanup.yaml
@@ -14,6 +14,8 @@ on:
           - "us-east-2"
           - "us-west-2"
           - "eu-west-1"
+permissions:
+  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   cleanup:
     name: cleanup-${{ inputs.cluster_name }}
@@ -22,6 +24,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git_ref }}
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.ACCOUNT_ID }}:role/${{ vars.ROLE_NAME }}
+          aws-region: ${{ inputs.region }}
+          role-duration-seconds: 21600
       - name: cleanup karpenter and cluster '${{ inputs.cluster_name }}' resources
         uses: ./.github/actions/e2e/cleanup
         with:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change ensures that the E2ECleanup workflow has permissions to use the OpenID connect token as well as configures credentials to talk to the AWS test account.

This also drops configuring credentials in composite actions in favor of having the credentials configured once at the workflow level.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.