### PR TITLE
Add cloudformation pointer to getting started

### DIFF
--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -68,7 +68,7 @@ echo $KARPENTER_VERSION $K8S_VERSION $CLUSTER_NAME $AWS_DEFAULT_REGION $AWS_ACCO
 Create a basic cluster with `eksctl`.
 The following cluster configuration will:
 
-* Use CloudFormation to set up the infrastructure needed by the EKS cluster. See [CloudFormation]({{< relref "../reference/cloudformation/" >}}) for a complete description of what `cloudformation.yaml` does for Karpenter.
+* Use CloudFormation to set up the infrastructure needed by the EKS cluster. See [CloudFormation]({{< relref "../../reference/cloudformation/" >}}) for a complete description of what `cloudformation.yaml` does for Karpenter.
 * Create a Kubernetes service account and AWS IAM Role, and associate them using IRSA to let Karpenter launch instances.
 * Add the Karpenter node role to the aws-auth configmap to allow nodes to connect.
 * Use [AWS EKS managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) for the kube-system and karpenter namespaces. Uncomment fargateProfiles settings (and comment out managedNodeGroups settings) to use Fargate for both namespaces instead.

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/_index.md
@@ -68,7 +68,7 @@ echo $KARPENTER_VERSION $K8S_VERSION $CLUSTER_NAME $AWS_DEFAULT_REGION $AWS_ACCO
 Create a basic cluster with `eksctl`.
 The following cluster configuration will:
 
-* Use CloudFormation to set up the infrastructure needed by the EKS cluster.
+* Use CloudFormation to set up the infrastructure needed by the EKS cluster. See [CloudFormation]({{< relref "../reference/cloudformation/" >}}) for a complete description of what `cloudformation.yaml` does for Karpenter.
 * Create a Kubernetes service account and AWS IAM Role, and associate them using IRSA to let Karpenter launch instances.
 * Add the Karpenter node role to the aws-auth configmap to allow nodes to connect.
 * Use [AWS EKS managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) for the kube-system and karpenter namespaces. Uncomment fargateProfiles settings (and comment out managedNodeGroups settings) to use Fargate for both namespaces instead.


### PR DESCRIPTION
**Description** There have been requests for more information about how the [Getting Started with Karpenter](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/) guide sets up permissions. This PR adds a pointer to the new [CloudFormation](https://karpenter.sh/docs/reference/cloudformation/) page to explain the setup that the `cloudformation.yaml` file does in that guide.

**Does this change impact docs?**
- [X] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.