### PR TITLE
docs: Reorder v1beta1 migration guide to place CRD migration first

### DIFF
--- a/website/content/en/docs/upgrading/v1beta1-migration.md
+++ b/website/content/en/docs/upgrading/v1beta1-migration.md
@@ -195,39 +195,6 @@ If you are using some IaC for managing your policy documents attached to the con
 
 ## Changelog
 
-### Annotations, Labels, and Status Conditions
-
-Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
-
-| Karpenter Labels                |                       |
-|---------------------------------|-----------------------|
-| **v1alpha5**                    | **v1beta1**           |
-| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
-| karpenter.k8s.aws/instance-pods | **Dropped**           |
-
-> **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
-
-
-| Karpenter Annotations               |                                     |
-|-------------------------------------|-------------------------------------|
-| **v1alpha5**                        | **v1beta1**                         |
-| karpenter.sh/provisioner-hash       | karpenter.sh/nodepool-hash          |
-| karpenter.k8s.aws/nodetemplate-hash | karpenter.k8s.aws/ec2nodeclass-hash |
-| karpenter.sh/do-not-consolidate     | karpenter.sh/do-not-disrupt         |
-| karpenter.sh/do-not-evict           | karpenter.sh/do-not-disrupt         |
-
-> **Note**: Karpenter dropped the `karpenter.sh/do-not-consolidate` annotation in favor of the `karpenter.sh/do-not-disrupt` annotation on nodes. This annotation specifies that no voluntary disruption should be performed by Karpenter against this node.
-
-| StatusCondition Types           |                |
-|---------------------------------|----------------|
-| **v1alpha5**                    | **v1beta1**    |
-| MachineLaunched                 | Launched       |
-| MachineRegistered               | Registered     |
-| MachineInitialized              | Initialized    |
-| MachineEmpty                    | Empty          |
-| MachineExpired                  | Expired        |
-| MachineDrifted                  | Drifted        |
-
 ### Provisioner -> NodePool
 
 Karpenter v1beta1 moves almost all top-level fields under the `NodePool` template field. Similar to Deployments (which template Pods that are orchestrated by the deployment controller), Karpenter NodePool templates NodeClaims (that are orchestrated by the Karpenter controller). Here is an example of a `Provisioner` (v1alpha5) migrated to a `NodePool` (v1beta1):
@@ -368,7 +335,7 @@ spec:
 
 #### TTLSecondsAfterEmpty
 
-The Karpenter `spec.ttlSecondsAfterEmpty` field has been removed in favor of a `consolidationPolicy` and `consolidateAfter` field. 
+The Karpenter `spec.ttlSecondsAfterEmpty` field has been removed in favor of a `consolidationPolicy` and `consolidateAfter` field.
 
 As part of the v1beta1 migration, Karpenter has chosen to collapse the concepts of emptiness and underutilization into a single concept: `consolidation`.
 You can now define the types of consolidation that you want to support in your `consolidationPolicy` field.
@@ -525,7 +492,7 @@ To configure AWS-specific settings, AWSNodeTemplate (v1alpha) is being changed t
 Tag-based [AMI Selection](https://karpenter.sh/v0.31/concepts/node-templates/#ami-selection) is no longer supported for the new v1beta1 `EC2NodeClass` API. That feature allowed users to tag their AMIs using EC2 tags to express “In” requirements on selected. We recommend using different NodePools with different EC2NodeClasses with your various AMI requirement constraints to appropriately constrain your AMIs based on the instance types you’ve selected for a given NodePool.
 {{% /alert %}}
 
-{{% alert title="Note" color="primary" %}} 
+{{% alert title="Note" color="primary" %}}
 Karpenter will now tag EC2 instances with their node name instead of with `karpenter.sh/provisioner-name: $PROVISIONER_NAME`. This makes it easier to map nodes to instances if you are not currently using [resource-based naming](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html).
 {{% /alert %}}
 
@@ -741,12 +708,45 @@ spec:
 
 #### LaunchTemplateName
 
-The `spec.launchTemplateName` field for referencing unmanaged launch templates within Karpenter has been removed. 
+The `spec.launchTemplateName` field for referencing unmanaged launch templates within Karpenter has been removed.
 Find a discussion of the decision to remove `spec.launchTemplateName`, see [RFC: Unmanaged LaunchTemplate Removal](https://github.com/aws/karpenter/blob/main/designs/unmanaged-launch-template-removal.md).
 
 #### AMIFamily
 
 The AMIFamily field is now required. If you were previously not specifying the AMIFamily field, having Karpenter default the AMIFamily to AL2, you will now have to specify AL2 explicitly.
+
+### Annotations, Labels, and Status Conditions
+
+Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
+
+| Karpenter Labels                |                       |
+|---------------------------------|-----------------------|
+| **v1alpha5**                    | **v1beta1**           |
+| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
+| karpenter.k8s.aws/instance-pods | **Dropped**           |
+
+> **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
+
+
+| Karpenter Annotations               |                                     |
+|-------------------------------------|-------------------------------------|
+| **v1alpha5**                        | **v1beta1**                         |
+| karpenter.sh/provisioner-hash       | karpenter.sh/nodepool-hash          |
+| karpenter.k8s.aws/nodetemplate-hash | karpenter.k8s.aws/ec2nodeclass-hash |
+| karpenter.sh/do-not-consolidate     | karpenter.sh/do-not-disrupt         |
+| karpenter.sh/do-not-evict           | karpenter.sh/do-not-disrupt         |
+
+> **Note**: Karpenter dropped the `karpenter.sh/do-not-consolidate` annotation in favor of the `karpenter.sh/do-not-disrupt` annotation on nodes. This annotation specifies that no voluntary disruption should be performed by Karpenter against this node.
+
+| StatusCondition Types           |                |
+|---------------------------------|----------------|
+| **v1alpha5**                    | **v1beta1**    |
+| MachineLaunched                 | Launched       |
+| MachineRegistered               | Registered     |
+| MachineInitialized              | Initialized    |
+| MachineEmpty                    | Empty          |
+| MachineExpired                  | Expired        |
+| MachineDrifted                  | Drifted        |
 
 ### Metrics
 

--- a/website/content/en/preview/upgrading/v1beta1-migration.md
+++ b/website/content/en/preview/upgrading/v1beta1-migration.md
@@ -195,39 +195,6 @@ If you are using some IaC for managing your policy documents attached to the con
 
 ## Changelog
 
-### Annotations, Labels, and Status Conditions
-
-Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
-
-| Karpenter Labels                |                       |
-|---------------------------------|-----------------------|
-| **v1alpha5**                    | **v1beta1**           |
-| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
-| karpenter.k8s.aws/instance-pods | **Dropped**           |
-
-> **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
-
-
-| Karpenter Annotations               |                                     |
-|-------------------------------------|-------------------------------------|
-| **v1alpha5**                        | **v1beta1**                         |
-| karpenter.sh/provisioner-hash       | karpenter.sh/nodepool-hash          |
-| karpenter.k8s.aws/nodetemplate-hash | karpenter.k8s.aws/ec2nodeclass-hash |
-| karpenter.sh/do-not-consolidate     | karpenter.sh/do-not-disrupt         |
-| karpenter.sh/do-not-evict           | karpenter.sh/do-not-disrupt         |
-
-> **Note**: Karpenter dropped the `karpenter.sh/do-not-consolidate` annotation in favor of the `karpenter.sh/do-not-disrupt` annotation on nodes. This annotation specifies that no voluntary disruption should be performed by Karpenter against this node.
-
-| StatusCondition Types           |                |
-|---------------------------------|----------------|
-| **v1alpha5**                    | **v1beta1**    |
-| MachineLaunched                 | Launched       |
-| MachineRegistered               | Registered     |
-| MachineInitialized              | Initialized    |
-| MachineEmpty                    | Empty          |
-| MachineExpired                  | Expired        |
-| MachineDrifted                  | Drifted        |
-
 ### Provisioner -> NodePool
 
 Karpenter v1beta1 moves almost all top-level fields under the `NodePool` template field. Similar to Deployments (which template Pods that are orchestrated by the deployment controller), Karpenter NodePool templates NodeClaims (that are orchestrated by the Karpenter controller). Here is an example of a `Provisioner` (v1alpha5) migrated to a `NodePool` (v1beta1):
@@ -368,7 +335,7 @@ spec:
 
 #### TTLSecondsAfterEmpty
 
-The Karpenter `spec.ttlSecondsAfterEmpty` field has been removed in favor of a `consolidationPolicy` and `consolidateAfter` field. 
+The Karpenter `spec.ttlSecondsAfterEmpty` field has been removed in favor of a `consolidationPolicy` and `consolidateAfter` field.
 
 As part of the v1beta1 migration, Karpenter has chosen to collapse the concepts of emptiness and underutilization into a single concept: `consolidation`.
 You can now define the types of consolidation that you want to support in your `consolidationPolicy` field.
@@ -525,7 +492,7 @@ To configure AWS-specific settings, AWSNodeTemplate (v1alpha) is being changed t
 Tag-based [AMI Selection](https://karpenter.sh/v0.31/concepts/node-templates/#ami-selection) is no longer supported for the new v1beta1 `EC2NodeClass` API. That feature allowed users to tag their AMIs using EC2 tags to express “In” requirements on selected. We recommend using different NodePools with different EC2NodeClasses with your various AMI requirement constraints to appropriately constrain your AMIs based on the instance types you’ve selected for a given NodePool.
 {{% /alert %}}
 
-{{% alert title="Note" color="primary" %}} 
+{{% alert title="Note" color="primary" %}}
 Karpenter will now tag EC2 instances with their node name instead of with `karpenter.sh/provisioner-name: $PROVISIONER_NAME`. This makes it easier to map nodes to instances if you are not currently using [resource-based naming](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html).
 {{% /alert %}}
 
@@ -741,12 +708,45 @@ spec:
 
 #### LaunchTemplateName
 
-The `spec.launchTemplateName` field for referencing unmanaged launch templates within Karpenter has been removed. 
+The `spec.launchTemplateName` field for referencing unmanaged launch templates within Karpenter has been removed.
 Find a discussion of the decision to remove `spec.launchTemplateName`, see [RFC: Unmanaged LaunchTemplate Removal](https://github.com/aws/karpenter/blob/main/designs/unmanaged-launch-template-removal.md).
 
 #### AMIFamily
 
 The AMIFamily field is now required. If you were previously not specifying the AMIFamily field, having Karpenter default the AMIFamily to AL2, you will now have to specify AL2 explicitly.
+
+### Annotations, Labels, and Status Conditions
+
+Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
+
+| Karpenter Labels                |                       |
+|---------------------------------|-----------------------|
+| **v1alpha5**                    | **v1beta1**           |
+| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
+| karpenter.k8s.aws/instance-pods | **Dropped**           |
+
+> **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
+
+
+| Karpenter Annotations               |                                     |
+|-------------------------------------|-------------------------------------|
+| **v1alpha5**                        | **v1beta1**                         |
+| karpenter.sh/provisioner-hash       | karpenter.sh/nodepool-hash          |
+| karpenter.k8s.aws/nodetemplate-hash | karpenter.k8s.aws/ec2nodeclass-hash |
+| karpenter.sh/do-not-consolidate     | karpenter.sh/do-not-disrupt         |
+| karpenter.sh/do-not-evict           | karpenter.sh/do-not-disrupt         |
+
+> **Note**: Karpenter dropped the `karpenter.sh/do-not-consolidate` annotation in favor of the `karpenter.sh/do-not-disrupt` annotation on nodes. This annotation specifies that no voluntary disruption should be performed by Karpenter against this node.
+
+| StatusCondition Types           |                |
+|---------------------------------|----------------|
+| **v1alpha5**                    | **v1beta1**    |
+| MachineLaunched                 | Launched       |
+| MachineRegistered               | Registered     |
+| MachineInitialized              | Initialized    |
+| MachineEmpty                    | Empty          |
+| MachineExpired                  | Expired        |
+| MachineDrifted                  | Drifted        |
 
 ### Metrics
 

--- a/website/content/en/v0.32/upgrading/v1beta1-migration.md
+++ b/website/content/en/v0.32/upgrading/v1beta1-migration.md
@@ -195,39 +195,6 @@ If you are using some IaC for managing your policy documents attached to the con
 
 ## Changelog
 
-### Annotations, Labels, and Status Conditions
-
-Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
-
-| Karpenter Labels                |                       |
-|---------------------------------|-----------------------|
-| **v1alpha5**                    | **v1beta1**           |
-| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
-| karpenter.k8s.aws/instance-pods | **Dropped**           |
-
-> **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
-
-
-| Karpenter Annotations               |                                     |
-|-------------------------------------|-------------------------------------|
-| **v1alpha5**                        | **v1beta1**                         |
-| karpenter.sh/provisioner-hash       | karpenter.sh/nodepool-hash          |
-| karpenter.k8s.aws/nodetemplate-hash | karpenter.k8s.aws/ec2nodeclass-hash |
-| karpenter.sh/do-not-consolidate     | karpenter.sh/do-not-disrupt         |
-| karpenter.sh/do-not-evict           | karpenter.sh/do-not-disrupt         |
-
-> **Note**: Karpenter dropped the `karpenter.sh/do-not-consolidate` annotation in favor of the `karpenter.sh/do-not-disrupt` annotation on nodes. This annotation specifies that no voluntary disruption should be performed by Karpenter against this node.
-
-| StatusCondition Types           |                |
-|---------------------------------|----------------|
-| **v1alpha5**                    | **v1beta1**    |
-| MachineLaunched                 | Launched       |
-| MachineRegistered               | Registered     |
-| MachineInitialized              | Initialized    |
-| MachineEmpty                    | Empty          |
-| MachineExpired                  | Expired        |
-| MachineDrifted                  | Drifted        |
-
 ### Provisioner -> NodePool
 
 Karpenter v1beta1 moves almost all top-level fields under the `NodePool` template field. Similar to Deployments (which template Pods that are orchestrated by the deployment controller), Karpenter NodePool templates NodeClaims (that are orchestrated by the Karpenter controller). Here is an example of a `Provisioner` (v1alpha5) migrated to a `NodePool` (v1beta1):
@@ -368,7 +335,7 @@ spec:
 
 #### TTLSecondsAfterEmpty
 
-The Karpenter `spec.ttlSecondsAfterEmpty` field has been removed in favor of a `consolidationPolicy` and `consolidateAfter` field. 
+The Karpenter `spec.ttlSecondsAfterEmpty` field has been removed in favor of a `consolidationPolicy` and `consolidateAfter` field.
 
 As part of the v1beta1 migration, Karpenter has chosen to collapse the concepts of emptiness and underutilization into a single concept: `consolidation`.
 You can now define the types of consolidation that you want to support in your `consolidationPolicy` field.
@@ -525,7 +492,7 @@ To configure AWS-specific settings, AWSNodeTemplate (v1alpha) is being changed t
 Tag-based [AMI Selection](https://karpenter.sh/v0.31/concepts/node-templates/#ami-selection) is no longer supported for the new v1beta1 `EC2NodeClass` API. That feature allowed users to tag their AMIs using EC2 tags to express “In” requirements on selected. We recommend using different NodePools with different EC2NodeClasses with your various AMI requirement constraints to appropriately constrain your AMIs based on the instance types you’ve selected for a given NodePool.
 {{% /alert %}}
 
-{{% alert title="Note" color="primary" %}} 
+{{% alert title="Note" color="primary" %}}
 Karpenter will now tag EC2 instances with their node name instead of with `karpenter.sh/provisioner-name: $PROVISIONER_NAME`. This makes it easier to map nodes to instances if you are not currently using [resource-based naming](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html).
 {{% /alert %}}
 
@@ -741,12 +708,45 @@ spec:
 
 #### LaunchTemplateName
 
-The `spec.launchTemplateName` field for referencing unmanaged launch templates within Karpenter has been removed. 
+The `spec.launchTemplateName` field for referencing unmanaged launch templates within Karpenter has been removed.
 Find a discussion of the decision to remove `spec.launchTemplateName`, see [RFC: Unmanaged LaunchTemplate Removal](https://github.com/aws/karpenter/blob/main/designs/unmanaged-launch-template-removal.md).
 
 #### AMIFamily
 
 The AMIFamily field is now required. If you were previously not specifying the AMIFamily field, having Karpenter default the AMIFamily to AL2, you will now have to specify AL2 explicitly.
+
+### Annotations, Labels, and Status Conditions
+
+Karpenter v1beta1 introduces changes to some common labels, annotations, and status conditions that are present in the project. The tables below lists the v1alpha5 values and their v1beta1 equivalent.
+
+| Karpenter Labels                |                       |
+|---------------------------------|-----------------------|
+| **v1alpha5**                    | **v1beta1**           |
+| karpenter.sh/provisioner-name   | karpenter.sh/nodepool |
+| karpenter.k8s.aws/instance-pods | **Dropped**           |
+
+> **Note**: Previously, you could use the `karpenter.sh/provisioner-name:DoesNotExist` requirement on pods to specify that pods should schedule to nodes unmanaged by Karpenter. With the addition of the `karpenter.sh/nodepool` label key, you now need to specify the `karpenter.sh/nodepool:DoesNotExist` requirement on these pods as well to ensure they don't schedule to nodes provisioned by the new NodePool resources.
+
+
+| Karpenter Annotations               |                                     |
+|-------------------------------------|-------------------------------------|
+| **v1alpha5**                        | **v1beta1**                         |
+| karpenter.sh/provisioner-hash       | karpenter.sh/nodepool-hash          |
+| karpenter.k8s.aws/nodetemplate-hash | karpenter.k8s.aws/ec2nodeclass-hash |
+| karpenter.sh/do-not-consolidate     | karpenter.sh/do-not-disrupt         |
+| karpenter.sh/do-not-evict           | karpenter.sh/do-not-disrupt         |
+
+> **Note**: Karpenter dropped the `karpenter.sh/do-not-consolidate` annotation in favor of the `karpenter.sh/do-not-disrupt` annotation on nodes. This annotation specifies that no voluntary disruption should be performed by Karpenter against this node.
+
+| StatusCondition Types           |                |
+|---------------------------------|----------------|
+| **v1alpha5**                    | **v1beta1**    |
+| MachineLaunched                 | Launched       |
+| MachineRegistered               | Registered     |
+| MachineInitialized              | Initialized    |
+| MachineEmpty                    | Empty          |
+| MachineExpired                  | Expired        |
+| MachineDrifted                  | Drifted        |
 
 ### Metrics
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change re-orders the v1beta1 migration guide so that the migration of the CRDs from alpha to beta comes first

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.