### PR TITLE
docs: Add note on instance-pods dropped in v1beta1

### DIFF
--- a/website/content/en/docs/upgrading/v1beta1-migration.md
+++ b/website/content/en/docs/upgrading/v1beta1-migration.md
@@ -199,10 +199,11 @@ If you are using some IaC for managing your policy documents attached to the con
 
 Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
 
-| Karpenter Labels                |                             |
-|---------------------------------|-----------------------------|
-| **v1alpha5**                    | **v1beta1**                 |
-| karpenter.sh/provisioner-name   | karpenter.sh/nodepool       |
+| Karpenter Labels                |                       |
+|---------------------------------|-----------------------|
+| **v1alpha5**                    | **v1beta1**           |
+| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
+| karpenter.k8s.aws/instance-pods | **Dropped**           |
 
 > **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
 

--- a/website/content/en/preview/upgrading/v1beta1-migration.md
+++ b/website/content/en/preview/upgrading/v1beta1-migration.md
@@ -199,10 +199,11 @@ If you are using some IaC for managing your policy documents attached to the con
 
 Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
 
-| Karpenter Labels                |                             |
-|---------------------------------|-----------------------------|
-| **v1alpha5**                    | **v1beta1**                 |
-| karpenter.sh/provisioner-name   | karpenter.sh/nodepool       |
+| Karpenter Labels                |                       |
+|---------------------------------|-----------------------|
+| **v1alpha5**                    | **v1beta1**           |
+| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
+| karpenter.k8s.aws/instance-pods | **Dropped**           |
 
 > **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
 

--- a/website/content/en/v0.32/upgrading/v1beta1-migration.md
+++ b/website/content/en/v0.32/upgrading/v1beta1-migration.md
@@ -199,10 +199,11 @@ If you are using some IaC for managing your policy documents attached to the con
 
 Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
 
-| Karpenter Labels                |                             |
-|---------------------------------|-----------------------------|
-| **v1alpha5**                    | **v1beta1**                 |
-| karpenter.sh/provisioner-name   | karpenter.sh/nodepool       |
+| Karpenter Labels                |                       |
+|---------------------------------|-----------------------|
+| **v1alpha5**                    | **v1beta1**           |
+| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
+| karpenter.k8s.aws/instance-pods | **Dropped**           |
 
 > **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds the note for `karpenter.k8s.aws/instance-pods` being dropped in v1beta1

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.