### PR TITLE
BREAKING CHANGE: Drop comma-delimited-list on tags for `subnetSelectorTerms`, `securityGroupSelectorTerms`, and `amiSelectorTerms`

### DIFF
--- a/pkg/providers/amifamily/ami.go
+++ b/pkg/providers/amifamily/ami.go
@@ -37,7 +37,6 @@ import (
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
-	"sigs.k8s.io/karpenter/pkg/utils/functional"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
@@ -267,7 +266,7 @@ func GetFilterAndOwnerSets(terms []v1beta1.AMISelectorTerm) (res []FiltersAndOwn
 				} else {
 					elem.Filters = append(elem.Filters, &ec2.Filter{
 						Name:   aws.String(fmt.Sprintf("tag:%s", k)),
-						Values: aws.StringSlice(functional.SplitCommaSeparatedString(v)),
+						Values: []*string{aws.String(v)},
 					})
 				}
 			}

--- a/pkg/providers/securitygroup/securitygroup.go
+++ b/pkg/providers/securitygroup/securitygroup.go
@@ -28,7 +28,6 @@ import (
 	"github.com/samber/lo"
 	"knative.dev/pkg/logging"
 
-	"sigs.k8s.io/karpenter/pkg/utils/functional"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
@@ -118,7 +117,7 @@ func getFilterSets(terms []v1beta1.SecurityGroupSelectorTerm) (res [][]*ec2.Filt
 				} else {
 					filters = append(filters, &ec2.Filter{
 						Name:   aws.String(fmt.Sprintf("tag:%s", k)),
-						Values: aws.StringSlice(functional.SplitCommaSeparatedString(v)),
+						Values: []*string{aws.String(v)},
 					})
 				}
 			}

--- a/pkg/providers/subnet/subnet.go
+++ b/pkg/providers/subnet/subnet.go
@@ -32,7 +32,6 @@ import (
 	"github.com/aws/karpenter/pkg/apis/v1beta1"
 
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
-	"sigs.k8s.io/karpenter/pkg/utils/functional"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
 
@@ -247,7 +246,7 @@ func getFilterSets(terms []v1beta1.SubnetSelectorTerm) (res [][]*ec2.Filter) {
 				} else {
 					filters = append(filters, &ec2.Filter{
 						Name:   aws.String(fmt.Sprintf("tag:%s", k)),
-						Values: aws.StringSlice(functional.SplitCommaSeparatedString(v)),
+						Values: []*string{aws.String(v)},
 					})
 				}
 			}

--- a/website/content/en/preview/upgrading/upgrade-guide.md
+++ b/website/content/en/preview/upgrading/upgrade-guide.md
@@ -42,6 +42,8 @@ kubectl apply -f https://raw.githubusercontent.com/aws/karpenter{{< githubRelRef
 * `v0.33.x` enables `Drift=true` by default in the `FEATURE_GATES`. If you previously didn't enable the feature gate, Karpenter will now check if there is a difference between the desired state of your nodes declared in your NodePool and the actual state of your nodes. View the [Drift Section of Disruption Conceptual Docs]({{<ref "../concepts/disruption#drift" >}}) for more details.
 * `v0.33.x` drops looking up the `zap-logger-config` through ConfigMap discovery. Instead, Karpenter now expects the logging config to be mounted on the filesystem if you are using this to configure Zap logging. This is not enabled by default, but can be enabled through `--set logConfig.enabled=true` in the helm values. Note that setting the Zap logging config is a deprecated feature in beta and is planned to be dropped at v1. View the [Logging Configuration Section of the v1beta1 Migration Guide]({{<ref "v1beta1-migration#logging-configuration-is-no-longer-dynamic" >}}) for more details.
 * `v0.33.x` change the default `LOG_LEVEL` from `debug` to `info` by default. If you are still enabling logging configuration through the `zap-logger-config`, no action is required.
+* `v0.33.x` drops support for comma delimited lists on tags for `SubnetSelectorTerm`, `SecurityGroupsSelectorTerm`, and `AMISelectorTerm`. Karpenter now supports multiple terms for each of the selectors which means that we can specify a more explicit OR-based constraint through separate terms rather than a comma-delimited list of values.
+
 
 ### Upgrading to v0.32.0+
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.

Please review the Karpenter contribution docs at https://karpenter.sh/docs/contributing/ before submitting your pull request.
-->

Fixes #5219 

**Description**
Dropping support for comma-delimited lists on subnetSelectorTerms, securityGroupTerms, and amiSelectorTerms. 

Users will now need to specify each tag key and value for all tags that may start with the same key 

Before 
```
 amiSelectorTerms:
    - test-1: "ami-name1,ami-name2"
 ```

After
```
 amiSelectorTerms:
    - test-1: "ami-name1"
    - test-1: "ami-name2"
 ```

**How was this change tested?**
- `make presubmit` and `/karpenter snapshot`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates <!-- docs must be added to /preview to be included in future version releases -->
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.