### PR TITLE
docs: Fix the placement of the upgrade guide warning for instance profiles

### DIFF
--- a/website/content/en/docs/upgrading/upgrade-guide.md
+++ b/website/content/en/docs/upgrading/upgrade-guide.md
@@ -22,12 +22,6 @@ Karpenter ships with a few Custom Resource Definitions (CRDs). These CRDs are pu
 If you get the error `invalid ownership metadata; label validation error:` while installing the `karpenter-crd` chart from an older version of Karpenter, follow the [Troubleshooting Guide]({{<ref "../troubleshooting#helm-error-when-upgrading-from-older-karpenter-version" >}}) for details on how to resolve these errors.
 {{% /alert %}}
 
-{{% alert title="Warning" color="warning" %}}
-As part of the v1beta1 APIs, v0.32.0 and v0.32.1 removed the InstanceProfile field, where Karpenter allows users to set a Role instead. This role is used to create/delete an instance profile for the user. This unintentionally removed support for clusters that do not have access to a private IAM endpoint. Karpenter is exploring options here to add back in support in and will release v0.32.2 to include that.
-
-Track https://github.com/aws/karpenter/issues/4985 for more.
-{{% /alert %}}
-
 * As part of the helm chart [karpenter](https://gallery.ecr.aws/karpenter/karpenter) - [source](https://github.com/aws/karpenter/blob/main/charts/karpenter/crds). Helm [does not manage the lifecycle of CRDs using this method](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/), the tool will only install the CRD during the first installation of the helm chart. Subsequent chart upgrades will not add or remove CRDs, even if the CRDs have changed. When CRDs are changed, we will make a note in the version's upgrade guide.
 
 In general, you can reapply the CRDs in the `crds` directory of the Karpenter helm chart:
@@ -44,6 +38,12 @@ kubectl apply -f https://raw.githubusercontent.com/aws/karpenter/v0.32.1/pkg/api
 Karpenter v0.32.0 introduces v1beta1 APIs, including _significant_ changes to the API and installation procedures for the Karpenter controllers. Do not upgrade to v0.32.0+ without referencing the [v1beta1 Migration Upgrade Procedure]({{<ref "v1beta1-migration#upgrade-procedure" >}}).
 
 Additionally, if rolling back after upgrading to v0.32.0, note that v0.31.2 is the only version that supports handling rollback after you have deployed the v1beta1 APIs to your cluster.
+{{% /alert %}}
+
+{{% alert title="Warning" color="warning" %}}
+As part of the v1beta1 APIs, v0.32.0 and v0.32.1 removed the InstanceProfile field, where Karpenter allows users to set a Role instead. This role is used to create/delete an instance profile for the user. This unintentionally removed support for clusters that do not have access to a private IAM endpoint. Karpenter is exploring options here to add back in support in and will release v0.32.2 to include that.
+
+Track https://github.com/aws/karpenter/issues/4985 for more.
 {{% /alert %}}
 
 * Karpenter now serves the webhook prometheus metrics server on port `8001`. If this port is already in-use on the pod or you are running in `hostNetworking` mode, you may need to change this port value. You can configure this port value through the `WEBHOOK_METRICS_PORT` environment variable or the `webhook.metrics.port` value if installing via Helm.

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -44,6 +44,12 @@ Karpenter v0.32.0 introduces v1beta1 APIs, including _significant_ changes to th
 Additionally, if rolling back after upgrading to v0.32.0, note that v0.31.2 is the only version that supports handling rollback after you have deployed the v1beta1 APIs to your cluster.
 {{% /alert %}}
 
+{{% alert title="Warning" color="warning" %}}
+As part of the v1beta1 APIs, v0.32.0 and v0.32.1 removed the InstanceProfile field, where Karpenter allows users to set a Role instead. This role is used to create/delete an instance profile for the user. This unintentionally removed support for clusters that do not have access to a private IAM endpoint. Karpenter is exploring options here to add back in support in and will release v0.32.2 to include that.
+
+Track https://github.com/aws/karpenter/issues/4985 for more.
+{{% /alert %}}
+
 * Karpenter now serves the webhook prometheus metrics server on port `8001`. If this port is already in-use on the pod or you are running in `hostNetworking` mode, you may need to change this port value. You can configure this port value through the `WEBHOOK_METRICS_PORT` environment variable or the `webhook.metrics.port` value if installing via Helm.
 * Karpenter now exposes the ability to disable webhooks through the `webhook.enabled=false` value. This value will disable the webhook server and will prevent any permissions, mutating or validating webhook configurations from being deployed to the cluster.
 * Karpenter now moves all logging configuration for the Zap logger into the `logConfig` values block. Configuring Karpenter logging with this mechanism _is_ deprecated and will be dropped at v1. Karpenter now only surfaces logLevel through the `logLevel` helm value. If you need more advanced configuration due to log parsing constraints, we recommend configuring your log parser to handle Karpenter's Zap JSON logging.


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR edits the docs to move the placement of the upgrade warning around instance profiles around the "Upgrading to v0.32.x+" section

**How was this change tested?**

**Does this change impact docs?**
- [x] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.