### PR TITLE
test: Add support for E2E testing for private clusters

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -15,15 +15,16 @@ inputs:
     required: true
   k8s_version:
     description: 'Version of Kubernetes to use for the launched cluster'
-    required: false
     default: "1.28"
   eksctl_version:
     description: "Version of eksctl to install"
     default: v0.164.0
   ip_family:
     description: "IP Family of the cluster. Valid values are IPv4 or IPv6"
-    required: false
     default: "IPv4"
+  private_cluster:
+    description: "Whether to create a private cluster which does not add access to the public internet. Valid values are 'true' or 'false'"
+    default: 'false'
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
     required: false
@@ -126,12 +127,35 @@ runs:
         wellKnownPolicies:
           ebsCSIController: true
       EOF
+      
+      if [[ ${{ inputs.private_cluster }} == 'true' ]]; then
+        yq -i '.privateCluster.enabled=true' clusterconfig.yaml
+        yq -i '.managedNodeGroups[0].privateNetworking=true' clusterconfig.yaml
+      fi
 
       eksctl ${cmd} cluster -f clusterconfig.yaml
 
       # We need to call these update iamserviceaccount commands again since the "eksctl upgrade cluster" action
       # doesn't handle updates to IAM serviceaccounts correctly when the roles assigned to them change
       eksctl update iamserviceaccount -f clusterconfig.yaml --approve
+      
+      # Add the SQS and SSM VPC endpoints if we are creating a private cluster
+      # We need to grab all of the VPC details for the cluster in order to add the endpoint
+      if [[ ${{ inputs.private_cluster }} == 'true' ]]; then
+        VPC_CONFIG=$(aws eks describe-cluster --name ${{ inputs.cluster_name }} --query "cluster.resourcesVpcConfig")
+        VPC_ID=$(echo $VPC_CONFIG | jq .vpcId -r)
+        SUBNET_IDS=($(echo $VPC_CONFIG | jq '.subnetIds | join(" ")' -r))
+        SECURITY_GROUP_IDS=($(echo $VPC_CONFIG | jq '.securityGroupIds | join(" ")' -r))
+        
+        for SERVICE in "com.amazonaws.${{ inputs.region }}.ssm" "com.amazonaws.${{ inputs.region }}.sqs"; do
+          aws ec2 create-vpc-endpoint \
+            --vpc-id "${VPC_ID}" \
+            --vpc-endpoint-type Interface \
+            --service-name "${SERVICE}" \
+            --subnet-ids ${SUBNET_IDS[@]} \
+            --security-group-ids ${SECURITY_GROUP_IDS[@]}
+        done
+      fi
   - name: tag oidc provider of the cluster
     if: always()
     shell: bash

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -64,6 +64,7 @@ jobs:
           - Expiration
           - Chaos
           - IPv6
+          - PrivateCluster
     uses: ./.github/workflows/e2e.yaml
     with:
       suite: ${{ matrix.suite }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,6 +25,7 @@ on:
           - Chaos
           - IPv6
           - Scale
+          - PrivateCluster
       k8s_version:
         type: choice
         options:
@@ -108,6 +109,7 @@ jobs:
           k8s_version: ${{ inputs.k8s_version }}
           eksctl_version: v0.164.0
           ip_family: ${{ contains(inputs.suite, 'IPv6') && 'IPv6' || 'IPv4' }} # Set the value to IPv6 if IPv6 suite, else IPv4
+          private_cluster: ${{ inputs.suite == 'PrivateCluster' }}
           git_ref: ${{ inputs.git_ref }}
       - name: install prometheus
         uses: ./.github/actions/e2e/install-prometheus
@@ -130,8 +132,13 @@ jobs:
           git_ref: ${{ inputs.git_ref }}
       - name: run the ${{ inputs.suite }} test suite
         run: |
+          TEST_SUITE="${{ inputs.suite }}"
+          # If we are performing the PrivateCluster test suite, then we should just run the 'Integration' test suite
+          if [[ inputs.suite == 'PrivateCluster' ]]; then
+            TEST_SUITE="Integration"
+          fi
           aws eks update-kubeconfig --name ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
-          TEST_SUITE="${{ inputs.suite }}" ENABLE_METRICS=${{ inputs.enable_metrics }} METRICS_REGION=${{ vars.TIMESTREAM_REGION }} GIT_REF="$(git rev-parse HEAD)" \
+          TEST_SUITE="$TEST_SUITE" ENABLE_METRICS=${{ inputs.enable_metrics }} METRICS_REGION=${{ vars.TIMESTREAM_REGION }} GIT_REF="$(git rev-parse HEAD)" \
             CLUSTER_NAME="${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}" CLUSTER_ENDPOINT="$(aws eks describe-cluster --name ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }} --query "cluster.endpoint" --output text)" \
             INTERRUPTION_QUEUE="${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}" make e2etests
       - name: notify slack of success or failure


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds support for the E2E test suites to have private cluster creation and a PrivateCluster suite. Currently, this private cluster suite will just run the Integration test suite on private clusters; however, we should have follow-up PR that selects a subset of tests from across all test suites to run against a private cluster

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.