### PR TITLE
feat: make karpenter-global-settings ConfigMap management optional

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,2 @@
+# See https://github.com/helm/chart-testing#configuration
+target-branch: main

--- a/.github/workflows/ci-test-chart.yaml
+++ b/.github/workflows/ci-test-chart.yaml
@@ -3,7 +3,7 @@ name: helm chart
 on:
   pull_request:
     paths:
-      - charts
+      - charts/**
 
 jobs:
   lint:

--- a/.github/workflows/ci-test-chart.yaml
+++ b/.github/workflows/ci-test-chart.yaml
@@ -1,0 +1,36 @@
+name: helm chart
+
+on:
+  pull_request:
+    paths:
+      - charts
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.12.0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config .github/ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config .github/ct.yaml

--- a/charts/karpenter/Chart.yaml
+++ b/charts/karpenter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: karpenter
 description: A Helm chart for Karpenter, an open-source node provisioning project built for Kubernetes.
 type: application
-version: 0.31.0
+version: 0.32.0
 appVersion: 0.31.0
 keywords:
   - cluster

--- a/charts/karpenter/ci/configmap-disabled-values.yaml
+++ b/charts/karpenter/ci/configmap-disabled-values.yaml
@@ -1,0 +1,1 @@
+manageConfigMap: false

--- a/charts/karpenter/templates/configmap.yaml
+++ b/charts/karpenter/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.manageConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -58,4 +59,4 @@ data:
 {{- with .Values.settings.featureGates.driftEnabled }}
   featureGates.driftEnabled: "{{ . }}"
 {{- end }}
-
+{{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -164,6 +164,10 @@ logConfig:
     controller: debug
     # -- Error log level, defaults to 'error'
     webhook: error
+
+# -- Set this to false if you want to manage the ConfigMap separately from this chart
+manageConfigMap: true
+
 # -- Global Settings to configure Karpenter
 settings:
   # -- AWS-specific settings (Deprecated: The AWS block inside of settings was flattened into settings)

--- a/website/content/en/docs/concepts/settings.md
+++ b/website/content/en/docs/concepts/settings.md
@@ -29,7 +29,9 @@ There are two main configuration mechanisms that can be used to configure Karpen
 
 ## ConfigMap
 
-Karpenter installs a default configuration via its Helm chart that should work for most.  Additional configuration can be performed by editing the `karpenter-global-settings` configmap within the namespace that Karpenter was installed in.
+Karpenter installs a default configuration via its Helm chart that should work for most. Additional configuration can be performed by editing the `karpenter-global-settings` configmap within the namespace that Karpenter was installed in.
+
+If you want to manage the ConfigMap separately from the helm chart, set `manageConfigMap: false` in the helm values. This can be useful to e.g. manage the IAM roles, the corresponding ServiceAccount and the ConfigMap with tools like terraform or pulumi.
 
 ```yaml
 apiVersion: v1

--- a/website/content/en/docs/contributing/development-guide.md
+++ b/website/content/en/docs/contributing/development-guide.md
@@ -40,6 +40,14 @@ make apply # Install Karpenter
 make delete # Uninstall Karpenter
 ```
 
+#### Helm chart testing
+
+Linting and testing of the helm charts is performed for all Pull Requests.
+
+If you're adding new functionality or fixing a templating issue, consider adding a new templating/installation test in the `ci` directory of the chart.
+
+_Note_: Values files for the ci **must** have the `-values.yaml` suffix in the filename for the chart-testing tool to use them.
+
 ### Developer Loop
 
 * Make sure dependencies are installed
@@ -106,8 +114,8 @@ stern -n karpenter -l app.kubernetes.io/name=karpenter
 ### AWS
 
 For local development on Karpenter you will need a Docker repo which can manage your images for Karpenter components.
-You can use the following command to provision an ECR repository. We recommend using a single "dev" repository for 
-development across multiple projects, and to use specific image hashes instead of image tags. 
+You can use the following command to provision an ECR repository. We recommend using a single "dev" repository for
+development across multiple projects, and to use specific image hashes instead of image tags.
 
 ```bash
 aws ecr create-repository \


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Relates to #2893

**Description**

This enables management of the ConfigMap outside of this chart, which is needed when e.g. managing the EKS cluster with terraform to be able to set the cluster name without manually syncing configuration files.

**How was this change tested?**

- Ran `helm template` locally to verify
- Added workflow using the **chart-testing** tool to lint the charts

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.