### PR TITLE
fix: karpenter-convert panic error when converting provisioners

### DIFF
--- a/tools/karpenter-convert/pkg/convert/convert.go
+++ b/tools/karpenter-convert/pkg/convert/convert.go
@@ -167,18 +167,19 @@ func convert(resource runtime.Object, o *Context) ([]runtime.Object, error) {
 	case "Provisioner":
 		provisioner := resource.(*corev1alpha5.Provisioner)
 
-		var providerObj *v1beta1.EC2NodeClass
-		var err error
 		if provider := provisioner.Spec.Provider; provider != nil {
-			providerObj, err = convertProvider(provider.Raw, provisioner.Name)
+			providerObj, err := convertProvider(provider.Raw, provisioner.Name)
 			if err != nil {
 				return nil, fmt.Errorf("converting spec.provider for Provisioner, %w", err)
 			}
 			provisioner.Spec.ProviderRef = &corev1alpha5.MachineTemplateRef{
 				Name: providerObj.Name,
 			}
+
+			return []runtime.Object{convertProvisioner(provisioner, o), providerObj}, nil
 		}
-		return lo.WithoutEmpty([]runtime.Object{convertProvisioner(provisioner, o), providerObj}), nil
+
+		return []runtime.Object{convertProvisioner(provisioner, o)}, nil
 	case "AWSNodeTemplate":
 		nodeTemplate := resource.(*v1alpha1.AWSNodeTemplate)
 		nodeClass, err := convertNodeTemplate(nodeTemplate)


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**
Fix panic error when converting provisioners

**How was this change tested?**
Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.