### PR TITLE
fix: Allow tags and owners for private AMIs

### DIFF
--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -92,8 +92,6 @@ spec:
                     of other fields in amiSelectorTerms'
                   rule: '!self.all(x, has(x.id) && (has(x.tags) || has(x.name) ||
                     has(x.owner)))'
-                - message: '''owner'' cannot be set with ''tags'''
-                  rule: '!self.all(x, has(x.owner) && has(x.tags))'
               blockDeviceMappings:
                 description: BlockDeviceMappings to be applied to provisioned nodes.
                 items:

--- a/pkg/apis/v1beta1/ec2nodeclass.go
+++ b/pkg/apis/v1beta1/ec2nodeclass.go
@@ -44,7 +44,6 @@ type EC2NodeClassSpec struct {
 	// AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
 	// +kubebuilder:validation:XValidation:message="expected at least one, got none, ['tags', 'id', 'name']",rule="self.all(x, has(x.tags) || has(x.id) || has(x.name))"
 	// +kubebuilder:validation:XValidation:message="'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",rule="!self.all(x, has(x.id) && (has(x.tags) || has(x.name) || has(x.owner)))"
-	// +kubebuilder:validation:XValidation:message="'owner' cannot be set with 'tags'",rule="!self.all(x, has(x.owner) && has(x.tags))"
 	// +kubebuilder:validation:MaxItems:=30
 	// +optional
 	AMISelectorTerms []AMISelectorTerm `json:"amiSelectorTerms,omitempty" hash:"ignore"`

--- a/pkg/apis/v1beta1/ec2nodeclass_validation.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation.go
@@ -133,8 +133,6 @@ func (in *AMISelectorTerm) validate() (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrGeneric("expect at least one, got none", "tags", "id", "name"))
 	} else if in.ID != "" && (len(in.Tags) > 0 || in.Name != "" || in.Owner != "") {
 		errs = errs.Also(apis.ErrGeneric(`"id" is mutually exclusive, cannot be set with a combination of other fields in`))
-	} else if in.Owner != "" && len(in.Tags) > 0 {
-		errs = errs.Also(apis.ErrGeneric(`"owner" cannot be set with "tags" in`))
 	}
 	return errs
 }

--- a/pkg/apis/v1beta1/ec2nodeclass_validation_cel_test.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation_cel_test.go
@@ -353,6 +353,17 @@ var _ = Describe("CEL/Validation", func() {
 			}
 			Expect(env.Client.Create(ctx, nc)).To(Succeed())
 		})
+		It("should succeed when an ami selector term has an owner key with tags", func() {
+			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
+				{
+					Owner: "testowner",
+					Tags: map[string]string{
+						"test": "testvalue",
+					},
+				},
+			}
+			Expect(env.Client.Create(ctx, nc)).To(Succeed())
+		})
 		It("should fail when a ami selector term has no values", func() {
 			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
 				{},
@@ -382,17 +393,6 @@ var _ = Describe("CEL/Validation", func() {
 				{
 					Tags: map[string]string{
 						"": "testvalue",
-					},
-				},
-			}
-			Expect(env.Client.Create(ctx, nc)).ToNot(Succeed())
-		})
-		It("should fail when an ami selector term has an owner key with tags", func() {
-			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
-				{
-					Owner: "testowner",
-					Tags: map[string]string{
-						"test": "testvalue",
 					},
 				},
 			}

--- a/pkg/apis/v1beta1/ec2nodeclass_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/ec2nodeclass_validation_webhook_test.go
@@ -364,6 +364,17 @@ var _ = Describe("Webhook/Validation", func() {
 			}
 			Expect(nc.Validate(ctx)).To(Succeed())
 		})
+		It("should succeed when an ami selector term has an owner key with tags", func() {
+			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
+				{
+					Owner: "testowner",
+					Tags: map[string]string{
+						"test": "testvalue",
+					},
+				},
+			}
+			Expect(nc.Validate(ctx)).To(Succeed())
+		})
 		It("should fail when a ami selector term has no values", func() {
 			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
 				{},
@@ -393,17 +404,6 @@ var _ = Describe("Webhook/Validation", func() {
 				{
 					Tags: map[string]string{
 						"": "testvalue",
-					},
-				},
-			}
-			Expect(nc.Validate(ctx)).ToNot(Succeed())
-		})
-		It("should fail when an ami selector term has an owner key with tags", func() {
-			nc.Spec.AMISelectorTerms = []v1beta1.AMISelectorTerm{
-				{
-					Owner: "testowner",
-					Tags: map[string]string{
-						"test": "testvalue",
 					},
 				},
 			}

--- a/pkg/providers/amifamily/ami_test.go
+++ b/pkg/providers/amifamily/ami_test.go
@@ -287,7 +287,9 @@ var _ = Describe("AMIProvider", func() {
 		})
 	})
 	Context("AMI Selectors", func() {
-		It("should have default owners and use tags when prefixes aren't set", func() {
+		// When you tag public or shared resources, the tags you assign are available only to your AWS account; no other AWS account will have access to those tags
+		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
+		It("should have empty owners and use tags when prefixes aren't set", func() {
 			amiSelectorTerms := []v1beta1.AMISelectorTerm{
 				{
 					Tags: map[string]string{
@@ -304,10 +306,7 @@ var _ = Describe("AMIProvider", func() {
 							Values: aws.StringSlice([]string{"my-ami"}),
 						},
 					},
-					Owners: []string{
-						"amazon",
-						"self",
-					},
+					Owners: []string{},
 				},
 			}, filterAndOwnersSets)
 		})

--- a/website/content/en/docs/concepts/nodeclasses.md
+++ b/website/content/en/docs/concepts/nodeclasses.md
@@ -338,7 +338,9 @@ spec:
 
 ## spec.amiSelectorTerms
 
-AMISelectorTerms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). This field is optional, and Karpenter will use the latest EKS-optimized AMIs for the AMIFamily if no amiSelectorTerms are specified. To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. `self` `amazon`, `your-aws-account-name`) and account IDs. If this is not set, it defaults to `self,amazon`.
+AMISelectorTerms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). This field is optional, and Karpenter will use the latest EKS-optimized AMIs for the AMIFamily if no amiSelectorTerms are specified. To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. `self` `amazon`, `your-aws-account-name`) and account IDs. 
+
+If owner is not set for `name`, it defaults to `self,amazon`, preventing Karpenter from inadvertently selecting an AMI that is owned by a different account. Tags don't require an owner as tags can only be discovered by the user who created them. 
 
 {{% alert title="Tip" color="secondary" %}}
 AMIs may be specified by any AWS tag, including `Name`. Selecting by tag or by name using wildcards (`*`) is supported.

--- a/website/content/en/preview/concepts/nodeclasses.md
+++ b/website/content/en/preview/concepts/nodeclasses.md
@@ -338,7 +338,9 @@ spec:
 
 ## spec.amiSelectorTerms
 
-AMISelectorTerms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). This field is optional, and Karpenter will use the latest EKS-optimized AMIs for the AMIFamily if no amiSelectorTerms are specified. To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. `self` `amazon`, `your-aws-account-name`) and account IDs. If this is not set, it defaults to `self,amazon`.
+AMISelectorTerms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). This field is optional, and Karpenter will use the latest EKS-optimized AMIs for the AMIFamily if no amiSelectorTerms are specified. To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. `self` `amazon`, `your-aws-account-name`) and account IDs. 
+
+If owner is not set for `name`, it defaults to `self,amazon`, preventing Karpenter from inadvertently selecting an AMI that is owned by a different account. Tags don't require an owner as tags can only be discovered by the user who created them. 
 
 {{% alert title="Tip" color="secondary" %}}
 AMIs may be specified by any AWS tag, including `Name`. Selecting by tag or by name using wildcards (`*`) is supported.

--- a/website/content/en/v0.32/concepts/nodeclasses.md
+++ b/website/content/en/v0.32/concepts/nodeclasses.md
@@ -338,7 +338,9 @@ spec:
 
 ## spec.amiSelectorTerms
 
-AMISelectorTerms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). This field is optional, and Karpenter will use the latest EKS-optimized AMIs for the AMIFamily if no amiSelectorTerms are specified. To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. `self` `amazon`, `your-aws-account-name`) and account IDs. If this is not set, it defaults to `self,amazon`.
+AMISelectorTerms are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). This field is optional, and Karpenter will use the latest EKS-optimized AMIs for the AMIFamily if no amiSelectorTerms are specified. To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. `self` `amazon`, `your-aws-account-name`) and account IDs. 
+
+If owner is not set for `name`, it defaults to `self,amazon`, preventing Karpenter from inadvertently selecting an AMI that is owned by a different account. Tags don't require an owner as tags can only be discovered by the user who created them. 
 
 {{% alert title="Tip" color="secondary" %}}
 AMIs may be specified by any AWS tag, including `Name`. Selecting by tag or by name using wildcards (`*`) is supported.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5013 

**Description**
- Karpenter should allow tags and owner to be placed for `amiSelectorTerm` for shared AMIs between accounts.

**How was this change tested?**
- Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.