### PR TITLE
test: Fix Kubernetes Version for AMI drift

### DIFF
--- a/test/pkg/environment/aws/expectations.go
+++ b/test/pkg/environment/aws/expectations.go
@@ -315,7 +315,7 @@ func (env *Environment) ExpectParsedProviderID(providerID string) string {
 	return providerIDSplit[len(providerIDSplit)-1]
 }
 
-func (env *Environment) GetCustomAMI(amiPath string, versionOffset int) string {
+func (env *Environment) GetK8sVersion(offset int) string {
 	serverVersion, err := env.KubeClient.Discovery().ServerVersion()
 	Expect(err).To(BeNil())
 	minorVersion, err := strconv.Atoi(strings.TrimSuffix(serverVersion.Minor, "+"))
@@ -323,7 +323,11 @@ func (env *Environment) GetCustomAMI(amiPath string, versionOffset int) string {
 	// Choose a minor version one lesser than the server's minor version. This ensures that we choose an AMI for
 	// this test that wouldn't be selected as Karpenter's SSM default (therefore avoiding false positives), and also
 	// ensures that we aren't violating version skew.
-	version := fmt.Sprintf("%s.%d", serverVersion.Major, minorVersion-versionOffset)
+	return fmt.Sprintf("%s.%d", serverVersion.Major, minorVersion-offset)
+}
+
+func (env *Environment) GetCustomAMI(amiPath string, versionOffset int) string {
+	version := env.GetK8sVersion(versionOffset)
 	parameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
 		Name: aws.String(fmt.Sprintf(amiPath, version)),
 	})

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -111,8 +111,9 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 		env.EventuallyExpectNotFound(pod, nodeClaim, node)
 	})
 	It("should return drifted if the AMI no longer matches the existing NodeClaims instance type", func() {
+		version := env.GetK8sVersion(1)
 		armParameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
-			Name: awssdk.String("/aws/service/eks/optimized-ami/1.28/amazon-linux-2-arm64/recommended/image_id"),
+			Name: awssdk.String(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version)),
 		})
 		Expect(err).To(BeNil())
 		armAMI := *armParameter.Parameter.Value
@@ -139,10 +140,11 @@ var _ = Describe("Beta/Drift", Label("AWS"), func() {
 		env.EventuallyExpectNotFound(pod, nodeClaim, node)
 	})
 	It("should not disrupt nodes that have drifted without the featureGate enabled", func() {
+		version := env.GetK8sVersion(1)
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=false"})
 		// choose an old static image
 		parameter, err := env.SSMAPI.GetParameter(&ssm.GetParameterInput{
-			Name: awssdk.String("/aws/service/eks/optimized-ami/1.23/amazon-linux-2/amazon-eks-node-1.23-v20230322/image_id"),
+			Name: awssdk.String(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2-arm64/recommended/image_id", version)),
 		})
 		Expect(err).To(BeNil())
 		oldCustomAMI := *parameter.Parameter.Value


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- We are seeing failures on our [E2EVersionCompatibility](https://github.com/aws/karpenter/actions/runs/6844076381) tests for AMI drift testing 
- The test was requesting 1.28 EKS AMI, however that should depend on the k8s version 

**How was this change tested?**
- Manually tested

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.