### PR TITLE
test: Fix Prefix Delegation enabling race condition

### DIFF
--- a/test/suites/scale/provisioning_test.go
+++ b/test/suites/scale/provisioning_test.go
@@ -72,6 +72,9 @@ var _ = Describe("Provisioning", Label(debug.NoWatch), Label(debug.NoEvents), fu
 		// that will be allocated across this large number of nodes, despite the fact that the ENI CIDR space will
 		// be extremely under-utilized
 		env.ExpectPrefixDelegationDisabled()
+		DeferCleanup(func() {
+			env.ExpectPrefixDelegationEnabled()
+		})
 
 		replicasPerNode := 1
 		expectedNodeCount := 500

--- a/test/suites/scale/suite_test.go
+++ b/test/suites/scale/suite_test.go
@@ -30,20 +30,20 @@ func TestScale(t *testing.T) {
 	RegisterFailHandler(Fail)
 	BeforeSuite(func() {
 		env = aws.NewEnvironment(t)
+		env.ExpectPrefixDelegationEnabled()
 		SetDefaultEventuallyTimeout(time.Hour)
 	})
 	AfterSuite(func() {
+		env.ExpectPrefixDelegationDisabled()
 		env.Stop()
 	})
 	RunSpecs(t, "Scale")
 }
 
 var _ = BeforeEach(func() {
-	env.ExpectPrefixDelegationEnabled()
 	env.BeforeEach()
 })
 var _ = AfterEach(func() { env.Cleanup() })
 var _ = AfterEach(func() {
 	env.AfterEach()
-	env.ExpectPrefixDelegationDisabled()
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Currently, our scale tests are experiencing a race condition between the object read and writes for updating the daemonSet `aws-node` after each test run.  The patch operation for enabling and disabling of the prefix delegation after each test creates a race between the object that's being written and the object that received for updating, causing the prefix delegation not to be enabled.   

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.