### PR TITLE
test: Fix Zonal Topology Spread E2E test

### DIFF
--- a/test/suites/integration/scheduling_test.go
+++ b/test/suites/integration/scheduling_test.go
@@ -348,6 +348,7 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 						TopologyKey:       v1.LabelTopologyZone,
 						WhenUnsatisfiable: v1.DoNotSchedule,
 						LabelSelector:     &metav1.LabelSelector{MatchLabels: podLabels},
+						MinDomains:        lo.ToPtr(int32(3)),
 					},
 				},
 			},
@@ -355,7 +356,10 @@ var _ = Describe("Scheduling", Ordered, ContinueOnFailure, func() {
 
 		env.ExpectCreated(nodeClass, nodePool, deployment)
 		env.EventuallyExpectHealthyPodCount(labels.SelectorFromSet(podLabels), 3)
-		env.ExpectCreatedNodeCount("==", 3)
+		// Karpenter will launch three nodes, however if all three nodes don't get register with the cluster at the same time, two pods will be placed on one node.
+		// This can result in a case where all 3 pods are healthy, while there are only two created nodes.
+		// In that case, we still expect to eventually have three nodes.
+		env.EventuallyExpectNodeCount("==", 3)
 	})
 	It("should provision a node using a NodePool with higher priority", func() {
 		nodePoolLowPri := test.NodePool(corev1beta1.NodePool{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- We are seeing that nodes launched by karpenter and entering a race condition for pods scheduling on the nodes. Three nodes were expected to be launched with pods having  topology spread with a maxSkew of one. `kube-scheduler` assigned one node with two pods. This is caused if there is a delay with one of the nodes coming up.

**How was this change tested?**
- make e2etests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.