### PR TITLE
Support InstanceMetadataTags within Metadata Options

### DIFF
--- a/pkg/apis/v1alpha1/provider.go
+++ b/pkg/apis/v1alpha1/provider.go
@@ -117,6 +117,15 @@ type MetadataOptions struct {
 	// 1.0 credentials are not available.
 	// +optional
 	HTTPTokens *string `json:"httpTokens,omitempty"`
+
+	// InstanceMetadataTags allow access to instance tags from the instance metadata.
+	// By accessing tags from the instance metadata, you no longer need to use the DescribeInstances
+	// or DescribeTags API calls to retrieve tag information, which reduces your API transactions per second,
+	// and lets your tag retrievals scale with the number of instances that you control. Furthermore,
+	// local processes that are running on an instance can view the instance's tag information directly
+	// from the instance metadata. This is disabled by default.
+	// +optional
+	InstanceMetadataTags *string `json:"instanceMetadataTags,omitempty"`
 }
 
 type BlockDeviceMapping struct {

--- a/pkg/apis/v1alpha1/provider_validation.go
+++ b/pkg/apis/v1alpha1/provider_validation.go
@@ -160,6 +160,7 @@ func (a *AWS) validateMetadataOptions() (errs *apis.FieldError) {
 		a.validateHTTPProtocolIpv6(),
 		a.validateHTTPPutResponseHopLimit(),
 		a.validateHTTPTokens(),
+		a.validateInstanceMetadataTags(),
 	).ViaField(metadataOptionsPath)
 }
 
@@ -193,6 +194,14 @@ func (a *AWS) validateHTTPTokens() *apis.FieldError {
 		return nil
 	}
 	return a.validateStringEnum(*a.MetadataOptions.HTTPTokens, "httpTokens", ec2.LaunchTemplateHttpTokensState_Values())
+}
+
+func (a *AWS) validateInstanceMetadataTags() *apis.FieldError {
+	if a.MetadataOptions.InstanceMetadataTags == nil {
+		return nil
+	}
+	allowedValues := []string{"enabled", "disabled"}
+	return a.validateStringEnum(*a.MetadataOptions.InstanceMetadataTags, "instanceMetadataTags", allowedValues)
 }
 
 func (a *AWS) validateAMIFamily() *apis.FieldError {

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -310,6 +310,27 @@ var _ = Describe("Provisioner", func() {
 					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
 				})
 			})
+			Context("InstanceMetadataTags", func() {
+				It("should allow enum values", func() {
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
+					Expect(err).ToNot(HaveOccurred())
+					for _, value := range ec2.LaunchTemplateInstanceMetadataTags_Values() {
+						provider.MetadataOptions = &v1alpha1.MetadataOptions{
+							InstanceMetadataTags: aws.String(value),
+						}
+						provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+						Expect(provisioner.Validate(ctx)).To(Succeed())
+					}
+				})
+				It("should not allow non-enum values", func() {
+					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
+					Expect(err).ToNot(HaveOccurred())
+					provider.MetadataOptions = &v1alpha1.MetadataOptions{
+						InstanceMetadataTags: aws.String(randomdata.SillyName()),
+					}
+					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+				})
+			})
 			Context("BlockDeviceMappings", func() {
 				It("should not allow with a custom launch template", func() {
 					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -311,10 +311,11 @@ var _ = Describe("Provisioner", func() {
 				})
 			})
 			Context("InstanceMetadataTags", func() {
-				It("should allow enum values", func() {
+				It("should allow valid enum values", func() {
 					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
-					for _, value := range ec2.LaunchTemplateInstanceMetadataTags_Values() {
+					validValues := []string{"enabled", "disabled"}
+					for _, value := range validValues {
 						provider.MetadataOptions = &v1alpha1.MetadataOptions{
 							InstanceMetadataTags: aws.String(value),
 						}
@@ -322,14 +323,17 @@ var _ = Describe("Provisioner", func() {
 						Expect(provisioner.Validate(ctx)).To(Succeed())
 					}
 				})
-				It("should not allow non-enum values", func() {
+				It("should reject invalid values", func() {
 					provider, err := v1alpha1.DeserializeProvider(provisioner.Spec.Provider.Raw)
 					Expect(err).ToNot(HaveOccurred())
+					invalidValue := "invalid"
 					provider.MetadataOptions = &v1alpha1.MetadataOptions{
-						InstanceMetadataTags: aws.String(randomdata.SillyName()),
+						InstanceMetadataTags: aws.String(invalidValue),
 					}
-					Expect(Validate(ctx, test.Provisioner(test.ProvisionerOptions{Provider: provider}))).ToNot(Succeed())
+					provisioner = test.Provisioner(test.ProvisionerOptions{Provider: provider})
+					Expect(provisioner.Validate(ctx)).NotTo(Succeed())
 				})
+			})
 			})
 			Context("BlockDeviceMappings", func() {
 				It("should not allow with a custom launch template", func() {

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -233,6 +233,15 @@ type MetadataOptions struct {
 	// +kubebuilder:validation:Enum:={required,optional}
 	// +optional
 	HTTPTokens *string `json:"httpTokens,omitempty"`
+
+	// InstanceMetadataTags allow access to instance tags from the instance metadata.
+	// By accessing tags from the instance metadata, you no longer need to use the DescribeInstances
+	// or DescribeTags API calls to retrieve tag information, which reduces your API transactions per second,
+	// and lets your tag retrievals scale with the number of instances that you control. Furthermore,
+	// local processes that are running on an instance can view the instance's tag information directly
+	// from the instance metadata. This is disabled by default.
+	// +optional
+	InstanceMetadataTags *string `json:"instanceMetadataTags,omitempty"`
 }
 
 type BlockDeviceMapping struct {

--- a/pkg/apis/v1beta1/ec2nodeclass_validation.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation.go
@@ -195,6 +195,14 @@ func (in *EC2NodeClassSpec) validateHTTPTokens() *apis.FieldError {
 	return in.validateStringEnum(*in.MetadataOptions.HTTPTokens, "httpTokens", ec2.LaunchTemplateHttpTokensState_Values())
 }
 
+func (in *EC2NodeClassSpec) validateInstanceMetadataTags() *apis.FieldError {
+	if in.MetadataOptions.InstanceMetadataTags == nil {
+		return nil
+	}
+	allowedValues := []string{"enabled", "disabled"}
+	return in.validateStringEnum(*in.MetadataOptions.InstanceMetadataTags, "instanceMetadataTags", allowedValues)
+}
+
 func (in *EC2NodeClassSpec) validateStringEnum(value, field string, validValues []string) *apis.FieldError {
 	for _, validValue := range validValues {
 		if value == validValue {

--- a/pkg/providers/launchtemplate/launchtemplate.go
+++ b/pkg/providers/launchtemplate/launchtemplate.go
@@ -255,6 +255,7 @@ func (p *Provider) createLaunchTemplate(ctx context.Context, options *amifamily.
 				HttpProtocolIpv6:        options.MetadataOptions.HTTPProtocolIPv6,
 				HttpPutResponseHopLimit: options.MetadataOptions.HTTPPutResponseHopLimit,
 				HttpTokens:              options.MetadataOptions.HTTPTokens,
+				InstanceMetadataTags:    options.MetadataOptions.InstanceMetadataTags,
 			},
 			NetworkInterfaces: networkInterface,
 			TagSpecifications: []*ec2.LaunchTemplateTagSpecificationRequest{

--- a/pkg/utils/nodeclass/nodeclass.go
+++ b/pkg/utils/nodeclass/nodeclass.go
@@ -193,6 +193,7 @@ func NewMetadataOptions(mo *v1alpha1.MetadataOptions) *v1beta1.MetadataOptions {
 		HTTPProtocolIPv6:        mo.HTTPProtocolIPv6,
 		HTTPPutResponseHopLimit: mo.HTTPPutResponseHopLimit,
 		HTTPTokens:              mo.HTTPTokens,
+		InstanceMetadataTags:    mo.InstanceMetadataTags,
 	}
 }
 

--- a/pkg/utils/nodetemplate/nodetemplate.go
+++ b/pkg/utils/nodetemplate/nodetemplate.go
@@ -95,6 +95,7 @@ func NewMetadataOptions(mo *v1beta1.MetadataOptions) *v1alpha1.MetadataOptions {
 		HTTPProtocolIPv6:        mo.HTTPProtocolIPv6,
 		HTTPPutResponseHopLimit: mo.HTTPPutResponseHopLimit,
 		HTTPTokens:              mo.HTTPTokens,
+		InstanceMetadataTags:    mo.InstanceMetadataTags,
 	}
 }
 


### PR DESCRIPTION
## Why and What:

> [!NOTE]
> This is my first contribution to this project, so assistance and guidance is appreciated

- Adds `InstanceMetadataTags` support to AWS API
- Creates `InstanceMetadataTags`, indicating whether access to instance tags from the instance metadata is enabled or disabled

#### Fixes: [Add InstanceMetadataTags option in awsnodetemplates.karpenter.k8s.aws metadataOptions](https://github.com/aws/karpenter/issues/4199)

**Description**

 I would like to enable querying metadata tags from AWS metadata.

Karpenter code right now supports 4 `metadataoptions`:
  - httpEndpoint
  - httpProtocolIPv6
  - httpPutResponseHopLimit
  - httpTokens

`instanceMetadataTags` indicates whether access to instance tags from the instance metadata is enabled or disabled. For more information, see [Work with instance tags using the instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS).

- Type: `String`
- Valid Values: `disabled | enabled`
- Required: `No`

**Does this change impact docs?**
- [X] Yes, PR does not include docs updates 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.