### PR TITLE
docs: Update naming of `v0.32` metrics

### DIFF
--- a/hack/docs/metrics_gen_docs.go
+++ b/hack/docs/metrics_gen_docs.go
@@ -263,13 +263,14 @@ func getIdentMapping(identName string) (string, error) {
 		"metrics.Namespace": metrics.Namespace,
 		"Namespace":         metrics.Namespace,
 
-		"NodeSubsystem":           "nodes",
-		"metrics.NodeSubsystem":   "nodes",
-		"machineSubsystem":        "machines",
-		"nodeClaimSubsystem":      "nodeclaims",
-		"nodePoolSubsystem":       "nodepools",
+		"NodeSubsystem":         "nodes",
+		"metrics.NodeSubsystem": "nodes",
+		"machineSubsystem":      "machines",
+		"nodeClaimSubsystem":    "nodeclaims",
+		// TODO @joinnis: We should eventually change this subsystem to be
+		// plural so that it aligns with the other subsystems
+		"nodePoolSubsystem":       "nodepool",
 		"interruptionSubsystem":   "interruption",
-		"nodeTemplateSubsystem":   "nodetemplate",
 		"deprovisioningSubsystem": "deprovisioning",
 		"disruptionSubsystem":     "disruption",
 		"consistencySubsystem":    "consistency",

--- a/website/content/en/preview/reference/metrics.md
+++ b/website/content/en/preview/reference/metrics.md
@@ -130,12 +130,12 @@ Number of nodeclaims registered in total by Karpenter. Labeled by the owning nod
 ### `karpenter_nodeclaims_terminated`
 Number of nodeclaims terminated in total by Karpenter. Labeled by reason the nodeclaim was terminated and the owning nodepool.
 
-## Nodepools Metrics
+## Nodepool Metrics
 
-### `karpenter_nodepools_limit`
+### `karpenter_nodepool_limit`
 The nodepool limits are the limits specified on the provisioner that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
 
-### `karpenter_nodepools_usage`
+### `karpenter_nodepool_usage`
 The nodepool usage is the amount of resources that have been provisioned by a particular nodepool. Labeled by nodepool name and resource type.
 
 ## Provisioner Metrics

--- a/website/content/en/v0.32/reference/metrics.md
+++ b/website/content/en/v0.32/reference/metrics.md
@@ -130,12 +130,12 @@ Number of nodeclaims registered in total by Karpenter. Labeled by the owning nod
 ### `karpenter_nodeclaims_terminated`
 Number of nodeclaims terminated in total by Karpenter. Labeled by reason the nodeclaim was terminated and the owning nodepool.
 
-## Nodepools Metrics
+## Nodepool Metrics
 
-### `karpenter_nodepools_limit`
+### `karpenter_nodepool_limit`
 The nodepool limits are the limits specified on the provisioner that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
 
-### `karpenter_nodepools_usage`
+### `karpenter_nodepool_usage`
 The nodepool usage is the amount of resources that have been provisioned by a particular nodepool. Labeled by nodepool name and resource type.
 
 ## Provisioner Metrics


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates the doc that describes the metrics for v0.32.0 to align with the correct naming

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.