### PR TITLE
ci: Ensure workflow callers to `workflow_run` describe permissions

### DIFF
--- a/.github/workflows/approval-comment.yaml
+++ b/.github/workflows/approval-comment.yaml
@@ -2,7 +2,6 @@ name: ApprovalComment
 on:
   pull_request_review:
     types: [submitted]
-
 jobs:
   approval-comment:
     if: startsWith(github.event.review.body, '/karpenter snapshot') || startsWith(github.event.review.body, '/karpenter scale') || startsWith(github.event.review.body, '/karpenter versionCompatibility')

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -2,12 +2,12 @@ name: "APICodeGen"
 on:
   schedule:
     - cron: '0 13 * * MON'
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
-  pull-requests: write # name: Create Pull Request
-  contents: write # name: Create Pull Request
 jobs:
   codegen:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      pull-requests: write # name: Create Pull Request
+      contents: write # name: Create Pull Request
     if: github.repository == 'aws/karpenter'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,5 +1,4 @@
 name: "CodeQL"
-
 on:
   push:
     branches:
@@ -7,7 +6,6 @@ on:
       - 'release-v*'
   schedule:
     - cron: '0 12 * * *'
-
 jobs:
   analyze:
     if: github.repository == 'aws/karpenter'

--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -1,16 +1,13 @@
 name: DocGenCI
-
 on:
   push:
     branches:
       - 'main'
       - 'release-v*'
-
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
-
 jobs:
   docgen-ci:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
     if: github.repository == 'aws/karpenter'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-cleanup.yaml
+++ b/.github/workflows/e2e-cleanup.yaml
@@ -14,10 +14,10 @@ on:
           - "us-east-2"
           - "us-west-2"
           - "eu-west-1"
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   cleanup:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
     name: cleanup-${{ inputs.cluster_name }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -31,6 +31,9 @@ jobs:
     with:
       allowed_comment: "snapshot"
   e2e-matrix:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      statuses: write # ./.github/actions/commit-status/start
     needs: [resolve]
     if: needs.resolve.outputs.SHOULD_RUN == 'true'
     uses: ./.github/workflows/e2e-matrix.yaml

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -51,6 +51,9 @@ on:
 #   3. Downstream fork triggered the job through dispatch and has set 'ENABLE_E2E' in repo environment variables
 jobs:
   e2e:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      statuses: write # ./.github/actions/commit-status/start
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.parallelism || 100 }}
@@ -75,6 +78,9 @@ jobs:
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   e2e-upgrade:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      statuses: write # ./.github/actions/commit-status/start
     uses: ./.github/workflows/e2e-upgrade.yaml
     with:
       # This version matches the steps of the newest version that contains the additional step

--- a/.github/workflows/e2e-scale-trigger.yaml
+++ b/.github/workflows/e2e-scale-trigger.yaml
@@ -29,6 +29,9 @@ jobs:
     with:
       allowed_comment: "scale"
   scale:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      statuses: write # ./.github/actions/commit-status/start
     needs: [resolve]
     if: needs.resolve.outputs.SHOULD_RUN == 'true'
     uses: ./.github/workflows/e2e.yaml

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -48,11 +48,11 @@ on:
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
-  statuses: write # ./.github/actions/commit-status/start
 jobs:
   run-suite:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      statuses: write # ./.github/actions/commit-status/start
     name: suite-upgrade
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-version-compatibility-trigger.yaml
+++ b/.github/workflows/e2e-version-compatibility-trigger.yaml
@@ -26,6 +26,9 @@ jobs:
     with:
       allowed_comment: "versionCompatibility"
   versionCompatibility:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      statuses: write # ./.github/actions/commit-status/start
     needs: [resolve]
     if: needs.resolve.outputs.SHOULD_RUN == 'true'
     strategy:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -67,11 +67,11 @@ on:
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
-  statuses: write # ./.github/actions/commit-status/start
 jobs:
   run-suite:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      statuses: write # ./.github/actions/commit-status/start
     name: suite-${{ inputs.suite }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-snapshot.yaml
+++ b/.github/workflows/pr-snapshot.yaml
@@ -3,12 +3,12 @@ on:
   workflow_run:
     workflows: [ApprovalComment]
     types: [completed]
-permissions:
-  id-token: write
-  pull-requests: write
-  statuses: write
 jobs:
   release:
+    permissions:
+      id-token: write
+      pull-requests: write
+      statuses: write
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-test-tools.yaml
+++ b/.github/workflows/publish-test-tools.yaml
@@ -9,10 +9,10 @@ on:
       - test/push-docker.sh
   schedule:
     - cron: '0 13 * * MON'
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   publish-tools:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
     if: github.repository == 'aws/karpenter'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,12 +7,12 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
-  contents: write # marvinpinto/action-automatic-releases@v1.2.1
-  pull-requests: write # name: Create PR
 jobs:
   release:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
+      contents: write # marvinpinto/action-automatic-releases@v1.2.1
+      pull-requests: write # name: Create PR
     if: github.repository == 'aws/karpenter'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -4,10 +4,10 @@ on:
     branches:
       - 'main'
       - 'release-v*'
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   release:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
     if: github.repository == 'aws/karpenter'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sweeper.yaml
+++ b/.github/workflows/sweeper.yaml
@@ -3,10 +3,10 @@ on:
   schedule:
     - cron: '0 */12 * * *'
   workflow_dispatch:
-permissions:
-  id-token: write # aws-actions/configure-aws-credentials@v4.0.1
 jobs:
   sweeper:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials@v4.0.1
     if: vars.ACCOUNT_ID != '' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

Ensure that permissions are explicitly called out for callers of workflows, including callers to `workflow_run`. This PR also ensures that the permissions are scoped to the job rather than the workflow to enforce tighter scoping for permissions.

**How was this change tested?**

`make presubmit`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.