### PR TITLE
chore: Drop `sqs:GetQueueAttributes` from cloudformation policy

### DIFF
--- a/pkg/fake/sqsapi.go
+++ b/pkg/fake/sqsapi.go
@@ -30,10 +30,9 @@ const (
 // SQSBehavior must be reset between tests otherwise tests will
 // pollute each other.
 type SQSBehavior struct {
-	GetQueueURLBehavior        MockedFunction[sqs.GetQueueUrlInput, sqs.GetQueueUrlOutput]
-	GetQueueAttributesBehavior MockedFunction[sqs.GetQueueAttributesInput, sqs.GetQueueAttributesOutput]
-	ReceiveMessageBehavior     MockedFunction[sqs.ReceiveMessageInput, sqs.ReceiveMessageOutput]
-	DeleteMessageBehavior      MockedFunction[sqs.DeleteMessageInput, sqs.DeleteMessageOutput]
+	GetQueueURLBehavior    MockedFunction[sqs.GetQueueUrlInput, sqs.GetQueueUrlOutput]
+	ReceiveMessageBehavior MockedFunction[sqs.ReceiveMessageInput, sqs.ReceiveMessageOutput]
+	DeleteMessageBehavior  MockedFunction[sqs.DeleteMessageInput, sqs.DeleteMessageOutput]
 }
 
 type SQSAPI struct {
@@ -45,7 +44,6 @@ type SQSAPI struct {
 // each other.
 func (s *SQSAPI) Reset() {
 	s.GetQueueURLBehavior.Reset()
-	s.GetQueueAttributesBehavior.Reset()
 	s.ReceiveMessageBehavior.Reset()
 	s.DeleteMessageBehavior.Reset()
 }

--- a/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/docs/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -178,7 +178,6 @@ Resources:
               "Resource": "${KarpenterInterruptionQueue.Arn}",
               "Action": [
                 "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
                 "sqs:GetQueueUrl",
                 "sqs:ReceiveMessage"
               ]

--- a/website/content/en/docs/reference/cloudformation.md
+++ b/website/content/en/docs/reference/cloudformation.md
@@ -313,7 +313,7 @@ Because pricing information does not exist in every region at the moment, the Al
 
 Karpenter supports interruption queues, that you can create as described in the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page.
 This section of the cloudformation.yaml template can give Karpenter permission to access those queues by specifying the resource ARN.
-For the interruption queue you created (`${KarepenterInterruptionQueue.Arn}`), the AllowInterruptionQueueActions Sid lets the Karpenter controller have permission to delete messages ([DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html)), get queue attributes ([GetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html)), get queue URL ([GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html)), and receive messages ([ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).
+For the interruption queue you created (`${KarpenterInterruptionQueue.Arn}`), the AllowInterruptionQueueActions Sid lets the Karpenter controller have permission to delete messages ([DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html)), get queue URL ([GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html)), and receive messages ([ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).
 
 ```json
 {
@@ -322,7 +322,6 @@ For the interruption queue you created (`${KarepenterInterruptionQueue.Arn}`), t
   "Resource": "${KarpenterInterruptionQueue.Arn}",
   "Action": [
     "sqs:DeleteMessage",
-    "sqs:GetQueueAttributes",
     "sqs:GetQueueUrl",
     "sqs:ReceiveMessage"
   ]

--- a/website/content/en/docs/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/docs/upgrading/v1beta1-controller-policy.json
@@ -145,7 +145,6 @@
       "Resource": "arn:aws:sqs:${AWS_REGION}:${AWS_ACCOUNT_ID}:${CLUSTER_NAME}",
       "Action": [
         "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl",
         "sqs:ReceiveMessage"
       ]

--- a/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -179,7 +179,6 @@ Resources:
               "Resource": "${KarpenterInterruptionQueue.Arn}",
               "Action": [
                 "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
                 "sqs:GetQueueUrl",
                 "sqs:ReceiveMessage"
               ]

--- a/website/content/en/preview/reference/cloudformation.md
+++ b/website/content/en/preview/reference/cloudformation.md
@@ -313,7 +313,7 @@ Because pricing information does not exist in every region at the moment, the Al
 
 Karpenter supports interruption queues, that you can create as described in the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page.
 This section of the cloudformation.yaml template can give Karpenter permission to access those queues by specifying the resource ARN.
-For the interruption queue you created (`${KarepenterInterruptionQueue.Arn}`), the AllowInterruptionQueueActions Sid lets the Karpenter controller have permission to delete messages ([DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html)), get queue attributes ([GetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html)), get queue URL ([GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html)), and receive messages ([ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).
+For the interruption queue you created (`${KarpenterInterruptionQueue.Arn}`), the AllowInterruptionQueueActions Sid lets the Karpenter controller have permission to delete messages ([DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html)), get queue URL ([GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html)), and receive messages ([ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).
 
 ```json
 {
@@ -322,7 +322,6 @@ For the interruption queue you created (`${KarepenterInterruptionQueue.Arn}`), t
   "Resource": "${KarpenterInterruptionQueue.Arn}",
   "Action": [
     "sqs:DeleteMessage",
-    "sqs:GetQueueAttributes",
     "sqs:GetQueueUrl",
     "sqs:ReceiveMessage"
   ]

--- a/website/content/en/preview/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/preview/upgrading/v1beta1-controller-policy.json
@@ -145,7 +145,6 @@
       "Resource": "arn:aws:sqs:${AWS_REGION}:${AWS_ACCOUNT_ID}:${CLUSTER_NAME}",
       "Action": [
         "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl",
         "sqs:ReceiveMessage"
       ]

--- a/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
+++ b/website/content/en/v0.32/getting-started/getting-started-with-karpenter/cloudformation.yaml
@@ -178,7 +178,6 @@ Resources:
               "Resource": "${KarpenterInterruptionQueue.Arn}",
               "Action": [
                 "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
                 "sqs:GetQueueUrl",
                 "sqs:ReceiveMessage"
               ]

--- a/website/content/en/v0.32/reference/cloudformation.md
+++ b/website/content/en/v0.32/reference/cloudformation.md
@@ -313,7 +313,7 @@ Because pricing information does not exist in every region at the moment, the Al
 
 Karpenter supports interruption queues, that you can create as described in the [Interruption]({{< relref "../concepts/disruption#interruption" >}}) section of the Disruption page.
 This section of the cloudformation.yaml template can give Karpenter permission to access those queues by specifying the resource ARN.
-For the interruption queue you created (`${KarepenterInterruptionQueue.Arn}`), the AllowInterruptionQueueActions Sid lets the Karpenter controller have permission to delete messages ([DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html)), get queue attributes ([GetQueueAttributes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html)), get queue URL ([GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html)), and receive messages ([ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).
+For the interruption queue you created (`${KarpenterInterruptionQueue.Arn}`), the AllowInterruptionQueueActions Sid lets the Karpenter controller have permission to delete messages ([DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html)), get queue URL ([GetQueueUrl](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html)), and receive messages ([ReceiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).
 
 ```json
 {
@@ -322,7 +322,6 @@ For the interruption queue you created (`${KarepenterInterruptionQueue.Arn}`), t
   "Resource": "${KarpenterInterruptionQueue.Arn}",
   "Action": [
     "sqs:DeleteMessage",
-    "sqs:GetQueueAttributes",
     "sqs:GetQueueUrl",
     "sqs:ReceiveMessage"
   ]

--- a/website/content/en/v0.32/upgrading/v1beta1-controller-policy.json
+++ b/website/content/en/v0.32/upgrading/v1beta1-controller-policy.json
@@ -145,7 +145,6 @@
       "Resource": "arn:aws:sqs:${AWS_REGION}:${AWS_ACCOUNT_ID}:${CLUSTER_NAME}",
       "Action": [
         "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl",
         "sqs:ReceiveMessage"
       ]


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**

This drops the `sqs:GetQueueAttributes` permission from the default IAM policy that is shipped with the Getting Started Guide. This permission isn't needed since we only get the QueueURL of the queue which we can achieve through a different permission scope.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.