### PR TITLE
chore: Error on `spec.launchTemplate` for `karpenter-convert`

### DIFF
--- a/tools/karpenter-convert/cmd/karpenter-convert/main.go
+++ b/tools/karpenter-convert/cmd/karpenter-convert/main.go
@@ -30,6 +30,5 @@ func main() {
 	kubeConfigFlags := genericclioptions.NewConfigFlags(false).WithDeprecatedPasswordFlag()
 	f := cmdutil.NewFactory(kubeConfigFlags)
 	cmd := convert.NewCmd(f, genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
-	code := cli.Run(cmd)
-	os.Exit(code)
+	os.Exit(cli.Run(cmd))
 }

--- a/tools/karpenter-convert/pkg/convert/convert.go
+++ b/tools/karpenter-convert/pkg/convert/convert.go
@@ -52,7 +52,7 @@ type Context struct {
 	PrintFlags *genericclioptions.PrintFlags
 	Printer    printers.ResourcePrinter
 
-	builder func() *resource.Builder
+	Builder func() *resource.Builder
 
 	resource.FilenameOptions
 	genericiooptions.IOStreams
@@ -65,7 +65,6 @@ func NewCmd(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Comm
 		PrintFlags: genericclioptions.NewPrintFlags("converted").WithDefaultOutput("yaml"),
 		IOStreams:  ioStreams,
 	}
-
 	var rootCmd = &cobra.Command{
 		Use: "karpenter-convert",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -73,13 +72,11 @@ func NewCmd(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Comm
 			cmdutil.CheckErr(o.RunConvert())
 		},
 	}
-
 	rootCmd.Flags().BoolVar(&o.IgnoreDefaults, "ignore-defaults", o.IgnoreDefaults, "Ignore defining default requirements when migrating Provisioners to NodePool.")
 	cmdutil.AddJsonFilenameFlag(rootCmd.Flags(), &o.Filenames, "Filename, directory, or URL to files to need to get converted.")
 	rootCmd.Flags().BoolVarP(&o.Recursive, "recursive", "R", o.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 
 	o.PrintFlags.AddFlags(rootCmd)
-
 	return rootCmd
 }
 
@@ -87,8 +84,7 @@ func (o *Context) Complete(f cmdutil.Factory, _ *cobra.Command) (err error) {
 	if len(o.Filenames) == 0 {
 		return fmt.Errorf("must specify -f")
 	}
-
-	o.builder = f.NewBuilder
+	o.Builder = f.NewBuilder
 	o.Printer, err = o.PrintFlags.ToPrinter()
 	return err
 }
@@ -103,7 +99,7 @@ func (o *Context) RunConvert() error {
 		return err
 	}
 
-	b := o.builder().
+	b := o.Builder().
 		WithScheme(scheme, v1alpha1.SchemeGroupVersion, corev1alpha5.SchemeGroupVersion).
 		LocalParam(true)
 
@@ -114,13 +110,7 @@ func (o *Context) RunConvert() error {
 		Do().
 		IgnoreErrors(func(err error) bool {
 			regexPattern := `no kind ".*" is registered for version`
-			regex := regexp.MustCompile(regexPattern)
-			if regex.MatchString(err.Error()) {
-				fmt.Fprintln(o.IOStreams.ErrOut, "#warning:", err.Error())
-				return true
-			}
-
-			return false
+			return regexp.MustCompile(regexPattern).MatchString(err.Error())
 		})
 
 	err := r.Err()
@@ -142,23 +132,18 @@ func (o *Context) RunConvert() error {
 		if info.Object == nil {
 			continue
 		}
-
 		obj, err := convert(info.Object, o)
 		if err != nil {
-			fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
-		} else {
-			var buffer bytes.Buffer
-			writer := io.Writer(&buffer)
-
-			if err := o.Printer.PrintObj(obj, writer); err != nil {
-				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
-			}
-
-			output := dropFields(buffer)
-
-			if _, err := o.Out.Write([]byte(output)); err != nil {
-				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
-			}
+			return err
+		}
+		var buffer bytes.Buffer
+		writer := io.Writer(&buffer)
+		if err = o.Printer.PrintObj(obj, writer); err != nil {
+			return err
+		}
+		output := dropFields(buffer)
+		if _, err = o.Out.Write([]byte(output)); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -191,7 +176,7 @@ func convertNodeTemplate(resource runtime.Object) (runtime.Object, error) {
 	nodetemplate := resource.(*v1alpha1.AWSNodeTemplate)
 
 	if nodetemplate.Spec.LaunchTemplateName != nil {
-		return nil, fmt.Errorf(`cannot convert AWSNodeTemplate with "spec.launchTemplateName"`)
+		return nil, fmt.Errorf(`cannot convert AWSNodeTemplate with "spec.launchTemplate"`)
 	}
 
 	// If the AMIFamily wasn't specified, then we know that it should be AL2 for the conversion

--- a/tools/karpenter-convert/pkg/convert/convert_test.go
+++ b/tools/karpenter-convert/pkg/convert/convert_test.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/printers"
 
 	"github.com/aws/karpenter/tools/karpenter-convert/pkg/convert"
 
@@ -37,103 +37,117 @@ func TestConvert(t *testing.T) {
 	RunSpecs(t, "Karpenter-Convert")
 }
 
-var _ = Describe("ConvertObject", func() {
-	type testcase struct {
-		name           string
-		ignoreDefaults bool
-		file           string
-		outputFile     string
-	}
-
-	DescribeTable("conversion tests",
-		func(tc testcase) {
-			tf := cmdtesting.NewTestFactory().WithNamespace("test")
-			defer tf.Cleanup()
-
-			tf.UnstructuredClient = &fake.RESTClient{
-				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					Fail(fmt.Sprintf("unexpected request: %#v\n%#v", req.URL, req))
-					return nil, nil
-				}),
-			}
-
-			buf := bytes.NewBuffer([]byte{})
-			cmd := convert.NewCmd(tf, genericiooptions.IOStreams{Out: buf, ErrOut: buf})
-			if err := cmd.Flags().Set("filename", tc.file); err != nil {
-				Expect(err).To(BeNil())
-			}
-			if err := cmd.Flags().Set("output", "yaml"); err != nil {
-				Expect(err).To(BeNil())
-			}
-			if err := cmd.Flags().Set("ignore-defaults", strconv.FormatBool(tc.ignoreDefaults)); err != nil {
-				Expect(err).To(BeNil())
-			}
-
-			cmd.Run(cmd, []string{})
-
-			bytes, _ := os.ReadFile(tc.outputFile)
+var _ = Describe("Convert", func() {
+	var buf *bytes.Buffer
+	var context convert.Context
+	BeforeEach(func() {
+		tf := cmdtesting.NewTestFactory().WithNamespace("test")
+		defer tf.Cleanup()
+		tf.UnstructuredClient = &fake.RESTClient{
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				Fail(fmt.Sprintf("unexpected request: %#v\n%#v", req.URL, req))
+				return nil, nil
+			}),
+		}
+		buf = bytes.NewBuffer([]byte{})
+		context = convert.Context{
+			IOStreams: genericiooptions.IOStreams{Out: buf, ErrOut: buf},
+			Builder:   tf.NewBuilder,
+			Printer:   &printers.YAMLPrinter{},
+		}
+	})
+	DescribeTable("Conversion",
+		func(inputFile, outputFile string, ignoreDefaults bool) {
+			context.FilenameOptions.Filenames = []string{inputFile}
+			context.IgnoreDefaults = ignoreDefaults
+			Expect(context.RunConvert()).To(Succeed())
+			bytes, _ := os.ReadFile(outputFile)
 			content := string(bytes)
-
-			Expect(buf.String()).To(Equal(content), fmt.Sprintf("unexpected output when converting %s to %q, expected: %q, but got %q", tc.file, tc.outputFile, content, buf.String()))
+			Expect(buf.String()).To(Equal(content))
 		},
-
 		Entry("provisioner to nodepool",
-			testcase{
-				name:       "provisioner to nodepool",
-				file:       "./testdata/provisioner.yaml",
-				outputFile: "./testdata/nodepool.yaml",
-			},
+			"./testdata/provisioner.yaml",
+			"./testdata/nodepool.yaml",
+			false,
 		),
-
 		Entry("provisioner (set defaults) to nodepool",
-			testcase{
-				name:           "provisioner to nodepool",
-				file:           "./testdata/provisioner_defaults.yaml",
-				outputFile:     "./testdata/nodepool_defaults.yaml",
-				ignoreDefaults: false,
-			},
+			"./testdata/provisioner_defaults.yaml",
+			"./testdata/nodepool_defaults.yaml",
+			false,
 		),
-
 		Entry("provisioner (no set defaults) to nodepool",
-			testcase{
-				name:           "provisioner to nodepool",
-				file:           "./testdata/provisioner_no_defaults.yaml",
-				outputFile:     "./testdata/nodepool_no_defaults.yaml",
-				ignoreDefaults: true,
-			},
+			"./testdata/provisioner_no_defaults.yaml",
+			"./testdata/nodepool_no_defaults.yaml",
+			true,
 		),
-
 		Entry("provisioner (kubectl output) to nodepool",
-			testcase{
-				name:           "provisioner to nodepool",
-				file:           "./testdata/provisioner_kubectl_output.yaml",
-				outputFile:     "./testdata/nodepool_kubectl_output.yaml",
-				ignoreDefaults: true,
-			},
+			"./testdata/provisioner_kubectl_output.yaml",
+			"./testdata/nodepool_kubectl_output.yaml",
+			true,
 		),
-
 		Entry("nodetemplate to nodeclass",
-			testcase{
-				name:       "nodetemplate to nodeclass",
-				file:       "./testdata/nodetemplate.yaml",
-				outputFile: "./testdata/nodeclass.yaml",
-			},
+			"./testdata/nodetemplate.yaml",
+			"./testdata/nodeclass.yaml",
+			false,
 		),
-
 		Entry("nodetemplate (empty amifamily) to nodeclass",
-			testcase{
-				name:       "nodetemplate (empty amifamily) to nodeclass",
-				file:       "./testdata/nodetemplate_no_amifamily.yaml",
-				outputFile: "./testdata/nodeclass_no_amifamily.yaml",
-			},
+			"./testdata/nodetemplate_no_amifamily.yaml",
+			"./testdata/nodeclass_no_amifamily.yaml",
+			false,
 		),
-
 		Entry("nodetemplate (kubectl output) to nodeclass",
-			testcase{
-				name:       "nodetemplate to nodeclass",
-				file:       "./testdata/nodetemplate_kubectl_output.yaml",
-				outputFile: "./testdata/nodeclass_kubectl_output.yaml",
-			},
+			"./testdata/nodetemplate_kubectl_output.yaml",
+			"./testdata/nodeclass_kubectl_output.yaml",
+			false,
 		),
 	)
+	It("should error when converting an AWSNodeTemplate with launchTemplateName", func() {
+		context.FilenameOptions.Filenames = []string{"./testdata/nodetemplate_launch_template_name.yaml"}
+		err := context.RunConvert()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(`cannot convert AWSNodeTemplate with "spec.launchTemplate"`))
+	})
+	It("should ignore errors when converting an unknown kind alongside a valid kind", func() {
+		context.FilenameOptions.Filenames = []string{"./testdata/unknown_kind.yaml", "./testdata/provisioner.yaml"}
+		err := context.RunConvert()
+		Expect(err).To(Succeed())
+
+		bytes, _ := os.ReadFile("./testdata/nodepool.yaml")
+		content := string(bytes)
+		Expect(buf.String()).To(Equal(content))
+	})
+})
+
+var _ = Describe("CLI Flags", func() {
+	var tf *cmdtesting.TestFactory
+	var buf *bytes.Buffer
+	BeforeEach(func() {
+		tf = cmdtesting.NewTestFactory().WithNamespace("test")
+		defer tf.Cleanup()
+		tf.UnstructuredClient = &fake.RESTClient{
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				Fail(fmt.Sprintf("unexpected request: %#v\n%#v", req.URL, req))
+				return nil, nil
+			}),
+		}
+		buf = bytes.NewBuffer([]byte{})
+	})
+	It("should succeed to pass the file option", func() {
+		cmd := convert.NewCmd(tf, genericiooptions.IOStreams{Out: buf, ErrOut: buf})
+		Expect(cmd.Flags().Set("filename", "./testdata/provisioner.yaml")).To(Succeed())
+		cmd.Run(nil, nil)
+		bytes, _ := os.ReadFile("./testdata/nodepool.yaml")
+		content := string(bytes)
+		Expect(buf.String()).To(Equal(content))
+	})
+	It("should succeed to pass the ignore-defaults option", func() {
+		cmd := convert.NewCmd(tf, genericiooptions.IOStreams{Out: buf, ErrOut: buf})
+		Expect(cmd.Flags().Set("filename", "./testdata/provisioner_no_defaults.yaml")).To(Succeed())
+		Expect(cmd.Flags().Set("ignore-defaults", "true")).To(Succeed())
+		cmd.Run(nil, nil)
+		bytes, _ := os.ReadFile("./testdata/nodepool_no_defaults.yaml")
+		content := string(bytes)
+		Expect(buf.String()).To(Equal(content))
+		fmt.Println(buf.String())
+	})
 })

--- a/tools/karpenter-convert/pkg/convert/testdata/nodetemplate_launch_template_name.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/nodetemplate_launch_template_name.yaml
@@ -1,0 +1,8 @@
+apiVersion: karpenter.k8s.aws/v1alpha1
+kind: AWSNodeTemplate
+metadata:
+  name: default
+spec:
+  subnetSelector:
+    karpenter.sh/discovery: $MY_CLUSTER_NAME
+  launchTemplate: my-custom-launch-template

--- a/tools/karpenter-convert/pkg/convert/testdata/unknown_kind.yaml
+++ b/tools/karpenter-convert/pkg/convert/testdata/unknown_kind.yaml
@@ -1,0 +1,7 @@
+apiVersion: test.sh/v1
+kind: Test
+metadata:
+  name: default
+spec:
+  testKey: testValue
+  testKey2: testValue2


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Throw an error to the user of `karpenter-convert` when trying to convert an `AWSNodeTemplate` with a `spec.launchTemplate` since this conversion is currently unsupported

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.