### PR TITLE
fix: Fix disabling webhooks in helm chart

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -160,13 +160,13 @@ spec:
           {{- if .Values.webhook.enabled }}
             - name: webhook-metrics
               containerPort: {{ .Values.webhook.metrics.port }}
-          {{- end }}
-              protocol: TCP
-            - name: http
-              containerPort: {{ .Values.controller.healthProbe.port }}
               protocol: TCP
             - name: https-webhook
               containerPort: {{ .Values.webhook.port }}
+              protocol: TCP
+          {{- end }}
+            - name: http
+              containerPort: {{ .Values.controller.healthProbe.port }}
               protocol: TCP
           livenessProbe:
             initialDelaySeconds: 30

--- a/charts/karpenter/templates/secret-webhook-cert.yaml
+++ b/charts/karpenter/templates/secret-webhook-cert.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 # data: {} # Injected by karpenter-webhook
+{{- end }}

--- a/charts/karpenter/templates/service.yaml
+++ b/charts/karpenter/templates/service.yaml
@@ -21,10 +21,10 @@ spec:
       port: {{ .Values.webhook.metrics.port }}
       targetPort: webhook-metrics
       protocol: TCP
-  {{- end }}
     - name: https-webhook
       port: {{ .Values.webhook.port }}
       targetPort: https-webhook
       protocol: TCP
+  {{- end }}
   selector:
     {{- include "karpenter.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #4979 

**Description**

An extra line was added when disabling webhooks on the Karpenter deployment. Additionally, additional ports were exposed while disabling the webhook that shouldn't be exposed when Karpenter is not running the webhook.

**How was this change tested?**

`make apply` with `--set webhook.enabled=false`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.