### PR TITLE
test: Instance profiles on EC2NodeClass to allow for cleanup 

### DIFF
--- a/test/pkg/environment/aws/environment.go
+++ b/test/pkg/environment/aws/environment.go
@@ -110,6 +110,9 @@ func GetTimeStreamAPI(session *session.Session) timestreamwriteiface.TimestreamW
 func (env *Environment) DefaultEC2NodeClass() *v1beta1.EC2NodeClass {
 	nodeClass := test.EC2NodeClass()
 	nodeClass.Spec.AMIFamily = &v1beta1.AMIFamilyAL2
+	nodeClass.Spec.Tags = map[string]string{
+		"testing/cluster": env.ClusterName,
+	}
 	nodeClass.Spec.SecurityGroupSelectorTerms = []v1beta1.SecurityGroupSelectorTerm{
 		{
 			Tags: map[string]string{"karpenter.sh/discovery": env.ClusterName},

--- a/test/suites/beta/integration/tags_test.go
+++ b/test/suites/beta/integration/tags_test.go
@@ -35,7 +35,7 @@ import (
 var _ = Describe("Tags", func() {
 	Context("Static Tags", func() {
 		It("should tag all associated resources", func() {
-			nodeClass.Spec.Tags = map[string]string{"TestTag": "TestVal"}
+			nodeClass.Spec.Tags["TestTag"] = "TestVal"
 			pod := coretest.Pod()
 
 			env.ExpectCreated(pod, nodeClass, nodePool)
@@ -72,7 +72,7 @@ var _ = Describe("Tags", func() {
 
 		It("shouldn't overwrite custom Name tags", func() {
 			nodeClass = test.EC2NodeClass(*nodeClass, v1beta1.EC2NodeClass{Spec: v1beta1.EC2NodeClassSpec{
-				Tags: map[string]string{"Name": "custom-name"},
+				Tags: map[string]string{"Name": "custom-name", "testing/cluster": env.ClusterName},
 			}})
 			nodePool = coretest.NodePool(*nodePool, corev1beta1.NodePool{
 				Spec: corev1beta1.NodePoolSpec{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Add cluster tag for instance profiles to allow cleanup by the sweeper 

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.