### PR TITLE
ci: Move prometheus and karpenter install to create_cluster action

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -4,11 +4,23 @@ inputs:
   account_id:
     description: "Account ID to access AWS"
     required: true
+  ecr_account_id:
+    description: "Account ID to access ECR Repository"
+    required: true
+  prometheus_workspace_id:
+    description: Workspace ID for the Prometheus workspace
+    required: true
   role:
     description: "Role to access AWS"
     required: true
   region:
     description: "Region to access AWS"
+    required: true
+  ecr_region:
+    description: "Region to access ECR Repository"
+    required: true
+  prometheus_region:
+    description: Region to access Prometheus 
     required: true
   cluster_name:
     description: 'Name of the cluster to be launched by eksctl'
@@ -28,6 +40,8 @@ inputs:
   git_ref:
     description: "The git commit, tag, or branch to check out. Requires a corresponding Karpenter snapshot release"
     required: false
+  create_cluster:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -184,3 +198,24 @@ runs:
         echo "Stack Events for $stack_name:"
         aws cloudformation describe-stack-events --stack-name $stack_name
       done
+  - name: install prometheus
+    uses: ./.github/actions/e2e/install-prometheus
+    if: always() && inputs.create_cluster
+    with:
+      account_id: ${{ inputs.account_id }}
+      role: ${{ inputs.role }}
+      region: ${{ inputs.prometheus_region }}
+      cluster_name: ${{ inputs.cluster_name }}
+      workspace_id: ${{ inputs.prometheus_workspace_id }}
+      git_ref: ${{ inputs.git_ref }}
+  - name: install karpenter
+    uses: ./.github/actions/e2e/install-karpenter
+    if: always() && inputs.create_cluster
+    with:
+      account_id: ${{ inputs.account_id  }}
+      role: ${{ inputs.role }}
+      region: ${{ inputs.region }}
+      ecr_account_id: ${{ inputs.ecr_account_id }}
+      ecr_region: ${{ inputs.ecr_region }}
+      cluster_name: ${{ inputs.cluster_name }}
+      git_ref: ${{ inputs.git_ref }}

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -76,6 +76,7 @@ jobs:
           aws-region: ${{ inputs.region }}
           role-duration-seconds: 21600
       - id: generate-cluster-name
+        name: generate cluster name
         run: |
           CLUSTER_NAME="upgrade-$RANDOM$RANDOM"
           echo "Using cluster name \"$CLUSTER_NAME\""
@@ -91,25 +92,11 @@ jobs:
           eksctl_version: v0.164.0
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.from_git_ref }}
-      - name: install prometheus
-        uses: ./.github/actions/e2e/install-prometheus
-        with:
-          account_id: ${{ vars.ACCOUNT_ID }}
-          role: ${{ vars.ROLE_NAME }}
-          region: ${{ vars.PROMETHEUS_REGION }}
-          cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
-          workspace_id: ${{ vars.WORKSPACE_ID }}
-          git_ref: ${{ inputs.from_git_ref }}
-      - name: install karpenter
-        uses: ./.github/actions/e2e/install-karpenter
-        with:
-          account_id: ${{ vars.ACCOUNT_ID }}
-          role: ${{ vars.ROLE_NAME }}
-          region: ${{ inputs.region }}
           ecr_account_id: ${{ vars.ECR_ACCOUNT_ID }}
           ecr_region: ${{ vars.ECR_REGION }}
-          cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
-          git_ref: ${{ inputs.from_git_ref }}
+          prometheus_workspace_id: ${{ vars.WORKSPACE_ID }}
+          prometheus_region: ${{ vars.PROMETHEUS_REGION }}
+          create_cluster: true
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.to_git_ref }}
@@ -124,6 +111,11 @@ jobs:
           eksctl_version: v0.164.0
           ip_family: IPv4 # Set the value to IPv6 if IPv6 suite, else IPv4
           git_ref: ${{ inputs.to_git_ref }}
+          ecr_account_id: ${{ vars.ECR_ACCOUNT_ID }}
+          ecr_region: ${{ vars.ECR_REGION }}
+          prometheus_workspace_id: ${{ vars.WORKSPACE_ID }}
+          prometheus_region: ${{ vars.PROMETHEUS_REGION }}
+          create_cluster: false
       - name: upgrade prometheus
         uses: ./.github/actions/e2e/install-prometheus
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -95,6 +95,7 @@ jobs:
           # Creating jitter so that we can stagger cluster creation to avoid throttling
           sleep $(( RANDOM % 300 + 1 ))
       - id: generate-cluster-name
+        name: generate cluster name
         run: |
           CLUSTER_NAME="$(echo ${{ inputs.suite }}-"$RANDOM$RANDOM" | awk '{print tolower($0)}' | tr / -)"
           echo Using cluster name "$CLUSTER_NAME"
@@ -111,25 +112,11 @@ jobs:
           ip_family: ${{ contains(inputs.suite, 'IPv6') && 'IPv6' || 'IPv4' }} # Set the value to IPv6 if IPv6 suite, else IPv4
           private_cluster: ${{ inputs.suite == 'PrivateCluster' }}
           git_ref: ${{ inputs.git_ref }}
-      - name: install prometheus
-        uses: ./.github/actions/e2e/install-prometheus
-        with:
-          account_id: ${{ vars.ACCOUNT_ID }}
-          role: ${{ vars.ROLE_NAME }}
-          region: ${{ vars.PROMETHEUS_REGION }}
-          cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
-          workspace_id: ${{ vars.WORKSPACE_ID }}
-          git_ref: ${{ inputs.git_ref }}
-      - name: install karpenter
-        uses: ./.github/actions/e2e/install-karpenter
-        with:
-          account_id: ${{ vars.ACCOUNT_ID }}
-          role: ${{ vars.ROLE_NAME }}
-          region: ${{ inputs.region }}
           ecr_account_id: ${{ vars.ECR_ACCOUNT_ID }}
           ecr_region: ${{ vars.ECR_REGION }}
-          cluster_name: ${{ steps.generate-cluster-name.outputs.CLUSTER_NAME }}
-          git_ref: ${{ inputs.git_ref }}
+          prometheus_workspace_id: ${{ vars.WORKSPACE_ID }}
+          prometheus_region: ${{ vars.PROMETHEUS_REGION }}
+          create_cluster: true
       - name: run the ${{ inputs.suite }} test suite
         run: |
           TEST_SUITE="${{ inputs.suite }}"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Move installing prometheus and karpenter in create cluster for better abstraction 

**How was this change tested?**
- Manually tested in a forked repo

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.