### PR TITLE
fix: deprioritize metal-24xl and metal-48xl in addition to non-suffixed metal instance types

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -483,7 +484,7 @@ func filterExoticInstanceTypes(instanceTypes []*cloudprovider.InstanceType, isMa
 	for _, it := range instanceTypes {
 		// deprioritize metal even if our opinionated filter isn't applied due to something like an instance family
 		// requirement
-		if it.Requirements.Get(lo.Ternary(isMachine, v1alpha1.LabelInstanceSize, v1beta1.LabelInstanceSize)).Has("metal") {
+		if _, ok := lo.Find(it.Requirements.Get(lo.Ternary(isMachine, v1alpha1.LabelInstanceSize, v1beta1.LabelInstanceSize)).Values(), func(size string) bool { return strings.Contains(size, "metal") }); ok {
 			continue
 		}
 		if !resources.IsZero(it.Capacity[lo.Ternary(isMachine, v1alpha1.ResourceAWSNeuron, v1beta1.ResourceAWSNeuron)]) ||

--- a/pkg/providers/instancetype/nodeclass_test.go
+++ b/pkg/providers/instancetype/nodeclass_test.go
@@ -383,7 +383,7 @@ var _ = Describe("NodeClass/InstanceTypes", func() {
 		call := awsEnv.EC2API.CreateFleetBehavior.CalledWithInput.Pop()
 		for _, ltc := range call.LaunchTemplateConfigs {
 			for _, ovr := range ltc.Overrides {
-				Expect(strings.HasSuffix(aws.StringValue(ovr.InstanceType), "metal")).To(BeFalse())
+				Expect(strings.Contains(aws.StringValue(ovr.InstanceType), "metal")).To(BeFalse())
 			}
 		}
 	})

--- a/pkg/providers/instancetype/nodetemplate_test.go
+++ b/pkg/providers/instancetype/nodetemplate_test.go
@@ -393,7 +393,7 @@ var _ = Describe("NodeTemplate/InstanceTypes", func() {
 		call := awsEnv.EC2API.CreateFleetBehavior.CalledWithInput.Pop()
 		for _, ltc := range call.LaunchTemplateConfigs {
 			for _, ovr := range ltc.Overrides {
-				Expect(strings.HasSuffix(aws.StringValue(ovr.InstanceType), "metal")).To(BeFalse())
+				Expect(strings.Contains(aws.StringValue(ovr.InstanceType), "metal")).To(BeFalse())
 			}
 		}
 	})


### PR DESCRIPTION

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
 - Karpenter should deprioritize metal instance types since they are the same price as non-metal and take a lot longer to startup. EC2 previously only had instance types of the form `x.metal`. EC2 recently added metal sized variants `x.metal-24xl` and `x.metal-48xl`. The size variants were not being deprioritized properly, only `x.metal` was being deprioritized. This change checks if `metal` is contained anywhere in the size.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.