### PR TITLE
docs: Fix v1beta1 migration guide

### DIFF
--- a/website/content/en/docs/upgrading/v1beta1-migration.md
+++ b/website/content/en/docs/upgrading/v1beta1-migration.md
@@ -85,7 +85,6 @@ This procedure assumes you are running the Karpenter controller on cluster and w
     
     helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
       --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
-      --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
       --set settings.clusterName=${CLUSTER_NAME} \
       --set settings.interruptionQueue=${CLUSTER_NAME} \
       --set controller.resources.requests.cpu=1 \

--- a/website/content/en/preview/upgrading/v1beta1-migration.md
+++ b/website/content/en/preview/upgrading/v1beta1-migration.md
@@ -85,7 +85,6 @@ This procedure assumes you are running the Karpenter controller on cluster and w
     
     helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
       --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
-      --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
       --set settings.clusterName=${CLUSTER_NAME} \
       --set settings.interruptionQueue=${CLUSTER_NAME} \
       --set controller.resources.requests.cpu=1 \

--- a/website/content/en/v0.32/upgrading/v1beta1-migration.md
+++ b/website/content/en/v0.32/upgrading/v1beta1-migration.md
@@ -85,7 +85,6 @@ This procedure assumes you are running the Karpenter controller on cluster and w
     
     helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version ${KARPENTER_VERSION} --namespace karpenter --create-namespace \
       --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=${KARPENTER_IAM_ROLE_ARN} \
-      --set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} \
       --set settings.clusterName=${CLUSTER_NAME} \
       --set settings.interruptionQueue=${CLUSTER_NAME} \
       --set controller.resources.requests.cpu=1 \


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #4980

**Description**
The website v1beta1 upgrade guide still has `--set settings.aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME} ` in the 

**How was this change tested?**
N/A

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.