### PR TITLE
docs: troubleshooting - use 'aws resourcegroupstaggingapi' to list resources that Karpenter will discover

### DIFF
--- a/website/content/en/docs/troubleshooting.md
+++ b/website/content/en/docs/troubleshooting.md
@@ -37,6 +37,17 @@ helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter \
   ...
 ```
 
+#### Check AWS resources with Karpenter Discovery tag
+
+You can use AWS Resource Groups Tagging API to find all resources tagged with `karpenter.sh/discovery`.
+
+```
+aws resourcegroupstaggingapi get-resources \
+    --tag-filters "Key=karpenter.sh/discovery,Values=${CLUSTER_NAME}" \
+    --query 'ResourceTagMappingList[]' --output text \
+    | sed 's/arn:/\n----------\narn:/g'
+```
+
 ## Installation
 
 ### Missing Service Linked Role


### PR DESCRIPTION
docs: troubleshooting: use `aws resourcegroupstaggingapi` to list resources that Karpenter will discover.

Fixes #N/A

**Description**
Include an AWS CLI command to find all resources tagged with `karpenter.sh/discovery=$CLUSTER_NAME`. 
It's a great debugging step for all to know.

**How was this change tested?**
Not tested.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: #N/A
- [] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.