### PR TITLE
fix: Parsing Selector IDs and Names with spaces

### DIFF
--- a/pkg/controllers/nodeclass/suite_test.go
+++ b/pkg/controllers/nodeclass/suite_test.go
@@ -155,7 +155,10 @@ var _ = Describe("NodeClassController", func() {
 		It("Should resolve a valid selectors for Subnet by tags", func() {
 			nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
 				{
-					Tags: map[string]string{`Name`: `test-subnet-1,test-subnet-2`},
+					Tags: map[string]string{`Name`: `test-subnet-1`},
+				},
+				{
+					Tags: map[string]string{`Name`: `test-subnet-2`},
 				},
 			}
 			ExpectApplied(ctx, env.Client, nodeClass)

--- a/pkg/providers/launchtemplate/suite_test.go
+++ b/pkg/providers/launchtemplate/suite_test.go
@@ -1654,7 +1654,10 @@ var _ = Describe("LaunchTemplates", func() {
 		})
 		Context("Subnet-based Launch Template Configration", func() {
 			It("should explicitly set 'AssignPublicIPv4' to false in the Launch Template", func() {
-				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{{Tags: map[string]string{"Name": "test-subnet-1,test-subnet-3"}}}
+				nodeClass.Spec.SubnetSelectorTerms = []v1beta1.SubnetSelectorTerm{
+					{Tags: map[string]string{"Name": "test-subnet-1"}},
+					{Tags: map[string]string{"Name": "test-subnet-3"}},
+				}
 				ExpectApplied(ctx, env.Client, nodePool, nodeClass)
 				pod := coretest.UnschedulablePod()
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)

--- a/pkg/utils/nodeclass/nodeclass.go
+++ b/pkg/utils/nodeclass/nodeclass.go
@@ -72,7 +72,7 @@ func NewSubnetSelectorTerms(subnetSelector map[string]string) (terms []v1beta1.S
 	for k, v := range subnetSelector {
 		switch k {
 		case "aws-ids", "aws::ids":
-			ids = strings.Split(strings.Trim(v, " "), ",")
+			ids = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		default:
 			tags[k] = v
 		}
@@ -97,7 +97,7 @@ func NewSecurityGroupSelectorTerms(securityGroupSelector map[string]string) (ter
 	for k, v := range securityGroupSelector {
 		switch k {
 		case "aws-ids", "aws::ids":
-			ids = strings.Split(strings.Trim(v, " "), ",")
+			ids = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		default:
 			tags[k] = v
 		}
@@ -124,11 +124,11 @@ func NewAMISelectorTerms(amiSelector map[string]string) (terms []v1beta1.AMISele
 	for k, v := range amiSelector {
 		switch k {
 		case "aws-ids", "aws::ids":
-			ids = strings.Split(strings.Trim(v, " "), ",")
+			ids = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		case "aws::name":
-			names = strings.Split(strings.Trim(v, " "), ",")
+			names = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		case "aws::owners":
-			owners = strings.Split(strings.Trim(v, " "), ",")
+			owners = lo.Map(strings.Split(v, ","), func(s string, _ int) string { return strings.Trim(s, " ") })
 		default:
 			tags[k] = v
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #4738
 
**Description**
- Karpenter should still support the comma-delimited list with spaces in it. , this config works with karpenter <v0.31:
```
  subnetSelector:
    aws-ids: subnet-123, subnet-456, subnet-789
```

**How was this change tested?**
- Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.