### PR TITLE
docs: update README.md to reflect go version requirement

### DIFF
--- a/tools/karpenter-convert/README.md
+++ b/tools/karpenter-convert/README.md
@@ -9,6 +9,7 @@ It converts `v1alpha5/Provisioner` to `v1beta1/NodePool` and `v1alpha1/AWSNodeTe
 go install github.com/aws/karpenter/tools/karpenter-convert/cmd/karpenter-convert@latest
 ```
 *NOTE:  requires go 1.21+*
+
 ## Usage
 ```console
 Usage:

--- a/tools/karpenter-convert/README.md
+++ b/tools/karpenter-convert/README.md
@@ -8,7 +8,7 @@ It converts `v1alpha5/Provisioner` to `v1beta1/NodePool` and `v1alpha1/AWSNodeTe
 ```
 go install github.com/aws/karpenter/tools/karpenter-convert/cmd/karpenter-convert@latest
 ```
-
+*NOTE:  requires go 1.21+*
 ## Usage
 ```console
 Usage:


### PR DESCRIPTION
When running `go install` to install karpenter-convert with an older go version without the `slices` package (introduced in go 1.21), we get the following error: `package slices is not in GOROOT`

Upgrading to go 1.21 fixes the problem

**Does this change impact docs?**
- [X] Yes, PR includes docs updates 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.