### PR TITLE
fix: Update step04-controller-iam.sh

### DIFF
--- a/website/content/en/v0.32/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/v0.32/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -52,7 +52,7 @@ cat << EOF > controller-policy.json
             "Action": "ec2:TerminateInstances",
             "Condition": {
                 "StringLike": {
-                    "ec2:ResourceTag/karpenter.sh/provisioner-name": "*"
+                    "ec2:ResourceTag/karpenter.sh/nodepool": "*"
                 }
             },
             "Effect": "Allow",


### PR DESCRIPTION
Replace provisioner-name with nodepool in controller-policy.json

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
Karpenter v0.32.x+ is not adding 'karpenter.sh/provisioner-name' tag on ec2 nodes. So we should  use 'karpenter.sh/nodepool' tag instead.

**How was this change tested?**
Yes

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.