### PR TITLE
Update step04-controller-iam.sh

### DIFF
--- a/website/content/en/docs/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/docs/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -52,7 +52,7 @@ cat << EOF > controller-policy.json
             "Action": "ec2:TerminateInstances",
             "Condition": {
                 "StringLike": {
-                    "ec2:ResourceTag/karpenter.sh/provisioner-name": "*"
+                    "ec2:ResourceTag/karpenter.sh/nodepool": "*"
                 }
             },
             "Effect": "Allow",

--- a/website/content/en/preview/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/preview/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -52,7 +52,7 @@ cat << EOF > controller-policy.json
             "Action": "ec2:TerminateInstances",
             "Condition": {
                 "StringLike": {
-                    "ec2:ResourceTag/karpenter.sh/provisioner-name": "*"
+                    "ec2:ResourceTag/karpenter.sh/nodepool": "*"
                 }
             },
             "Effect": "Allow",

--- a/website/content/en/v0.32/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
+++ b/website/content/en/v0.32/getting-started/migrating-from-cas/scripts/step04-controller-iam.sh
@@ -52,7 +52,7 @@ cat << EOF > controller-policy.json
             "Action": "ec2:TerminateInstances",
             "Condition": {
                 "StringLike": {
-                    "ec2:ResourceTag/karpenter.sh/provisioner-name": "*"
+                    "ec2:ResourceTag/karpenter.sh/nodepool": "*"
                 }
             },
             "Effect": "Allow",


### PR DESCRIPTION
Changes provisioner to nodepool in condtional terminate policy

**Description**

The conditional terminate policy to allow termination of ec2 instance if they have tag `karpenter.sh/provisioner-name`, does not work anymore as the tags added in v0.32 are `karpenter.sh/nodepool`. This causes karpenter to fail while trying to terminate underutilized instances with the error:

User: <iam role arn> is not authorized to perform: ec2:TerminateInstances on resource: <instance arn> because no identity-based policy allows the ec2:TerminateInstances action.

**How was this change tested?**
edited the policy, and implemented it on EKS cluster. Karpenter was able to terminate instances after the change was made.

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.