### PR TITLE
ci: Adjust regions for metrics of resource counter and sweeper

### DIFF
--- a/test/hack/resource/clean/main.go
+++ b/test/hack/resource/clean/main.go
@@ -87,8 +87,11 @@ func main() {
 			if err != nil {
 				resourceLogger.Errorf("%v", err)
 			}
-			if err = metricsClient.FireMetric(ctx, sweeperCleanedResourcesTableName, fmt.Sprintf("%sDeleted", resourceTypes[i].String()), float64(len(cleaned)), cfg.Region); err != nil {
-				resourceLogger.Errorf("%v", err)
+			// Should only fire metrics if the resource have expired
+			if clusterName == "" {
+				if err = metricsClient.FireMetric(ctx, sweeperCleanedResourcesTableName, fmt.Sprintf("%sDeleted", resourceTypes[i].String()), float64(len(cleaned)), lo.Ternary(resourceTypes[i].Global(), "global", cfg.Region)); err != nil {
+					resourceLogger.Errorf("%v", err)
+				}
 			}
 			resourceLogger.With("ids", cleaned, "count", len(cleaned)).Infof("deleted resourceTypes")
 		}

--- a/test/hack/resource/count/main.go
+++ b/test/hack/resource/count/main.go
@@ -59,7 +59,7 @@ func main() {
 			resourceLogger.Errorf("%v", err)
 		}
 
-		if err = metricsClient.FireMetric(ctx, resourceCountTableName, resourceTypes[i].String(), float64(resourceCount), cfg.Region); err != nil {
+		if err = metricsClient.FireMetric(ctx, resourceCountTableName, resourceTypes[i].String(), float64(resourceCount), lo.Ternary(resourceTypes[i].Global(), "global", cfg.Region)); err != nil {
 			resourceLogger.Errorf("%v", err)
 		}
 		resourceLogger.With("count", resourceCount).Infof("counted resourceTypes")

--- a/test/hack/resource/pkg/resourcetypes/eni.go
+++ b/test/hack/resource/pkg/resourcetypes/eni.go
@@ -37,6 +37,10 @@ func (e *ENI) String() string {
 	return "ElasticNetworkInterface"
 }
 
+func (e *ENI) Global() bool {
+	return false
+}
+
 func (e *ENI) GetExpired(ctx context.Context, expirationTime time.Time) (ids []string, err error) {
 	var nextToken *string
 	for {

--- a/test/hack/resource/pkg/resourcetypes/instance.go
+++ b/test/hack/resource/pkg/resourcetypes/instance.go
@@ -35,6 +35,10 @@ func (i *Instance) String() string {
 	return "Instances"
 }
 
+func (i *Instance) Global() bool {
+	return false
+}
+
 func (i *Instance) GetExpired(ctx context.Context, expirationTime time.Time) (ids []string, err error) {
 	var nextToken *string
 	for {

--- a/test/hack/resource/pkg/resourcetypes/instanceprofile.go
+++ b/test/hack/resource/pkg/resourcetypes/instanceprofile.go
@@ -35,6 +35,10 @@ func (ip *InstanceProfile) String() string {
 	return "InstanceProfile"
 }
 
+func (ip *InstanceProfile) Global() bool {
+	return true
+}
+
 func (ip *InstanceProfile) GetExpired(ctx context.Context, expirationTime time.Time) (names []string, err error) {
 	out, err := ip.iamClient.ListInstanceProfiles(ctx, &iam.ListInstanceProfilesInput{})
 	if err != nil {

--- a/test/hack/resource/pkg/resourcetypes/launchtemplate.go
+++ b/test/hack/resource/pkg/resourcetypes/launchtemplate.go
@@ -36,6 +36,10 @@ func (lt *LaunchTemplate) String() string {
 	return "LaunchTemplates"
 }
 
+func (lt *LaunchTemplate) Global() bool {
+	return false
+}
+
 func (lt *LaunchTemplate) GetExpired(ctx context.Context, expirationTime time.Time) (names []string, err error) {
 	var nextToken *string
 	for {

--- a/test/hack/resource/pkg/resourcetypes/oidc.go
+++ b/test/hack/resource/pkg/resourcetypes/oidc.go
@@ -35,6 +35,10 @@ func (o *OIDC) String() string {
 	return "OpenIDConnectProvider"
 }
 
+func (o *OIDC) Global() bool {
+	return true
+}
+
 func (o *OIDC) GetExpired(ctx context.Context, expirationTime time.Time) (names []string, err error) {
 	out, err := o.iamClient.ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
 	if err != nil {

--- a/test/hack/resource/pkg/resourcetypes/resourcetypes.go
+++ b/test/hack/resource/pkg/resourcetypes/resourcetypes.go
@@ -34,6 +34,8 @@ const (
 type Type interface {
 	// String is the string representation of the type
 	String() string
+	// Global determines if a resource is globally located in an account
+	Global() bool
 	// Get returns all resources of the type associated with the clusterName
 	Get(ctx context.Context, clusterName string) (ids []string, err error)
 	// GetExpired returns all resources of the type that were provisioned before the expirationTime

--- a/test/hack/resource/pkg/resourcetypes/securitygroup.go
+++ b/test/hack/resource/pkg/resourcetypes/securitygroup.go
@@ -37,6 +37,10 @@ func (sg *SecurityGroup) String() string {
 	return "SecurityGroup"
 }
 
+func (sg *SecurityGroup) Global() bool {
+	return false
+}
+
 func (sg *SecurityGroup) GetExpired(ctx context.Context, expirationTime time.Time) (ids []string, err error) {
 	var nextToken *string
 	for {

--- a/test/hack/resource/pkg/resourcetypes/stack.go
+++ b/test/hack/resource/pkg/resourcetypes/stack.go
@@ -36,6 +36,10 @@ func (s *Stack) String() string {
 	return "CloudformationStacks"
 }
 
+func (s *Stack) Global() bool {
+	return false
+}
+
 func (s *Stack) GetExpired(ctx context.Context, expirationTime time.Time) (names []string, err error) {
 	var nextToken *string
 	for {

--- a/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
+++ b/test/hack/resource/pkg/resourcetypes/vpc_endpoint.go
@@ -35,6 +35,10 @@ func (v *VPCEndpoint) String() string {
 	return "VPCEndpoints"
 }
 
+func (v *VPCEndpoint) Global() bool {
+	return true
+}
+
 func (v *VPCEndpoint) Get(ctx context.Context, clusterName string) (ids []string, err error) {
 	var nextToken *string
 	for {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Differentiate  between global and regional resources for the sweeper and counter for the metrics that are pushed to Timestream.  

**How was this change tested?**
- N/A

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.