### PR TITLE
ci: Limit parallelism for `E2EVersionCompatibilityTrigger`

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -16,6 +16,8 @@ on:
       workflow_trigger:
         type: string
         required: true
+      parallelism:
+        type: number
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
@@ -51,6 +53,7 @@ jobs:
   e2e:
     strategy:
       fail-fast: false
+      max-parallel: ${{ inputs.parallelism || 100 }}
       matrix:
         suite:
           - Beta/Integration

--- a/.github/workflows/e2e-version-compatibility-trigger.yaml
+++ b/.github/workflows/e2e-version-compatibility-trigger.yaml
@@ -39,5 +39,6 @@ jobs:
       workflow_trigger: "versionCompatibility"
       # Default to true unless using a workflow_dispatch
       cleanup: ${{ github.event_name != 'workflow_dispatch' && true || inputs.cleanup }}
+      parallelism: 2
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- E2EVersionCompatibilityTrigger is getting throttled on cluster creation. To prevent test failure, the E2E test will be limited to run two suites are a time for each k8s version. 
- https://github.com/aws/karpenter/actions/runs/6686719803

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.