### PR TITLE
docs: Update the top-level index file

### DIFF
--- a/website/content/en/docs/_index.md
+++ b/website/content/en/docs/_index.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Documentation"
 linkTitle: "Docs"
@@ -8,19 +7,19 @@ cascade:
   tags:
     - preview
 ---
-Karpenter is an open-source node provisioning project built for Kubernetes.
+Karpenter is an open-source node lifecycle management project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.
 Karpenter works by:
 
 * **Watching** for pods that the Kubernetes scheduler has marked as unschedulable
 * **Evaluating** scheduling constraints (resource requests, nodeselectors, affinities, tolerations, and topology spread constraints) requested by the pods
 * **Provisioning** nodes that meet the requirements of the pods
-* **Removing** the nodes when the nodes are no longer needed
+* **Disrupting** the nodes when the nodes are no longer needed
 
 As someone using Karpenter, once your Kubernetes cluster and the Karpenter controller are up and running (see [Getting Started]({{<ref "./getting-started" >}})), you can:
 
-* **Set up provisioners**: By applying a provisioner to Karpenter, you can configure constraints on node provisioning and set timeout values for node expiry or Kubelet configuration values.
-Provisioner-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
+* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidastion, or Kubelet configuration values.
+  NodePool-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
 
   - Taints (`taints`): Identify taints to add to provisioned nodes. If a pod doesn't have a matching toleration for the taint, the effect set by the taint occurs (NoSchedule, PreferNoSchedule, or NoExecute). See Kubernetes [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.
   - Labels (`labels`): Apply arbitrary key-value pairs to nodes that can be matched by pods.

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -130,12 +130,12 @@ Number of nodeclaims registered in total by Karpenter. Labeled by the owning nod
 ### `karpenter_nodeclaims_terminated`
 Number of nodeclaims terminated in total by Karpenter. Labeled by reason the nodeclaim was terminated and the owning nodepool.
 
-## Nodepools Metrics
+## Nodepool Metrics
 
-### `karpenter_nodepools_limit`
+### `karpenter_nodepool_limit`
 The nodepool limits are the limits specified on the provisioner that restrict the quantity of resources provisioned. Labeled by nodepool name and resource type.
 
-### `karpenter_nodepools_usage`
+### `karpenter_nodepool_usage`
 The nodepool usage is the amount of resources that have been provisioned by a particular nodepool. Labeled by nodepool name and resource type.
 
 ## Provisioner Metrics

--- a/website/content/en/preview/_index.md
+++ b/website/content/en/preview/_index.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Documentation"
 linkTitle: "Docs"
@@ -8,19 +7,19 @@ cascade:
   tags:
     - preview
 ---
-Karpenter is an open-source node provisioning project built for Kubernetes.
+Karpenter is an open-source node lifecycle management project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.
 Karpenter works by:
 
 * **Watching** for pods that the Kubernetes scheduler has marked as unschedulable
 * **Evaluating** scheduling constraints (resource requests, nodeselectors, affinities, tolerations, and topology spread constraints) requested by the pods
 * **Provisioning** nodes that meet the requirements of the pods
-* **Removing** the nodes when the nodes are no longer needed
+* **Disrupting** the nodes when the nodes are no longer needed
 
 As someone using Karpenter, once your Kubernetes cluster and the Karpenter controller are up and running (see [Getting Started]({{<ref "./getting-started" >}})), you can:
 
-* **Set up provisioners**: By applying a provisioner to Karpenter, you can configure constraints on node provisioning and set timeout values for node expiry or Kubelet configuration values.
-Provisioner-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
+* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidastion, or Kubelet configuration values.
+  NodePool-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
 
   - Taints (`taints`): Identify taints to add to provisioned nodes. If a pod doesn't have a matching toleration for the taint, the effect set by the taint occurs (NoSchedule, PreferNoSchedule, or NoExecute). See Kubernetes [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.
   - Labels (`labels`): Apply arbitrary key-value pairs to nodes that can be matched by pods.

--- a/website/content/en/v0.32/_index.md
+++ b/website/content/en/v0.32/_index.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Documentation"
 linkTitle: "Docs"
@@ -8,19 +7,19 @@ cascade:
   tags:
     - preview
 ---
-Karpenter is an open-source node provisioning project built for Kubernetes.
+Karpenter is an open-source node lifecycle management project built for Kubernetes.
 Adding Karpenter to a Kubernetes cluster can dramatically improve the efficiency and cost of running workloads on that cluster.
 Karpenter works by:
 
 * **Watching** for pods that the Kubernetes scheduler has marked as unschedulable
 * **Evaluating** scheduling constraints (resource requests, nodeselectors, affinities, tolerations, and topology spread constraints) requested by the pods
 * **Provisioning** nodes that meet the requirements of the pods
-* **Removing** the nodes when the nodes are no longer needed
+* **Disrupting** the nodes when the nodes are no longer needed
 
 As someone using Karpenter, once your Kubernetes cluster and the Karpenter controller are up and running (see [Getting Started]({{<ref "./getting-started" >}})), you can:
 
-* **Set up provisioners**: By applying a provisioner to Karpenter, you can configure constraints on node provisioning and set timeout values for node expiry or Kubelet configuration values.
-Provisioner-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
+* **Set up NodePools**: By applying a NodePool to Karpenter, you can configure constraints on node provisioning and set values for node expiry, node consolidastion, or Kubelet configuration values.
+NodePool-level constraints related to Kubernetes and your cloud provider (AWS, for example) include:
 
   - Taints (`taints`): Identify taints to add to provisioned nodes. If a pod doesn't have a matching toleration for the taint, the effect set by the taint occurs (NoSchedule, PreferNoSchedule, or NoExecute). See Kubernetes [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for details.
   - Labels (`labels`): Apply arbitrary key-value pairs to nodes that can be matched by pods.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR updates the top-level index file to no longer refer to Provisioners but refer to NodePools and EC2NodeClasses instead

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.