### PR TITLE
docs: Fix old defaulting note for capacity-type

### DIFF
--- a/website/content/en/docs/concepts/nodepools.md
+++ b/website/content/en/docs/concepts/nodepools.md
@@ -6,9 +6,7 @@ description: >
   Configure Karpenter with NodePools
 ---
 
-When you first installed Karpenter, you set up a default NodePool.
-The NodePool sets constraints on the nodes that can be created by Karpenter and the pods that can run on those nodes.
-The NodePool can be set to do things like:
+When you first installed Karpenter, you set up a default NodePool. The NodePool sets constraints on the nodes that can be created by Karpenter and the pods that can run on those nodes. The NodePool can be set to do things like:
 
 * Define taints to limit the pods that can run on nodes Karpenter creates
 * Define any startup taints to inform Karpenter that it should taint the node initially, but that the taint is temporary.
@@ -86,7 +84,7 @@ spec:
         - key: "kubernetes.io/arch"
           operator: In
           values: ["arm64", "amd64"]
-        - key: "karpenter.sh/capacity-type" # If not included, the webhook for the AWS cloud provider will default to on-demand
+        - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["spot", "on-demand"]
 

--- a/website/content/en/preview/concepts/nodepools.md
+++ b/website/content/en/preview/concepts/nodepools.md
@@ -6,9 +6,7 @@ description: >
   Configure Karpenter with NodePools
 ---
 
-When you first installed Karpenter, you set up a default NodePool.
-The NodePool sets constraints on the nodes that can be created by Karpenter and the pods that can run on those nodes.
-The NodePool can be set to do things like:
+When you first installed Karpenter, you set up a default NodePool. The NodePool sets constraints on the nodes that can be created by Karpenter and the pods that can run on those nodes. The NodePool can be set to do things like:
 
 * Define taints to limit the pods that can run on nodes Karpenter creates
 * Define any startup taints to inform Karpenter that it should taint the node initially, but that the taint is temporary.
@@ -86,7 +84,7 @@ spec:
         - key: "kubernetes.io/arch"
           operator: In
           values: ["arm64", "amd64"]
-        - key: "karpenter.sh/capacity-type" # If not included, the webhook for the AWS cloud provider will default to on-demand
+        - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["spot", "on-demand"]
 

--- a/website/content/en/v0.32/concepts/nodepools.md
+++ b/website/content/en/v0.32/concepts/nodepools.md
@@ -6,9 +6,7 @@ description: >
   Configure Karpenter with NodePools
 ---
 
-When you first installed Karpenter, you set up a default NodePool.
-The NodePool sets constraints on the nodes that can be created by Karpenter and the pods that can run on those nodes.
-The NodePool can be set to do things like:
+When you first installed Karpenter, you set up a default NodePool. The NodePool sets constraints on the nodes that can be created by Karpenter and the pods that can run on those nodes. The NodePool can be set to do things like:
 
 * Define taints to limit the pods that can run on nodes Karpenter creates
 * Define any startup taints to inform Karpenter that it should taint the node initially, but that the taint is temporary.
@@ -86,7 +84,7 @@ spec:
         - key: "kubernetes.io/arch"
           operator: In
           values: ["arm64", "amd64"]
-        - key: "karpenter.sh/capacity-type" # If not included, the webhook for the AWS cloud provider will default to on-demand
+        - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["spot", "on-demand"]
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Removes an older docs note for webhook defaulting for `karpenter.sh/capacity-type`. This resolves a docs issue that was mentioned in #5015

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.