### PR TITLE
Add FAQ info for security issues

### DIFF
--- a/website/content/en/preview/faq.md
+++ b/website/content/en/preview/faq.md
@@ -31,6 +31,9 @@ All the required RBAC rules can be found in the helm chart template. See [cluste
 ### Can I run Karpenter outside of a Kubernetes cluster?
 Yes, as long as the controller has network and IAM/RBAC access to the Kubernetes API and your provider API.
 
+### What do I do if I encounter a security issue with Karpenter?
+Refer to [Reporting Security Issues](https://github.com/aws/karpenter/security/policy) for information on how to report Karpenter security issues. Do not create a public GitHub issue.
+
 ## Compatibility
 
 ### Which versions of Kubernetes does Karpenter support?


### PR DESCRIPTION
Fixes Issue [#4944](https://github.com/aws/karpenter/issues/4944)

**Description** Added a link to the Karpenter [Reporting Security Issues](https://github.com/aws/karpenter/security/policy) page from the FAQ.

**How was this change tested?**

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.