### PR TITLE
docs: Add note about RBAC permissions requirement for Windows support

### DIFF
--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -186,7 +186,8 @@ runs:
       --cluster "${{ inputs.cluster_name }}" \
       --arn "arn:aws:iam::${{ inputs.account_id }}:role/KarpenterNodeRole-${{ inputs.cluster_name }}" \
       --group system:bootstrappers \
-      --group system:nodes
+      --group system:nodes \
+      --group eks:kube-proxy-windows
   - name: cloudformation describe stack events
     shell: bash
     if: failure()

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -33,6 +33,9 @@ iamIdentityMappings:
   groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
 
 managedNodeGroups:
 - instanceType: m5.large

--- a/website/content/en/docs/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/docs/getting-started/migrating-from-cas/_index.md
@@ -76,6 +76,9 @@ Replace the `${AWS_PARTITION}` variable with the account partition, `${AWS_ACCOU
 - groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
   rolearn: arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}
   username: system:node:{{EC2PrivateDNSName}}
 ```

--- a/website/content/en/docs/troubleshooting.md
+++ b/website/content/en/docs/troubleshooting.md
@@ -351,6 +351,24 @@ Windows requires the host OS version to match the container OS version.
 
 1. Define your pod's `nodeSelector` to ensure that your containers are scheduled on a compatible OS host version. To learn more, see [Windows container version compatibility](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
+### Windows pods unable to resolve DNS
+Causes for DNS resolution failure may vary, but in the case where DNS resolution is working for Linux pods but not for Windows pods,
+then the following solution(s) may resolve your issue.
+
+#### Solution(s)
+1. Verify that the instance role of the Windows node includes the RBAC permission group `eks:kube-proxy-windows` as shown below.
+   This group is required for Windows nodes because in Windows, `kube-proxy` runs as a process on the node, and as such, the node requires the necessary RBAC cluster permissions to allow access to the resources required by `kube-proxy`.
+   For more information, see https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html.
+```yaml
+...
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+    - eks:kube-proxy-windows # This is required for Windows DNS resolution to work
+...
+```
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -33,6 +33,9 @@ iamIdentityMappings:
   groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
 
 managedNodeGroups:
 - instanceType: m5.large

--- a/website/content/en/preview/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/preview/getting-started/migrating-from-cas/_index.md
@@ -76,6 +76,9 @@ Replace the `${AWS_PARTITION}` variable with the account partition, `${AWS_ACCOU
 - groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
   rolearn: arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}
   username: system:node:{{EC2PrivateDNSName}}
 ```

--- a/website/content/en/preview/troubleshooting.md
+++ b/website/content/en/preview/troubleshooting.md
@@ -351,6 +351,24 @@ Windows requires the host OS version to match the container OS version.
 
 1. Define your pod's `nodeSelector` to ensure that your containers are scheduled on a compatible OS host version. To learn more, see [Windows container version compatibility](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
+### Windows pods unable to resolve DNS
+Causes for DNS resolution failure may vary, but in the case where DNS resolution is working for Linux pods but not for Windows pods,
+then the following solution(s) may resolve your issue.
+
+#### Solution(s)
+1. Verify that the instance role of the Windows node includes the RBAC permission group `eks:kube-proxy-windows` as shown below.
+   This group is required for Windows nodes because in Windows, `kube-proxy` runs as a process on the node, and as such, the node requires the necessary RBAC cluster permissions to allow access to the resources required by `kube-proxy`.
+   For more information, see https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html.
+```yaml
+...
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+    - eks:kube-proxy-windows # This is required for Windows DNS resolution to work
+...
+```
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v0.29/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/v0.29/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -33,6 +33,9 @@ iamIdentityMappings:
   groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
 
 managedNodeGroups:
 - instanceType: m5.large

--- a/website/content/en/v0.29/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.29/getting-started/migrating-from-cas/_index.md
@@ -80,6 +80,9 @@ Replace the `${AWS_PARTITION}` variable with the account partition, `${AWS_ACCOU
 - groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
   rolearn: arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}
   username: system:node:{{EC2PrivateDNSName}}
 ```

--- a/website/content/en/v0.29/troubleshooting.md
+++ b/website/content/en/v0.29/troubleshooting.md
@@ -351,6 +351,24 @@ Windows requires the host OS version to match the container OS version.
 
 1. Define your pod's `nodeSelector` to ensure that your containers are scheduled on a compatible OS host version. To learn more, see [Windows container version compatibility](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
+### Windows pods unable to resolve DNS
+Causes for DNS resolution failure may vary, but in the case where DNS resolution is working for Linux pods but not for Windows pods,
+then the following solution(s) may resolve your issue.
+
+#### Solution(s)
+1. Verify that the instance role of the Windows node includes the RBAC permission group `eks:kube-proxy-windows` as shown below.
+   This group is required for Windows nodes because in Windows, `kube-proxy` runs as a process on the node, and as such, the node requires the necessary RBAC cluster permissions to allow access to the resources required by `kube-proxy`.
+   For more information, see https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html.
+```yaml
+...
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+    - eks:kube-proxy-windows # This is required for Windows DNS resolution to work
+...
+```
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v0.30/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/v0.30/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -33,6 +33,9 @@ iamIdentityMappings:
   groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
 
 managedNodeGroups:
 - instanceType: m5.large

--- a/website/content/en/v0.30/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.30/getting-started/migrating-from-cas/_index.md
@@ -80,6 +80,9 @@ Replace the `${AWS_PARTITION}` variable with the account partition, `${AWS_ACCOU
 - groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
   rolearn: arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}
   username: system:node:{{EC2PrivateDNSName}}
 ```

--- a/website/content/en/v0.30/troubleshooting.md
+++ b/website/content/en/v0.30/troubleshooting.md
@@ -351,6 +351,24 @@ Windows requires the host OS version to match the container OS version.
 
 1. Define your pod's `nodeSelector` to ensure that your containers are scheduled on a compatible OS host version. To learn more, see [Windows container version compatibility](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
+### Windows pods unable to resolve DNS
+Causes for DNS resolution failure may vary, but in the case where DNS resolution is working for Linux pods but not for Windows pods,
+then the following solution(s) may resolve your issue.
+
+#### Solution(s)
+1. Verify that the instance role of the Windows node includes the RBAC permission group `eks:kube-proxy-windows` as shown below.
+   This group is required for Windows nodes because in Windows, `kube-proxy` runs as a process on the node, and as such, the node requires the necessary RBAC cluster permissions to allow access to the resources required by `kube-proxy`.
+   For more information, see https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html.
+```yaml
+...
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+    - eks:kube-proxy-windows # This is required for Windows DNS resolution to work
+...
+```
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v0.31/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/v0.31/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -33,6 +33,9 @@ iamIdentityMappings:
   groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
 
 managedNodeGroups:
 - instanceType: m5.large

--- a/website/content/en/v0.31/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.31/getting-started/migrating-from-cas/_index.md
@@ -80,6 +80,9 @@ Replace the `${AWS_PARTITION}` variable with the account partition, `${AWS_ACCOU
 - groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows  
   rolearn: arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}
   username: system:node:{{EC2PrivateDNSName}}
 ```

--- a/website/content/en/v0.31/troubleshooting.md
+++ b/website/content/en/v0.31/troubleshooting.md
@@ -351,6 +351,24 @@ Windows requires the host OS version to match the container OS version.
 
 1. Define your pod's `nodeSelector` to ensure that your containers are scheduled on a compatible OS host version. To learn more, see [Windows container version compatibility](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
+### Windows pods unable to resolve DNS
+Causes for DNS resolution failure may vary, but in the case where DNS resolution is working for Linux pods but not for Windows pods,
+then the following solution(s) may resolve your issue.
+
+#### Solution(s)
+1. Verify that the instance role of the Windows node includes the RBAC permission group `eks:kube-proxy-windows` as shown below.
+   This group is required for Windows nodes because in Windows, `kube-proxy` runs as a process on the node, and as such, the node requires the necessary RBAC cluster permissions to allow access to the resources required by `kube-proxy`.
+   For more information, see https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html.
+```yaml
+...
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+    - eks:kube-proxy-windows # This is required for Windows DNS resolution to work
+...
+```
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/scripts/step02-create-cluster.sh
@@ -33,6 +33,9 @@ iamIdentityMappings:
   groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
 
 managedNodeGroups:
 - instanceType: m5.large

--- a/website/content/en/v0.32/getting-started/migrating-from-cas/_index.md
+++ b/website/content/en/v0.32/getting-started/migrating-from-cas/_index.md
@@ -76,6 +76,9 @@ Replace the `${AWS_PARTITION}` variable with the account partition, `${AWS_ACCOU
 - groups:
   - system:bootstrappers
   - system:nodes
+  ## If you intend to run Windows workloads, the kube-proxy group should be specified.
+  # For more information, see https://github.com/aws/karpenter/issues/5099.
+  # - eks:kube-proxy-windows
   rolearn: arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}
   username: system:node:{{EC2PrivateDNSName}}
 ```

--- a/website/content/en/v0.32/troubleshooting.md
+++ b/website/content/en/v0.32/troubleshooting.md
@@ -351,6 +351,24 @@ Windows requires the host OS version to match the container OS version.
 
 1. Define your pod's `nodeSelector` to ensure that your containers are scheduled on a compatible OS host version. To learn more, see [Windows container version compatibility](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
+### Windows pods unable to resolve DNS
+Causes for DNS resolution failure may vary, but in the case where DNS resolution is working for Linux pods but not for Windows pods,
+then the following solution(s) may resolve your issue.
+
+#### Solution(s)
+1. Verify that the instance role of the Windows node includes the RBAC permission group `eks:kube-proxy-windows` as shown below.
+   This group is required for Windows nodes because in Windows, `kube-proxy` runs as a process on the node, and as such, the node requires the necessary RBAC cluster permissions to allow access to the resources required by `kube-proxy`.
+   For more information, see https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html. 
+```yaml
+...
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+    - eks:kube-proxy-windows # This is required for Windows DNS resolution to work
+...
+```
+
 ## Deprovisioning
 
 ### Nodes not deprovisioned


### PR DESCRIPTION
Fixes #5099

**Description**
This doc change is meant to aid in bringing awareness to a requirement for running Windows nodes. Windows nodes have the kube-proxy binary running on the node, and as such, the node requires the necessary RBAC cluster permissions to allow access to the resources required by the `kube-proxy` component. Therefore, anyone intending to have Karpenter launch Windows nodes should specify this group. Without this change when creating the Karpenter node role, service communication and DNS resolution for pods fails.

**How was this change tested?**
Created a cluster and configured a cluster using the following snippet.

```
...
iamIdentityMappings:
- arn: "arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${CLUSTER_NAME}"
  username: system:node:{{EC2PrivateDNSName}}
  groups:
  - system:bootstrappers
  - system:nodes
  - eks:kube-proxy-windows
...
```

Tested on Karpentev v32 and the same applies for all Karpenter versions since Windows support was added (>v30.0). 

**Does this change impact docs?**
- [x] Yes, PR includes docs updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.