### PR TITLE
ci: Pin helm version for `release.yaml`

### DIFF
--- a/.github/actions/e2e/install-helm/action.yaml
+++ b/.github/actions/e2e/install-helm/action.yaml
@@ -10,9 +10,10 @@ runs:
     - name: install helm
       shell: bash
       run: |
-        curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-        chmod 700 get_helm.sh
-        ./get_helm.sh --version ${{ inputs.version }}
+        TEMPDIR=$(mktemp -d)
+        curl -fsSL -o "${TEMPDIR}/get_helm.sh" https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+        chmod 700 "${TEMPDIR}/get_helm.sh"
+        "${TEMPDIR}/get_helm.sh" --version ${{ inputs.version }}
     - name: install helm-diff
       shell: bash
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,9 @@ jobs:
           TAG="$(git describe --tags --exact-match)"
           echo TAG="${TAG}" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/install-deps
+      - uses: ./.github/actions/e2e/install-helm
+        with:
+          version: v3.12.3 # Pinned to this version since v3.13.0 has issues with pushing to public ECR: https://github.com/helm/helm/issues/12442
       - uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: 'arn:aws:iam::${{ vars.ECR_ACCOUNT_ID }}:role/${{ vars.ECR_RELEASE_ROLE_NAME }}'


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Pins helm version to `v3.12.3` in the release process since the ubuntu version used by GHA is still using a broken helm version right now (`v3.13.0`)

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.