### PR TITLE
fix: do not error on capacity-block capacity-type

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -155,6 +155,9 @@ func (p *Provider) createOfferings(ctx context.Context, instanceType *ec2.Instan
 				price, ok = p.pricingProvider.SpotPrice(*instanceType.InstanceType, az)
 			case ec2.UsageClassTypeOnDemand:
 				price, ok = p.pricingProvider.OnDemandPrice(*instanceType.InstanceType)
+			case "capacity-block":
+				// ignore since karpenter doesn't support it yet, but do not log an unknown capacity type error
+				continue
 			default:
 				logging.FromContext(ctx).Errorf("Received unknown capacity type %s for instance type %s", capacityType, *instanceType.InstanceType)
 				continue


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->
N/A

**Description**
 - A new SupportedUsageClass was released called `capacity-block`. This maps to a capacity-type in Karpenter. This was throwing an error since Karpenter was not aware of `capacity-block`, only `on-demand` and `spot`. 


```
karpenter-b8b6f98dc-l8r7r controller {"level":"ERROR","time":"2023-10-31T17:48:41.639Z","logger":"controller.disruption","message":"Received unknown capacity type capacity-block for instance type p5.48xlarge","commit":"4a56c66"}
```

```
> aws ec2 describe-instance-types --filters "Name=instance-type,Values=p5.48xlarge" --region us-east-2 | jq -r '.InstanceTypes[] .SupportedUsageClasses'
[
  "capacity-block",
  "on-demand",
  "spot"
]
```

**How was this change tested?**
`make apply` observed no more error logs

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.